### PR TITLE
[MUIC-304] Fix keyboard disappearing on operator's message received

### DIFF
--- a/GliaWidgets/View/Chat/Entry/ChatMessageEntryView.swift
+++ b/GliaWidgets/View/Chat/Entry/ChatMessageEntryView.swift
@@ -14,19 +14,24 @@ public class ChatMessageEntryView: UIView {
             updateTextViewHeight()
         }
     }
+
     var isChoiceCardModeEnabled: Bool {
         didSet {
             isEnabled = !isChoiceCardModeEnabled
-            textView.resignFirstResponder()
+            if isChoiceCardModeEnabled {
+                textView.resignFirstResponder()
+            }
             placeholderLabel.text = isChoiceCardModeEnabled
                 ? style.choiceCardPlaceholder
                 : style.placeholder
         }
     }
+
     var showsSendButton: Bool {
         get { return !sendButton.isHidden }
         set { sendButton.isHidden = !newValue }
     }
+
     var isEnabled: Bool {
         get { return isUserInteractionEnabled }
         set { isUserInteractionEnabled = newValue }
@@ -59,7 +64,7 @@ public class ChatMessageEntryView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    public override func layoutSubviews() {
+    override public func layoutSubviews() {
         super.layoutSubviews()
         updateTextViewHeight()
     }
@@ -71,8 +76,10 @@ public class ChatMessageEntryView: UIView {
 
         messageContainerView.backgroundColor = style.backgroundColor
 
-        let tapRecognizer = UITapGestureRecognizer(target: self,
-                                                   action: #selector(textViewContainerTap))
+        let tapRecognizer = UITapGestureRecognizer(
+            target: self,
+            action: #selector(textViewContainerTap)
+        )
         messageContainerView.addGestureRecognizer(tapRecognizer)
 
         textView.delegate = self
@@ -98,8 +105,10 @@ public class ChatMessageEntryView: UIView {
 
     private func layout() {
         messageContainerView.addSubview(textView)
-        textViewHeightConstraint = textView.autoSetDimension(.height,
-                                                             toSize: kMinTextViewHeight)
+        textViewHeightConstraint = textView.autoSetDimension(
+            .height,
+            toSize: kMinTextViewHeight
+        )
 
         textView.autoPinEdge(toSuperviewEdge: .left, withInset: 16)
         textView.autoPinEdge(toSuperviewEdge: .top, withInset: 13)
@@ -137,8 +146,10 @@ public class ChatMessageEntryView: UIView {
     }
 
     private func updateTextViewHeight() {
-        let size = CGSize(width: textView.frame.size.width,
-                          height: CGFloat.greatestFiniteMagnitude)
+        let size = CGSize(
+            width: textView.frame.size.width,
+            height: CGFloat.greatestFiniteMagnitude
+        )
         var newHeight = textView.sizeThatFits(size).height
 
         textView.isScrollEnabled = newHeight > kMaxTextViewHeight
@@ -162,8 +173,15 @@ public class ChatMessageEntryView: UIView {
 }
 
 extension ChatMessageEntryView: UITextViewDelegate {
-    public func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
-        let newText = (textView.text as NSString).replacingCharacters(in: range, with: text)
+    public func textView(
+        _ textView: UITextView,
+        shouldChangeTextIn range: NSRange,
+        replacementText text: String
+    ) -> Bool {
+        let newText = (textView.text as NSString).replacingCharacters(
+            in: range,
+            with: text
+        )
         return newText.count < maxCharacters
     }
 
@@ -172,7 +190,7 @@ extension ChatMessageEntryView: UITextViewDelegate {
         textChanged?(textView.text)
     }
 
-    public func textViewDidBeginEditing(_ textView: UITextView) {
+    public func textViewDidBeginEditing(_: UITextView) {
         placeholderLabel.isHidden = true
     }
 

--- a/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
@@ -410,7 +410,9 @@ extension ChatViewModel {
                 appendItem(item, to: messagesSection, animated: true)
                 action?(.updateItemsUserImage(animated: true))
 
-                action?(.setChoiceCardInputModeEnabled(message.isChoiceCard))
+                if message.isChoiceCard {
+                    action?(.setChoiceCardInputModeEnabled(true))
+                }
                 if isChatScrolledToBottom.value {
                     action?(.scrollToBottom(animated: true))
                 }

--- a/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
@@ -410,9 +410,7 @@ extension ChatViewModel {
                 appendItem(item, to: messagesSection, animated: true)
                 action?(.updateItemsUserImage(animated: true))
 
-                if message.isChoiceCard {
-                    action?(.setChoiceCardInputModeEnabled(true))
-                }
+                action?(.setChoiceCardInputModeEnabled(message.isChoiceCard))
                 if isChatScrolledToBottom.value {
                     action?(.scrollToBottom(animated: true))
                 }


### PR DESCRIPTION
Previously the app resigned the first responder from the message entry view on any new message (oversight from choice cards PR). 
Now it does so **only** if the received message is a choice card (to deactivate the message entry until it is answered).