### PR TITLE
MUIC-310: Message sending logic is wrong

### DIFF
--- a/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
@@ -339,18 +339,19 @@ extension ChatViewModel {
         uploader.removeAllUploads()
         action?(.removeAllUploads)
         action?(.scrollToBottom(animated: true))
+        let messageTextTemp = messageText
+        self.messageText = ""
 
-        interactor.send(messageText, attachment: attachment) { message in
-            self.messageText = ""
+        interactor.send(messageTextTemp, attachment: attachment) { message in
             self.replace(
                 outgoingMessage,
                 uploads: uploads,
                 with: message,
                 in: self.messagesSection
             )
+
             self.action?(.scrollToBottom(animated: true))
         } failure: { _ in
-            self.messageText = ""
             self.showAlert(with: self.alertConfiguration.unexpectedError,
                            dismissed: nil)
         }


### PR DESCRIPTION
Previously the text was cleared only after the response was received (either success or error). Now we clear the text before sending the message request.