### PR TITLE
MUIC-314: Chat -Tapping on the screen will hide the keyboard

### DIFF
--- a/GliaWidgets/View/Chat/ChatView.swift
+++ b/GliaWidgets/View/Chat/ChatView.swift
@@ -146,6 +146,7 @@ class ChatView: EngagementView {
         tableView.estimatedRowHeight = UITableView.automaticDimension
         tableView.separatorStyle = .none
         tableView.contentInset = kChatTableViewInsets
+        tableView.keyboardDismissMode = .onDrag
         tableView.register(cell: ChatItemCell.self)
 
         unreadMessageIndicatorView.tapped = { [weak self] in
@@ -153,6 +154,7 @@ class ChatView: EngagementView {
         }
 
         observeKeyboard()
+        addTapGesture()
     }
 
     private func layout() {
@@ -183,6 +185,24 @@ class ChatView: EngagementView {
             of: messageEntryView,
             withOffset: kUnreadMessageIndicatorInset
         )
+    }
+
+    private func addTapGesture() {
+        let tapGesture = UITapGestureRecognizer(
+            target: self,
+            action: #selector(dismissKeyboard)
+        )
+
+        tapGesture.cancelsTouchesInView = false
+
+        addGestureRecognizer(tapGesture)
+    }
+    
+    @objc
+    private func dismissKeyboard(sender: UITapGestureRecognizer) {
+        if sender.state == .ended {
+            endEditing(true)
+        }
     }
 
     private func content(for item: ChatItem) -> ChatItemCell.Content {

--- a/GliaWidgets/View/Chat/ChatView.swift
+++ b/GliaWidgets/View/Chat/ChatView.swift
@@ -146,7 +146,6 @@ class ChatView: EngagementView {
         tableView.estimatedRowHeight = UITableView.automaticDimension
         tableView.separatorStyle = .none
         tableView.contentInset = kChatTableViewInsets
-        tableView.keyboardDismissMode = .onDrag
         tableView.register(cell: ChatItemCell.self)
 
         unreadMessageIndicatorView.tapped = { [weak self] in
@@ -154,7 +153,7 @@ class ChatView: EngagementView {
         }
 
         observeKeyboard()
-        addTapGesture()
+        addKeyboardDismissalTapGesture()
     }
 
     private func layout() {
@@ -187,7 +186,7 @@ class ChatView: EngagementView {
         )
     }
 
-    private func addTapGesture() {
+    private func addKeyboardDismissalTapGesture() {
         let tapGesture = UITapGestureRecognizer(
             target: self,
             action: #selector(dismissKeyboard)


### PR DESCRIPTION
Addresses issues where there would be no way to dismiss the keyboard in the Chat view. Main concern being that when user wants to view previous messages, there would not be that much space left to view the messages once the focus is set on input field.

**What is done**:
* Add tap gesture to view to hide the keyboard when user taps tableview. Also make sure that taps go through to tableview views too, eg. opening a photo or selection a choice card option
* Add keyboard dismissal to tableview on drag