### PR TITLE
[MUIC-319] Fix new message indicator sometimes appearing unexpectedly

### DIFF
--- a/GliaWidgets/View/Chat/ChatView.swift
+++ b/GliaWidgets/View/Chat/ChatView.swift
@@ -248,7 +248,15 @@ class ChatView: EngagementView {
             }
         }
     }
+
+    private func isBottomReached(for scrollView: UIScrollView) -> Bool {
+        let chatBottomOffset = scrollView.contentSize.height - scrollView.frame.size.height
+        let currentPositionOffset = scrollView.contentOffset.y + scrollView.contentInset.top
+        return currentPositionOffset >= chatBottomOffset
+    }
 }
+
+// MARK: Call Bubble
 
 extension ChatView {
     func showCallBubble(with imageUrl: String?, animated: Bool) {
@@ -303,6 +311,8 @@ extension ChatView {
     }
 }
 
+// MARK: Keyboard
+
 extension ChatView {
     private func observeKeyboard() {
         keyboardObserver.keyboardWillShow = { [unowned self] properties in
@@ -336,6 +346,8 @@ extension ChatView {
     }
 }
 
+// MARK: UITableViewDataSource
+
 extension ChatView: UITableViewDataSource {
     func numberOfSections(in tableView: UITableView) -> Int {
         return numberOfSections?() ?? 0
@@ -355,18 +367,14 @@ extension ChatView: UITableViewDataSource {
     }
 }
 
+// MARK: UITableViewDelegate
+
 extension ChatView: UITableViewDelegate {
     public func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
         endEditing(true)
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        let chatBottomOffset = scrollView.contentSize.height - scrollView.frame.size.height
-        let currentPositionOffset = scrollView.contentOffset.y + scrollView.contentInset.top
-        if currentPositionOffset >= chatBottomOffset {
-            chatScrolledToBottom?(true)
-        } else {
-            chatScrolledToBottom?(false)
-        }
+        chatScrolledToBottom?(isBottomReached(for: scrollView))
     }
 }

--- a/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
@@ -427,12 +427,12 @@ extension ChatViewModel {
                 operator: interactor.engagedOperator
             )
             if let item = ChatItem(with: message) {
-                let isChatScrolledToBottom = isChatScrolledToBottom.value
+                let isChatBottomReached = isChatScrolledToBottom.value
                 appendItem(item, to: messagesSection, animated: true)
                 action?(.updateItemsUserImage(animated: true))
 
                 action?(.setChoiceCardInputModeEnabled(message.isChoiceCard))
-                if isChatScrolledToBottom {
+                if isChatBottomReached {
                     action?(.scrollToBottom(animated: true))
                 }
                 unreadMessages.received(1)

--- a/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
@@ -193,6 +193,21 @@ class ChatViewModel: EngagementViewModel, ViewModel {
         }
     }
 
+    override func interactorEvent(_ event: InteractorEvent) {
+        super.interactorEvent(event)
+
+        switch event {
+        case .receivedMessage(let message):
+            receivedMessage(message)
+        case .messagesUpdated(let messages):
+            messagesUpdated(messages)
+        case .upgradeOffer(let offer, answer: let answer):
+            offerMediaUpgrade(offer, answer: answer)
+        default:
+            break
+        }
+    }
+
     override func updateScreenSharingState(to state: VisitorScreenSharingState) {
         super.updateScreenSharingState(to: state)
         switch state.status {
@@ -209,7 +224,11 @@ class ChatViewModel: EngagementViewModel, ViewModel {
         super.endScreenSharing()
         action?(.showEndButton)
     }
+}
 
+// MARK: Section management
+
+extension ChatViewModel {
     private func appendItem(
         _ item: ChatItem,
         to section: Section<ChatItem>,
@@ -241,21 +260,6 @@ class ChatViewModel: EngagementViewModel, ViewModel {
     ) {
         section.set(items)
         action?(.refreshAll)
-    }
-
-    override func interactorEvent(_ event: InteractorEvent) {
-        super.interactorEvent(event)
-
-        switch event {
-        case .receivedMessage(let message):
-            receivedMessage(message)
-        case .messagesUpdated(let messages):
-            messagesUpdated(messages)
-        case .upgradeOffer(let offer, answer: let answer):
-            offerMediaUpgrade(offer, answer: answer)
-        default:
-            break
-        }
     }
 }
 
@@ -423,11 +427,12 @@ extension ChatViewModel {
                 operator: interactor.engagedOperator
             )
             if let item = ChatItem(with: message) {
+                let isChatScrolledToBottom = isChatScrolledToBottom.value
                 appendItem(item, to: messagesSection, animated: true)
                 action?(.updateItemsUserImage(animated: true))
 
                 action?(.setChoiceCardInputModeEnabled(message.isChoiceCard))
-                if isChatScrolledToBottom.value {
+                if isChatScrolledToBottom {
                     action?(.scrollToBottom(animated: true))
                 }
                 unreadMessages.received(1)


### PR DESCRIPTION
Previously, the new message indicator checked for chat scroll status (whether it reached the end or not) right before showing it. The new message would already call `append` but wouldn't scroll to the bottom yet at that point in time. That caused the indicator to appear when it shouldn't have.

Also, reorganized `ChatViewModel` a bit (`type_body_length` warning appeared from SwiftLint) and added marks to `ChatView` for easier navigation.