### PR TITLE
[MUIC-353] Fix buttons layout on turning to landscape

### DIFF
--- a/GliaWidgets/Component/Bar/CallButtonBar/CallButtonBar.swift
+++ b/GliaWidgets/Component/Bar/CallButtonBar/CallButtonBar.swift
@@ -42,6 +42,7 @@ class CallButtonBar: View {
     override func layoutSubviews() {
         super.layoutSubviews()
         adjustBottomSpacing()
+        adjustStackConstraints()
     }
 
     func adjustStackConstraints() {


### PR DESCRIPTION
Implemented a fix for the bottom button bar in call's view landscape view some time ago (#31), but forgot to add this line to `layoutSubviews`.  

Previously, the buttons would lay out correctly only if the phone was already in landscape prior to starting the call. Now they should always readjust themselves, not only on initialization.