### PR TITLE
[MUIC-341] Fix black background in Glia views

### DIFF
--- a/GliaWidgets/ViewController/GliaViewController.swift
+++ b/GliaWidgets/ViewController/GliaViewController.swift
@@ -76,7 +76,7 @@ class GliaViewController: UIViewController {
     }
 
     private func setup() {
-        modalPresentationStyle = .fullScreen
+        modalPresentationStyle = .overFullScreen
         modalTransitionStyle = .crossDissolve
     }
 }


### PR DESCRIPTION
Some Glia views suffered from the erroneous setting of `modalPresentationStyle` to `.fullScreen`, which meant that presenting views were removed from the view hierarchy and would not be seen through some elements with transparency.

This huge PR is meant to fix that error.