### PR TITLE
[MUIC-352] Fix "Stop screen share" button not disappearing in chat view

### DIFF
--- a/GliaWidgets/Component/Header/Header.swift
+++ b/GliaWidgets/Component/Header/Header.swift
@@ -70,24 +70,18 @@ class Header: UIView {
     }
 
     private func setItem(_ item: UIView?, to container: UIView, animated: Bool) {
-        let currentItem = container.subviews.first
+        container.subviews.forEach { $0.removeFromSuperview() }
 
+        guard let item = item else { return }
+        item.alpha = 0.0
+        container.addSubview(item)
+        item.autoPinEdge(toSuperviewEdge: .left, withInset: 0, relation: .greaterThanOrEqual)
+        item.autoPinEdge(toSuperviewEdge: .top, withInset: 0, relation: .greaterThanOrEqual)
+        item.autoPinEdge(toSuperviewEdge: .right, withInset: 0, relation: .greaterThanOrEqual)
+        item.autoPinEdge(toSuperviewEdge: .bottom, withInset: 0, relation: .greaterThanOrEqual)
+        item.autoCenterInSuperview()
         UIView.animate(withDuration: animated ? 0.2 : 0.0) {
-            currentItem?.alpha = 0.0
-        } completion: { _ in
-            currentItem?.removeFromSuperview()
-            if let item = item {
-                item.alpha = 0.0
-                container.addSubview(item)
-                item.autoPinEdge(toSuperviewEdge: .left, withInset: 0, relation: .greaterThanOrEqual)
-                item.autoPinEdge(toSuperviewEdge: .top, withInset: 0, relation: .greaterThanOrEqual)
-                item.autoPinEdge(toSuperviewEdge: .right, withInset: 0, relation: .greaterThanOrEqual)
-                item.autoPinEdge(toSuperviewEdge: .bottom, withInset: 0, relation: .greaterThanOrEqual)
-                item.autoCenterInSuperview()
-                UIView.animate(withDuration: animated ? 0.2 : 0.0) {
-                    item.alpha = 1.0
-                }
-            }
+            item.alpha = 1.0
         }
     }
 

--- a/GliaWidgets/Coordinator/RootCoordinator.swift
+++ b/GliaWidgets/Coordinator/RootCoordinator.swift
@@ -79,8 +79,8 @@ class RootCoordinator: SubFlowCoordinator, FlowCoordinator {
                 ? .audio
                 : .video
             let call = Call(kind)
-            call.kind.addObserver(self) { _, _ in
-                self.engagementKind = EngagementKind(with: call.kind.value)
+            call.kind.addObserver(self) { [weak self] _, _ in
+                self?.engagementKind = EngagementKind(with: call.kind.value)
             }
             let chatViewController = startChat(
                 withAction: .none,
@@ -255,8 +255,8 @@ extension RootCoordinator {
         case .chat(let chatViewController):
             guard let kind = CallKind(with: offer) else { return }
             let call = Call(kind)
-            call.kind.addObserver(self) { _, _ in
-                self.engagementKind = EngagementKind(with: call.kind.value)
+            call.kind.addObserver(self) { [weak self] _, _ in
+                self?.engagementKind = EngagementKind(with: call.kind.value)
             }
             let callViewController = startCall(call, withAction: .call(offer: offer, answer: answer))
             engagement = .call(

--- a/GliaWidgets/Lib/Screensharing/ScreenShareHandler.swift
+++ b/GliaWidgets/Lib/Screensharing/ScreenShareHandler.swift
@@ -1,19 +1,39 @@
 import SalemoveSDK
 
+enum ScreenSharingStatus {
+    case started
+    case stopped
+}
+
 class ScreenShareHandler {
+    let status = ObservableValue<ScreenSharingStatus>(with: .stopped)
     private var visitorState: VisitorScreenSharingState?
 
     func updateState(to state: VisitorScreenSharingState?) {
         visitorState = state
+        guard let state = state else {
+            status.value = .stopped
+            return
+        }
+        switch state.status {
+        case .sharing:
+            status.value = .started
+        case .notSharing:
+            status.value = .stopped
+        @unknown default:
+            break
+        }
     }
 
     func stop(completion: (() -> Void)? = nil) {
         visitorState?.localScreen?.stopSharing()
         visitorState = nil
+        status.value = .stopped
         completion?()
     }
 
     func cleanUp() {
         visitorState = nil
+        status.value = .stopped
     }
 }

--- a/GliaWidgets/Lib/Upload/FileUploader.swift
+++ b/GliaWidgets/Lib/Upload/FileUploader.swift
@@ -61,8 +61,8 @@ class FileUploader {
         guard !limitReached.value else { return nil }
         let localFile = LocalFile(with: url)
         let upload = FileUpload(with: localFile, storage: storage)
-        upload.state.addObserver(self) { _, _ in
-            self.updateState()
+        upload.state.addObserver(self) { [weak self] _, _ in
+            self?.updateState()
         }
         uploads.append(upload)
         upload.startUpload()

--- a/GliaWidgets/View/Chat/Entry/Upload/FileUploadView.swift
+++ b/GliaWidgets/View/Chat/Entry/Upload/FileUploadView.swift
@@ -40,8 +40,8 @@ class FileUploadView: UIView {
         removeButton.addTarget(self, action: #selector(remove), for: .touchUpInside)
 
         update(for: upload.state.value)
-        upload.state.addObserver(self) { state, _ in
-            self.update(for: state)
+        upload.state.addObserver(self) { [weak self] state, _ in
+            self?.update(for: state)
         }
     }
 
@@ -94,8 +94,8 @@ class FileUploadView: UIView {
             stateLabel.textColor = style.uploading.textColor
             progressView.tintColor = style.progressColor
             progressView.progress = Float(progress.value)
-            progress.addObserver(self) { progress, _ in
-                self.progressView.progress = Float(progress)
+            progress.addObserver(self) { [weak self] progress, _ in
+                self?.progressView.progress = Float(progress)
             }
         case .uploaded:
             fileImageView.kind = .file(upload.localFile)

--- a/GliaWidgets/View/Chat/Message/Content/File/ChatFileContentView.swift
+++ b/GliaWidgets/View/Chat/Message/Content/File/ChatFileContentView.swift
@@ -32,8 +32,8 @@ class ChatFileContentView: UIView {
             update(with: file)
         case .download(let download):
             update(with: download)
-            download.state.addObserver(self) { _, _ in
-                self.update(with: download)
+            download.state.addObserver(self) { [weak self] _, _ in
+                self?.update(with: download)
             }
         }
 

--- a/GliaWidgets/View/Chat/Message/Content/File/Download/ChatFileDownloadContentView.swift
+++ b/GliaWidgets/View/Chat/Message/Content/File/Download/ChatFileDownloadContentView.swift
@@ -90,8 +90,8 @@ class ChatFileDownloadContentView: ChatFileContentView {
             progressView.tintColor = style.progressColor
             progressView.progress = Float(progress.value)
             progressView.isHidden = false
-            progress.addObserver(self) { progress, _ in
-                self.progressView.progress = Float(progress)
+            progress.addObserver(self) { [weak self] progress, _ in
+                self?.progressView.progress = Float(progress)
             }
         case .downloaded(let file):
             fileImageView.kind = .file(file)

--- a/GliaWidgets/View/Chat/Upgrade/ChatCallUpgradeView.swift
+++ b/GliaWidgets/View/Chat/Upgrade/ChatCallUpgradeView.swift
@@ -32,8 +32,8 @@ class ChatCallUpgradeView: UIView {
     private func setup() {
         update(with: style)
 
-        duration.addObserver(self) { duration, _ in
-            self.durationLabel.text = duration.asDurationString
+        duration.addObserver(self) { [weak self] duration, _ in
+            self?.durationLabel.text = duration.asDurationString
         }
     }
 

--- a/GliaWidgets/ViewController/Call/CallViewController.swift
+++ b/GliaWidgets/ViewController/Call/CallViewController.swift
@@ -32,7 +32,6 @@ class CallViewController: EngagementViewController, MediaUpgradePresenter {
         view.willRotate(to: orientation, duration: duration)
     }
 
-    // swiftlint:disable function_body_length
     private func bind(viewModel: CallViewModel, to view: CallView) {
         showBackButton(with: viewFactory.theme.call.backButton, in: view.header)
         showCloseButton(with: viewFactory.theme.call.closeButton, in: view.header)
@@ -57,16 +56,6 @@ class CallViewController: EngagementViewController, MediaUpgradePresenter {
                 view.switchTo(.video)
             case .switchToUpgradeMode:
                 view.switchTo(.upgrading)
-            case .showEndButton:
-                let rightItem = ActionButton(with: self.viewFactory.theme.call.endButton)
-                rightItem.tap = { viewModel.event(.closeTapped) }
-                view.header.setRightItem(rightItem, animated: true)
-            case .showEndScreenShareButton:
-                let endEngagementButton = ActionButton(with: self.viewFactory.theme.call.endButton)
-                endEngagementButton.tap = { viewModel.event(.closeTapped) }
-                let endScreenShareButton = HeaderButton(with: self.viewFactory.theme.call.endScreenShareButton)
-                endScreenShareButton.tap = { viewModel.event(.endScreenSharingTapped) }
-                view.header.setRightItems([endScreenShareButton, endEngagementButton], animated: true)
             case .setTitle(let title):
                 view.header.title = title
             case .setOperatorName(let name):

--- a/GliaWidgets/ViewController/Call/CallViewController.swift
+++ b/GliaWidgets/ViewController/Call/CallViewController.swift
@@ -3,17 +3,17 @@ import UIKit
 class CallViewController: EngagementViewController, MediaUpgradePresenter {
     private let viewModel: CallViewModel
 
-    init(viewModel: CallViewModel,
-         viewFactory: ViewFactory) {
+    init(viewModel: CallViewModel, viewFactory: ViewFactory) {
         self.viewModel = viewModel
         super.init(viewModel: viewModel, viewFactory: viewFactory)
     }
 
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    public override func loadView() {
+    override public func loadView() {
         super.loadView()
         let view = viewFactory.makeCallView()
         self.view = view

--- a/GliaWidgets/ViewController/Chat/ChatViewController.swift
+++ b/GliaWidgets/ViewController/Chat/ChatViewController.swift
@@ -69,16 +69,6 @@ class ChatViewController: EngagementViewController, MediaUpgradePresenter,
             case .connected(let name, let imageUrl):
                 view.setConnectState(.connected(name: name, imageUrl: imageUrl), animated: true)
                 view.unreadMessageIndicatorView.setImage(fromUrl: imageUrl, animated: true)
-            case .showEndButton:
-                let rightItem = ActionButton(with: self.viewFactory.theme.chat.endButton)
-                rightItem.tap = { viewModel.event(.closeTapped) }
-                view.header.setRightItem(rightItem, animated: true)
-            case .showEndScreenShareButton:
-                let endEngagementButton = ActionButton(with: self.viewFactory.theme.chat.endButton)
-                endEngagementButton.tap = { viewModel.event(.closeTapped) }
-                let endScreenShareButton = HeaderButton(with: self.viewFactory.theme.chat.endScreenShareButton)
-                endScreenShareButton.tap = { viewModel.event(.endScreenSharingTapped) }
-                view.header.setRightItems([endScreenShareButton, endEngagementButton], animated: true)
             case .setMessageEntryEnabled(let enabled):
                 view.messageEntryView.isEnabled = enabled
             case .setChoiceCardInputModeEnabled(let enabled):

--- a/GliaWidgets/ViewController/Chat/ChatViewController.swift
+++ b/GliaWidgets/ViewController/Chat/ChatViewController.swift
@@ -49,9 +49,9 @@ class ChatViewController: EngagementViewController, MediaUpgradePresenter,
         showBackButton(with: viewFactory.theme.chat.backButton, in: view.header)
         showCloseButton(with: viewFactory.theme.chat.closeButton, in: view.header)
 
-        view.numberOfSections = { return viewModel.numberOfSections }
-        view.numberOfRows = { return viewModel.numberOfItems(in: $0) }
-        view.itemForRow = { return viewModel.item(for: $0, in: $1) }
+        view.numberOfSections = { viewModel.numberOfSections }
+        view.numberOfRows = { viewModel.numberOfItems(in: $0) }
+        view.itemForRow = { viewModel.item(for: $0, in: $1) }
         view.messageEntryView.textChanged = { viewModel.event(.messageTextChanged($0)) }
         view.messageEntryView.sendTapped = { viewModel.event(.sendTapped) }
         view.messageEntryView.pickMediaTapped = { viewModel.event(.pickMediaTapped) }

--- a/GliaWidgets/ViewController/EngagementViewController.swift
+++ b/GliaWidgets/ViewController/EngagementViewController.swift
@@ -4,13 +4,13 @@ class EngagementViewController: ViewController, AlertPresenter {
     internal let viewFactory: ViewFactory
     private let viewModel: EngagementViewModel
 
-    init(viewModel: EngagementViewModel,
-         viewFactory: ViewFactory) {
+    init(viewModel: EngagementViewModel, viewFactory: ViewFactory) {
         self.viewModel = viewModel
         self.viewFactory = viewFactory
         super.init(nibName: nil, bundle: nil)
     }
 
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/GliaWidgets/ViewController/EngagementViewController.swift
+++ b/GliaWidgets/ViewController/EngagementViewController.swift
@@ -55,6 +55,16 @@ class EngagementViewController: ViewController, AlertPresenter {
                 self.presentSettingsAlert(with: conf, cancelled: cancelled)
             case .offerScreenShare(let conf, accepted: let accepted, declined: let declined):
                 self.offerScreenShare(with: conf, accepted: accepted, declined: declined)
+            case .showEndButton:
+                let endEngagementButton = ActionButton(with: self.viewFactory.theme.chat.endButton)
+                endEngagementButton.tap = { viewModel.event(.closeTapped) }
+                view.header.setRightItem(endEngagementButton, animated: true)
+            case .showEndScreenShareButton:
+                let endEngagementButton = ActionButton(with: self.viewFactory.theme.chat.endButton)
+                endEngagementButton.tap = { viewModel.event(.closeTapped) }
+                let endScreenShareButton = HeaderButton(with: self.viewFactory.theme.chat.endScreenShareButton)
+                endScreenShareButton.tap = { viewModel.event(.endScreenSharingTapped) }
+                view.header.setRightItems([endScreenShareButton, endEngagementButton], animated: true)
             }
         }
     }

--- a/GliaWidgets/ViewModel/Call/CallViewModel.swift
+++ b/GliaWidgets/ViewModel/Call/CallViewModel.swift
@@ -78,23 +78,23 @@ class CallViewModel: EngagementViewModel, ViewModel {
             alertConfiguration: alertConfiguration,
             screenShareHandler: screenShareHandler
         )
-        unreadMessages.addObserver(self) { unreadCount, _ in
-            self.action?(.setButtonBadge(.chat, itemCount: unreadCount))
+        unreadMessages.addObserver(self) { [weak self] unreadCount, _ in
+            self?.action?(.setButtonBadge(.chat, itemCount: unreadCount))
         }
-        call.kind.addObserver(self) { kind, _ in
-            self.onKindChanged(kind)
+        call.kind.addObserver(self) { [weak self] kind, _ in
+            self?.onKindChanged(kind)
         }
-        call.state.addObserver(self) { state, _ in
-            self.onStateChanged(state)
+        call.state.addObserver(self) { [weak self] state, _ in
+            self?.onStateChanged(state)
         }
-        call.video.stream.addObserver(self) { audio, _ in
-            self.onVideoChanged(audio)
+        call.video.stream.addObserver(self) { [weak self] audio, _ in
+            self?.onVideoChanged(audio)
         }
-        call.audio.stream.addObserver(self) { audio, _ in
-            self.onAudioChanged(audio)
+        call.audio.stream.addObserver(self) { [weak self] audio, _ in
+            self?.onAudioChanged(audio)
         }
-        call.duration.addObserver(self) { duration, _ in
-            self.onDurationChanged(duration)
+        call.duration.addObserver(self) { [weak self] duration, _ in
+            self?.onDurationChanged(duration)
         }
     }
 

--- a/GliaWidgets/ViewModel/Call/CallViewModel.swift
+++ b/GliaWidgets/ViewModel/Call/CallViewModel.swift
@@ -28,8 +28,6 @@ class CallViewModel: EngagementViewModel, ViewModel {
         case setOperatorName(String?)
         case setTopTextHidden(Bool)
         case setBottomTextHidden(Bool)
-        case showEndButton
-        case showEndScreenShareButton
         case switchToVideoMode
         case switchToUpgradeMode
         case setCallDurationText(String)
@@ -144,23 +142,6 @@ class CallViewModel: EngagementViewModel, ViewModel {
         }
     }
 
-    override func updateScreenSharingState(to state: VisitorScreenSharingState) {
-        super.updateScreenSharingState(to: state)
-        switch state.status {
-        case .sharing:
-            action?(.showEndScreenShareButton)
-        case .notSharing:
-            action?(.showEndButton)
-        @unknown default:
-            break
-        }
-    }
-
-    override func endScreenSharing() {
-        super.endScreenSharing()
-        action?(.showEndButton)
-    }
-
     private func update(for callKind: CallKind) {
         switch callKind {
         case .audio:
@@ -189,7 +170,7 @@ class CallViewModel: EngagementViewModel, ViewModel {
     }
 
     private func showConnected() {
-        action?(.showEndButton)
+        engagementAction?(.showEndButton)
         action?(.setTopTextHidden(true))
         action?(.setBottomTextHidden(true))
 

--- a/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
@@ -18,8 +18,6 @@ class ChatViewModel: EngagementViewModel, ViewModel {
 
     enum Action {
         case queue
-        case showEndButton
-        case showEndScreenShareButton
         case connected(name: String?, imageUrl: String?)
         case setMessageEntryEnabled(Bool)
         case setChoiceCardInputModeEnabled(Bool)
@@ -191,7 +189,7 @@ class ChatViewModel: EngagementViewModel, ViewModel {
             let pictureUrl = engagedOperator?.picture?.url
             action?(.connected(name: name, imageUrl: pictureUrl))
             action?(.setMessageEntryEnabled(true))
-            action?(.showEndButton)
+            engagementAction?(.showEndButton)
             loadHistory()
         default:
             break
@@ -211,23 +209,6 @@ class ChatViewModel: EngagementViewModel, ViewModel {
         default:
             break
         }
-    }
-
-    override func updateScreenSharingState(to state: VisitorScreenSharingState) {
-        super.updateScreenSharingState(to: state)
-        switch state.status {
-        case .sharing:
-            action?(.showEndScreenShareButton)
-        case .notSharing:
-            action?(.showEndButton)
-        @unknown default:
-            break
-        }
-    }
-
-    override func endScreenSharing() {
-        super.endScreenSharing()
-        action?(.showEndButton)
     }
 }
 

--- a/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
@@ -115,14 +115,14 @@ class ChatViewModel: EngagementViewModel, ViewModel {
             isViewVisible: isViewActive,
             isChatScrolledToBottom: isChatScrolledToBottom
         )
-        self.call.addObserver(self) { call, _ in
-            self.onCall(call)
+        self.call.addObserver(self) { [weak self] call, _ in
+            self?.onCall(call)
         }
-        uploader.state.addObserver(self) { state, _ in
-            self.onUploaderStateChanged(state)
+        uploader.state.addObserver(self) { [weak self] state, _ in
+            self?.onUploaderStateChanged(state)
         }
-        uploader.limitReached.addObserver(self) { limitReached, _ in
-            self.action?(.pickMediaButtonEnabled(!limitReached))
+        uploader.limitReached.addObserver(self) { [weak self] limitReached, _ in
+            self?.action?(.pickMediaButtonEnabled(!limitReached))
         }
     }
 
@@ -452,7 +452,8 @@ extension ChatViewModel {
     private func presentMediaPicker() {
         let itemSelected = { (kind: ListItemKind) -> Void in
             let media = ObservableValue<MediaPickerEvent>(with: .none)
-            media.addObserver(self) { event, _ in
+            media.addObserver(self) { [weak self] event, _ in
+                guard let self = self else { return }
                 switch event {
                 case .none, .cancelled:
                     break
@@ -468,12 +469,12 @@ extension ChatViewModel {
                 }
             }
             let file = ObservableValue<FilePickerEvent>(with: .none)
-            file.addObserver(self) { event, _ in
+            file.addObserver(self) { [weak self] event, _ in
                 switch event {
                 case .none, .cancelled:
                     break
                 case .pickedFile(let url):
-                    self.filePicked(url)
+                    self?.filePicked(url)
                 }
             }
             switch kind {

--- a/GliaWidgets/ViewModel/EngagementViewModel.swift
+++ b/GliaWidgets/ViewModel/EngagementViewModel.swift
@@ -56,8 +56,8 @@ class EngagementViewModel {
         self.alertConfiguration = alertConfiguration
         self.screenShareHandler = screenShareHandler
         interactor.addObserver(self, handler: interactorEvent)
-        screenShareHandler.status.addObserver(self) { status, _ in
-            self.onScreenSharingStatusChange(status)
+        screenShareHandler.status.addObserver(self) { [weak self] status, _ in
+            self?.onScreenSharingStatusChange(status)
         }
     }
 

--- a/GliaWidgets/ViewModel/EngagementViewModel.swift
+++ b/GliaWidgets/ViewModel/EngagementViewModel.swift
@@ -56,10 +56,14 @@ class EngagementViewModel {
         self.alertConfiguration = alertConfiguration
         self.screenShareHandler = screenShareHandler
         interactor.addObserver(self, handler: interactorEvent)
+        screenShareHandler.status.addObserver(self) { status, _ in
+            self.onScreenSharingStatusChange(status)
+        }
     }
 
     deinit {
         interactor.removeObserver(self)
+        screenShareHandler.status.removeObserver(self)
         screenShareHandler.cleanUp()
     }
 
@@ -177,14 +181,6 @@ class EngagementViewModel {
 
     func updateScreenSharingState(to state: VisitorScreenSharingState) {
         screenShareHandler.updateState(to: state)
-        switch state.status {
-        case .sharing:
-            engagementAction?(.showEndScreenShareButton)
-        case .notSharing:
-            engagementAction?(.showEndButton)
-        @unknown default:
-            break
-        }
     }
 
     func endScreenSharing() {
@@ -253,6 +249,15 @@ class EngagementViewModel {
                 with: alertConfiguration.unexpectedError,
                 dismissed: { self.endSession() }
             )
+        }
+    }
+
+    private func onScreenSharingStatusChange(_ status: ScreenSharingStatus) {
+        switch status {
+        case .started:
+            engagementAction?(.showEndScreenShareButton)
+        default:
+            engagementAction?(.showEndButton)
         }
     }
 }

--- a/GliaWidgets/ViewModel/EngagementViewModel.swift
+++ b/GliaWidgets/ViewModel/EngagementViewModel.swift
@@ -27,6 +27,8 @@ class EngagementViewModel {
             accepted: () -> Void,
             declined: () -> Void
         )
+        case showEndButton
+        case showEndScreenShareButton
     }
 
     enum DelegateEvent {
@@ -175,10 +177,19 @@ class EngagementViewModel {
 
     func updateScreenSharingState(to state: VisitorScreenSharingState) {
         screenShareHandler.updateState(to: state)
+        switch state.status {
+        case .sharing:
+            engagementAction?(.showEndScreenShareButton)
+        case .notSharing:
+            engagementAction?(.showEndButton)
+        @unknown default:
+            break
+        }
     }
 
     func endScreenSharing() {
         screenShareHandler.stop()
+        engagementAction?(.showEndButton)
     }
 
     private func offerScreenShare(answer: @escaping AnswerBlock) {


### PR DESCRIPTION
Previously the "Stop screen share" button would stay in the chat header if screen sharing was stopped from the upgraded call view.

I've introduced a new observable variable to `ScreenShareHandler` that reflects the changes in screen sharing status. Views subscribe to that observable to modify header buttons as needed.

I've also modified the code for setting item in the header as it sometimes caused some leftover views.

Additionally, moved the screen-share-related code to `EngagementViewModel` and `EngagementViewController`, because previously this code was basically duplicated in Call and Chat VM & VC, which are both subclasses of Engagement VM & VC correspondingly.