### PR TITLE
[MUIC-309] Fix local video view sometimes not appearing

### DIFF
--- a/GliaWidgets/View/Call/Video/VideoStreamView.swift
+++ b/GliaWidgets/View/Call/Video/VideoStreamView.swift
@@ -7,17 +7,9 @@ class VideoStreamView: View {
         case remote
     }
 
-    var streamView: StreamView? {
-        get { return subviews.first as? StreamView }
-        set {
-            guard newValue != streamView else { return }
-            streamView?.removeFromSuperview()
-            if let streamView = newValue {
-                streamView.scale = .aspectFill
-                addSubview(streamView)
-                streamView.autoPinEdgesToSuperviewEdges()
-                streamView.layoutIfNeeded()
-            }
+    weak var streamView: StreamView? {
+        didSet {
+            replace(oldStreamView: oldValue, with: streamView)
         }
     }
 
@@ -27,7 +19,6 @@ class VideoStreamView: View {
         self.kind = kind
         super.init()
         setup()
-        layout()
     }
 
     private func setup() {
@@ -35,5 +26,15 @@ class VideoStreamView: View {
         layer.cornerRadius = kind == .local ? 6.0 : 0.0
     }
 
-    private func layout() {}
+    private func replace(
+        oldStreamView: StreamView?,
+        with streamView: StreamView?
+    ) {
+        oldStreamView?.removeFromSuperview()
+        guard let streamView = streamView else { return }
+        streamView.scale = .aspectFill
+        addSubview(streamView)
+        streamView.autoPinEdgesToSuperviewEdges()
+        streamView.layoutIfNeeded()
+    }
 }

--- a/GliaWidgets/View/Call/Video/VideoStreamView.swift
+++ b/GliaWidgets/View/Call/Video/VideoStreamView.swift
@@ -16,6 +16,7 @@ class VideoStreamView: View {
                 streamView.scale = .aspectFill
                 addSubview(streamView)
                 streamView.autoPinEdgesToSuperviewEdges()
+                streamView.layoutIfNeeded()
             }
         }
     }


### PR DESCRIPTION
This is kind of a band-aid fix over a bigger issue. But it seems to work - with this fix I wasn't able to replicate the issue of local video view not appearing even once in 5+ engagements with hundreds of clicks on the "Toggle video" button.

All the "Unable to satisfy constraints" warnings are still there but it seems that iOS resolves them correctly all the time now, whereas before it would sometimes behave in a way that made the view zero-sized (hence the seemingly random behaviour of the button).

I think this should suffice for now, but we should definitely look into what constraints conflict with each other in Widgets' `VideoStreamView`, Glia SDK's `StreamView` and WebRTC's `RTCEAGLVideoView` in the future. I didn't find a way to get rid of these messages by just changing the Widgets, so maybe some action from the SDK side would be required too.

Here below are two bits of console layout warning output (captured before the fix):

- https://hastebin.com/lihadufuhu.xml - local video view is shown correctly
- https://hastebin.com/qafemocohu.coffeescript - local video view is not shown

@gersonnoboa and @dukhovnyi - maybe you have any ideas about this issue?