### PR TITLE
[MUIC-376] Fix sent message canceling active uploads

### DIFF
--- a/GliaWidgets/Lib/Upload/FileUploader.swift
+++ b/GliaWidgets/Lib/Upload/FileUploader.swift
@@ -95,8 +95,15 @@ class FileUploader {
         updateLimitReached()
     }
 
-    func removeAllUploads() {
-        uploads.removeAll()
+    func removeSucceededUploads() {
+        uploads.removeAll(where: { upload in
+            switch upload.state.value {
+            case .uploaded:
+                return true
+            default:
+                return false
+            }
+        })
         updateState()
         updateLimitReached()
     }

--- a/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
@@ -336,8 +336,8 @@ extension ChatViewModel {
         )
         let item = ChatItem(with: outgoingMessage)
         appendItem(item, to: messagesSection, animated: true)
-        uploader.removeAllUploads()
-        action?(.removeAllUploads)
+        uploader.succeededUploads.forEach { action?(.removeUpload($0)) }
+        uploader.removeSucceededUploads()
         action?(.scrollToBottom(animated: true))
         let messageTextTemp = messageText
         messageText = ""


### PR DESCRIPTION
Previously sending a message would remove all uploads regardless of their status.

Now it only removes (and attaches) the files that have been successfully uploaded. All the other files stay in the file upload area and get attached to some new message as soon as they are uploaded.