### PR TITLE
MUIC-377: [iOS] Turning off the screen while on an audio/video engagement resets the timer

### DIFF
--- a/GliaWidgets/ViewModel/Call/Duration/CallDurationCounter.swift
+++ b/GliaWidgets/ViewModel/Call/Duration/CallDurationCounter.swift
@@ -1,62 +1,40 @@
 import UIKit
 
 class CallDurationCounter {
-    var isActive: Bool { return timer != nil }
+    var isActive: Bool { timer != nil }
 
     private var onUpdate: ((Int) -> Void)?
     private var timer: Timer?
-    private var backgroundedTime: Date?
-    private var duration = 0 {
-        didSet { onUpdate?(duration) }
-    }
-
-    init() {
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(didEnterBackground),
-                                               name: UIApplication.didEnterBackgroundNotification, object: nil)
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(willEnterForeground),
-                                               name: UIApplication.willEnterForegroundNotification, object: nil)
-    }
-
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
+    private var startTime: TimeInterval?
 
     func start(onUpdate: @escaping (Int) -> Void) {
         self.onUpdate = onUpdate
-        startTimer()
+        
+        startTime = Date().timeIntervalSince1970
+        timer = Timer.scheduledTimer(
+            timeInterval: 1.0,
+            target: self,
+            selector: #selector(update),
+            userInfo: nil,
+            repeats: true
+        )
     }
 
     func stop() {
         timer?.invalidate()
         timer = nil
+        startTime = nil
     }
 
-    private func startTimer() {
-        guard !isActive else { return }
-
-        duration = 0
-        timer = Timer.scheduledTimer(timeInterval: 1.0,
-                                     target: self,
-                                     selector: #selector(update),
-                                     userInfo: nil,
-                                     repeats: true)
-    }
-
-    @objc private func update() {
-        duration += 1
-    }
-
-    @objc private func didEnterBackground() {
-        backgroundedTime = Date()
-        stop()
-    }
-
-    @objc private func willEnterForeground() {
-        guard let backgroundedTime = backgroundedTime else { return }
-        let backgroundTime = Int( Date().timeIntervalSince(backgroundedTime) )
-        duration += backgroundTime
-        startTimer()
+    @objc
+    private func update() {
+        guard
+            let startTime = startTime
+        else { return }
+        
+        let currentTime = Date().timeIntervalSince1970
+        let duration = Int(currentTime - startTime)
+        
+        onUpdate?(duration)
     }
 }


### PR DESCRIPTION
This solves the issue where timer would reset to 0.
Simplified the logic a lot, since the audio/video call is using background modes anyway, I don't really see why the notifications for foreground/background were implemented in the first place. Looks to work just fine without them.
Also calculate the correct time on every timer update instead of incrementing duration.