### PR TITLE
MUIC-408: [iOS] Font sizes for media type headers are different

### DIFF
--- a/GliaWidgets/Theme/Theme+Call.swift
+++ b/GliaWidgets/Theme/Theme+Call.swift
@@ -5,7 +5,7 @@ extension Theme {
         typealias Call = L10n.Call
 
         let header = HeaderStyle(
-            titleFont: font.subtitle,
+            titleFont: font.header2,
             titleColor: color.baseLight,
             backgroundColor: .clear
         )


### PR DESCRIPTION
Fixes wrong Font in Call theme. Now uses same as Chat theme.