### PR TITLE
[MUIC-359] Fix views hiding in landscape call view

### DIFF
--- a/GliaWidgets/View/Call/CallView.swift
+++ b/GliaWidgets/View/Call/CallView.swift
@@ -32,7 +32,7 @@ class CallView: EngagementView {
     private let kRemoteVideoViewPortraitHeightMultiplier: CGFloat = 0.3
     private let kRemoteVideoViewLandscapeHeightMultiplier: CGFloat = 1.0
     private let kBarsHideDelay: TimeInterval = 3.2
-    private let barsAreHidden = ObservableValue<Bool>(with: false)
+    private var barsAreHidden: Bool = false
 
     init(with style: CallStyle) {
         self.style = style
@@ -90,7 +90,7 @@ class CallView: EngagementView {
     }
 
     func checkBarsOrientation() {
-        if barsAreHidden.value {
+        if barsAreHidden {
             let newHeaderConstraint = -header.frame.size.height + safeAreaInsets.top
             headerTopConstraint.constant = newHeaderConstraint
             buttonBarBottomConstraint.constant = buttonBar.frame.size.height
@@ -243,7 +243,7 @@ class CallView: EngagementView {
             self.buttonBarBottomConstraint.constant = 0
             self.layoutIfNeeded()
         }
-        barsAreHidden.value = true
+        barsAreHidden = true
     }
 
     private func hideBars(duration: TimeInterval) {
@@ -254,7 +254,7 @@ class CallView: EngagementView {
             self.buttonBarBottomConstraint.constant = self.buttonBar.frame.size.height
             self.layoutIfNeeded()
         }
-        barsAreHidden.value = false
+        barsAreHidden = false
     }
 
     private func hideLandscapeBars() {

--- a/GliaWidgets/View/Call/CallView.swift
+++ b/GliaWidgets/View/Call/CallView.swift
@@ -249,7 +249,7 @@ class CallView: EngagementView {
     }
 
     private func hideLandscapeBarsAfterDelay() {
-        guard mode == .video else { return }
+        guard mode == .video, currentOrientation.isLandscape else { return }
         hideBarsWorkItem?.cancel()
         let hideBarsWorkItem = DispatchWorkItem { self.hideLandscapeBars() }
         self.hideBarsWorkItem = hideBarsWorkItem

--- a/GliaWidgets/View/Call/CallView.swift
+++ b/GliaWidgets/View/Call/CallView.swift
@@ -32,6 +32,7 @@ class CallView: EngagementView {
     private let kRemoteVideoViewPortraitHeightMultiplier: CGFloat = 0.3
     private let kRemoteVideoViewLandscapeHeightMultiplier: CGFloat = 1.0
     private let kBarsHideDelay: TimeInterval = 3.2
+    private let barsAreHidden = ObservableValue<Bool>(with: false)
 
     init(with style: CallStyle) {
         self.style = style
@@ -86,6 +87,17 @@ class CallView: EngagementView {
             showBars(duration: duration)
         }
         buttonBar.adjustStackConstraints()
+    }
+
+    func checkBarsOrientation() {
+        if barsAreHidden.value {
+            let newHeaderConstraint = -header.frame.size.height + safeAreaInsets.top
+            headerTopConstraint.constant = newHeaderConstraint
+            buttonBarBottomConstraint.constant = buttonBar.frame.size.height
+        } else {
+            headerTopConstraint.constant = 0
+            buttonBarBottomConstraint.constant = 0
+        }
     }
 
     private func setup() {
@@ -231,6 +243,7 @@ class CallView: EngagementView {
             self.buttonBarBottomConstraint.constant = 0
             self.layoutIfNeeded()
         }
+        barsAreHidden.value = true
     }
 
     private func hideBars(duration: TimeInterval) {
@@ -241,6 +254,7 @@ class CallView: EngagementView {
             self.buttonBarBottomConstraint.constant = self.buttonBar.frame.size.height
             self.layoutIfNeeded()
         }
+        barsAreHidden.value = false
     }
 
     private func hideLandscapeBars() {
@@ -249,7 +263,7 @@ class CallView: EngagementView {
     }
 
     private func hideLandscapeBarsAfterDelay() {
-        guard mode == .video, currentOrientation.isLandscape else { return }
+        guard mode == .video else { return }
         hideBarsWorkItem?.cancel()
         let hideBarsWorkItem = DispatchWorkItem { self.hideLandscapeBars() }
         self.hideBarsWorkItem = hideBarsWorkItem

--- a/GliaWidgets/ViewController/Call/CallViewController.swift
+++ b/GliaWidgets/ViewController/Call/CallViewController.swift
@@ -28,6 +28,7 @@ class CallViewController: EngagementViewController, MediaUpgradePresenter {
     }
 
     override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         guard let view = view as? CallView else { return }
         view.checkBarsOrientation()
     }

--- a/GliaWidgets/ViewController/Call/CallViewController.swift
+++ b/GliaWidgets/ViewController/Call/CallViewController.swift
@@ -27,6 +27,11 @@ class CallViewController: EngagementViewController, MediaUpgradePresenter {
         view.willRotate(to: orientation, duration: duration)
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        guard let view = view as? CallView else { return }
+        view.checkBarsOrientation()
+    }
+
     private func bind(viewModel: CallViewModel, to view: CallView) {
         showBackButton(with: viewFactory.theme.call.backButton, in: view.header)
         showCloseButton(with: viewFactory.theme.call.closeButton, in: view.header)


### PR DESCRIPTION
There was an issue where the header and buttons bar would break due to the CallView in the background not receiving orientation change events.

Thus I introduced a fix that adjusts the constraints on `viewWillAppear` call.