### PR TITLE
[MUIC-359] Fix incorrect layout in landscape call view

### DIFF
--- a/GliaWidgets/Coordinator/RootCoordinator.swift
+++ b/GliaWidgets/Coordinator/RootCoordinator.swift
@@ -141,7 +141,7 @@ class RootCoordinator: SubFlowCoordinator, FlowCoordinator {
                     } else {
                         self?.gliaViewController?.minimize(animated: true)
                     }
-                    
+
                 case .call(let callViewController, _, let upgradedFrom):
                     if upgradedFrom == .chat {
                         self?.gliaViewController?.minimize(animated: true)

--- a/GliaWidgets/View/Call/CallView.swift
+++ b/GliaWidgets/View/Call/CallView.swift
@@ -90,6 +90,7 @@ class CallView: EngagementView {
     }
 
     func checkBarsOrientation() {
+        guard mode == .video else { return }
         if barsAreHidden {
             let newHeaderConstraint = -header.frame.size.height + safeAreaInsets.top
             headerTopConstraint.constant = newHeaderConstraint

--- a/GliaWidgets/View/Call/CallView.swift
+++ b/GliaWidgets/View/Call/CallView.swift
@@ -32,6 +32,7 @@ class CallView: EngagementView {
     private let kRemoteVideoViewPortraitHeightMultiplier: CGFloat = 0.3
     private let kRemoteVideoViewLandscapeHeightMultiplier: CGFloat = 1.0
     private let kBarsHideDelay: TimeInterval = 3.2
+    private var barsAreHidden: Bool = false
 
     init(with style: CallStyle) {
         self.style = style
@@ -86,6 +87,17 @@ class CallView: EngagementView {
             showBars(duration: duration)
         }
         buttonBar.adjustStackConstraints()
+    }
+
+    func checkBarsOrientation() {
+        if barsAreHidden {
+            let newHeaderConstraint = -header.frame.size.height + safeAreaInsets.top
+            headerTopConstraint.constant = newHeaderConstraint
+            buttonBarBottomConstraint.constant = buttonBar.frame.size.height
+        } else {
+            headerTopConstraint.constant = 0
+            buttonBarBottomConstraint.constant = 0
+        }
     }
 
     private func setup() {
@@ -231,6 +243,7 @@ class CallView: EngagementView {
             self.buttonBarBottomConstraint.constant = 0
             self.layoutIfNeeded()
         }
+        barsAreHidden = true
     }
 
     private func hideBars(duration: TimeInterval) {
@@ -241,6 +254,7 @@ class CallView: EngagementView {
             self.buttonBarBottomConstraint.constant = self.buttonBar.frame.size.height
             self.layoutIfNeeded()
         }
+        barsAreHidden = false
     }
 
     private func hideLandscapeBars() {

--- a/GliaWidgets/View/Chat/Cells/ChatItemCell.swift
+++ b/GliaWidgets/View/Chat/Cells/ChatItemCell.swift
@@ -42,7 +42,7 @@ class ChatItemCell: UITableViewCell {
             }
         }
     }
-    
+
     private let containerView = UIStackView()
 
     public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {

--- a/GliaWidgets/ViewController/Call/CallViewController.swift
+++ b/GliaWidgets/ViewController/Call/CallViewController.swift
@@ -27,6 +27,12 @@ class CallViewController: EngagementViewController, MediaUpgradePresenter {
         view.willRotate(to: orientation, duration: duration)
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        guard let view = view as? CallView else { return }
+        view.checkBarsOrientation()
+    }
+
     private func bind(viewModel: CallViewModel, to view: CallView) {
         showBackButton(with: viewFactory.theme.call.backButton, in: view.header)
         showCloseButton(with: viewFactory.theme.call.closeButton, in: view.header)

--- a/GliaWidgets/ViewModel/Call/Duration/CallDurationCounter.swift
+++ b/GliaWidgets/ViewModel/Call/Duration/CallDurationCounter.swift
@@ -9,7 +9,7 @@ class CallDurationCounter {
 
     func start(onUpdate: @escaping (Int) -> Void) {
         self.onUpdate = onUpdate
-        
+
         startTime = Date().timeIntervalSince1970
         timer = Timer.scheduledTimer(
             timeInterval: 1.0,
@@ -31,10 +31,10 @@ class CallDurationCounter {
         guard
             let startTime = startTime
         else { return }
-        
+
         let currentTime = Date().timeIntervalSince1970
         let duration = Int(currentTime - startTime)
-        
+
         onUpdate?(duration)
     }
 }

--- a/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
@@ -90,7 +90,7 @@ class ChatViewModel: EngagementViewModel, ViewModel {
             action?(.setMessageText(messageText))
         }
     }
-    
+
     private var pendingMessages: [OutgoingMessage] = []
 
     init(
@@ -159,7 +159,7 @@ class ChatViewModel: EngagementViewModel, ViewModel {
 
     override func viewDidAppear() {
         super.viewDidAppear()
-        
+
         if showsCallBubble {
             showCallBubble()
         }
@@ -171,13 +171,13 @@ class ChatViewModel: EngagementViewModel, ViewModel {
         switch startAction {
         case .startEngagement:
             let item = ChatItem(kind: .queueOperator)
-           
+
             appendItem(
                 item,
                 to: queueOperatorSection,
                 animated: false
             )
-            
+
             enqueue()
         case .none:
             if !storage.isEmpty() {
@@ -185,13 +185,13 @@ class ChatViewModel: EngagementViewModel, ViewModel {
                 update(for: interactor.state)
             } else {
                 let item = ChatItem(kind: .queueOperator)
-               
+
                 appendItem(
                     item,
                     to: queueOperatorSection,
                     animated: false
                 )
-                
+
                 enqueue()
             }
         }
@@ -204,7 +204,7 @@ class ChatViewModel: EngagementViewModel, ViewModel {
         case .enqueueing:
             action?(.queue)
             action?(.scrollToBottom(animated: false))
-            
+
         case .engaged(let engagedOperator):
             let name = engagedOperator?.firstName
             let pictureUrl = engagedOperator?.picture?.url
@@ -217,11 +217,11 @@ class ChatViewModel: EngagementViewModel, ViewModel {
             case .stopped:
                 engagementAction?(.showEndButton)
             }
-            
+
             pendingMessages.forEach({ [weak self] outgoingMessage in
                 self?.interactor.send(outgoingMessage.content, attachment: nil) { [weak self] message in
                     guard let self = self else { return }
-                    
+
                     self.replace(
                         outgoingMessage,
                         uploads: [],
@@ -375,7 +375,7 @@ extension ChatViewModel {
             content: messageText,
             files: files
         )
-        
+
         if interactor.isEngaged {
             let item = ChatItem(with: outgoingMessage)
             appendItem(item, to: messagesSection, animated: true)
@@ -387,7 +387,7 @@ extension ChatViewModel {
 
             interactor.send(messageTextTemp, attachment: attachment) { [weak self] message in
                 guard let self = self else { return }
-                
+
                 self.replace(
                     outgoingMessage,
                     uploads: uploads,
@@ -407,23 +407,22 @@ extension ChatViewModel {
         } else {
             let messageItem = ChatItem(with: outgoingMessage)
             appendItem(messageItem, to: pendingSection, animated: true)
-            
+
             uploader.succeededUploads.forEach { action?(.removeUpload($0)) }
             uploader.removeSucceededUploads()
             action?(.removeAllUploads)
 
             pendingMessages.append(outgoingMessage)
-            
+
             let queueItem = ChatItem(kind: .queueOperator)
-           
+
             queueOperatorSection.set([queueItem])
-            
             action?(.refreshSection(2))
             action?(.scrollToBottom(animated: true))
 
             enqueue()
         }
-        
+
         messageText = ""
     }
 

--- a/GliaWidgets/ViewModel/Chat/Storage/ChatStorage.swift
+++ b/GliaWidgets/ViewModel/Chat/Storage/ChatStorage.swift
@@ -60,7 +60,7 @@ class ChatStorage {
         try prepare(sql) { statement in
             values?.enumerated().forEach {
                 let index = Int32($0.offset + 1)
-                
+
                 switch $0.element {
                 case nil:
                     sqlite3_bind_null(statement, index)
@@ -122,12 +122,12 @@ extension ChatStorage {
             SELECT JSON FROM Message
             ORDER BY ID;
         """
-        
+
         do {
             try prepare(sql) {
                 while sqlite3_step($0) == SQLITE_ROW {
                     let json = String(cString: sqlite3_column_text($0, 0))
-                    
+
                     if let data = json.data(using: .utf8) {
                         do {
                             let message = try JSONDecoder().decode(ChatMessage.self, from: data)
@@ -149,7 +149,7 @@ extension ChatStorage {
     func isEmpty() -> Bool {
         return messages.isEmpty
     }
-    
+
     func messages(forQueue queueID: String) -> [ChatMessage] {
         return messages.filter { $0.queueID == queueID }
     }


### PR DESCRIPTION
A pull request to merge MUIC-359 fix into dev branch after passing the QA.

Almost identical to #101, but also contains a small guard (`CallView.swift`, line 93) for checking the orientation only in video mode (audio always has the header and buttons shown) and removing the trailing whitespaces so that SwiftLint stops screaming at me.

Because of these small differences, I've included the reviewers this time. Just in case :)