### PR TITLE
[MUIC-381] Fix call bubble not moving in small screen space

### DIFF
--- a/GliaWidgets/Component/Bubble/BubbleView.swift
+++ b/GliaWidgets/Component/Bubble/BubbleView.swift
@@ -68,17 +68,17 @@ class BubbleView: UIView {
         badgeView?.newItemCount = itemCount
     }
 
-    func adjustInnerFrame(to bounds: CGRect) {
+    func adjustInnerFrame(to callBubbleBounds: CGRect) {
         innerSmallerFrame = frame
 
-        if bounds.width < frame.width {
-            let difference = frame.width - bounds.width
-            innerSmallerFrame.size.width = bounds.width
+        if callBubbleBounds.width < frame.width {
+            let difference = frame.width - callBubbleBounds.width
+            innerSmallerFrame.size.width = callBubbleBounds.width
             innerSmallerFrame.origin.x += difference / 2
         }
-        if bounds.height < frame.height {
-            let difference = frame.height - bounds.height
-            innerSmallerFrame.size.height = bounds.height
+        if callBubbleBounds.height < frame.height {
+            let difference = frame.height - callBubbleBounds.height
+            innerSmallerFrame.size.height = callBubbleBounds.height
             innerSmallerFrame.origin.y += difference / 2
         }
     }

--- a/GliaWidgets/Component/Bubble/BubbleView.swift
+++ b/GliaWidgets/Component/Bubble/BubbleView.swift
@@ -11,12 +11,23 @@ class BubbleView: UIView {
     var tap: (() -> Void)?
     var pan: ((CGPoint) -> Void)?
 
+    var innerSmallerFrame: CGRect {
+        didSet {
+            let xDifference = frame.width - innerSmallerFrame.width
+            let yDifference = frame.height - innerSmallerFrame.height
+
+            frame.origin.x = innerSmallerFrame.origin.x - xDifference / 2
+            frame.origin.y = innerSmallerFrame.origin.y - yDifference / 2
+        }
+    }
+
     private let style: BubbleStyle
     private var userImageView: UserImageView?
     private var badgeView: BadgeView?
 
     init(with style: BubbleStyle) {
         self.style = style
+        self.innerSmallerFrame = CGRect.zero
         super.init(frame: .zero)
         setup()
         layout()
@@ -55,6 +66,21 @@ class BubbleView: UIView {
             }
         }
         badgeView?.newItemCount = itemCount
+    }
+
+    func adjustInnerFrame(to bounds: CGRect) {
+        innerSmallerFrame = frame
+
+        if bounds.width < frame.width {
+            let difference = frame.width - bounds.width
+            innerSmallerFrame.size.width = bounds.width
+            innerSmallerFrame.origin.x += difference / 2
+        }
+        if bounds.height < frame.height {
+            let difference = frame.height - bounds.height
+            innerSmallerFrame.size.height = bounds.height
+            innerSmallerFrame.origin.y += difference / 2
+        }
     }
 
     private func setup() {

--- a/GliaWidgets/Coordinator/RootCoordinator.swift
+++ b/GliaWidgets/Coordinator/RootCoordinator.swift
@@ -141,7 +141,7 @@ class RootCoordinator: SubFlowCoordinator, FlowCoordinator {
                         self?.end()
                     } else {
                         self?.gliaViewController?.minimize(animated: true)
-                    }                    
+                    }
                 case .call(let callViewController, _, let upgradedFrom, _):
                     if upgradedFrom == .chat {
                         self?.gliaViewController?.minimize(animated: true)
@@ -291,7 +291,7 @@ extension RootCoordinator {
             )
             chatCall.value = call
             navigationPresenter.push(callViewController)
-            
+
         case .call(_, _, _, let call):
             call.upgrade(to: offer)
             navigationPresenter.pop()

--- a/GliaWidgets/Theme/ThemeFont.swift
+++ b/GliaWidgets/Theme/ThemeFont.swift
@@ -26,7 +26,6 @@ public struct ThemeFont {
     /// Button label text font. By default, used in "End" buttons in chat and call view headers and buttons in alerts. Default is Roboto Regular 16.
     public var buttonLabel: UIFont
 
-
     ///
     /// - Parameters:
     ///   - header1: Biggest header font. By default, used in top label of connection view during queue and for operator's name during audio or video call. Default is Roboto Bold 24.

--- a/GliaWidgets/View/Call/CallView.swift
+++ b/GliaWidgets/View/Call/CallView.swift
@@ -89,18 +89,6 @@ class CallView: EngagementView {
         buttonBar.adjustStackConstraints()
     }
 
-    func checkBarsOrientation() {
-        guard mode == .video else { return }
-        if barsAreHidden {
-            let newHeaderConstraint = -header.frame.size.height + safeAreaInsets.top
-            headerTopConstraint.constant = newHeaderConstraint
-            buttonBarBottomConstraint.constant = buttonBar.frame.size.height
-        } else {
-            headerTopConstraint.constant = 0
-            buttonBarBottomConstraint.constant = 0
-        }
-    }
-
     private func setup() {
         topStackView.axis = .vertical
         topStackView.spacing = 8
@@ -237,6 +225,33 @@ class CallView: EngagementView {
         }
     }
 
+    @objc private func chatTap() {
+        chatTapped?()
+    }
+
+    @objc private func tap() {
+        if currentOrientation.isLandscape {
+            showBars(duration: 0.3)
+            hideLandscapeBarsAfterDelay()
+        }
+    }
+}
+
+// MARK: Landscape header & buttons bar logic
+
+extension CallView {
+    func checkBarsOrientation() {
+        guard mode == .video else { return }
+        if barsAreHidden {
+            let newHeaderConstraint = -header.frame.size.height + safeAreaInsets.top
+            headerTopConstraint.constant = newHeaderConstraint
+            buttonBarBottomConstraint.constant = buttonBar.frame.size.height
+        } else {
+            headerTopConstraint.constant = 0
+            buttonBarBottomConstraint.constant = 0
+        }
+    }
+
     private func showBars(duration: TimeInterval) {
         layoutIfNeeded()
         UIView.animate(withDuration: duration) {
@@ -272,16 +287,5 @@ class CallView: EngagementView {
             deadline: .now() + kBarsHideDelay,
             execute: hideBarsWorkItem
         )
-    }
-
-    @objc private func chatTap() {
-        chatTapped?()
-    }
-
-    @objc private func tap() {
-        if currentOrientation.isLandscape {
-            showBars(duration: 0.3)
-            hideLandscapeBarsAfterDelay()
-        }
     }
 }

--- a/GliaWidgets/View/Call/CallView.swift
+++ b/GliaWidgets/View/Call/CallView.swift
@@ -14,7 +14,6 @@ class CallView: EngagementView {
     let buttonBar: CallButtonBar
     let localVideoView = VideoStreamView(.local)
     let remoteVideoView = VideoStreamView(.remote)
-    var chatTapped: (() -> Void)?
     var callButtonTapped: ((CallButton.Kind) -> Void)?
 
     private let style: CallStyle
@@ -223,10 +222,6 @@ class CallView: EngagementView {
             localVideoViewTopConstraint.constant = top
             localVideoViewRightConstraint.constant = kRightInset
         }
-    }
-
-    @objc private func chatTap() {
-        chatTapped?()
     }
 
     @objc private func tap() {

--- a/GliaWidgets/View/Chat/ChatView.swift
+++ b/GliaWidgets/View/Chat/ChatView.swift
@@ -43,7 +43,7 @@ class ChatView: EngagementView {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        moveCallBubbleVisible(animated: true)
+        moveCallBubbleVisible()
     }
 
     func setConnectState(_ state: ConnectView.State, animated: Bool) {
@@ -299,34 +299,38 @@ extension ChatView {
     private func moveCallBubble(_ translation: CGPoint, animated: Bool) {
         guard let callBubble = callBubble else { return }
 
-        var frame = callBubble.frame
+        callBubble.adjustInnerFrame(to: callBubbleBounds)
+
+        var frame = callBubble.innerSmallerFrame
         frame.origin.x += translation.x
         frame.origin.y += translation.y
 
-        if callBubbleBounds.contains(frame) {
-            callBubble.frame = frame
+        if callBubbleBounds.contains(callBubble.innerSmallerFrame) {
+            callBubble.innerSmallerFrame = frame
         }
     }
 
-    private func moveCallBubbleVisible(animated: Bool) {
+    private func moveCallBubbleVisible() {
         guard let callBubble = callBubble else { return }
         bringSubviewToFront(callBubble)
 
-        var frame: CGRect = callBubble.frame
+        callBubble.adjustInnerFrame(to: callBubbleBounds)
+        var frame: CGRect = callBubble.innerSmallerFrame
 
-        if callBubble.frame.minX < callBubbleBounds.minX {
+        if callBubble.innerSmallerFrame.minX < callBubbleBounds.minX {
             frame.origin.x = callBubbleBounds.minX
         }
-        if callBubble.frame.minY < callBubbleBounds.minY {
+        if callBubble.innerSmallerFrame.minY < callBubbleBounds.minY {
             frame.origin.y = callBubbleBounds.minY
         }
-        if callBubble.frame.maxX > callBubbleBounds.maxX {
-            frame.origin.x = callBubbleBounds.maxX - kCallBubbleSize.width
+        if callBubble.innerSmallerFrame.maxX > callBubbleBounds.maxX {
+            frame.origin.x = callBubbleBounds.maxX - callBubble.innerSmallerFrame.width
         }
-        if callBubble.frame.maxY > callBubbleBounds.maxY {
-            frame.origin.y = callBubbleBounds.maxY - kCallBubbleSize.height
+        if callBubble.innerSmallerFrame.maxY > callBubbleBounds.maxY {
+            frame.origin.y = callBubbleBounds.maxY - callBubble.innerSmallerFrame.height
         }
-        callBubble.frame = frame
+
+        callBubble.innerSmallerFrame = frame
     }
 }
 

--- a/GliaWidgets/View/Chat/Entry/ChatMessageEntryStyle.swift
+++ b/GliaWidgets/View/Chat/Entry/ChatMessageEntryStyle.swift
@@ -10,7 +10,7 @@ public struct ChatMessageEntryStyle {
 
     /// Placeholder text of the message input view used when the user is engaged.
     public var enterMessagePlaceholder: String
-    
+
     /// Placeholder text of the message input view used when user input is required to start engagement.
     public var startEngagementPlaceholder: String
 

--- a/GliaWidgets/View/Chat/Entry/ChatMessageEntryView.swift
+++ b/GliaWidgets/View/Chat/Entry/ChatMessageEntryView.swift
@@ -21,11 +21,11 @@ class ChatMessageEntryView: UIView {
             if isChoiceCardModeEnabled {
                 textView.resignFirstResponder()
             }
-            
+
             updatePlaceholderText()
         }
     }
-    
+
     var isConnected: Bool {
         didSet {
             updatePlaceholderText()
@@ -100,12 +100,12 @@ class ChatMessageEntryView: UIView {
         placeholderLabel.font = style.placeholderFont
         placeholderLabel.textColor = style.placeholderColor
         updatePlaceholderText()
-        
+
         pickMediaButton.tap = { [weak self] in self?.pickMediaTapped?() }
         sendButton.tap = { [weak self] in self?.sendTap() }
-        
+
         showsSendButton = false
-        
+
         buttonsStackView.axis = .horizontal
         buttonsStackView.spacing = 15
         buttonsStackView.addArrangedSubviews([pickMediaButton, sendButton])
@@ -128,7 +128,7 @@ class ChatMessageEntryView: UIView {
         placeholderLabel.autoPinEdge(toSuperviewEdge: .left)
         placeholderLabel.autoPinEdge(toSuperviewEdge: .top)
         placeholderLabel.autoPinEdge(toSuperviewEdge: .right)
-        
+
         addSubview(separator)
         addSubview(uploadListView)
         addSubview(messageContainerView)
@@ -153,10 +153,10 @@ class ChatMessageEntryView: UIView {
 
         updateTextViewHeight()
     }
-    
+
     private func updatePlaceholderText() {
         var text: String
-        
+
         if isChoiceCardModeEnabled {
             text = style.choiceCardPlaceholder
         } else if !isConnected {
@@ -164,7 +164,7 @@ class ChatMessageEntryView: UIView {
         } else {
             text = style.enterMessagePlaceholder
         }
-        
+
         placeholderLabel.text = text
     }
 


### PR DESCRIPTION
Call bubble has bounds (`callBubbleBounds`) in which it may be moved. When chat was in landscape mode + the keyboard was open, they would become so small (42 in height on iPhone 12 Pro while the bubble size is 60x60) that the bubble couldn't be moved at all anymore.

I've introduced a new, smaller inner frame to the bubble which adjusts for the call bubble bounds. When the bounds are too small, the inner frame will decrease to such a size that it fits exactly, allowing to move call bubble in at least one dimension. In the aforementioned scenario (landscape chat + keyboard) it means that the bubble can now be dragged along the X-axis.

Also included are the formatting fixes created by `swiftlint --fix` for warnings that have been in `dev` for some time.