### PR TITLE
[MUIC-504] Fix endScreenShare button

### DIFF
--- a/GliaWidgets/Lib/Screensharing/ScreenShareHandler.swift
+++ b/GliaWidgets/Lib/Screensharing/ScreenShareHandler.swift
@@ -34,6 +34,5 @@ class ScreenShareHandler {
 
     func cleanUp() {
         visitorState = nil
-        status.value = .stopped
     }
 }

--- a/GliaWidgets/ViewModel/EngagementViewModel.swift
+++ b/GliaWidgets/ViewModel/EngagementViewModel.swift
@@ -257,7 +257,7 @@ class EngagementViewModel {
         case .started:
             engagementAction?(.showEndScreenShareButton)
         case .stopped:
-            return
+            engagementAction?(.showEndButton)
         }
     }
 }


### PR DESCRIPTION
The problem was that when you start screenShare during call and then open chat and end the screenSharing from the chat, coming back to the call you will see the screenSharing button. Now this problem fixed along with the issue when endButton appears after closeButton tapped.