### PR TITLE
MUIC-379: Going from chat screen to audio screen shows weird animation on the background

### DIFF
--- a/GliaWidgets/Lib/ViewController/NavigationController/NavigationController.swift
+++ b/GliaWidgets/Lib/ViewController/NavigationController/NavigationController.swift
@@ -1,3 +1,47 @@
 import UIKit
 
-class NavigationController: UINavigationController {}
+class NavigationController: UINavigationController {
+    private let transitionDuration: CFTimeInterval = 0.3
+
+    override func pushViewController(_ viewController: UIViewController, animated: Bool) {
+        if animated {
+            let transition = CATransition()
+            transition.duration = transitionDuration
+            transition.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            transition.type = .push
+            transition.subtype = .fromRight
+            view.layer.add(transition, forKey: nil)
+        }
+        
+        super.pushViewController(viewController, animated: false)
+    }
+    @discardableResult
+    override func popViewController(animated: Bool) -> UIViewController? {
+        if animated {
+            let transition = CATransition()
+            transition.duration = transitionDuration
+            transition.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            transition.type = .push
+            transition.subtype = .fromLeft
+            
+            view.layer.add(transition, forKey: nil)
+        }
+        
+        return super.popViewController(animated: false)
+    }
+    
+    @discardableResult
+    override func popToRootViewController(animated: Bool) -> [UIViewController]? {
+        if animated {
+            let transition = CATransition()
+            transition.duration = transitionDuration
+            transition.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            transition.type = .push
+            transition.subtype = .fromLeft
+            
+            view.layer.add(transition, forKey: nil)
+        }
+        
+        return super.popToRootViewController(animated: false)
+    }
+}


### PR DESCRIPTION
This PR fixes weird default UINavigationController animation, when pushed ViewController background is transparent.
Basically we just override the default behaviour and add our own simple transition to combat the issue.