### PR TITLE
[MUIC-381] Allow bubble to go over message area if chat is too small

### DIFF
--- a/GliaWidgets/View/Chat/ChatView.swift
+++ b/GliaWidgets/View/Chat/ChatView.swift
@@ -29,7 +29,10 @@ class ChatView: EngagementView {
         let x = safeAreaInsets.left + kCallBubbleEdgeInset
         let y = header.frame.maxY + kCallBubbleEdgeInset
         let width = frame.size.width - x - safeAreaInsets.right - kCallBubbleEdgeInset
-        let height = messageEntryView.frame.minY - header.frame.maxY - 2 * kCallBubbleEdgeInset
+        var height = messageEntryView.frame.minY - header.frame.maxY - 2 * kCallBubbleEdgeInset
+        if height < 1 {
+            height = messageEntryView.frame.maxY - header.frame.maxY - 2 * kCallBubbleEdgeInset
+        }
         return CGRect(x: x, y: y, width: width, height: height)
     }
 


### PR DESCRIPTION
The fix implemented in #119 was not enough for some smaller screens (namely, iPhone SE 1st gen). In these phones such a situation was possible where the chat area would become missing entirely, and as such call bubble wasn't allowed to go anywhere and was stuck completely.

This patch allows the call bubble to go over the message input area if the calculated bounds are too small to fit it. This area is always on-screen, so now there's always at least some space for call bubble to go.