### PR TITLE
[MUIC-491] Hide attachment button if visitor hasn't started the engagement

### DIFF
--- a/GliaWidgets/View/Chat/Entry/ChatMessageEntryView.swift
+++ b/GliaWidgets/View/Chat/Entry/ChatMessageEntryView.swift
@@ -22,6 +22,7 @@ class ChatMessageEntryView: UIView {
                 textView.resignFirstResponder()
             }
 
+            updatePickMediaButtonVisibility()
             updatePlaceholderText()
         }
     }
@@ -29,6 +30,7 @@ class ChatMessageEntryView: UIView {
     var isConnected: Bool {
         didSet {
             updatePlaceholderText()
+            updatePickMediaButtonVisibility()
         }
     }
 
@@ -102,8 +104,9 @@ class ChatMessageEntryView: UIView {
         updatePlaceholderText()
 
         pickMediaButton.tap = { [weak self] in self?.pickMediaTapped?() }
-        sendButton.tap = { [weak self] in self?.sendTap() }
+        updatePickMediaButtonVisibility()
 
+        sendButton.tap = { [weak self] in self?.sendTap() }
         showsSendButton = false
 
         buttonsStackView.axis = .horizontal
@@ -144,6 +147,7 @@ class ChatMessageEntryView: UIView {
         messageContainerView.autoPinEdge(.top, to: .bottom, of: uploadListView)
         messageContainerView.autoPinEdge(toSuperviewEdge: .left)
         messageContainerView.autoPinEdge(toSuperviewEdge: .bottom)
+        messageContainerView.autoPinEdge(toSuperviewEdge: .right)
 
         addSubview(buttonsStackView)
         buttonsStackView.autoSetDimension(.height, toSize: 50)
@@ -166,6 +170,14 @@ class ChatMessageEntryView: UIView {
         }
 
         placeholderLabel.text = text
+    }
+
+    private func updatePickMediaButtonVisibility() {
+        if isChoiceCardModeEnabled {
+            pickMediaButton.isHidden = true
+        } else {
+            pickMediaButton.isHidden = !isConnected
+        }
     }
 
     private func updateTextViewHeight() {


### PR DESCRIPTION
Attachment button was visible when visitor hasn't started engagement, and when visitor pressed it and uploaded files it gave error. Now attachment button (pickMediaButton) is hidden when visitor is not connected with operator.