### PR TITLE
[MUIC-468] Fix video bar buttons in portrait mode

### DIFF
--- a/GliaWidgets/View/Call/CallView.swift
+++ b/GliaWidgets/View/Call/CallView.swift
@@ -80,7 +80,7 @@ class CallView: EngagementView {
     func willRotate(to orientation: UIInterfaceOrientation, duration: TimeInterval) {
         if orientation.isLandscape {
             if mode == .video {
-                hideBars(duration: duration)
+                hideLandscapeBarsAfterDelay()
             }
         } else {
             showBars(duration: duration)
@@ -90,8 +90,12 @@ class CallView: EngagementView {
 
     func checkBarsOrientation() {
         guard mode == .video else { return }
-        headerTopConstraint.constant = 0
-        buttonBarBottomConstraint.constant = 0
+        if currentOrientation.isLandscape {
+            hideLandscapeBarsAfterDelay()
+        } else {
+            headerTopConstraint.constant = 0
+            buttonBarBottomConstraint.constant = 0
+        }
     }
 
     private func setup() {


### PR DESCRIPTION
This PR fixes the issue with :
1. Start a two-way video call (or upgrade from chat)
2. Open chat 
3. Open call again from bubble
bar buttons were hidden, back and end buttons were broken.