### PR TITLE
[MUIC-536] Remove operator image if engagement ended

### DIFF
--- a/GliaWidgets/ViewModel/EngagementViewModel.swift
+++ b/GliaWidgets/ViewModel/EngagementViewModel.swift
@@ -133,6 +133,11 @@ class EngagementViewModel {
                 )
             )
         case .ended:
+            engagementDelegate?(
+                .engaged(
+                    operatorImageUrl: nil
+                )
+            )
             if isEngagementEnded {
                 if EngagementViewModel.alertPresenters.isEmpty {
                         engagementDelegate?(.finished)


### PR DESCRIPTION
in this PR when visitor minimize the engagement view, operator image in bubble will be removed if engagement is ended