### PR TITLE
Fix ActionButton title color

### DIFF
--- a/GliaWidgets/Component/Button/Action/ActionButton.swift
+++ b/GliaWidgets/Component/Button/Action/ActionButton.swift
@@ -48,7 +48,7 @@ class ActionButton: UIButton {
         layer.shadowOpacity = 0.2
 
         titleLabel?.font = style.titleFont
-        titleLabel?.textColor = style.titleColor
+        setTitleColor(style.titleColor, for: .normal)
         titleLabel?.textAlignment = .center
         setTitle(style.title, for: .normal)
 


### PR DESCRIPTION
### How to reproduce?

I've tried to apply theme with this kind of customisation:
```swift
theme.chat.header = .init(
   titleFont: ...,
   titleColor: ...,
   backgroundColor: ...,
   backButton: ...,
   closeButton: ...,
   endButton: .init(title: "End", titleFont: .systemFont(ofSize: 16), titleColor: .green, backgroundColor: .yellow),
   endScreenShareButton: ...
)
```
title color has not been applied due to an incorrect setter called.