### PR TITLE
[MUIC-550] Fix button constraints

### DIFF
--- a/GliaWidgets/View/Chat/Entry/ChatMessageEntryView.swift
+++ b/GliaWidgets/View/Chat/Entry/ChatMessageEntryView.swift
@@ -147,10 +147,10 @@ class ChatMessageEntryView: UIView {
         messageContainerView.autoPinEdge(.top, to: .bottom, of: uploadListView)
         messageContainerView.autoPinEdge(toSuperviewEdge: .left)
         messageContainerView.autoPinEdge(toSuperviewEdge: .bottom)
-        messageContainerView.autoPinEdge(toSuperviewEdge: .right)
 
         addSubview(buttonsStackView)
         buttonsStackView.autoSetDimension(.height, toSize: 50)
+        buttonsStackView.autoSetDimension(.width, toSize: 72, relation: .lessThanOrEqual)
         buttonsStackView.autoPinEdge(.left, to: .right, of: messageContainerView)
         buttonsStackView.autoPinEdge(toSuperviewEdge: .right, withInset: 16)
         buttonsStackView.autoPinEdge(toSuperviewEdge: .bottom)


### PR DESCRIPTION
Problem:
<p align="center">
<img src="https://user-images.githubusercontent.com/72576875/139279299-41e36eb7-f738-47da-a184-42eef52ba546.png">
</p>

Fixes:
pickMediaButton size = 30, sendButton size = 30, space size = 12. Overall width <= 72