### PR TITLE
Clear visitor session

### DIFF
--- a/GliaWidgets/Glia.swift
+++ b/GliaWidgets/Glia.swift
@@ -195,4 +195,20 @@ public class Glia {
         }
         rootCoordinator?.start()
     }
+
+    /// Clear visitor session
+    public func clearVisitorSession() {
+        Salemove.sharedInstance.clearSession()
+
+        guard
+            let dbUrl = ChatStorage.dbUrl,
+            FileManager.default.fileExists(atPath: dbUrl.standardizedFileURL.path)
+        else { return }
+
+        do {
+            try FileManager.default.removeItem(at: dbUrl)
+        } catch {
+            print("DB has not been removed due to: '\(error)'.")
+        }
+    }
 }

--- a/GliaWidgets/ViewModel/Chat/Storage/ChatStorage.swift
+++ b/GliaWidgets/ViewModel/Chat/Storage/ChatStorage.swift
@@ -2,6 +2,12 @@ import SalemoveSDK
 import SQLite3
 
 class ChatStorage {
+
+    static let dbName = "GliaChat.sqlite"
+    static let dbUrl = try? FileManager.default
+        .url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+        .appendingPathComponent(dbName)
+
     private enum SQLiteError: Error {
         case openDatabase
         case prepare
@@ -14,13 +20,8 @@ class ChatStorage {
 
     private let encoder = JSONEncoder()
     private var db: OpaquePointer?
-    private let dbURL: URL?
-    private let kDBName = "GliaChat.sqlite"
 
     init() {
-        dbURL = try? FileManager.default
-            .url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
-            .appendingPathComponent(kDBName)
 
         do {
             try openDatabase()
@@ -35,7 +36,7 @@ class ChatStorage {
     }
 
     private func openDatabase() throws {
-        guard let dbPath = dbURL?.path else { return }
+        guard let dbPath = Self.dbUrl?.path else { return }
         if sqlite3_open(dbPath, &db) != SQLITE_OK {
             throw SQLiteError.openDatabase
         }

--- a/TestingApp/Main.storyboard
+++ b/TestingApp/Main.storyboard
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="A3Y-Xf-Ufg">
-                                <rect key="frame" x="0.0" y="358" width="414" height="180"/>
+                                <rect key="frame" x="0.0" y="333" width="414" height="230"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FAP-5O-GCi">
                                         <rect key="frame" x="164.5" y="0.0" width="85" height="30"/>
@@ -58,6 +58,16 @@
                                         <state key="normal" title="Video call"/>
                                         <connections>
                                             <action selector="videoTapped" destination="Y6W-OH-hqX" eventType="touchUpInside" id="gAa-VI-Ha1"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="P9U-ba-KVy">
+                                        <rect key="frame" x="161" y="200" width="92" height="30"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="30" id="mbg-qw-hCC"/>
+                                        </constraints>
+                                        <state key="normal" title="Clear session"/>
+                                        <connections>
+                                            <action selector="clearSession" destination="Y6W-OH-hqX" eventType="touchUpInside" id="XjZ-Yk-UVX"/>
                                         </connections>
                                     </button>
                                 </subviews>

--- a/TestingApp/ViewController.swift
+++ b/TestingApp/ViewController.swift
@@ -28,6 +28,10 @@ class ViewController: UIViewController {
     @IBAction private func videoTapped() {
         presentGlia(.videoCall)
     }
+
+    @IBAction private func clearSession() {
+        Salemove.sharedInstance.clearSession()
+    }
 }
 
 extension ViewController {

--- a/TestingApp/ViewController.swift
+++ b/TestingApp/ViewController.swift
@@ -30,7 +30,7 @@ class ViewController: UIViewController {
     }
 
     @IBAction private func clearSession() {
-        Salemove.sharedInstance.clearSession()
+        Glia.sharedInstance.clearVisitorSession()
     }
 }
 


### PR DESCRIPTION
### The problem
In case of different sign-in in the final application, visitor history is shared between all application users.

### Hotfix Proposal
The SalemoveSDK has the feature for clearing visitor sessions, so we need additionally to clean up local sqlite3 db to avoid sharing chat history between sessions.