### PR TITLE
MUIC-547: Upload file - Uploading picture wait for like (2min) after uploading, those pictures are not shown in chat view

### DIFF
--- a/GliaWidgets/Lib/Download/FileDownload.swift
+++ b/GliaWidgets/Lib/Download/FileDownload.swift
@@ -41,14 +41,12 @@ class FileDownload {
     }
     private let storage: DataStorage
 
-    init(with file: ChatEngagementFile, storage: DataStorage, localFile: LocalFile? = nil) {
+    init(with file: ChatEngagementFile, storage: DataStorage) {
         self.file = file
         self.storage = storage
 
         if file.isDeleted == true {
             state.value = .error(.deleted)
-        } else if let localFile = localFile {
-            state.value = .downloaded(localFile)
         } else if let storageID = storageID, storage.hasData(for: storageID) {
             let url = storage.url(for: storageID)
             let localFile = LocalFile(with: url)

--- a/GliaWidgets/Lib/Download/FileDownloader.swift
+++ b/GliaWidgets/Lib/Download/FileDownloader.swift
@@ -35,18 +35,16 @@ class FileDownloader {
         }
     }
 
-    func addDownloads(for files: [ChatEngagementFile]?, with uploads: [FileUpload]) {
+    func addDownloads(for files: [ChatEngagementFile]?) {
         guard let files = files else { return }
 
-        files.forEach { file in
-            if let upload = uploads.first(where: { $0.engagementFileInformation?.id == file.id }) {
-                self.addDownload(for: file, localFile: upload.localFile)
-            }
+        files.forEach { [weak self] in
+            self?.addDownload(for: $0)
         }
     }
 
     @discardableResult
-    private func addDownload(for file: ChatEngagementFile, localFile: LocalFile? = nil) -> FileDownload? {
+    private func addDownload(for file: ChatEngagementFile) -> FileDownload? {
         guard let fileID = file.id else { return nil }
 
         if let download = downloads[fileID] {
@@ -54,8 +52,7 @@ class FileDownloader {
         } else {
             let download = FileDownload(
                 with: file,
-                storage: storage,
-                localFile: localFile
+                storage: storage
             )
             downloads[fileID] = download
             return download

--- a/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
@@ -399,7 +399,7 @@ extension ChatViewModel {
                     outgoingMessage,
                     uploads: uploads,
                     with: message,
-                    in: self.pendingSection
+                    in: self.messagesSection
                 )
 
                 self.action?(.scrollToBottom(animated: true))
@@ -464,7 +464,7 @@ extension ChatViewModel {
 
         let deliveredMessage = ChatMessage(with: message)
         let item = ChatItem(kind: .visitorMessage(deliveredMessage, status: deliveredStatus))
-        downloader.addDownloads(for: deliveredMessage.attachment?.files, with: uploads)
+        downloader.addDownloads(for: deliveredMessage.attachment?.files)
         section.replaceItem(at: index, with: item)
         affectedRows.append(index)
         action?(.refreshRows(affectedRows, in: section.index, animated: false))


### PR DESCRIPTION
Checking for and passing in local file is not nececcary due to it being in the storage anyway by the time it's uploaded. Therefore matching key can fetch it anyway. Lessens complications.