### PR TITLE
MUIC-578: Chat/Audio/Video - Pictures with capitalized file extension do not show in chat view

### DIFF
--- a/GliaWidgets/Lib/File/LocalFile.swift
+++ b/GliaWidgets/Lib/File/LocalFile.swift
@@ -25,7 +25,9 @@ class LocalFile {
         }
     }()
     lazy var isImage: Bool = {
-        return ["jpg", "jpeg", "png", "gif"].contains(fileExtension)
+        return ["jpg", "jpeg", "png", "gif"].contains(where: {
+            $0.lowercased() == fileExtension.lowercased()
+        })
     }()
     let url: URL
 


### PR DESCRIPTION
Modified:
* Check case insensitivity while checking whtether file is an image or not