### PR TITLE
Introduce interfaces for fetching and updating visitor info

### DIFF
--- a/GliaWidgets/Glia.swift
+++ b/GliaWidgets/Glia.swift
@@ -125,6 +125,15 @@ public class Glia {
 
     private init() {}
 
+
+    /// Setup SDK using specific engagement configuration without starting the engagement.
+    /// - Parameter configuration: Engagement configuration.
+    public func configure(with configuration: Configuration) throws {
+        try Salemove.sharedInstance.configure(appToken: configuration.appToken)
+        try Salemove.sharedInstance.configure(environment: configuration.environment.url)
+        try Salemove.sharedInstance.configure(site: configuration.site)
+    }
+
     /// Starts the engagement.
     ///
     /// - Parameters:

--- a/GliaWidgets/Glia.swift
+++ b/GliaWidgets/Glia.swift
@@ -133,12 +133,12 @@ public class Glia {
     ///   - visitorContext: Visitor context.
     public func configure(
         with configuration: Configuration,
-        queueID: String,
+        queueId: String,
         visitorContext: VisitorContext
     ) throws {
         interactor = try Interactor(
             with: configuration,
-            queueID: queueID,
+            queueID: queueId,
             visitorContext: visitorContext
         )
     }
@@ -213,7 +213,7 @@ public class Glia {
     ) throws {
         try configure(
             with: configuration,
-            queueID: queueID,
+            queueId: queueID,
             visitorContext: visitorContext
         )
 

--- a/GliaWidgets/Glia.swift
+++ b/GliaWidgets/Glia.swift
@@ -207,22 +207,17 @@ public class Glia {
         features: Features = .all,
         sceneProvider: SceneProvider? = nil
     ) throws {
-        guard engagement == .none else {
-            throw GliaError.engagementExists
-        }
-
-        let interactor = try Interactor(
+        try configure(
             with: configuration,
             queueID: queueID,
             visitorContext: visitorContext
         )
-        let viewFactory = ViewFactory(with: theme)
-        startRootCoordinator(
-            with: interactor,
-            viewFactory: viewFactory,
-            sceneProvider: sceneProvider,
+
+        try startEngagement(
             engagementKind: engagementKind,
-            features: features
+            theme: theme,
+            features: features,
+            sceneProvider: sceneProvider
         )
     }
 

--- a/GliaWidgets/Glia.swift
+++ b/GliaWidgets/Glia.swift
@@ -153,10 +153,14 @@ public class Glia {
     ///   - sceneProvider: Used to provide `UIWindowScene` to the framework. Defaults to the first active foreground scene.
     ///
     /// - throws:
-    ///   - `ConfigurationError.invalidSite`
-    ///   - `ConfigurationError.invalidEnvironment`
-    ///   - `ConfigurationError.invalidAppToken`
-    ///   - `GliaError.engagementExists`
+    ///   - `SalemoveSDK.ConfigurationError.invalidSite`
+    ///   - `SalemoveSDK.ConfigurationError.invalidEnvironment`
+    ///   - `SalemoveSDK.ConfigurationError.invalidAppToken`
+    ///   - `GliaError.engagementExists
+    ///   - `GliaError.sdkIsNotConfigured`
+    ///
+    /// - Important: Note, that `configure(with:queueID:visitorContext:)` must be called initially prior to this method,
+    /// because `GliaError.sdkIsNotConfigured` will occur otherwise.
     ///
     public func startEngagement(
         engagementKind: EngagementKind,
@@ -193,9 +197,9 @@ public class Glia {
     ///   - sceneProvider: Used to provide `UIWindowScene` to the framework. Defaults to the first active foreground scene.
     ///
     /// - throws:
-    ///   - `ConfigurationError.invalidSite`
-    ///   - `ConfigurationError.invalidEnvironment`
-    ///   - `ConfigurationError.invalidAppToken`
+    ///   - `SalemoveSDK.ConfigurationError.invalidSite`
+    ///   - `SalemoveSDK.ConfigurationError.invalidEnvironment`
+    ///   - `SalemoveSDK.ConfigurationError.invalidAppToken`
     ///   - `GliaError.engagementExists`
     ///
     public func start(
@@ -288,14 +292,22 @@ public class Glia {
     /// If the request is unsuccessful for any reason then the completion will have an Error.
     /// The Error may have one of the following causes:
     ///
-    /// - `GeneralError.internalError`
-    /// - `GeneralError.networkError`
-    /// - `ConfigurationError.invalidSite`
-    /// - `ConfigurationError.invalidEnvironment`
-    /// - `ConfigurationError.invalidAppToken`
-    /// - `ConfigurationError.invalidApiToken`
+    /// - `SalemoveSDK.GeneralError.internalError`
+    /// - `SalemoveSDK.GeneralError.networkError`
+    /// - `SalemoveSDK.ConfigurationError.invalidSite`
+    /// - `SalemoveSDK.ConfigurationError.invalidEnvironment`
+    /// - `SalemoveSDK.ConfigurationError.invalidAppToken`
+    /// - `SalemoveSDK.ConfigurationError.invalidApiToken`
+    /// - `GliaError.sdkIsNotConfigured`
+    ///
+    /// - Important: Note, that in case of engagement has not been started yet, `configure(with:queueID:visitorContext:)` must be called initially prior to this method,
+    /// because `GliaError.sdkIsNotConfigured` will occur otherwise.
     ///
     public func fetchVisitorInfo(completion: @escaping (Result<Salemove.VisitorInfo, Error>) -> Void) {
+        guard interactor != nil else {
+            completion(.failure(GliaError.sdkIsNotConfigured))
+            return
+        }
         Salemove.sharedInstance.fetchVisitorInfo(completion)
     }
 
@@ -322,11 +334,19 @@ public class Glia {
     /// - `SalemoveSDK.ConfigurationError.invalidEnvironment`
     /// - `SalemoveSDK.ConfigurationError.invalidAppToken`
     /// - `SalemoveSDK.ConfigurationError.invalidApiToken`
+    /// - `GliaError.sdkIsNotConfigured`
+    ///
+    /// - Important: Note, that in case of engagement has not been started yet, `configure(with:queueID:visitorContext:)` must be called initially prior to this method,
+    /// because `GliaError.sdkIsNotConfigured` will occur otherwise.
     ///
     public func updateVisitorInfo(
         _ info: VisitorInfoUpdate,
         completion: @escaping (Result<Bool, Error>) -> Void
     ) {
+        guard interactor != nil else {
+            completion(.failure(GliaError.sdkIsNotConfigured))
+            return
+        }
         Salemove.sharedInstance.updateVisitorInfo(info, completion: completion)
     }
 }

--- a/GliaWidgets/Glia.swift
+++ b/GliaWidgets/Glia.swift
@@ -129,7 +129,7 @@ public class Glia {
     /// Setup SDK using specific engagement configuration without starting the engagement.
     /// - Parameters:
     ///   - configuration: Engagement configuration.
-    ///   - queueID: Queue identifier.
+    ///   - queueId: Queue identifier.
     ///   - visitorContext: Visitor context.
     public func configure(
         with configuration: Configuration,

--- a/GliaWidgets/GliaError.swift
+++ b/GliaWidgets/GliaError.swift
@@ -2,4 +2,5 @@
 public enum GliaError: Error {
     case engagementExists
     case engagementNotExist
+    case sdkIsNotConfigured
 }


### PR DESCRIPTION
Currently widgets allow fetching and updating visitor info only after engagement has been started. This PR aims to resolve this by introducing interfaces that will setup the configuration but avoid starting the engagement.

MOB-1007