### PR TITLE
[iOS] Chat/Audio/Video - Hint "Enter Message" disappears if visitor sent a message with closed phone's keyboard

### DIFF
--- a/GliaWidgets/View/Chat/Entry/ChatMessageEntryView.swift
+++ b/GliaWidgets/View/Chat/Entry/ChatMessageEntryView.swift
@@ -11,6 +11,7 @@ class ChatMessageEntryView: UIView {
         get { return textView.text }
         set {
             textView.text = newValue
+            placeholderLabel.isHidden = !textView.text.isEmpty
             updateTextViewHeight()
         }
     }


### PR DESCRIPTION
## Context

**Jira issue URL:** https://glia.atlassian.net/browse/MUIC-577

**Summary:**
Previously placeHolderLabel visibility was only checked while begin/end editing events would trigger for textView. This means, when we set text programatically (we set it to empty after sending message), the placeHolder visibility check would not trigger. This PR changes this behaviour - **also check whether placeHolder should be hidden or not based on text set programatically**.

**Screenshots:**
Before|After
:-:|:-:
![Simulator Screen Shot - iPhone 12 - 2021-12-21 at 08 17 58](https://user-images.githubusercontent.com/26465109/146881217-78be1ead-41b1-41a6-9ba5-f1e9585e02cd.png)|![Simulator Screen Shot - iPhone 12 - 2021-12-21 at 08 16 35](https://user-images.githubusercontent.com/26465109/146881234-a7722c65-8405-4c0f-b3e7-2c177d5cdead.png)

## Checklist
- [x] My code follows the style guidelines of this project (linters/formatters)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have followed the agreed architectural patterns
