### PR TITLE
[iOS] Audio/Video - The bubble moves to the left and right but does not follow the visitor’s finger

### DIFF
--- a/GliaWidgets/Component/Bubble/BubbleView.swift
+++ b/GliaWidgets/Component/Bubble/BubbleView.swift
@@ -11,23 +11,12 @@ class BubbleView: UIView {
     var tap: (() -> Void)?
     var pan: ((CGPoint) -> Void)?
 
-    var innerSmallerFrame: CGRect {
-        didSet {
-            let xDifference = frame.width - innerSmallerFrame.width
-            let yDifference = frame.height - innerSmallerFrame.height
-
-            frame.origin.x = innerSmallerFrame.origin.x - xDifference / 2
-            frame.origin.y = innerSmallerFrame.origin.y - yDifference / 2
-        }
-    }
-
     private let style: BubbleStyle
     private var userImageView: UserImageView?
     private var badgeView: BadgeView?
 
     init(with style: BubbleStyle) {
         self.style = style
-        self.innerSmallerFrame = CGRect.zero
         super.init(frame: .zero)
         setup()
         layout()
@@ -50,21 +39,6 @@ class BubbleView: UIView {
         ).cgPath
     }
 
-    func adjustInnerFrame(to callBubbleBounds: CGRect) {
-        innerSmallerFrame = frame
-
-        if callBubbleBounds.width < frame.width {
-            let difference = frame.width - callBubbleBounds.width
-            innerSmallerFrame.size.width = callBubbleBounds.width
-            innerSmallerFrame.origin.x += difference / 2
-        }
-        if callBubbleBounds.height < frame.height {
-            let difference = frame.height - callBubbleBounds.height
-            innerSmallerFrame.size.height = callBubbleBounds.height
-            innerSmallerFrame.origin.y += difference / 2
-        }
-    }
-    
     func setBadge(itemCount: Int) {
         guard let style = style.badge else { return }
 

--- a/GliaWidgets/View/Chat/ChatView.swift
+++ b/GliaWidgets/View/Chat/ChatView.swift
@@ -28,12 +28,10 @@ class ChatView: EngagementView {
     private let kOperatorTypingIndicatorViewSize = CGSize(width: 28, height: 28)
     private var callBubbleBounds: CGRect {
         let x = safeAreaInsets.left + kCallBubbleEdgeInset
-        let y = header.frame.maxY + kCallBubbleEdgeInset
-        let width = frame.size.width - x - safeAreaInsets.right - kCallBubbleEdgeInset
-        var height = messageEntryView.frame.minY - header.frame.maxY - 2 * kCallBubbleEdgeInset
-        if height < 1 {
-            height = messageEntryView.frame.maxY - header.frame.maxY - 2 * kCallBubbleEdgeInset
-        }
+        let y = safeAreaInsets.top + kCallBubbleEdgeInset
+        let width = frame.width - safeAreaInsets.left - safeAreaInsets.right - 2 * kCallBubbleEdgeInset
+        let height = messageEntryView.frame.maxY - safeAreaInsets.top - 2 * kCallBubbleEdgeInset
+
         return CGRect(x: x, y: y, width: width, height: height)
     }
 
@@ -321,14 +319,12 @@ extension ChatView {
     private func moveCallBubble(_ translation: CGPoint, animated: Bool) {
         guard let callBubble = callBubble else { return }
 
-        callBubble.adjustInnerFrame(to: callBubbleBounds)
-
-        var frame = callBubble.innerSmallerFrame
+        var frame = callBubble.frame
         frame.origin.x += translation.x
         frame.origin.y += translation.y
 
         if callBubbleBounds.contains(frame) {
-            callBubble.innerSmallerFrame = frame
+            callBubble.frame = frame
         }
     }
 
@@ -336,23 +332,22 @@ extension ChatView {
         guard let callBubble = callBubble else { return }
         bringSubviewToFront(callBubble)
 
-        callBubble.adjustInnerFrame(to: callBubbleBounds)
-        var frame: CGRect = callBubble.innerSmallerFrame
+        var frame: CGRect = callBubble.frame
 
-        if callBubble.innerSmallerFrame.minX < callBubbleBounds.minX {
+        if callBubble.frame.minX < callBubbleBounds.minX {
             frame.origin.x = callBubbleBounds.minX
         }
-        if callBubble.innerSmallerFrame.minY < callBubbleBounds.minY {
+        if callBubble.frame.minY < callBubbleBounds.minY {
             frame.origin.y = callBubbleBounds.minY
         }
-        if callBubble.innerSmallerFrame.maxX > callBubbleBounds.maxX {
-            frame.origin.x = callBubbleBounds.maxX - callBubble.innerSmallerFrame.width
+        if callBubble.frame.maxX > callBubbleBounds.maxX {
+            frame.origin.x = callBubbleBounds.maxX - callBubble.frame.width
         }
-        if callBubble.innerSmallerFrame.maxY > callBubbleBounds.maxY {
-            frame.origin.y = callBubbleBounds.maxY - callBubble.innerSmallerFrame.height
+        if callBubble.frame.maxY > callBubbleBounds.maxY {
+            frame.origin.y = callBubbleBounds.maxY - callBubble.frame.height
         }
 
-        callBubble.innerSmallerFrame = frame
+        callBubble.frame = frame
     }
 }
 


### PR DESCRIPTION
## Context

**Jira issue URL:** https://glia.atlassian.net/browse/MUIC-588

**Summary:**
The bubble would not follow user finger, when the bounds for movement are small. It would stop tracking user finger when the finger moves outside of the bubble moving bounds. The bounds could be very small in cases while phone is in landscape orientation and keyboard is open (eg. iPhone SE 1/2 gen). This PR combats it by allowing bubble to also move on top of header and textview, as it does on Android.
 
## Checklist
- [x] My code follows the style guidelines of this project (linters/formatters)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have followed the agreed architectural patterns
