### PR TITLE
Introduce interface for supporting Site API Key

### DIFF
--- a/GliaWidgets/Glia.swift
+++ b/GliaWidgets/Glia.swift
@@ -45,8 +45,75 @@ public class Glia {
     public var onEvent: ((GliaEvent) -> Void)?
 
     private var rootCoordinator: RootCoordinator?
+    private var interactor: Interactor?
 
     private init() {}
+
+    /// Setup SDK using specific engagement configuration without starting the engagement.
+    /// - Parameters:
+    ///   - configuration: Engagement configuration.
+    ///   - queueId: Queue identifier.
+    ///   - visitorContext: Visitor context.
+    public func configure(
+        with configuration: Configuration,
+        queueId: String,
+        visitorContext: VisitorContext
+    ) throws {
+
+        let sdkConfiguration = try Salemove.Configuration(
+            siteId: configuration.site,
+            region: configuration.environment.region,
+            authorizingMethod: configuration.authorizationMethod.coreAuthorizationMethod
+        )
+        interactor = Interactor(
+            with: sdkConfiguration,
+            queueID: queueId,
+            visitorContext: visitorContext
+        )
+    }
+
+    /// Starts the engagement.
+    ///
+    /// - Parameters:
+    ///   - engagementKind: Engagement media type.
+    ///   - theme: A custom theme to use with the engagement.
+    ///   - visitorContext: Visitor context.
+    ///   - features: Set of features to be enabled in the SDK.
+    ///   - sceneProvider: Used to provide `UIWindowScene` to the framework. Defaults to the first active foreground scene.
+    ///
+    /// - throws:
+    ///   - `SalemoveSDK.ConfigurationError.invalidSite`
+    ///   - `SalemoveSDK.ConfigurationError.invalidEnvironment`
+    ///   - `SalemoveSDK.ConfigurationError.invalidAppToken`
+    ///   - `GliaError.engagementExists
+    ///   - `GliaError.sdkIsNotConfigured`
+    ///
+    /// - Important: Note, that `configure(with:queueID:visitorContext:)` must be called initially prior to this method,
+    /// because `GliaError.sdkIsNotConfigured` will occur otherwise.
+    ///
+    public func startEngagement(
+        engagementKind: EngagementKind,
+        theme: Theme = Theme(),
+        features: Features = .all,
+        sceneProvider: SceneProvider? = nil
+    ) throws {
+        guard engagement == .none else {
+            throw GliaError.engagementExists
+        }
+
+        guard let interactor = self.interactor else {
+            throw GliaError.sdkIsNotConfigured
+        }
+
+        let viewFactory = ViewFactory(with: theme)
+        startRootCoordinator(
+            with: interactor,
+            viewFactory: viewFactory,
+            sceneProvider: sceneProvider,
+            engagementKind: engagementKind,
+            features: features
+        )
+    }
 
     /// Starts the engagement.
     ///
@@ -59,9 +126,11 @@ public class Glia {
     ///   - sceneProvider: Used to provide `UIWindowScene` to the framework. Defaults to the first active foreground scene.
     ///
     /// - throws:
-    ///   - `ConfigurationError.invalidSite`
-    ///   - `ConfigurationError.invalidEnvironment`
-    ///   - `ConfigurationError.invalidAppToken`
+    ///   - `SalemoveSDK.ConfigurationError.invalidSite`
+    ///   - `SalemoveSDK.ConfigurationError.invalidEnvironment`
+    ///   - `SalemoveSDK.ConfigurationError.invalidRegionEndpoint`
+    ///   - `SalemoveSDK.ConfigurationError.invalidSiteApiKey`
+    ///   - `SalemoveSDK.ConfigurationError.invalidAppToken`
     ///   - `GliaError.engagementExists`
     ///
     public func start(
@@ -73,22 +142,17 @@ public class Glia {
         features: Features = .all,
         sceneProvider: SceneProvider? = nil
     ) throws {
-        guard engagement == .none else {
-            throw GliaError.engagementExists
-        }
-
-        let interactor = try Interactor(
+        try configure(
             with: configuration,
-            queueID: queueID,
+            queueId: queueID,
             visitorContext: visitorContext
         )
-        let viewFactory = ViewFactory(with: theme)
-        startRootCoordinator(
-            with: interactor,
-            viewFactory: viewFactory,
-            sceneProvider: sceneProvider,
+
+        try startEngagement(
             engagementKind: engagementKind,
-            features: features
+            theme: theme,
+            features: features,
+            sceneProvider: sceneProvider
         )
     }
 
@@ -145,5 +209,75 @@ public class Glia {
         } catch {
             print("DB has not been removed due to: '\(error)'.")
         }
+    }
+
+    /// Fetch current Visitor's information.
+    ///
+    /// The information provided by this endpoint is available to all the Operators observing or interacting with the
+    /// Visitor. This means that this endpoint can be used to provide additional context about the Visitor to the
+    /// Operators.
+    ///
+    /// - Parameters:
+    ///   - completion: A callback that will return the update result or `SalemoveError`
+    ///
+    /// If the request is unsuccessful for any reason then the completion will have an Error.
+    /// The Error may have one of the following causes:
+    ///
+    /// - `SalemoveSDK.GeneralError.internalError`
+    /// - `SalemoveSDK.GeneralError.networkError`
+    /// - `SalemoveSDK.ConfigurationError.invalidSite`
+    /// - `SalemoveSDK.ConfigurationError.invalidEnvironment`
+    /// - `SalemoveSDK.ConfigurationError.invalidAppToken`
+    /// - `SalemoveSDK.ConfigurationError.invalidApiToken`
+    /// - `GliaError.sdkIsNotConfigured`
+    ///
+    /// - Important: Note, that in case of engagement has not been started yet, `configure(with:queueID:visitorContext:)` must be called initially prior to this method,
+    /// because `GliaError.sdkIsNotConfigured` will occur otherwise.
+    ///
+    public func fetchVisitorInfo(completion: @escaping (Result<Salemove.VisitorInfo, Error>) -> Void) {
+        guard interactor != nil else {
+            completion(.failure(GliaError.sdkIsNotConfigured))
+            return
+        }
+        Salemove.sharedInstance.fetchVisitorInfo(completion)
+    }
+
+    /// Update current Visitor's information.
+    ///
+    /// The information provided by this endpoint is available to all the Operators observing or interacting with the
+    /// Visitor. This means that this endpoint can be used to provide additional context about the Visitor to the
+    /// Operators.
+    ///
+    /// In a similar manner custom attributes can be also be used to provide additional context. For example, if your
+    /// site separates paying users from free users, then setting a custom attribute of 'user_type' with a value of
+    /// either 'free' or 'paying' depending on the Visitor's account can help Operators prioritize different Visitors.
+    ///
+    /// - Parameters:
+    ///   - info: The information for updating Visitor
+    ///   - completion: A callback that will return the update result or `SalemoveError`
+    ///
+    /// If the request is unsuccessful for any reason then the completion will have an Error.
+    /// The Error may have one of the following causes:
+    ///
+    /// - `SalemoveSDK.GeneralError.internalError`
+    /// - `SalemoveSDK.GeneralError.networkError`
+    /// - `SalemoveSDK.ConfigurationError.invalidSite`
+    /// - `SalemoveSDK.ConfigurationError.invalidEnvironment`
+    /// - `SalemoveSDK.ConfigurationError.invalidAppToken`
+    /// - `SalemoveSDK.ConfigurationError.invalidApiToken`
+    /// - `GliaError.sdkIsNotConfigured`
+    ///
+    /// - Important: Note, that in case of engagement has not been started yet, `configure(with:queueID:visitorContext:)` must be called initially prior to this method,
+    /// because `GliaError.sdkIsNotConfigured` will occur otherwise.
+    ///
+    public func updateVisitorInfo(
+        _ info: VisitorInfoUpdate,
+        completion: @escaping (Result<Bool, Error>) -> Void
+    ) {
+        guard interactor != nil else {
+            completion(.failure(GliaError.sdkIsNotConfigured))
+            return
+        }
+        Salemove.sharedInstance.updateVisitorInfo(info, completion: completion)
     }
 }

--- a/GliaWidgets/GliaError.swift
+++ b/GliaWidgets/GliaError.swift
@@ -2,4 +2,5 @@
 public enum GliaError: Error {
     case engagementExists
     case engagementNotExist
+    case sdkIsNotConfigured
 }

--- a/GliaWidgets/Interactor/Interactor.swift
+++ b/GliaWidgets/Interactor/Interactor.swift
@@ -64,13 +64,13 @@ class Interactor {
     }
 
     init(
-        with conf: Configuration,
+        with conf: Salemove.Configuration,
         queueID: String,
         visitorContext: VisitorContext
-    ) throws {
+    ) {
         self.queueID = queueID
         self.visitorContext = visitorContext
-        try configure(with: conf)
+        configure(with: conf)
     }
 
     func addObserver(_ observer: AnyObject, handler: @escaping EventHandler) {
@@ -82,10 +82,10 @@ class Interactor {
         observers.removeAll(where: { $0().0 === observer })
     }
 
-    private func configure(with conf: Configuration) throws {
-        try Salemove.sharedInstance.configure(appToken: conf.appToken)
-        try Salemove.sharedInstance.configure(environment: conf.environment.url)
-        try Salemove.sharedInstance.configure(site: conf.site)
+    private func configure(with conf: Salemove.Configuration) {
+        Salemove.sharedInstance.configure(with: conf) {
+            // SDK is initialized and ready to use.
+        }
         Salemove.sharedInstance.configure(interactor: self)
     }
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,9 +2,17 @@ PODS:
   - glia-webrtc/bitcode (0.0.3)
   - lottie-ios (3.2.3)
   - PureLayout (3.1.9)
-  - SalemoveSDK (0.31.0):
+  - ReactiveSwift (6.5.0-xcf)
+  - SalemoveSDK (0.32.0):
     - glia-webrtc/bitcode (= 0.0.3)
+    - ReactiveSwift (= 6.5.0-xcf)
+    - SocketIO (= 9.2.0-xcf)
+    - Starscream (= 3.1.1-xcf)
+    - SwiftPhoenixClient (= 1.2.1-xcf)
     - TwilioVoice (= 6.2.0)
+  - SocketIO (9.2.0-xcf)
+  - Starscream (3.1.1-xcf)
+  - SwiftPhoenixClient (1.2.1-xcf)
   - TwilioVoice (6.2.0)
 
 DEPENDENCIES:
@@ -19,13 +27,21 @@ SPEC REPOS:
     - PureLayout
     - TwilioVoice
   https://github.com/salemove/glia-ios-podspecs.git:
+    - ReactiveSwift
     - SalemoveSDK
+    - SocketIO
+    - Starscream
+    - SwiftPhoenixClient
 
 SPEC CHECKSUMS:
   glia-webrtc: a5c7e59ae752281d19734b4f918db9da39e8009d
   lottie-ios: c058aeafa76daa4cf64d773554bccc8385d0150e
   PureLayout: 5fb5e5429519627d60d079ccb1eaa7265ce7cf88
-  SalemoveSDK: 8b733d16ea8bb7b7d5b4c534607bd586baf23a33
+  ReactiveSwift: 377d0a5621761a57c61829541b2ee0b9fdcd98f2
+  SalemoveSDK: 40c1df1557ca73ad7447056eec6cb57974fcc228
+  SocketIO: 07583ad0005148194dcdfb89feda88b2180e1391
+  Starscream: 54f05f3e7aa58f5ad1d5b4339ab55784bc74a35f
+  SwiftPhoenixClient: 77dadbfee8eecd7a41cc8cccdd883dd0df093ddb
   TwilioVoice: 5e6fd6b5e99dfec03dcb57331f7e7c77ad79f1f0
 
 PODFILE CHECKSUM: 02f95f2cc3c8cf305a0d1b9d19eae34ddaa10146

--- a/TestingApp/Settings/Cells/SettingsSwitchCell.swift
+++ b/TestingApp/Settings/Cells/SettingsSwitchCell.swift
@@ -16,3 +16,20 @@ final class SettingsSwitchCell: SettingsCell {
                                               excludingEdge: .left)
     }
 }
+
+final class SettingsSegmentedCell: SettingsCell {
+    let segmentedControl: UISegmentedControl
+
+    init(title: String, items: String...) {
+        self.segmentedControl = .init(items: items.map(NSString.init(string:)))
+        super.init(title: title)
+        layout()
+    }
+
+    private func layout() {
+        contentView.addSubview(segmentedControl)
+        segmentedControl.autoPinEdge(.left, to: .right, of: titleLabel, withOffset: 10, relation: .greaterThanOrEqual)
+        segmentedControl.autoPinEdgesToSuperviewEdges(with: UIEdgeInsets(top: 10, left: 0, bottom: 10, right: 20),
+                                              excludingEdge: .left)
+    }
+}


### PR DESCRIPTION
1. Updated Core SDK dependency to 0.32.0
2. Introduced a new public interface for configuration SDK with Site API Key
3. Extended TestingApp with a switcher that can change authorization method (appToken or siteApiKey)

<img src="https://user-images.githubusercontent.com/28916962/147296297-24334b05-71e7-4d72-86b8-65567c8fcab3.png" width="300" /><img src="https://user-images.githubusercontent.com/28916962/147296338-a8dfa119-0c61-46d6-b763-eda8c59ece1a.png" width="300" />

How to obtain [Site API Key](https://docs.glia.com/glia-support/docs/site-api-keys)
