### PR TITLE
Fix video not shown correctly on landscape orientation

### DIFF
--- a/GliaWidgets/View/Call/CallView.swift
+++ b/GliaWidgets/View/Call/CallView.swift
@@ -27,9 +27,8 @@ class CallView: EngagementView {
     private var localVideoViewRightConstraint: NSLayoutConstraint!
     private var localVideoViewHeightConstraint: NSLayoutConstraint!
     private var remoteVideoViewHeightConstraint: NSLayoutConstraint!
+    private var remoteVideoViewWidthConstraint: NSLayoutConstraint!
     private let kLocalVideoViewDefaultHeight: CGFloat = 186
-    private let kRemoteVideoViewPortraitHeightMultiplier: CGFloat = 0.3
-    private let kRemoteVideoViewLandscapeHeightMultiplier: CGFloat = 1.0
     private let kBarsHideDelay: TimeInterval = 3.2
 
     init(with style: CallStyle) {
@@ -142,9 +141,9 @@ class CallView: EngagementView {
 
         addSubview(remoteVideoView)
         remoteVideoView.autoAlignAxis(toSuperviewAxis: .horizontal)
-        remoteVideoView.autoPinEdge(toSuperviewEdge: .left)
-        remoteVideoView.autoPinEdge(toSuperviewEdge: .right)
+        remoteVideoView.autoAlignAxis(toSuperviewAxis: .vertical)
         remoteVideoViewHeightConstraint = remoteVideoView.autoSetDimension(.height, toSize: 0)
+        remoteVideoViewWidthConstraint = remoteVideoView.autoSetDimension(.width, toSize: 0)
 
         addSubview(localVideoView)
         localVideoViewTopConstraint = localVideoView.autoPinEdge(toSuperviewEdge: .top)
@@ -211,10 +210,8 @@ class CallView: EngagementView {
     }
 
     private func adjustRemoteVideoView() {
-        let multiplier = currentOrientation.isLandscape
-            ? kRemoteVideoViewLandscapeHeightMultiplier
-            : kRemoteVideoViewPortraitHeightMultiplier
-        remoteVideoViewHeightConstraint.constant = frame.size.height * multiplier
+        remoteVideoViewHeightConstraint.constant = frame.size.height
+        remoteVideoViewWidthConstraint.constant = frame.size.width
     }
 
     private func adjustLocalVideoView() {

--- a/GliaWidgets/View/Call/Video/VideoStreamView.swift
+++ b/GliaWidgets/View/Call/Video/VideoStreamView.swift
@@ -32,7 +32,7 @@ class VideoStreamView: View {
     ) {
         oldStreamView?.removeFromSuperview()
         guard let streamView = streamView else { return }
-        streamView.scale = .aspectFill
+        streamView.scale = .aspectFit
         addSubview(streamView)
         streamView.autoPinEdgesToSuperviewEdges()
         streamView.layoutIfNeeded()


### PR DESCRIPTION
Reverts salemove/ios-sdk-widgets#200