### PR TITLE
Abstract CoreSDK in Widgets to introduce unit tests

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -189,6 +189,9 @@
 		6EA3516926E139DA00BF5941 /* GliaViewTransitionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA3516826E139DA00BF5941 /* GliaViewTransitionController.swift */; };
 		6EEAD84E2701A8C10074C191 /* ChoiceCardOptionStateStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EEAD84D2701A8C10074C191 /* ChoiceCardOptionStateStyle.swift */; };
 		756087E127837EC000158604 /* BundleManaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 756087E027837EC000158604 /* BundleManaging.swift */; };
+		9A66172727A94587001C8E03 /* CoreSDKClient.Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A66172627A94587001C8E03 /* CoreSDKClient.Interface.swift */; };
+		9A66172A27A94826001C8E03 /* CoreSDKClient.Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A66172927A94826001C8E03 /* CoreSDKClient.Live.swift */; };
+		9A66172C27A94A4B001C8E03 /* CoreSDKClient.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A66172B27A94A4B001C8E03 /* CoreSDKClient.Mock.swift */; };
 		C4119E04268F411D004DFEFB /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4119E03268F411D004DFEFB /* SceneDelegate.swift */; };
 		C4119E06268F41D1004DFEFB /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C4119E05268F41D1004DFEFB /* Main.storyboard */; };
 		C42463742673ABE10082C135 /* ScreenShareHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42463732673ABE10082C135 /* ScreenShareHandler.swift */; };
@@ -436,6 +439,9 @@
 		6EEAD84D2701A8C10074C191 /* ChoiceCardOptionStateStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChoiceCardOptionStateStyle.swift; sourceTree = "<group>"; };
 		756087E027837EC000158604 /* BundleManaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleManaging.swift; sourceTree = "<group>"; };
 		85639A838514258D976E1B2A /* Pods_GliaWidgets.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GliaWidgets.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9A66172627A94587001C8E03 /* CoreSDKClient.Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSDKClient.Interface.swift; sourceTree = "<group>"; };
+		9A66172927A94826001C8E03 /* CoreSDKClient.Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSDKClient.Live.swift; sourceTree = "<group>"; };
+		9A66172B27A94A4B001C8E03 /* CoreSDKClient.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSDKClient.Mock.swift; sourceTree = "<group>"; };
 		9B8252BE9AE93B4EA9A50E55 /* Pods-TestingApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestingApp.release.xcconfig"; path = "Target Support Files/Pods-TestingApp/Pods-TestingApp.release.xcconfig"; sourceTree = "<group>"; };
 		9C45ADF8988F719DA1AC8444 /* Pods_TestingApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TestingApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A099487F3CEB09E6C42C7AB4 /* Pods-TestingApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestingApp.debug.xcconfig"; path = "Target Support Files/Pods-TestingApp/Pods-TestingApp.debug.xcconfig"; sourceTree = "<group>"; };
@@ -664,6 +670,7 @@
 		1A205D5A25655CB1003AA3CD /* GliaWidgets */ = {
 			isa = PBXGroup;
 			children = (
+				9A66172827A945A2001C8E03 /* CoreSDKClient */,
 				756087DF27837EB100158604 /* BundleManaging */,
 				1A60AFB12566821B00E53F53 /* Asset.swift */,
 				1A60AF8F256674F000E53F53 /* Font.swift */,
@@ -1444,6 +1451,16 @@
 			path = BundleManaging;
 			sourceTree = "<group>";
 		};
+		9A66172827A945A2001C8E03 /* CoreSDKClient */ = {
+			isa = PBXGroup;
+			children = (
+				9A66172627A94587001C8E03 /* CoreSDKClient.Interface.swift */,
+				9A66172927A94826001C8E03 /* CoreSDKClient.Live.swift */,
+				9A66172B27A94A4B001C8E03 /* CoreSDKClient.Mock.swift */,
+			);
+			path = CoreSDKClient;
+			sourceTree = "<group>";
+		};
 		C42463722673ABCD0082C135 /* Screensharing */ = {
 			isa = PBXGroup;
 			children = (
@@ -1837,6 +1854,7 @@
 				1A60AFB62566825400E53F53 /* ViewModel.swift in Sources */,
 				1A0C9AE025C9624500815406 /* ObservableValue.swift in Sources */,
 				1A60AFB9256682AF00E53F53 /* FlowCoordinator.swift in Sources */,
+				9A66172A27A94826001C8E03 /* CoreSDKClient.Live.swift in Sources */,
 				1A0C9A9125C41AB900815406 /* CallButtonBar.swift in Sources */,
 				1AE15E3B257A5CC900A642C0 /* AlertConfiguration.swift in Sources */,
 				1A60AF9F25667CA800E53F53 /* FontProvider.swift in Sources */,
@@ -1873,6 +1891,7 @@
 				1A38A8BA258B94D60089DE7B /* ImageView.swift in Sources */,
 				1A60B031256BF81500E53F53 /* VisitorChatMessageView.swift in Sources */,
 				1A5892B12608C68000E183CC /* QuickLookController.swift in Sources */,
+				9A66172727A94587001C8E03 /* CoreSDKClient.Interface.swift in Sources */,
 				C49A29DB2614A22600819269 /* QuickLookViewModel.swift in Sources */,
 				1A4AD3C4256E7A0C00468BFB /* ThemeFontStyle.swift in Sources */,
 				1A0C9AC825C9493D00815406 /* Int+Extensions.swift in Sources */,
@@ -1936,6 +1955,7 @@
 				EB750F53273BA9BB00BE5FBD /* GliaError.swift in Sources */,
 				1A0C142D25B8545600B00695 /* EngagementView.swift in Sources */,
 				1A5F814D2588C0B800A605DA /* KeyboardObserver.swift in Sources */,
+				9A66172C27A94A4B001C8E03 /* CoreSDKClient.Mock.swift in Sources */,
 				1A5F8182258B4F0E00A605DA /* OutgoingMessage.swift in Sources */,
 				6B48213E2735873300F2900A /* Feature.swift in Sources */,
 				1A60AFCA2566943F00E53F53 /* RootCoordinator.swift in Sources */,

--- a/GliaWidgets/Configuration.swift
+++ b/GliaWidgets/Configuration.swift
@@ -1,5 +1,3 @@
-import SalemoveSDK
-
 /// Glia's environment. Use the one that our account manager has assigned to you.
 public enum Environment {
     /// Europe
@@ -9,7 +7,7 @@ public enum Environment {
     /// Beta environment. For development use.
     case beta
 
-    var region: Salemove.Region {
+    var region: CoreSdkClient.Salemove.Region {
         switch self {
         case .usa:
             return .us
@@ -107,7 +105,7 @@ public extension Configuration {
         /// Site API key authorization
         case siteApiKey(id: String, secret: String)
 
-        var coreAuthorizationMethod: Salemove.AuthorizationMethod {
+        var coreAuthorizationMethod: CoreSdkClient.Salemove.AuthorizationMethod {
             switch self {
             case .siteApiKey(let id, let secret):
                 return .siteApiKey(id: id, secret: secret)

--- a/GliaWidgets/Coordinator/Chat/ChatCoordinator.swift
+++ b/GliaWidgets/Coordinator/Chat/ChatCoordinator.swift
@@ -1,4 +1,3 @@
-import SalemoveSDK
 import SafariServices
 import UIKit
 
@@ -7,8 +6,8 @@ class ChatCoordinator: SubFlowCoordinator, FlowCoordinator {
         case back
         case engaged(operatorImageUrl: String?)
         case mediaUpgradeAccepted(
-            offer: MediaUpgradeOffer,
-            answer: AnswerWithSuccessBlock
+            offer: CoreSdkClient.MediaUpgradeOffer,
+            answer: CoreSdkClient.AnswerWithSuccessBlock
         )
         case call
         case finished

--- a/GliaWidgets/Coordinator/RootCoordinator.swift
+++ b/GliaWidgets/Coordinator/RootCoordinator.swift
@@ -1,4 +1,3 @@
-import SalemoveSDK
 import UIKit
 
 class RootCoordinator: SubFlowCoordinator, FlowCoordinator {
@@ -80,7 +79,7 @@ class RootCoordinator: SubFlowCoordinator, FlowCoordinator {
                 ? .audio
                 : .video(direction: .twoWay)
 
-            let mediaType: MediaType = engagementKind == .audioCall
+            let mediaType: CoreSdkClient.MediaType = engagementKind == .audioCall
                 ? .audio
                 : .video
             let call = Call(kind)
@@ -296,8 +295,8 @@ extension RootCoordinator {
 
 extension RootCoordinator {
     private func chatMediaUpgradeAccepted(
-        offer: MediaUpgradeOffer,
-        answer: @escaping AnswerWithSuccessBlock
+        offer: CoreSdkClient.MediaUpgradeOffer,
+        answer: @escaping CoreSdkClient.AnswerWithSuccessBlock
     ) {
         switch engagement {
         case .chat(let chatViewController):

--- a/GliaWidgets/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -1,0 +1,70 @@
+import SalemoveSDK
+import UIKit
+
+struct CoreSdkClient {
+    var pushNotifications: PushNotifications
+    var createAppDelegate: () -> AppDelegate
+}
+
+extension CoreSdkClient {
+    struct PushNotifications {
+        var applicationDidRegisterForRemoteNotificationsWithDeviceToken: (
+            _ application: UIApplication,
+            _ deviceToken: Data
+        ) -> Void
+    }
+}
+
+extension CoreSdkClient {
+    struct AppDelegate {
+        var applicationDidFinishLaunchingWithOptions: (
+            _ application: UIApplication,
+            _ launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+        ) -> Bool
+
+        var applicationDidBecomeActive: (_ application: UIApplication) -> Void
+    }
+}
+
+extension CoreSdkClient {
+    typealias AnswerBlock = SalemoveSDK.AnswerBlock
+    typealias AnswerWithSuccessBlock = SalemoveSDK.AnswerWithSuccessBlock
+    typealias Attachment = SalemoveSDK.Attachment
+    typealias AttachmentType = SalemoveSDK.AttachmentType
+    typealias AudioStreamable = SalemoveSDK.AudioStreamable
+    typealias AudioStreamAddedBlock = SalemoveSDK.AudioStreamAddedBlock
+    typealias EngagementFile = SalemoveSDK.EngagementFile
+    typealias EngagementFileCompletionBlock = SalemoveSDK.EngagementFileCompletionBlock
+    typealias EngagementFileFetchCompletionBlock = SalemoveSDK.EngagementFileFetchCompletionBlock
+    typealias EngagementFileInformation = SalemoveSDK.EngagementFileInformation
+    typealias EngagementFileProgressBlock = SalemoveSDK.EngagementFileProgressBlock
+    typealias EngagementOptions = SalemoveSDK.EngagementOptions
+    typealias EngagementTransferBlock = SalemoveSDK.EngagementTransferBlock
+    typealias FileError = SalemoveSDK.FileError
+    typealias GeneralError = SalemoveSDK.GeneralError
+    typealias Interactable = SalemoveSDK.Interactable
+    typealias MediaDirection = SalemoveSDK.MediaDirection
+    typealias MediaError = SalemoveSDK.MediaError
+    typealias MediaType = SalemoveSDK.MediaType
+    typealias MediaUgradeOfferBlock = SalemoveSDK.MediaUgradeOfferBlock
+    typealias MediaUpgradeOffer = SalemoveSDK.MediaUpgradeOffer
+    typealias Message = SalemoveSDK.Message
+    typealias MessageSender = SalemoveSDK.MessageSender
+    typealias MessagesUpdateBlock = SalemoveSDK.MessagesUpdateBlock
+    typealias Operator = SalemoveSDK.Operator
+    typealias OperatorTypingStatus = SalemoveSDK.OperatorTypingStatus
+    typealias OperatorTypingStatusUpdate = SalemoveSDK.OperatorTypingStatusUpdate
+    typealias QueueError = SalemoveSDK.QueueError
+    typealias QueueTicket = SalemoveSDK.QueueTicket
+    typealias RequestOfferBlock = SalemoveSDK.RequestOfferBlock
+    typealias Salemove = SalemoveSDK.Salemove
+    typealias SalemoveError = SalemoveSDK.SalemoveError
+    typealias ScreenshareOfferBlock = SalemoveSDK.ScreenshareOfferBlock
+    typealias SingleChoiceOption = SalemoveSDK.SingleChoiceOption
+    typealias StreamView = SalemoveSDK.StreamView
+    typealias VideoStreamable = SalemoveSDK.VideoStreamable
+    typealias VideoStreamAddedBlock = SalemoveSDK.VideoStreamAddedBlock
+    typealias VisitorContext = SalemoveSDK.VisitorContext
+    typealias VisitorScreenSharingState = SalemoveSDK.VisitorScreenSharingState
+    typealias VisitorScreenSharingStateChange = SalemoveSDK.VisitorScreenSharingStateChange
+}

--- a/GliaWidgets/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/CoreSDKClient/CoreSDKClient.Live.swift
@@ -1,0 +1,27 @@
+import SalemoveSDK
+
+extension CoreSdkClient {
+    static let live: Self = {
+        .init(
+            pushNotifications: .live,
+            createAppDelegate: Self.AppDelegate.live
+        )
+    }()
+}
+
+extension CoreSdkClient.PushNotifications {
+    static let live = Self(
+        applicationDidRegisterForRemoteNotificationsWithDeviceToken:
+            Salemove.sharedInstance.pushNotifications.application(_:didRegisterForRemoteNotificationsWithDeviceToken:)
+    )
+}
+
+extension CoreSdkClient.AppDelegate {
+    static func live() -> Self {
+        let salemoveDelegate = SalemoveAppDelegate()
+        return .init(
+            applicationDidFinishLaunchingWithOptions: salemoveDelegate.application(_:didFinishLaunchingWithOptions:),
+            applicationDidBecomeActive: salemoveDelegate.applicationDidBecomeActive
+        )
+    }
+}

--- a/GliaWidgets/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -1,0 +1,3 @@
+extension CoreSdkClient {
+    
+}

--- a/GliaWidgets/Lib/Download/FileDownload.swift
+++ b/GliaWidgets/Lib/Download/FileDownload.swift
@@ -1,5 +1,3 @@
-import SalemoveSDK
-
 class FileDownload {
     enum Error {
         case network
@@ -7,9 +5,9 @@ class FileDownload {
         case missingFileURL
         case deleted
 
-        init(with error: SalemoveError) {
+        init(with error: CoreSdkClient.SalemoveError) {
             switch error.error {
-            case let genericError as GeneralError:
+            case let genericError as CoreSdkClient.GeneralError:
                 switch genericError {
                 case .networkError:
                     self = .network
@@ -60,15 +58,15 @@ class FileDownload {
             return
         }
 
-        let engagementFile = EngagementFile(url: fileUrl)
+        let engagementFile = CoreSdkClient.EngagementFile(url: fileUrl)
 
         let progress = ObservableValue<Double>(with: 0)
-        let onProgress: EngagementFileProgressBlock = {
+        let onProgress: CoreSdkClient.EngagementFileProgressBlock = {
             if case .downloading(progress: let progress) = self.state.value {
                 progress.value = $0.fractionCompleted
             }
         }
-        let onCompletion: EngagementFileFetchCompletionBlock = { data, error in
+        let onCompletion: CoreSdkClient.EngagementFileFetchCompletionBlock = { data, error in
             if let data = data, let storageID = self.storageID {
                 let url = self.storage.url(for: storageID)
                 let file = LocalFile(with: url)
@@ -81,7 +79,7 @@ class FileDownload {
 
         state.value = .downloading(progress: progress)
 
-        Salemove.sharedInstance.fetchFile(
+        CoreSdkClient.Salemove.sharedInstance.fetchFile(
             engagementFile: engagementFile,
             progress: onProgress,
             completion: onCompletion

--- a/GliaWidgets/Lib/Download/FileDownloader.swift
+++ b/GliaWidgets/Lib/Download/FileDownloader.swift
@@ -1,5 +1,3 @@
-import SalemoveSDK
-
 class FileDownloader {
     enum AutoDownload {
         case nothing

--- a/GliaWidgets/Lib/Extensions/Operator+Extensions.swift
+++ b/GliaWidgets/Lib/Extensions/Operator+Extensions.swift
@@ -1,6 +1,4 @@
-import SalemoveSDK
-
-extension Operator {
+extension CoreSdkClient.Operator {
     var firstName: String? {
         guard let first = name.split(separator: " ").first else { return nil }
         return String(first)

--- a/GliaWidgets/Lib/Screensharing/ScreenShareHandler.swift
+++ b/GliaWidgets/Lib/Screensharing/ScreenShareHandler.swift
@@ -1,5 +1,3 @@
-import SalemoveSDK
-
 enum ScreenSharingStatus {
     case started
     case stopped
@@ -7,9 +5,9 @@ enum ScreenSharingStatus {
 
 class ScreenShareHandler {
     let status = ObservableValue<ScreenSharingStatus>(with: .stopped)
-    private var visitorState: VisitorScreenSharingState?
+    private var visitorState: CoreSdkClient.VisitorScreenSharingState?
 
-    func updateState(to state: VisitorScreenSharingState?) {
+    func updateState(to state: CoreSdkClient.VisitorScreenSharingState?) {
         visitorState = state
         guard let state = state else {
             status.value = .stopped

--- a/GliaWidgets/Lib/Upload/FileUpload.swift
+++ b/GliaWidgets/Lib/Upload/FileUpload.swift
@@ -1,5 +1,3 @@
-import SalemoveSDK
-
 class FileUpload {
     enum Error {
         case fileTooBig
@@ -8,16 +6,16 @@ class FileUpload {
         case network
         case generic
 
-        init(with error: SalemoveError) {
+        init(with error: CoreSdkClient.SalemoveError) {
             switch error.error {
-            case let genericError as GeneralError:
+            case let genericError as CoreSdkClient.GeneralError:
                 switch genericError {
                 case .networkError:
                     self = .network
                 default:
                     self = .generic
                 }
-            case let fileError as FileError:
+            case let fileError as CoreSdkClient.FileError:
                 switch fileError {
                 case .fileTooBig:
                     self = .fileTooBig
@@ -37,11 +35,11 @@ class FileUpload {
     enum State {
         case none
         case uploading(progress: ObservableValue<Double>)
-        case uploaded(file: EngagementFileInformation)
+        case uploaded(file: CoreSdkClient.EngagementFileInformation)
         case error(Error)
     }
 
-    var engagementFileInformation: EngagementFileInformation? {
+    var engagementFileInformation: CoreSdkClient.EngagementFileInformation? {
         switch state.value {
         case .uploaded(file: let file):
             return file
@@ -61,14 +59,14 @@ class FileUpload {
     }
 
     func startUpload() {
-        let file = EngagementFile(url: localFile.url)
+        let file = CoreSdkClient.EngagementFile(url: localFile.url)
         let progress = ObservableValue<Double>(with: 0)
-        let onProgress: EngagementFileProgressBlock = {
+        let onProgress: CoreSdkClient.EngagementFileProgressBlock = {
             if case .uploading(progress: let progress) = self.state.value {
                 progress.value = $0.fractionCompleted
             }
         }
-        let onCompletion: EngagementFileCompletionBlock = { engagementFile, error in
+        let onCompletion: CoreSdkClient.EngagementFileCompletionBlock = { engagementFile, error in
             if let engagementFile = engagementFile {
                 let storageID = "\(engagementFile.id)/\(self.localFile.url.lastPathComponent)"
                 self.storage.store(from: self.localFile.url, for: storageID)
@@ -79,7 +77,7 @@ class FileUpload {
         }
 
         state.value = .uploading(progress: progress)
-        Salemove.sharedInstance.uploadFileToEngagement(file,
+        CoreSdkClient.Salemove.sharedInstance.uploadFileToEngagement(file,
                                                        progress: onProgress,
                                                        completion: onCompletion)
     }

--- a/GliaWidgets/Lib/Upload/FileUploader.swift
+++ b/GliaWidgets/Lib/Upload/FileUploader.swift
@@ -1,5 +1,3 @@
-import SalemoveSDK
-
 class FileUploader {
     enum State {
         case idle
@@ -37,12 +35,12 @@ class FileUploader {
             }
         }
     }
-    var attachment: Attachment? {
+    var attachment: CoreSdkClient.Attachment? {
         guard !succeededUploads.isEmpty else { return nil }
         let files = succeededUploads
             .compactMap { $0.engagementFileInformation }
-            .map { EngagementFile(id: $0.id) }
-        return Attachment(files: files)
+            .map { CoreSdkClient.EngagementFile(id: $0.id) }
+        return CoreSdkClient.Attachment(files: files)
     }
     var count: Int { return uploads.count }
     let state = ObservableValue<State>(with: .idle)

--- a/GliaWidgets/Theme/Alert/MessageAlertConfiguration.swift
+++ b/GliaWidgets/Theme/Alert/MessageAlertConfiguration.swift
@@ -1,5 +1,3 @@
-import SalemoveSDK
-
 /// Configuration of a generic alert.
 public struct MessageAlertConfiguration {
     /// Title of the alert.
@@ -20,7 +18,7 @@ public struct MessageAlertConfiguration {
         self.message = message
     }
 
-    init(with error: SalemoveError, templateConf: MessageAlertConfiguration) {
+    init(with error: CoreSdkClient.SalemoveError, templateConf: MessageAlertConfiguration) {
         self.title = templateConf.title
         self.message = templateConf.message?.replacingOccurrences(of: kMessagePlaceholder,
                                                                   with: error.reason)

--- a/GliaWidgets/View/Call/Video/VideoStreamView.swift
+++ b/GliaWidgets/View/Call/Video/VideoStreamView.swift
@@ -1,5 +1,4 @@
 import UIKit
-import SalemoveSDK
 
 class VideoStreamView: UIView {
     enum Kind {
@@ -10,7 +9,7 @@ class VideoStreamView: UIView {
     var pan: ((CGPoint) -> Void)?
     var show: ((Bool) -> Void)?
 
-    weak var streamView: StreamView? {
+    weak var streamView: CoreSdkClient.StreamView? {
         didSet {
             replace(oldStreamView: oldValue, with: streamView)
         }
@@ -40,8 +39,8 @@ class VideoStreamView: UIView {
     }
 
     private func replace(
-        oldStreamView: StreamView?,
-        with streamView: StreamView?
+        oldStreamView: CoreSdkClient.StreamView?,
+        with streamView: CoreSdkClient.StreamView?
     ) {
         oldStreamView?.removeFromSuperview()
         guard let streamView = streamView else {

--- a/GliaWidgets/View/Call/Video/VideoStreamView.swift
+++ b/GliaWidgets/View/Call/Video/VideoStreamView.swift
@@ -9,7 +9,7 @@ class VideoStreamView: UIView {
     var pan: ((CGPoint) -> Void)?
     var show: ((Bool) -> Void)?
 
-    weak var streamView: StreamView? {
+    weak var streamView: CoreSdkClient.StreamView? {
         didSet {
             replace(oldStreamView: oldValue, with: streamView)
         }

--- a/GliaWidgets/View/Call/Video/VideoStreamView.swift
+++ b/GliaWidgets/View/Call/Video/VideoStreamView.swift
@@ -9,7 +9,7 @@ class VideoStreamView: UIView {
     var pan: ((CGPoint) -> Void)?
     var show: ((Bool) -> Void)?
 
-    weak var streamView: CoreSdkClient.StreamView? {
+    weak var streamView: StreamView? {
         didSet {
             replace(oldStreamView: oldValue, with: streamView)
         }

--- a/GliaWidgets/ViewController/Common/Alert/AlertViewController.swift
+++ b/GliaWidgets/ViewController/Common/Alert/AlertViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import SalemoveSDK
 
 class AlertViewController: ViewController {
     enum Kind {

--- a/GliaWidgets/ViewController/Common/MediaUpgrade/MediaUpgradePresenter.swift
+++ b/GliaWidgets/ViewController/Common/MediaUpgrade/MediaUpgradePresenter.swift
@@ -1,5 +1,4 @@
 import UIKit
-import SalemoveSDK
 
 protocol MediaUpgradePresenter where Self: UIViewController {
     var viewFactory: ViewFactory { get }

--- a/GliaWidgets/ViewController/Common/ScreenShare/ScreenShareOfferPresenter.swift
+++ b/GliaWidgets/ViewController/Common/ScreenShare/ScreenShareOfferPresenter.swift
@@ -1,4 +1,3 @@
-import SalemoveSDK
 import UIKit
 
 protocol ScreenShareOfferPresenter where Self: UIViewController {

--- a/GliaWidgets/ViewModel/Call/CallViewModel.swift
+++ b/GliaWidgets/ViewModel/Call/CallViewModel.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SalemoveSDK
 
 class CallViewModel: EngagementViewModel, ViewModel {
     private typealias Strings = L10n.Call
@@ -42,8 +41,8 @@ class CallViewModel: EngagementViewModel, ViewModel {
             accepted: () -> Void,
             declined: () -> Void
         )
-        case setRemoteVideo(StreamView?)
-        case setLocalVideo(StreamView?)
+        case setRemoteVideo(CoreSdkClient.StreamView?)
+        case setLocalVideo(CoreSdkClient.StreamView?)
     }
 
     enum DelegateEvent {
@@ -52,9 +51,9 @@ class CallViewModel: EngagementViewModel, ViewModel {
     }
 
     enum StartAction {
-        case engagement(mediaType: MediaType)
-        case call(offer: MediaUpgradeOffer,
-                  answer: AnswerWithSuccessBlock)
+        case engagement(mediaType: CoreSdkClient.MediaType)
+        case call(offer: CoreSdkClient.MediaUpgradeOffer,
+                  answer: CoreSdkClient.AnswerWithSuccessBlock)
     }
 
     var action: ((Action) -> Void)?
@@ -221,9 +220,9 @@ class CallViewModel: EngagementViewModel, ViewModel {
         }
     }
 
-    private func handleAudioStreamError(_ error: SalemoveError) {
+    private func handleAudioStreamError(_ error: CoreSdkClient.SalemoveError) {
         switch error.error {
-        case let mediaError as MediaError:
+        case let mediaError as CoreSdkClient.MediaError:
             switch mediaError {
             case .permissionDenied:
                 showSettingsAlert(
@@ -237,9 +236,9 @@ class CallViewModel: EngagementViewModel, ViewModel {
         }
     }
 
-    private func handleVideoStreamError(_ error: SalemoveError) {
+    private func handleVideoStreamError(_ error: CoreSdkClient.SalemoveError) {
         switch error.error {
-        case let mediaError as MediaError:
+        case let mediaError as CoreSdkClient.MediaError:
             switch mediaError {
             case .permissionDenied:
                 showSettingsAlert(with: alertConfiguration.cameraSettings)
@@ -273,8 +272,8 @@ class CallViewModel: EngagementViewModel, ViewModel {
 
 extension CallViewModel {
     private func offerMediaUpgrade(
-        _ offer: MediaUpgradeOffer,
-        answer: @escaping AnswerWithSuccessBlock
+        _ offer: CoreSdkClient.MediaUpgradeOffer,
+        answer: @escaping CoreSdkClient.AnswerWithSuccessBlock
     ) {
         switch offer.type {
         case .video:
@@ -293,8 +292,8 @@ extension CallViewModel {
 
     private func offerMediaUpgrade(
         with configuration: SingleMediaUpgradeAlertConfiguration,
-        offer: MediaUpgradeOffer,
-        answer: @escaping AnswerWithSuccessBlock
+        offer: CoreSdkClient.MediaUpgradeOffer,
+        answer: @escaping CoreSdkClient.AnswerWithSuccessBlock
     ) {
         guard isViewActive.value else { return }
         let operatorName = interactor.engagedOperator?.firstName
@@ -313,13 +312,13 @@ extension CallViewModel {
 }
 
 extension CallViewModel {
-    private func showRemoteVideo(with stream: VideoStreamable) {
+    private func showRemoteVideo(with stream: CoreSdkClient.VideoStreamable) {
         action?(.switchToVideoMode)
         action?(.setRemoteVideo(stream.getStreamView()))
         stream.playVideo()
     }
 
-    private func showLocalVideo(with stream: VideoStreamable) {
+    private func showLocalVideo(with stream: CoreSdkClient.VideoStreamable) {
         action?(.switchToVideoMode)
         action?(.setLocalVideo(stream.getStreamView()))
         stream.playVideo()
@@ -375,11 +374,11 @@ extension CallViewModel {
         update(for: kind)
     }
 
-    private func onAudioChanged(_ stream: MediaStream<AudioStreamable>) {
+    private func onAudioChanged(_ stream: MediaStream<CoreSdkClient.AudioStreamable>) {
         updateButtons()
     }
 
-    private func onVideoChanged(_ stream: MediaStream<VideoStreamable>) {
+    private func onVideoChanged(_ stream: MediaStream<CoreSdkClient.VideoStreamable>) {
         updateButtons()
         updateRemoteVideoVisible()
         updateLocalVideoVisible()

--- a/GliaWidgets/ViewModel/Call/Data/Call.swift
+++ b/GliaWidgets/ViewModel/Call/Data/Call.swift
@@ -1,12 +1,11 @@
 import Foundation
-import SalemoveSDK
 import AVFoundation
 
 enum CallKind {
     case audio
-    case video(direction: MediaDirection)
+    case video(direction: CoreSdkClient.MediaDirection)
 
-    init?(with offer: MediaUpgradeOffer) {
+    init?(with offer: CoreSdkClient.MediaUpgradeOffer) {
         switch offer.type {
         case .audio:
             self = .audio
@@ -72,9 +71,9 @@ enum MediaStream<Streamable> {
 
 class MediaChannel<Streamable> {
     let stream = ObservableValue<MediaStream<Streamable>>(with: .none)
-    private(set) var neededDirection: MediaDirection = .twoWay
+    private(set) var neededDirection: CoreSdkClient.MediaDirection = .twoWay
 
-    func setNeededDirection(_ direction: MediaDirection) {
+    func setNeededDirection(_ direction: CoreSdkClient.MediaDirection) {
         neededDirection = direction
     }
 }
@@ -84,27 +83,27 @@ class Call {
     let kind = ObservableValue<CallKind>(with: .audio)
     let state = ObservableValue<CallState>(with: .none)
     let duration = ObservableValue<Int>(with: 0)
-    let audio = MediaChannel<AudioStreamable>()
-    let video = MediaChannel<VideoStreamable>()
+    let audio = MediaChannel<CoreSdkClient.AudioStreamable>()
+    let video = MediaChannel<CoreSdkClient.VideoStreamable>()
     private(set) var audioPortOverride = AVAudioSession.PortOverride.none
 
     init(_ kind: CallKind) {
         self.kind.value = kind
     }
 
-    func upgrade(to offer: MediaUpgradeOffer) {
+    func upgrade(to offer: CoreSdkClient.MediaUpgradeOffer) {
         setKind(for: offer.type, direction: offer.direction)
         setNeededDirection(offer.direction, for: offer.type)
         state.value = .upgrading
     }
 
-    func updateAudioStream(with stream: AudioStreamable) {
+    func updateAudioStream(with stream: CoreSdkClient.AudioStreamable) {
         updateMediaStream(audio.stream,
                           with: stream,
                           isRemote: stream.isRemote)
     }
 
-    func updateVideoStream(with stream: VideoStreamable) {
+    func updateVideoStream(with stream: CoreSdkClient.VideoStreamable) {
         updateMediaStream(video.stream,
                           with: stream,
                           isRemote: stream.isRemote)
@@ -158,7 +157,7 @@ class Call {
         state.value = .ended
     }
 
-    private func setKind(for type: MediaType, direction: MediaDirection) {
+    private func setKind(for type: CoreSdkClient.MediaType, direction: CoreSdkClient.MediaDirection) {
         switch type {
         case .audio:
             kind.value = .audio
@@ -169,7 +168,7 @@ class Call {
         }
     }
 
-    private func setNeededDirection(_ direction: MediaDirection, for type: MediaType) {
+    private func setNeededDirection(_ direction: CoreSdkClient.MediaDirection, for type: CoreSdkClient.MediaType) {
         switch type {
         case .audio:
             audio.setNeededDirection(direction)

--- a/GliaWidgets/ViewModel/Call/Data/Call.swift
+++ b/GliaWidgets/ViewModel/Call/Data/Call.swift
@@ -3,7 +3,7 @@ import AVFoundation
 
 enum CallKind {
     case audio
-    case video(direction: MediaDirection)
+    case video(direction: CoreSdkClient.MediaDirection)
 
     init?(with offer: CoreSdkClient.MediaUpgradeOffer) {
         switch offer.type {
@@ -91,7 +91,7 @@ class Call {
         self.kind.value = kind
     }
 
-    func upgrade(to offer: MediaUpgradeOffer) {
+    func upgrade(to offer: CoreSdkClient.MediaUpgradeOffer) {
         setKind(for: offer.type, direction: offer.direction)
         setNeededDirection(offer.direction, for: offer.type)
         state.value = .upgrading
@@ -157,7 +157,7 @@ class Call {
         state.value = .ended
     }
 
-    private func setKind(for type: MediaType, direction: MediaDirection) {
+    private func setKind(for type: CoreSdkClient.MediaType, direction: CoreSdkClient.MediaDirection) {
         switch type {
         case .audio:
             kind.value = .audio

--- a/GliaWidgets/ViewModel/Call/Data/Call.swift
+++ b/GliaWidgets/ViewModel/Call/Data/Call.swift
@@ -3,7 +3,7 @@ import AVFoundation
 
 enum CallKind {
     case audio
-    case video(direction: CoreSdkClient.MediaDirection)
+    case video(direction: MediaDirection)
 
     init?(with offer: CoreSdkClient.MediaUpgradeOffer) {
         switch offer.type {
@@ -91,7 +91,7 @@ class Call {
         self.kind.value = kind
     }
 
-    func upgrade(to offer: CoreSdkClient.MediaUpgradeOffer) {
+    func upgrade(to offer: MediaUpgradeOffer) {
         setKind(for: offer.type, direction: offer.direction)
         setNeededDirection(offer.direction, for: offer.type)
         state.value = .upgrading
@@ -157,7 +157,7 @@ class Call {
         state.value = .ended
     }
 
-    private func setKind(for type: CoreSdkClient.MediaType, direction: CoreSdkClient.MediaDirection) {
+    private func setKind(for type: MediaType, direction: MediaDirection) {
         switch type {
         case .audio:
             kind.value = .audio

--- a/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SalemoveSDK
 
 class ChatViewModel: EngagementViewModel, ViewModel {
     typealias Strings = L10n.Chat
@@ -52,8 +51,8 @@ class ChatViewModel: EngagementViewModel, ViewModel {
         case takeMedia(ObservableValue<MediaPickerEvent>)
         case pickFile(ObservableValue<FilePickerEvent>)
         case mediaUpgradeAccepted(
-            offer: MediaUpgradeOffer,
-            answer: AnswerWithSuccessBlock
+            offer: CoreSdkClient.MediaUpgradeOffer,
+            answer: CoreSdkClient.AnswerWithSuccessBlock
         )
         case showFile(LocalFile)
         case call
@@ -314,8 +313,8 @@ extension ChatViewModel {
 
 extension ChatViewModel {
     private func offerMediaUpgrade(
-        _ offer: MediaUpgradeOffer,
-        answer: @escaping AnswerWithSuccessBlock
+        _ offer: CoreSdkClient.MediaUpgradeOffer,
+        answer: @escaping CoreSdkClient.AnswerWithSuccessBlock
     ) {
         switch offer.type {
         case .audio:
@@ -340,8 +339,8 @@ extension ChatViewModel {
 
     private func offerMediaUpgrade(
         with configuration: SingleMediaUpgradeAlertConfiguration,
-        offer: MediaUpgradeOffer,
-        answer: @escaping AnswerWithSuccessBlock
+        offer: CoreSdkClient.MediaUpgradeOffer,
+        answer: @escaping CoreSdkClient.AnswerWithSuccessBlock
     ) {
         guard isViewActive.value else { return }
         let operatorName = interactor.engagedOperator?.firstName
@@ -428,7 +427,7 @@ extension ChatViewModel {
     private func replace(
         _ outgoingMessage: OutgoingMessage,
         uploads: [FileUpload],
-        with message: Message,
+        with message: CoreSdkClient.Message,
         in section: Section<ChatItem>
     ) {
         guard let index = section.items
@@ -474,7 +473,7 @@ extension ChatViewModel {
         return isValid
     }
 
-    private func receivedMessage(_ message: Message) {
+    private func receivedMessage(_ message: CoreSdkClient.Message) {
         guard storage.isNewMessage(message) else { return }
 
         storage.storeMessage(
@@ -509,7 +508,7 @@ extension ChatViewModel {
         }
     }
 
-    private func messagesUpdated(_ messages: [Message]) {
+    private func messagesUpdated(_ messages: [CoreSdkClient.Message]) {
         let newMessages = storage.newMessages(messages)
         unreadMessages.received(newMessages.count)
 
@@ -526,7 +525,7 @@ extension ChatViewModel {
         }
     }
 
-    private func typingStatusUpdated(_ status: OperatorTypingStatus) {
+    private func typingStatusUpdated(_ status: CoreSdkClient.OperatorTypingStatus) {
         action?(.setOperatorTypingIndicatorIsHiddenTo(
             !status.isTyping, isChatScrolledToBottom.value
         ))
@@ -728,7 +727,7 @@ extension ChatViewModel {
 extension ChatViewModel {
     private func sendChoiceCardResponse(_ option: ChatChoiceCardOption, to messageId: String) {
         guard let value = option.value else { return }
-        Salemove.sharedInstance.send(
+        CoreSdkClient.Salemove.sharedInstance.send(
             selectedOptionValue: value
         ) { [weak self] result in
             guard let self = self else { return }

--- a/GliaWidgets/ViewModel/Chat/Data/ChatAttachment.swift
+++ b/GliaWidgets/ViewModel/Chat/Data/ChatAttachment.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SalemoveSDK
 
 enum ChatAttachmentType: Int, Codable {
     case files = 0
@@ -7,7 +6,7 @@ enum ChatAttachmentType: Int, Codable {
     case singleChoiceResponse = 2
     case unknown = 100
 
-    init?(with type: SalemoveSDK.AttachmentType?) {
+    init?(with type: CoreSdkClient.AttachmentType?) {
         switch type {
         case .files:
             self = .files
@@ -38,7 +37,7 @@ class ChatAttachment: Codable {
         case selectedOption
     }
 
-    init?(with attachment: SalemoveSDK.Attachment?) {
+    init?(with attachment: CoreSdkClient.Attachment?) {
         guard let attachment = attachment else { return nil }
         type = ChatAttachmentType(with: attachment.type)
         files = attachment.files.map { $0.map { ChatEngagementFile(with: $0) } }

--- a/GliaWidgets/ViewModel/Chat/Data/ChatChoiceCardOption.swift
+++ b/GliaWidgets/ViewModel/Chat/Data/ChatChoiceCardOption.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SalemoveSDK
 
 final class ChatChoiceCardOption: Codable {
     let text: String?
@@ -10,7 +9,7 @@ final class ChatChoiceCardOption: Codable {
         case value
     }
 
-    init(with option: SalemoveSDK.SingleChoiceOption) {
+    init(with option: CoreSdkClient.SingleChoiceOption) {
         text = option.text
         value = option.value
     }

--- a/GliaWidgets/ViewModel/Chat/Data/ChatEngagementFile.swift
+++ b/GliaWidgets/ViewModel/Chat/Data/ChatEngagementFile.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SalemoveSDK
 
 class ChatEngagementFile: Codable {
     let id: String?
@@ -18,7 +17,7 @@ class ChatEngagementFile: Codable {
         case isDeleted
     }
 
-    init(with file: SalemoveSDK.EngagementFile) {
+    init(with file: CoreSdkClient.EngagementFile) {
         id = file.id
         url = file.url
         name = file.name

--- a/GliaWidgets/ViewModel/Chat/Data/ChatItem.swift
+++ b/GliaWidgets/ViewModel/Chat/Data/ChatItem.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SalemoveSDK
 
 class ChatItem {
     enum Kind {

--- a/GliaWidgets/ViewModel/Chat/Data/ChatMessage.swift
+++ b/GliaWidgets/ViewModel/Chat/Data/ChatMessage.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SalemoveSDK
 
 enum ChatMessageSender: Int, Codable {
     case visitor = 0
@@ -8,7 +7,7 @@ enum ChatMessageSender: Int, Codable {
     case system = 3
     case unknown = 100
 
-    init(with sender: SalemoveSDK.MessageSender) {
+    init(with sender: CoreSdkClient.MessageSender) {
         switch sender {
         case .visitor:
             self = .visitor
@@ -46,9 +45,9 @@ class ChatMessage: Codable {
         case attachment
     }
 
-    init(with message: SalemoveSDK.Message,
+    init(with message: CoreSdkClient.Message,
          queueID: String? = nil,
-         operator salemoveOperator: Operator? = nil) {
+         operator salemoveOperator: CoreSdkClient.Operator? = nil) {
         id = message.id
         self.queueID = queueID
         self.operator = salemoveOperator.map { ChatOperator(with: $0) }

--- a/GliaWidgets/ViewModel/Chat/Data/ChatOperator.swift
+++ b/GliaWidgets/ViewModel/Chat/Data/ChatOperator.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SalemoveSDK
 
 class ChatOperator: Codable {
     let name: String
@@ -10,7 +9,7 @@ class ChatOperator: Codable {
         case pictureUrl
     }
 
-    init(with salemoveOperator: SalemoveSDK.Operator) {
+    init(with salemoveOperator: CoreSdkClient.Operator) {
         name = salemoveOperator.name
         pictureUrl = salemoveOperator.picture?.url
     }

--- a/GliaWidgets/ViewModel/Chat/Data/OutgoingMessage.swift
+++ b/GliaWidgets/ViewModel/Chat/Data/OutgoingMessage.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SalemoveSDK
 
 class OutgoingMessage {
     let id = UUID().uuidString

--- a/GliaWidgets/ViewModel/Chat/Storage/ChatStorage.swift
+++ b/GliaWidgets/ViewModel/Chat/Storage/ChatStorage.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SalemoveSDK
 import SQLite3
 
 class ChatStorage {
@@ -164,9 +163,9 @@ extension ChatStorage {
     }
 
     func storeMessage(
-        _ message: SalemoveSDK.Message,
+        _ message: CoreSdkClient.Message,
         queueID: String,
-        operator salemoveOperator: SalemoveSDK.Operator?
+        operator salemoveOperator: CoreSdkClient.Operator?
     ) {
         let salemoveOperator = message.sender == .operator
             ? salemoveOperator
@@ -177,18 +176,18 @@ extension ChatStorage {
     }
 
     func storeMessages(
-        _ messages: [SalemoveSDK.Message],
+        _ messages: [CoreSdkClient.Message],
         queueID: String,
-        operator salemoveOperator: SalemoveSDK.Operator?
+        operator salemoveOperator: CoreSdkClient.Operator?
     ) {
         messages.forEach { storeMessage($0, queueID: queueID, operator: salemoveOperator) }
     }
 
-    func isNewMessage(_ message: SalemoveSDK.Message) -> Bool {
+    func isNewMessage(_ message: CoreSdkClient.Message) -> Bool {
         return messages.first(where: { $0.id == message.id }) == nil
     }
 
-    func newMessages(_ messages: [SalemoveSDK.Message]) -> [SalemoveSDK.Message] {
+    func newMessages(_ messages: [CoreSdkClient.Message]) -> [CoreSdkClient.Message] {
         let existingMessageIDs = messages.map { $0.id }
         return messages.filter { !existingMessageIDs.contains($0.id) }
     }

--- a/GliaWidgets/ViewModel/EngagementViewModel.swift
+++ b/GliaWidgets/ViewModel/EngagementViewModel.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SalemoveSDK
 
 class EngagementViewModel {
     enum Event {
@@ -116,7 +115,7 @@ class EngagementViewModel {
         update(for: interactor.state)
     }
 
-    func enqueue(mediaType: MediaType) {
+    func enqueue(mediaType: CoreSdkClient.MediaType) {
         interactor.enqueueForEngagement(
             mediaType: mediaType,
             success: {},
@@ -204,7 +203,7 @@ class EngagementViewModel {
         showAlert(with: alertConfiguration.unexpectedError)
     }
 
-    func showAlert(for error: SalemoveError) {
+    func showAlert(for error: CoreSdkClient.SalemoveError) {
         showAlert(with: alertConfiguration.unexpectedError)
     }
 
@@ -216,7 +215,7 @@ class EngagementViewModel {
     }
 
     func alertConfiguration(
-        with error: SalemoveError
+        with error: CoreSdkClient.SalemoveError
     ) -> MessageAlertConfiguration {
         return MessageAlertConfiguration(
             with: error,
@@ -224,7 +223,7 @@ class EngagementViewModel {
         )
     }
 
-    func updateScreenSharingState(to state: VisitorScreenSharingState) {
+    func updateScreenSharingState(to state: CoreSdkClient.VisitorScreenSharingState) {
         screenShareHandler.updateState(to: state)
     }
 
@@ -233,7 +232,7 @@ class EngagementViewModel {
         engagementAction?(.showEndButton)
     }
 
-    private func offerScreenShare(answer: @escaping AnswerBlock) {
+    private func offerScreenShare(answer: @escaping CoreSdkClient.AnswerBlock) {
         guard isViewActive.value else { return }
         let operatorName = interactor.engagedOperator?.firstName
         let configuration = alertConfiguration.screenShareOffer
@@ -278,9 +277,9 @@ class EngagementViewModel {
         }
     }
 
-    private func handleError(_ error: SalemoveError) {
+    private func handleError(_ error: CoreSdkClient.SalemoveError) {
         switch error.error {
-        case let queueError as QueueError:
+        case let queueError as CoreSdkClient.QueueError:
             switch queueError {
             case .queueClosed, .queueFull:
                 showAlert(


### PR DESCRIPTION
This PR aims to start process of abstraction core SDK in order make Widgets testable. This is the first step: narrow down imports of core SDK and use CoreSDKClient namespace instead. It is necessary to be done soon since changes are impactful and may introduce merge conflicts with ongoing development of features if addressed later.

MOB-1120