### PR TITLE
Introduce DI instead of singleton and side-effects for testability

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -192,6 +192,9 @@
 		9A66172727A94587001C8E03 /* CoreSDKClient.Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A66172627A94587001C8E03 /* CoreSDKClient.Interface.swift */; };
 		9A66172A27A94826001C8E03 /* CoreSDKClient.Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A66172927A94826001C8E03 /* CoreSDKClient.Live.swift */; };
 		9A66172C27A94A4B001C8E03 /* CoreSDKClient.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A66172B27A94A4B001C8E03 /* CoreSDKClient.Mock.swift */; };
+		9A83D77F27B181C500681C9F /* Glia.Environment.Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A83D77E27B181C500681C9F /* Glia.Environment.Interface.swift */; };
+		9A83D78127B18DB600681C9F /* Glia.Environment.Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A83D78027B18DB600681C9F /* Glia.Environment.Live.swift */; };
+		9A83D78327B18DF000681C9F /* Glia.Environment.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A83D78227B18DF000681C9F /* Glia.Environment.Mock.swift */; };
 		C4119E04268F411D004DFEFB /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4119E03268F411D004DFEFB /* SceneDelegate.swift */; };
 		C4119E06268F41D1004DFEFB /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C4119E05268F41D1004DFEFB /* Main.storyboard */; };
 		C42463742673ABE10082C135 /* ScreenShareHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42463732673ABE10082C135 /* ScreenShareHandler.swift */; };
@@ -442,6 +445,9 @@
 		9A66172627A94587001C8E03 /* CoreSDKClient.Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSDKClient.Interface.swift; sourceTree = "<group>"; };
 		9A66172927A94826001C8E03 /* CoreSDKClient.Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSDKClient.Live.swift; sourceTree = "<group>"; };
 		9A66172B27A94A4B001C8E03 /* CoreSDKClient.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSDKClient.Mock.swift; sourceTree = "<group>"; };
+		9A83D77E27B181C500681C9F /* Glia.Environment.Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Glia.Environment.Interface.swift; sourceTree = "<group>"; };
+		9A83D78027B18DB600681C9F /* Glia.Environment.Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Glia.Environment.Live.swift; sourceTree = "<group>"; };
+		9A83D78227B18DF000681C9F /* Glia.Environment.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Glia.Environment.Mock.swift; sourceTree = "<group>"; };
 		9B8252BE9AE93B4EA9A50E55 /* Pods-TestingApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestingApp.release.xcconfig"; path = "Target Support Files/Pods-TestingApp/Pods-TestingApp.release.xcconfig"; sourceTree = "<group>"; };
 		9C45ADF8988F719DA1AC8444 /* Pods_TestingApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TestingApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A099487F3CEB09E6C42C7AB4 /* Pods-TestingApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestingApp.debug.xcconfig"; path = "Target Support Files/Pods-TestingApp/Pods-TestingApp.debug.xcconfig"; sourceTree = "<group>"; };
@@ -689,6 +695,9 @@
 				1A60AFC12566857200E53F53 /* Lib */,
 				1A60AF6C25656C3600E53F53 /* Resources */,
 				1A60AF7D25656F0400E53F53 /* Glia.swift */,
+				9A83D77E27B181C500681C9F /* Glia.Environment.Interface.swift */,
+				9A83D78027B18DB600681C9F /* Glia.Environment.Live.swift */,
+				9A83D78227B18DF000681C9F /* Glia.Environment.Mock.swift */,
 				EB750F52273BA9BB00BE5FBD /* GliaError.swift */,
 				1AC7A7542582594200567FF8 /* Configuration.swift */,
 				1A205D5B25655CB1003AA3CD /* GliaWidgets.h */,
@@ -1822,6 +1831,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9A83D77F27B181C500681C9F /* Glia.Environment.Interface.swift in Sources */,
 				6E9C01AF26D3BE2300EBE1D4 /* OperatorTypingIndicatorStyle.swift in Sources */,
 				1A60AFD925669A1500E53F53 /* View.swift in Sources */,
 				1A6EBB0325ADB82000EE325D /* MediaUpgradeActionView.swift in Sources */,
@@ -1842,6 +1852,7 @@
 				1A0C9A7925C16F9700815406 /* Theme+AlertConfiguration.swift in Sources */,
 				1AC8AADD25D419CE00DAFE50 /* VideoStreamView.swift in Sources */,
 				1A4AD3C7256E863900468BFB /* ThemeColor.swift in Sources */,
+				9A83D78327B18DF000681C9F /* Glia.Environment.Mock.swift in Sources */,
 				1A63B2F3257A3F3D00508478 /* AlertViewController.swift in Sources */,
 				C499A58426382FBE009962AC /* UnreadMessageIndicatorStyle.swift in Sources */,
 				1A60B01D2567FCAD00E53F53 /* ButtonProperties.swift in Sources */,
@@ -1867,6 +1878,7 @@
 				1ABD6C5525B574FF00D56EFA /* BubbleView.swift in Sources */,
 				C43D7A1525FF9A590064B1DA /* ChatChoiceCardOption.swift in Sources */,
 				1A2DA73B25EFC00500032611 /* FileUploadListStyle.swift in Sources */,
+				9A83D78127B18DB600681C9F /* Glia.Environment.Live.swift in Sources */,
 				C4F176CE261D1543009D9F07 /* ChatFileDownloadContentStyle.swift in Sources */,
 				C43D7A0D25FF92530064B1DA /* ChoiceCardView.swift in Sources */,
 				1A0C142925B84E5500B00695 /* EngagementViewController.swift in Sources */,

--- a/GliaWidgets/Coordinator/Chat/ChatCoordinator.swift
+++ b/GliaWidgets/Coordinator/Chat/ChatCoordinator.swift
@@ -27,6 +27,7 @@ class ChatCoordinator: SubFlowCoordinator, FlowCoordinator {
     private var mediaPickerController: MediaPickerController?
     private var filePickerController: FilePickerController?
     private var quickLookController: QuickLookController?
+    private let environment: Environment
 
     init(
         interactor: Interactor,
@@ -37,7 +38,8 @@ class ChatCoordinator: SubFlowCoordinator, FlowCoordinator {
         showsCallBubble: Bool,
         screenShareHandler: ScreenShareHandler,
         isWindowVisible: ObservableValue<Bool>,
-        startAction: ChatViewModel.StartAction
+        startAction: ChatViewModel.StartAction,
+        environment: Environment
     ) {
         self.interactor = interactor
         self.viewFactory = viewFactory
@@ -48,6 +50,7 @@ class ChatCoordinator: SubFlowCoordinator, FlowCoordinator {
         self.screenShareHandler = screenShareHandler
         self.isWindowVisible = isWindowVisible
         self.startAction = startAction
+        self.environment = environment
     }
 
     func start() -> ChatViewController {
@@ -64,7 +67,12 @@ class ChatCoordinator: SubFlowCoordinator, FlowCoordinator {
             unreadMessages: unreadMessages,
             showsCallBubble: showsCallBubble,
             isWindowVisible: isWindowVisible,
-            startAction: startAction
+            startAction: startAction,
+            environment: .init(
+                fetchFile: environment.fetchFile,
+                sendSelectedOptionValue: environment.sendSelectedOptionValue,
+                uploadFileToEngagement: environment.uploadFileToEngagement
+            )
         )
         viewModel.engagementDelegate = { [weak self] event in
             switch event {
@@ -161,5 +169,13 @@ class ChatCoordinator: SubFlowCoordinator, FlowCoordinator {
         configuration.entersReaderIfAvailable = true
         let safariViewController = SFSafariViewController(url: url, configuration: configuration)
         navigationPresenter.present(safariViewController)
+    }
+}
+
+extension ChatCoordinator {
+    struct Environment {
+        var fetchFile: CoreSdkClient.FetchFile
+        var sendSelectedOptionValue: CoreSdkClient.SendSelectedOptionValue
+        var uploadFileToEngagement: CoreSdkClient.UploadFileToEngagement
     }
 }

--- a/GliaWidgets/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -4,6 +4,88 @@ import UIKit
 struct CoreSdkClient {
     var pushNotifications: PushNotifications
     var createAppDelegate: () -> AppDelegate
+    var clearSession: () -> Void
+
+    typealias FetchVisitorInfo = (_ completion: @escaping (Result<Self.Salemove.VisitorInfo, Error>) -> Void) -> Void
+    var fetchVisitorInfo: FetchVisitorInfo
+
+    typealias UpdateVisitorInfo = (
+        _ info: Self.VisitorInfoUpdate,
+        _ completion: @escaping (Result<Bool, Error>) -> Void
+    ) -> Void
+    var updateVisitorInfo: UpdateVisitorInfo
+
+    @available(*, deprecated, message: "Use `CoreSdkClient.Salemove.send(option:completion:)` instead.")
+    typealias SendSelectedOptionValue = (
+        _ selectedOptionValue: String,
+        _ completion: @escaping (Result<Self.Message, Error>) -> Void
+    ) -> Void
+    var sendSelectedOptionValue: SendSelectedOptionValue
+
+    typealias ConfigureWithConfiguration = (
+        _ sdkConfiguration: Self.Salemove.Configuration,
+        _ completion: (() -> Void)?
+    ) -> Void
+    var configureWithConfiguration: ConfigureWithConfiguration
+
+    typealias ConfigureWithInteractor = (_ interactor: Self.Interactable) -> Void
+    var configureWithInteractor: ConfigureWithInteractor
+
+    typealias QueueForEngagement = (
+        _ queueID: String,
+        _ visitorContext: Self.VisitorContext,
+        _ shouldCloseAllQueues: Bool,
+        _ mediaType: Self.MediaType,
+        _ options: Self.EngagementOptions?,
+        _ completion: @escaping Self.QueueTicketBlock
+    ) -> Void
+    var queueForEngagement: QueueForEngagement
+
+    typealias RequestMediaUpgradeWithOffer = (
+        _ offer: Self.MediaUpgradeOffer,
+        _ completion: @escaping Self.SuccessBlock
+    ) -> Void
+    var requestMediaUpgradeWithOffer: RequestMediaUpgradeWithOffer
+
+    typealias SendMessagePreview = (
+        _ message: String,
+        _ completion: @escaping Self.SuccessBlock
+    ) -> Void
+    var sendMessagePreview: SendMessagePreview
+
+    typealias SendMessageWithAttachment = (
+        _ message: String,
+        _ attachment: Self.Attachment?,
+        _ completion: @escaping Self.MessageBlock
+    ) -> Void
+    var sendMessageWithAttachment: SendMessageWithAttachment
+
+    typealias CancelQueueTicket = (
+        _ queueTicket: Self.QueueTicket,
+        _ completion: @escaping SalemoveSDK.SuccessBlock
+    ) -> Void
+    var cancelQueueTicket: CancelQueueTicket
+
+    typealias EndEngagement = (_ completion: @escaping Self.SuccessBlock) -> Void
+    var endEngagement: EndEngagement
+
+    typealias RequestEngagedOperator = (_ completion: @escaping Self.OperatorBlock) -> Void
+    var requestEngagedOperator: RequestEngagedOperator
+
+    typealias UploadFileToEngagement = (
+        _ file: Self.EngagementFile,
+        _ progress: Self.EngagementFileProgressBlock?,
+        _ completion: @escaping Self.EngagementFileCompletionBlock
+    ) -> Void
+    var uploadFileToEngagement: UploadFileToEngagement
+
+    typealias FetchFile = (
+        _ engagementFile: Self.EngagementFile,
+        _ progress: Self.EngagementFileProgressBlock?,
+        _ completion: @escaping Self.EngagementFileFetchCompletionBlock
+    ) -> Void
+    var fetchFile: FetchFile
+
 }
 
 extension CoreSdkClient {
@@ -50,21 +132,26 @@ extension CoreSdkClient {
     typealias MediaUpgradeOffer = SalemoveSDK.MediaUpgradeOffer
     typealias Message = SalemoveSDK.Message
     typealias MessageSender = SalemoveSDK.MessageSender
+    typealias MessageBlock = SalemoveSDK.MessageBlock
     typealias MessagesUpdateBlock = SalemoveSDK.MessagesUpdateBlock
     typealias Operator = SalemoveSDK.Operator
+    typealias OperatorBlock = SalemoveSDK.OperatorBlock
     typealias OperatorTypingStatus = SalemoveSDK.OperatorTypingStatus
     typealias OperatorTypingStatusUpdate = SalemoveSDK.OperatorTypingStatusUpdate
     typealias QueueError = SalemoveSDK.QueueError
     typealias QueueTicket = SalemoveSDK.QueueTicket
+    typealias QueueTicketBlock = SalemoveSDK.QueueTicketBlock
     typealias RequestOfferBlock = SalemoveSDK.RequestOfferBlock
     typealias Salemove = SalemoveSDK.Salemove
     typealias SalemoveError = SalemoveSDK.SalemoveError
     typealias ScreenshareOfferBlock = SalemoveSDK.ScreenshareOfferBlock
     typealias SingleChoiceOption = SalemoveSDK.SingleChoiceOption
     typealias StreamView = SalemoveSDK.StreamView
+    typealias SuccessBlock = SalemoveSDK.SuccessBlock
     typealias VideoStreamable = SalemoveSDK.VideoStreamable
     typealias VideoStreamAddedBlock = SalemoveSDK.VideoStreamAddedBlock
     typealias VisitorContext = SalemoveSDK.VisitorContext
+    typealias VisitorInfoUpdate = SalemoveSDK.VisitorInfoUpdate
     typealias VisitorScreenSharingState = SalemoveSDK.VisitorScreenSharingState
     typealias VisitorScreenSharingStateChange = SalemoveSDK.VisitorScreenSharingStateChange
 }

--- a/GliaWidgets/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/CoreSDKClient/CoreSDKClient.Live.swift
@@ -4,7 +4,23 @@ extension CoreSdkClient {
     static let live: Self = {
         .init(
             pushNotifications: .live,
-            createAppDelegate: Self.AppDelegate.live
+            createAppDelegate: Self.AppDelegate.live,
+            clearSession: Salemove.sharedInstance.clearSession,
+            fetchVisitorInfo: Salemove.sharedInstance.fetchVisitorInfo(_:),
+            updateVisitorInfo: Salemove.sharedInstance.updateVisitorInfo(_:completion:),
+            sendSelectedOptionValue: Salemove.sharedInstance.send(selectedOptionValue:completion:),
+            configureWithConfiguration: Salemove.sharedInstance.configure(with:completion:),
+            configureWithInteractor: Salemove.sharedInstance.configure(interactor:),
+            queueForEngagement: Salemove.sharedInstance
+                .queueForEngagement(queueID:visitorContext:shouldCloseAllQueues:mediaType:options:completion:),
+            requestMediaUpgradeWithOffer: Salemove.sharedInstance.requestMediaUpgrade(offer:completion:),
+            sendMessagePreview: Salemove.sharedInstance.sendMessagePreview(message:completion:),
+            sendMessageWithAttachment: Salemove.sharedInstance.send(message:attachment:completion:),
+            cancelQueueTicket: Salemove.sharedInstance.cancel(queueTicket:completion:),
+            endEngagement: Salemove.sharedInstance.endEngagement(completion:),
+            requestEngagedOperator: Salemove.sharedInstance.requestEngagedOperator(completion:),
+            uploadFileToEngagement: Salemove.sharedInstance.uploadFileToEngagement(_:progress:completion:),
+            fetchFile: Salemove.sharedInstance.fetchFile(engagementFile:progress:completion:)
         )
     }()
 }

--- a/GliaWidgets/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -1,3 +1,32 @@
 extension CoreSdkClient {
-    
+    static let mock = Self(
+        pushNotifications: .mock,
+        createAppDelegate: { .mock },
+        clearSession: {},
+        fetchVisitorInfo: { _ in },
+        updateVisitorInfo: { _, _ in },
+        sendSelectedOptionValue: { _, _ in },
+        configureWithConfiguration: { _, _ in },
+        configureWithInteractor: { _ in },
+        queueForEngagement: { _, _, _, _, _, _ in },
+        requestMediaUpgradeWithOffer: { _, _ in },
+        sendMessagePreview: { _, _ in },
+        sendMessageWithAttachment: { _, _, _ in },
+        cancelQueueTicket: { _, _ in },
+        endEngagement: { _ in },
+        requestEngagedOperator: { _ in },
+        uploadFileToEngagement: { _, _, _ in },
+        fetchFile: { _, _, _ in }
+    )
+}
+
+extension CoreSdkClient.PushNotifications {
+    static let mock = Self(applicationDidRegisterForRemoteNotificationsWithDeviceToken: { _, _ in })
+}
+
+extension CoreSdkClient.AppDelegate {
+    static let mock = Self(
+        applicationDidFinishLaunchingWithOptions: { _, _ in false },
+        applicationDidBecomeActive: { _ in }
+    )
 }

--- a/GliaWidgets/Glia.Environment.Interface.swift
+++ b/GliaWidgets/Glia.Environment.Interface.swift
@@ -1,0 +1,22 @@
+import AVFoundation
+import Foundation
+
+extension Glia {
+    struct Environment {
+        var coreSdk: CoreSdkClient
+        var fileManager: FileManager
+        var audioSession: AudioSession
+        var uuid: () -> UUID
+    }
+}
+
+extension Glia.Environment {
+    struct FileManager {
+        var fileExistsAtPath: (String) -> Bool
+        var removeItemAtURL: (URL) throws -> Void
+    }
+
+    struct AudioSession {
+        var overrideOutputAudioPort: (AVAudioSession.PortOverride) throws -> Void
+    }
+}

--- a/GliaWidgets/Glia.Environment.Live.swift
+++ b/GliaWidgets/Glia.Environment.Live.swift
@@ -1,0 +1,22 @@
+import Foundation
+import AVFoundation
+
+extension Glia.Environment {
+    static let live = Self(
+        coreSdk: .live,
+        fileManager: .live,
+        audioSession: .live,
+        uuid: UUID.init
+    )
+}
+
+extension Glia.Environment.FileManager {
+    static let live = Self(
+        fileExistsAtPath: Foundation.FileManager.default.fileExists(atPath:),
+        removeItemAtURL: Foundation.FileManager.default.removeItem(at:)
+    )
+}
+
+extension Glia.Environment.AudioSession {
+    static let live = Self(overrideOutputAudioPort: AVAudioSession.sharedInstance().overrideOutputAudioPort(_:))
+}

--- a/GliaWidgets/Glia.Environment.Mock.swift
+++ b/GliaWidgets/Glia.Environment.Mock.swift
@@ -1,0 +1,27 @@
+extension Glia.Environment {
+    static let mock = Self(
+        coreSdk: .mock,
+        fileManager: .mock,
+        audioSession: .mock,
+        uuid: { .mock }
+    )
+}
+
+extension Glia.Environment.FileManager {
+    static let mock = Self(
+        fileExistsAtPath: { _ in false },
+        removeItemAtURL: { _ in }
+    )
+}
+
+extension Glia.Environment.AudioSession {
+    static let mock = Self(overrideOutputAudioPort: { _ in })
+}
+
+extension UUID {
+    static let mock = Self(uuidString: "deadbeef-dead-beef-dead-beefdeadbeef").unsafelyUnwrapped
+}
+
+extension URL {
+    static let mock = Self(string: "https://mock.mock").unsafelyUnwrapped
+}

--- a/GliaWidgets/Lib/Download/FileDownload.swift
+++ b/GliaWidgets/Lib/Download/FileDownload.swift
@@ -38,10 +38,12 @@ class FileDownload {
         }
     }
     private let storage: DataStorage
+    private let environment: Environment
 
-    init(with file: ChatEngagementFile, storage: DataStorage) {
+    init(with file: ChatEngagementFile, storage: DataStorage, environment: Environment) {
         self.file = file
         self.storage = storage
+        self.environment = environment
 
         if file.isDeleted == true {
             state.value = .error(.deleted)
@@ -79,10 +81,16 @@ class FileDownload {
 
         state.value = .downloading(progress: progress)
 
-        CoreSdkClient.Salemove.sharedInstance.fetchFile(
-            engagementFile: engagementFile,
-            progress: onProgress,
-            completion: onCompletion
+        environment.fetchFile(
+            engagementFile,
+            onProgress,
+            onCompletion
         )
+    }
+}
+
+extension FileDownload {
+    struct Environment {
+        var fetchFile: CoreSdkClient.FetchFile
     }
 }

--- a/GliaWidgets/Lib/Download/FileDownloader.swift
+++ b/GliaWidgets/Lib/Download/FileDownloader.swift
@@ -6,6 +6,11 @@ class FileDownloader {
 
     private var downloads = [String: FileDownload]()
     private var storage = FileSystemStorage(directory: .documents)
+    private var environment: Environment
+
+    init(environment: Environment) {
+        self.environment = environment
+    }
 
     func downloads(for files: [ChatEngagementFile]?,
                    autoDownload: AutoDownload = .nothing) -> [FileDownload] {
@@ -50,7 +55,8 @@ class FileDownloader {
         } else {
             let download = FileDownload(
                 with: file,
-                storage: storage
+                storage: storage,
+                environment: .init(fetchFile: environment.fetchFile)
             )
             downloads[fileID] = download
             return download
@@ -69,5 +75,11 @@ class FileDownloader {
                 }
             }
             .forEach { $0.startDownload() }
+    }
+}
+
+extension FileDownloader {
+    struct Environment {
+        var fetchFile: CoreSdkClient.FetchFile
     }
 }

--- a/GliaWidgets/Lib/Upload/FileUpload.swift
+++ b/GliaWidgets/Lib/Upload/FileUpload.swift
@@ -52,10 +52,12 @@ class FileUpload {
     let localFile: LocalFile
 
     private let storage: DataStorage
+    private let environment: Environment
 
-    init(with localFile: LocalFile, storage: DataStorage) {
+    init(with localFile: LocalFile, storage: DataStorage, environment: Environment) {
         self.localFile = localFile
         self.storage = storage
+        self.environment = environment
     }
 
     func startUpload() {
@@ -77,9 +79,11 @@ class FileUpload {
         }
 
         state.value = .uploading(progress: progress)
-        CoreSdkClient.Salemove.sharedInstance.uploadFileToEngagement(file,
-                                                       progress: onProgress,
-                                                       completion: onCompletion)
+        environment.uploadFileToEngagement(
+            file,
+            onProgress,
+            onCompletion
+        )
     }
 
     func removeLocalFile() {
@@ -91,5 +95,11 @@ class FileUpload {
 extension FileUpload: Equatable {
     static func == (lhs: FileUpload, rhs: FileUpload) -> Bool {
         return lhs.localFile == rhs.localFile
+    }
+}
+
+extension FileUpload {
+    struct Environment {
+        var uploadFileToEngagement: CoreSdkClient.UploadFileToEngagement
     }
 }

--- a/GliaWidgets/Lib/Upload/FileUploader.swift
+++ b/GliaWidgets/Lib/Upload/FileUploader.swift
@@ -49,16 +49,18 @@ class FileUploader {
     private var uploads = [FileUpload]()
     private var storage = FileSystemStorage(directory: .documents)
     private let maximumUploads: Int
+    private let environment: Environment
 
-    init(maximumUploads: Int) {
+    init(maximumUploads: Int, environment: Environment) {
         self.maximumUploads = maximumUploads
+        self.environment = environment
         updateLimitReached()
     }
 
     func addUpload(with url: URL) -> FileUpload? {
         guard !limitReached.value else { return nil }
         let localFile = LocalFile(with: url)
-        let upload = FileUpload(with: localFile, storage: storage)
+        let upload = FileUpload(with: localFile, storage: storage, environment: .init(uploadFileToEngagement: environment.uploadFileToEngagement))
         upload.state.addObserver(self) { [weak self] _, _ in
             self?.updateState()
         }
@@ -124,5 +126,11 @@ class FileUploader {
 
     private func updateLimitReached() {
         limitReached.value = count >= maximumUploads
+    }
+}
+
+extension FileUploader {
+    struct Environment {
+        var uploadFileToEngagement: CoreSdkClient.UploadFileToEngagement
     }
 }

--- a/GliaWidgets/ViewModel/Call/Data/Call.swift
+++ b/GliaWidgets/ViewModel/Call/Data/Call.swift
@@ -79,16 +79,19 @@ class MediaChannel<Streamable> {
 }
 
 class Call {
-    let id = UUID().uuidString
+    let id: String
     let kind = ObservableValue<CallKind>(with: .audio)
     let state = ObservableValue<CallState>(with: .none)
     let duration = ObservableValue<Int>(with: 0)
     let audio = MediaChannel<CoreSdkClient.AudioStreamable>()
     let video = MediaChannel<CoreSdkClient.VideoStreamable>()
     private(set) var audioPortOverride = AVAudioSession.PortOverride.none
+    var environment: Environment
 
-    init(_ kind: CallKind) {
+    init(_ kind: CallKind, environment: Environment) {
+        self.id = environment.uuid().uuidString
         self.kind.value = kind
+        self.environment = environment
     }
 
     func upgrade(to offer: CoreSdkClient.MediaUpgradeOffer) {
@@ -141,7 +144,7 @@ class Call {
             }
         }()
 
-        let session = AVAudioSession.sharedInstance()
+        let session = environment.audioSession
 
         do {
             try session.overrideOutputAudioPort(newOverride)
@@ -230,5 +233,12 @@ class Call {
                 break
             }
         }
+    }
+}
+
+extension Call {
+    struct Environment {
+        var audioSession: Glia.Environment.AudioSession
+        var uuid: () -> UUID
     }
 }


### PR DESCRIPTION
This PR introduces a way to inject and control dependencies instead of using them directly to facilitate testability of the SDK.
Note that not all dependencies are covered: specifically ChatStorage still needs to be reworked in order to have dependencies injected. However since there are quite a lot of changes already, it makes sense to review them first and decide if this approach is clear and appropriate. If it is, then other dependencies will be managed in the upcoming PR(s).

MOB-1120