### PR TITLE
Add AccessibilitySnapshot dependency

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0E1ABC3F0A0443BA5F2EC59B /* Pods_GliaWidgetsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 97422AD1FF7D9E4B3E887116 /* Pods_GliaWidgetsTests.framework */; };
 		1A0452DD25DBD0A4000DA0C1 /* HeaderButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A0452DC25DBD0A4000DA0C1 /* HeaderButton.swift */; };
 		1A0452E325DBD0B4000DA0C1 /* HeaderButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A0452E225DBD0B4000DA0C1 /* HeaderButtonStyle.swift */; };
 		1A0452EA25DBE259000DA0C1 /* MessageButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A0452E925DBE259000DA0C1 /* MessageButton.swift */; };
@@ -236,6 +237,13 @@
 			remoteGlobalIDString = 1A205D5725655CB1003AA3CD;
 			remoteInfo = GliaWidgets;
 		};
+		9ACC25CF27B4332900BC5335 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1A205D4F25655CB1003AA3CD /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1A205D7725655CEC003AA3CD;
+			remoteInfo = TestingApp;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -430,6 +438,7 @@
 		1AFB1E6725F7AE3C00CA460D /* ChatAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachment.swift; sourceTree = "<group>"; };
 		1AFB1E7325F8B00B00CA460D /* ChatTextContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTextContentView.swift; sourceTree = "<group>"; };
 		1AFB1E7725F8B26800CA460D /* ChatTextContentStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTextContentStyle.swift; sourceTree = "<group>"; };
+		2DF264CC3CC1228516F289EE /* Pods-GliaWidgetsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GliaWidgetsTests.release.xcconfig"; path = "Target Support Files/Pods-GliaWidgetsTests/Pods-GliaWidgetsTests.release.xcconfig"; sourceTree = "<group>"; };
 		34707AE4070DC82EFBA9C844 /* Pods-GliaWidgets.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GliaWidgets.release.xcconfig"; path = "Target Support Files/Pods-GliaWidgets/Pods-GliaWidgets.release.xcconfig"; sourceTree = "<group>"; };
 		6B2BFCE1274297F100B68506 /* SettingsSwitchCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSwitchCell.swift; sourceTree = "<group>"; };
 		6B48213D2735873300F2900A /* Feature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature.swift; sourceTree = "<group>"; };
@@ -442,6 +451,7 @@
 		6EEAD84D2701A8C10074C191 /* ChoiceCardOptionStateStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChoiceCardOptionStateStyle.swift; sourceTree = "<group>"; };
 		756087E027837EC000158604 /* BundleManaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleManaging.swift; sourceTree = "<group>"; };
 		85639A838514258D976E1B2A /* Pods_GliaWidgets.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GliaWidgets.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		97422AD1FF7D9E4B3E887116 /* Pods_GliaWidgetsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GliaWidgetsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A66172627A94587001C8E03 /* CoreSDKClient.Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSDKClient.Interface.swift; sourceTree = "<group>"; };
 		9A66172927A94826001C8E03 /* CoreSDKClient.Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSDKClient.Live.swift; sourceTree = "<group>"; };
 		9A66172B27A94A4B001C8E03 /* CoreSDKClient.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSDKClient.Mock.swift; sourceTree = "<group>"; };
@@ -476,6 +486,7 @@
 		C4F176CB261D1543009D9F07 /* ChatFileDownloadContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatFileDownloadContentView.swift; sourceTree = "<group>"; };
 		C4F176CC261D1543009D9F07 /* ChatFileDownloadContentStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatFileDownloadContentStyle.swift; sourceTree = "<group>"; };
 		EB750F52273BA9BB00BE5FBD /* GliaError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GliaError.swift; sourceTree = "<group>"; };
+		F08274A374F775EE39BFBDB1 /* Pods-GliaWidgetsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GliaWidgetsTests.debug.xcconfig"; path = "Target Support Files/Pods-GliaWidgetsTests/Pods-GliaWidgetsTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -492,6 +503,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1A205D6225655CB2003AA3CD /* GliaWidgets.framework in Frameworks */,
+				0E1ABC3F0A0443BA5F2EC59B /* Pods_GliaWidgetsTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1437,6 +1449,7 @@
 			children = (
 				85639A838514258D976E1B2A /* Pods_GliaWidgets.framework */,
 				9C45ADF8988F719DA1AC8444 /* Pods_TestingApp.framework */,
+				97422AD1FF7D9E4B3E887116 /* Pods_GliaWidgetsTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1448,6 +1461,8 @@
 				34707AE4070DC82EFBA9C844 /* Pods-GliaWidgets.release.xcconfig */,
 				A099487F3CEB09E6C42C7AB4 /* Pods-TestingApp.debug.xcconfig */,
 				9B8252BE9AE93B4EA9A50E55 /* Pods-TestingApp.release.xcconfig */,
+				F08274A374F775EE39BFBDB1 /* Pods-GliaWidgetsTests.debug.xcconfig */,
+				2DF264CC3CC1228516F289EE /* Pods-GliaWidgetsTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -1600,14 +1615,17 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1A205D6F25655CB2003AA3CD /* Build configuration list for PBXNativeTarget "GliaWidgetsTests" */;
 			buildPhases = (
+				41A76E1F19B129EF98646CE8 /* [CP] Check Pods Manifest.lock */,
 				1A205D5D25655CB2003AA3CD /* Sources */,
 				1A205D5E25655CB2003AA3CD /* Frameworks */,
 				1A205D5F25655CB2003AA3CD /* Resources */,
+				47C7DDCDD3740A6BC592800E /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				1A205D6425655CB2003AA3CD /* PBXTargetDependency */,
+				9ACC25D027B4332900BC5335 /* PBXTargetDependency */,
 			);
 			name = GliaWidgetsTests;
 			productName = GliaWidgetsTests;
@@ -1650,6 +1668,7 @@
 					};
 					1A205D6025655CB2003AA3CD = {
 						CreatedOnToolsVersion = 12.1;
+						TestTargetID = 1A205D7725655CEC003AA3CD;
 					};
 					1A205D7725655CEC003AA3CD = {
 						CreatedOnToolsVersion = 12.1;
@@ -1744,6 +1763,45 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if which swiftgen >/dev/null; then\n    swiftgen\nelse\n    echo \"warning: SwiftGen not installed, download it from https://github.com/SwiftGen/SwiftGen\"\nfi\n";
+		};
+		41A76E1F19B129EF98646CE8 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-GliaWidgetsTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		47C7DDCDD3740A6BC592800E /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-GliaWidgetsTests/Pods-GliaWidgetsTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-GliaWidgetsTests/Pods-GliaWidgetsTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-GliaWidgetsTests/Pods-GliaWidgetsTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		E5F85521D269848906913F41 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2059,6 +2117,11 @@
 			target = 1A205D5725655CB1003AA3CD /* GliaWidgets */;
 			targetProxy = 1A205DB6256566BB003AA3CD /* PBXContainerItemProxy */;
 		};
+		9ACC25D027B4332900BC5335 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1A205D7725655CEC003AA3CD /* TestingApp */;
+			targetProxy = 9ACC25CF27B4332900BC5335 /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
@@ -2266,8 +2329,8 @@
 		};
 		1A205D7025655CB2003AA3CD /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F08274A374F775EE39BFBDB1 /* Pods-GliaWidgetsTests.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = GliaWidgetsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2279,13 +2342,14 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestingApp.app/TestingApp";
 			};
 			name = Debug;
 		};
 		1A205D7125655CB2003AA3CD /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2DF264CC3CC1228516F289EE /* Pods-GliaWidgetsTests.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = GliaWidgetsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2297,6 +2361,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestingApp.app/TestingApp";
 			};
 			name = Release;
 		};

--- a/GliaWidgetsTests/GliaWidgetsTests.swift
+++ b/GliaWidgetsTests/GliaWidgetsTests.swift
@@ -1,5 +1,6 @@
-import XCTest
+import AccessibilitySnapshot
 @testable import GliaWidgets
+import XCTest
 
 class GliaWidgetsTests: XCTestCase {
 

--- a/Podfile
+++ b/Podfile
@@ -21,6 +21,12 @@ target 'GliaWidgets' do
   pod 'lottie-ios', '3.2.3'
 end
 
+target 'GliaWidgetsTests' do
+  use_frameworks!
+
+  pod 'AccessibilitySnapshot', '0.5.0'
+end
+
 post_install do |installer|
     installer.pods_project.targets.each do |target|
         target.build_configurations.each do |config|

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,4 +1,11 @@
 PODS:
+  - AccessibilitySnapshot (0.5.0):
+    - AccessibilitySnapshot/Core (= 0.5.0)
+    - AccessibilitySnapshot/SnapshotTesting (= 0.5.0)
+  - AccessibilitySnapshot/Core (0.5.0)
+  - AccessibilitySnapshot/SnapshotTesting (0.5.0):
+    - AccessibilitySnapshot/Core
+    - SnapshotTesting (~> 1.0)
   - glia-webrtc/bitcode (0.0.3)
   - lottie-ios (3.2.3)
   - PureLayout (3.1.9)
@@ -10,21 +17,25 @@ PODS:
     - Starscream (= 3.1.1-xcf)
     - SwiftPhoenixClient (= 1.2.1-xcf)
     - TwilioVoice (= 6.2.0)
+  - SnapshotTesting (1.9.0)
   - SocketIO (9.2.0-xcf)
   - Starscream (3.1.1-xcf)
   - SwiftPhoenixClient (1.2.1-xcf)
   - TwilioVoice (6.2.0)
 
 DEPENDENCIES:
+  - AccessibilitySnapshot (= 0.5.0)
   - lottie-ios (= 3.2.3)
   - PureLayout (~> 3.1)
   - SalemoveSDK
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
+    - AccessibilitySnapshot
     - glia-webrtc
     - lottie-ios
     - PureLayout
+    - SnapshotTesting
     - TwilioVoice
   https://github.com/salemove/glia-ios-podspecs.git:
     - ReactiveSwift
@@ -34,16 +45,18 @@ SPEC REPOS:
     - SwiftPhoenixClient
 
 SPEC CHECKSUMS:
+  AccessibilitySnapshot: a91e4a69f870188b51f43863d9fc7269d07cdd93
   glia-webrtc: a5c7e59ae752281d19734b4f918db9da39e8009d
   lottie-ios: c058aeafa76daa4cf64d773554bccc8385d0150e
   PureLayout: 5fb5e5429519627d60d079ccb1eaa7265ce7cf88
   ReactiveSwift: 377d0a5621761a57c61829541b2ee0b9fdcd98f2
   SalemoveSDK: dd14c39308aeff846055d6a0bb3dfd1972daa155
+  SnapshotTesting: 6141c48b6aa76ead61431ca665c14ab9a066c53b
   SocketIO: 07583ad0005148194dcdfb89feda88b2180e1391
   Starscream: 54f05f3e7aa58f5ad1d5b4339ab55784bc74a35f
   SwiftPhoenixClient: 77dadbfee8eecd7a41cc8cccdd883dd0df093ddb
   TwilioVoice: 5e6fd6b5e99dfec03dcb57331f7e7c77ad79f1f0
 
-PODFILE CHECKSUM: 02f95f2cc3c8cf305a0d1b9d19eae34ddaa10146
+PODFILE CHECKSUM: 895b263ada78f18509192880bbf18229bdfe4e71
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
Since we are targeting to have accessibility tests (as snapshot tests) along with regular unit test, it is required to have access to simulator runtime. Because of this GliaWidgetsTests uses TestingApp as host app for unit tests in this PR. Also AccessibilitySnapshot in added via Cocoapods.

MOB-1120