### PR TITLE
Introduce failable mocks

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -190,6 +190,7 @@
 		6EA3516926E139DA00BF5941 /* GliaViewTransitionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA3516826E139DA00BF5941 /* GliaViewTransitionController.swift */; };
 		6EEAD84E2701A8C10074C191 /* ChoiceCardOptionStateStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EEAD84D2701A8C10074C191 /* ChoiceCardOptionStateStyle.swift */; };
 		756087E127837EC000158604 /* BundleManaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 756087E027837EC000158604 /* BundleManaging.swift */; };
+		9A3E1D8427B67F1B005634EB /* Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3E1D8327B67F1B005634EB /* Helper.swift */; };
 		9A66172727A94587001C8E03 /* CoreSDKClient.Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A66172627A94587001C8E03 /* CoreSDKClient.Interface.swift */; };
 		9A66172A27A94826001C8E03 /* CoreSDKClient.Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A66172927A94826001C8E03 /* CoreSDKClient.Live.swift */; };
 		9A66172C27A94A4B001C8E03 /* CoreSDKClient.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A66172B27A94A4B001C8E03 /* CoreSDKClient.Mock.swift */; };
@@ -454,6 +455,7 @@
 		756087E027837EC000158604 /* BundleManaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleManaging.swift; sourceTree = "<group>"; };
 		85639A838514258D976E1B2A /* Pods_GliaWidgets.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GliaWidgets.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		97422AD1FF7D9E4B3E887116 /* Pods_GliaWidgetsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GliaWidgetsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9A3E1D8327B67F1B005634EB /* Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helper.swift; sourceTree = "<group>"; };
 		9A66172627A94587001C8E03 /* CoreSDKClient.Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSDKClient.Interface.swift; sourceTree = "<group>"; };
 		9A66172927A94826001C8E03 /* CoreSDKClient.Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSDKClient.Live.swift; sourceTree = "<group>"; };
 		9A66172B27A94A4B001C8E03 /* CoreSDKClient.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSDKClient.Mock.swift; sourceTree = "<group>"; };
@@ -730,6 +732,7 @@
 				1A205D6825655CB2003AA3CD /* Info.plist */,
 				9ACC25D127B4727500BC5335 /* CoreSDKClient.Failing.swift */,
 				9ACC25D327B474E800BC5335 /* Glia.Environment.Failing.swift */,
+				9A3E1D8327B67F1B005634EB /* Helper.swift */,
 			);
 			path = GliaWidgetsTests;
 			sourceTree = "<group>";
@@ -2092,6 +2095,7 @@
 				9ACC25D427B474E800BC5335 /* Glia.Environment.Failing.swift in Sources */,
 				1A205D6725655CB2003AA3CD /* GliaWidgetsTests.swift in Sources */,
 				9ACC25D227B4727500BC5335 /* CoreSDKClient.Failing.swift in Sources */,
+				9A3E1D8427B67F1B005634EB /* Helper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -196,6 +196,8 @@
 		9A83D77F27B181C500681C9F /* Glia.Environment.Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A83D77E27B181C500681C9F /* Glia.Environment.Interface.swift */; };
 		9A83D78127B18DB600681C9F /* Glia.Environment.Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A83D78027B18DB600681C9F /* Glia.Environment.Live.swift */; };
 		9A83D78327B18DF000681C9F /* Glia.Environment.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A83D78227B18DF000681C9F /* Glia.Environment.Mock.swift */; };
+		9ACC25D227B4727500BC5335 /* CoreSDKClient.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACC25D127B4727500BC5335 /* CoreSDKClient.Failing.swift */; };
+		9ACC25D427B474E800BC5335 /* Glia.Environment.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACC25D327B474E800BC5335 /* Glia.Environment.Failing.swift */; };
 		C4119E04268F411D004DFEFB /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4119E03268F411D004DFEFB /* SceneDelegate.swift */; };
 		C4119E06268F41D1004DFEFB /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C4119E05268F41D1004DFEFB /* Main.storyboard */; };
 		C42463742673ABE10082C135 /* ScreenShareHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42463732673ABE10082C135 /* ScreenShareHandler.swift */; };
@@ -458,6 +460,8 @@
 		9A83D77E27B181C500681C9F /* Glia.Environment.Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Glia.Environment.Interface.swift; sourceTree = "<group>"; };
 		9A83D78027B18DB600681C9F /* Glia.Environment.Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Glia.Environment.Live.swift; sourceTree = "<group>"; };
 		9A83D78227B18DF000681C9F /* Glia.Environment.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Glia.Environment.Mock.swift; sourceTree = "<group>"; };
+		9ACC25D127B4727500BC5335 /* CoreSDKClient.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSDKClient.Failing.swift; sourceTree = "<group>"; };
+		9ACC25D327B474E800BC5335 /* Glia.Environment.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Glia.Environment.Failing.swift; sourceTree = "<group>"; };
 		9B8252BE9AE93B4EA9A50E55 /* Pods-TestingApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestingApp.release.xcconfig"; path = "Target Support Files/Pods-TestingApp/Pods-TestingApp.release.xcconfig"; sourceTree = "<group>"; };
 		9C45ADF8988F719DA1AC8444 /* Pods_TestingApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TestingApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A099487F3CEB09E6C42C7AB4 /* Pods-TestingApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestingApp.debug.xcconfig"; path = "Target Support Files/Pods-TestingApp/Pods-TestingApp.debug.xcconfig"; sourceTree = "<group>"; };
@@ -724,6 +728,8 @@
 			children = (
 				1A205D6625655CB2003AA3CD /* GliaWidgetsTests.swift */,
 				1A205D6825655CB2003AA3CD /* Info.plist */,
+				9ACC25D127B4727500BC5335 /* CoreSDKClient.Failing.swift */,
+				9ACC25D327B474E800BC5335 /* Glia.Environment.Failing.swift */,
 			);
 			path = GliaWidgetsTests;
 			sourceTree = "<group>";
@@ -2083,7 +2089,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9ACC25D427B474E800BC5335 /* Glia.Environment.Failing.swift in Sources */,
 				1A205D6725655CB2003AA3CD /* GliaWidgetsTests.swift in Sources */,
+				9ACC25D227B4727500BC5335 /* CoreSDKClient.Failing.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GliaWidgetsTests/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/CoreSDKClient.Failing.swift
@@ -1,32 +1,31 @@
 @testable import GliaWidgets
-import XCTest
 
 extension CoreSdkClient {
     static let failing = Self(
         pushNotifications: .failing,
         createAppDelegate: { .failing },
-        clearSession: { XCTFail("clearSession") },
-        fetchVisitorInfo: { _ in XCTFail("fetchVisitorInfo") },
-        updateVisitorInfo: { _, _ in XCTFail("updateVisitorInfo") },
-        sendSelectedOptionValue: { _, _ in XCTFail("sendSelectedOptionValue") },
-        configureWithConfiguration: { _, _ in XCTFail("configureWithConfiguration") },
-        configureWithInteractor: { _ in XCTFail("configureWithInteractor") },
-        queueForEngagement: { _, _, _, _, _, _ in XCTFail("queueForEngagement") },
-        requestMediaUpgradeWithOffer: { _, _ in XCTFail("requestMediaUpgradeWithOffer") },
-        sendMessagePreview: { _, _ in XCTFail("sendMessagePreview") },
-        sendMessageWithAttachment: { _, _, _ in XCTFail("sendMessageWithAttachment") },
-        cancelQueueTicket: { _, _ in XCTFail("cancelQueueTicket") },
-        endEngagement: { _ in XCTFail("endEngagement") },
-        requestEngagedOperator: { _ in XCTFail("requestEngagedOperator") },
-        uploadFileToEngagement: { _, _, _ in XCTFail("uploadFileToEngagement") },
-        fetchFile: { _, _, _ in XCTFail("fetchFile") }
+        clearSession: { fail("\(Self.self).clearSession") },
+        fetchVisitorInfo: { _ in fail("\(Self.self).fetchVisitorInfo") },
+        updateVisitorInfo: { _, _ in fail("\(Self.self).updateVisitorInfo") },
+        sendSelectedOptionValue: { _, _ in fail("\(Self.self).sendSelectedOptionValue") },
+        configureWithConfiguration: { _, _ in fail("\(Self.self).configureWithConfiguration") },
+        configureWithInteractor: { _ in fail("\(Self.self).configureWithInteractor") },
+        queueForEngagement: { _, _, _, _, _, _ in fail("\(Self.self).queueForEngagement") },
+        requestMediaUpgradeWithOffer: { _, _ in fail("\(Self.self).requestMediaUpgradeWithOffer") },
+        sendMessagePreview: { _, _ in fail("\(Self.self).sendMessagePreview") },
+        sendMessageWithAttachment: { _, _, _ in fail("\(Self.self).sendMessageWithAttachment") },
+        cancelQueueTicket: { _, _ in fail("cancelQueueTicket") },
+        endEngagement: { _ in fail("\(Self.self).endEngagement") },
+        requestEngagedOperator: { _ in fail("\(Self.self).requestEngagedOperator") },
+        uploadFileToEngagement: { _, _, _ in fail("\(Self.self).uploadFileToEngagement") },
+        fetchFile: { _, _, _ in fail("\(Self.self).fetchFile") }
     )
 }
 
 extension CoreSdkClient.PushNotifications {
     static let failing = Self(
         applicationDidRegisterForRemoteNotificationsWithDeviceToken: { _, _ in
-            XCTFail("applicationDidRegisterForRemoteNotificationsWithDeviceToken")
+            fail("\(Self.self).applicationDidRegisterForRemoteNotificationsWithDeviceToken")
         }
     )
 }
@@ -34,11 +33,11 @@ extension CoreSdkClient.PushNotifications {
 extension CoreSdkClient.AppDelegate {
     static let failing = Self(
         applicationDidFinishLaunchingWithOptions: { _, _ in
-            XCTFail("applicationDidFinishLaunchingWithOptions")
+            fail("\(Self.self).applicationDidFinishLaunchingWithOptions")
             return false
         },
         applicationDidBecomeActive: { _ in
-            XCTFail("applicationDidBecomeActive")
+            fail("\(Self.self).applicationDidBecomeActive")
         }
     )
 }

--- a/GliaWidgetsTests/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/CoreSDKClient.Failing.swift
@@ -1,0 +1,44 @@
+@testable import GliaWidgets
+import XCTest
+
+extension CoreSdkClient {
+    static let failing = Self(
+        pushNotifications: .failing,
+        createAppDelegate: { .failing },
+        clearSession: { XCTFail("clearSession") },
+        fetchVisitorInfo: { _ in XCTFail("fetchVisitorInfo") },
+        updateVisitorInfo: { _, _ in XCTFail("updateVisitorInfo") },
+        sendSelectedOptionValue: { _, _ in XCTFail("sendSelectedOptionValue") },
+        configureWithConfiguration: { _, _ in XCTFail("configureWithConfiguration") },
+        configureWithInteractor: { _ in XCTFail("configureWithInteractor") },
+        queueForEngagement: { _, _, _, _, _, _ in XCTFail("queueForEngagement") },
+        requestMediaUpgradeWithOffer: { _, _ in XCTFail("requestMediaUpgradeWithOffer") },
+        sendMessagePreview: { _, _ in XCTFail("sendMessagePreview") },
+        sendMessageWithAttachment: { _, _, _ in XCTFail("sendMessageWithAttachment") },
+        cancelQueueTicket: { _, _ in XCTFail("cancelQueueTicket") },
+        endEngagement: { _ in XCTFail("endEngagement") },
+        requestEngagedOperator: { _ in XCTFail("requestEngagedOperator") },
+        uploadFileToEngagement: { _, _, _ in XCTFail("uploadFileToEngagement") },
+        fetchFile: { _, _, _ in XCTFail("fetchFile") }
+    )
+}
+
+extension CoreSdkClient.PushNotifications {
+    static let failing = Self(
+        applicationDidRegisterForRemoteNotificationsWithDeviceToken: { _, _ in
+            XCTFail("applicationDidRegisterForRemoteNotificationsWithDeviceToken")
+        }
+    )
+}
+
+extension CoreSdkClient.AppDelegate {
+    static let failing = Self(
+        applicationDidFinishLaunchingWithOptions: { _, _ in
+            XCTFail("applicationDidFinishLaunchingWithOptions")
+            return false
+        },
+        applicationDidBecomeActive: { _ in
+            XCTFail("applicationDidBecomeActive")
+        }
+    )
+}

--- a/GliaWidgetsTests/Glia.Environment.Failing.swift
+++ b/GliaWidgetsTests/Glia.Environment.Failing.swift
@@ -1,26 +1,13 @@
 @testable import GliaWidgets
-import XCTest
 
 extension Glia.Environment {
     static let failing = Self(
         coreSdk: .failing,
-        fileManager: .failing,
+        chatStorage: .failing,
         audioSession: .failing,
         uuid: {
-            XCTFail("uuid")
+            fail("\(Self.self).uuid")
             return .mock
-        }
-    )
-}
-
-extension Glia.Environment.FileManager {
-    static let failing = Self(
-        fileExistsAtPath: { _ in
-            XCTFail("fileExistsAtPath")
-            return false
-        },
-        removeItemAtURL: { _ in
-            XCTFail("removeItemAtURL")
         }
     )
 }
@@ -28,7 +15,44 @@ extension Glia.Environment.FileManager {
 extension Glia.Environment.AudioSession {
     static let failing = Self(
         overrideOutputAudioPort: { _ in
-            XCTFail("overrideOutputAudioPort")
+            fail("\(Self.self).overrideOutputAudioPort")
+        }
+    )
+}
+
+extension Glia.Environment.ChatStorage {
+    static let failing = Self(
+        databaseUrl: {
+            fail("\(Self.self).databaseUrl")
+            return nil
+
+        },
+        dropDatabase: {
+            fail("\(Self.self).dropDatabase")
+        },
+        isEmpty: {
+            fail("\(Self.self).isEmpty")
+            return false
+        },
+        messages: { _ in
+            fail("\(Self.self).messages")
+            return []
+        },
+        updateMessage: { _ in
+            fail("\(Self.self).updateMessage")
+        },
+        storeMessage: { _, _, _ in
+            fail("\(Self.self).storeMessage")
+        },
+        storeMessages: { _, _, _ in
+            fail("\(Self.self).storeMessages")
+        },
+        isNewMessage: { _ in return true
+            fail("\(Self.self).isNewMessage")
+        },
+        newMessages: { _ in
+            fail("\(Self.self).newMessages")
+            return []
         }
     )
 }

--- a/GliaWidgetsTests/Glia.Environment.Failing.swift
+++ b/GliaWidgetsTests/Glia.Environment.Failing.swift
@@ -1,0 +1,34 @@
+@testable import GliaWidgets
+import XCTest
+
+extension Glia.Environment {
+    static let failing = Self(
+        coreSdk: .failing,
+        fileManager: .failing,
+        audioSession: .failing,
+        uuid: {
+            XCTFail("uuid")
+            return .mock
+        }
+    )
+}
+
+extension Glia.Environment.FileManager {
+    static let failing = Self(
+        fileExistsAtPath: { _ in
+            XCTFail("fileExistsAtPath")
+            return false
+        },
+        removeItemAtURL: { _ in
+            XCTFail("removeItemAtURL")
+        }
+    )
+}
+
+extension Glia.Environment.AudioSession {
+    static let failing = Self(
+        overrideOutputAudioPort: { _ in
+            XCTFail("overrideOutputAudioPort")
+        }
+    )
+}

--- a/GliaWidgetsTests/Helper.swift
+++ b/GliaWidgetsTests/Helper.swift
@@ -1,0 +1,5 @@
+import XCTest
+
+func fail(_ failingFuncName: String, file: StaticString = #filePath, line: UInt = #line) {
+    XCTFail("\(failingFuncName) - A failing environment function is invoked.", file: file, line: line)
+}


### PR DESCRIPTION
This PR introduces failable mocks for CoreSDK and Glia.Environment, that will guarantee that these dependencies are not to be called unless we specifically allow them in unit tests.

MOB-1128