### PR TITLE
File Upload - Visitor can upload more than 25 files after removing of last uploaded file

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -230,6 +230,8 @@
 		C4C2A1702670E848003AC039 /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4C2A16F2670E848003AC039 /* UIViewController+Extensions.swift */; };
 		C4F176CD261D1543009D9F07 /* ChatFileDownloadContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4F176CB261D1543009D9F07 /* ChatFileDownloadContentView.swift */; };
 		C4F176CE261D1543009D9F07 /* ChatFileDownloadContentStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4F176CC261D1543009D9F07 /* ChatFileDownloadContentStyle.swift */; };
+		EB22C26027C53F0E00FD307F /* FileUploaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB22C25F27C53F0E00FD307F /* FileUploaderTests.swift */; };
+		EB22C26227CB870100FD307F /* FileUploader.Environment.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB22C26127CB870100FD307F /* FileUploader.Environment.Failing.swift */; };
 		EB750F53273BA9BB00BE5FBD /* GliaError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB750F52273BA9BB00BE5FBD /* GliaError.swift */; };
 		FD01A52B483418AB02DCFBFC /* Pods_GliaWidgets.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85639A838514258D976E1B2A /* Pods_GliaWidgets.framework */; };
 /* End PBXBuildFile section */
@@ -509,6 +511,8 @@
 		C4C2A16F2670E848003AC039 /* UIViewController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extensions.swift"; sourceTree = "<group>"; };
 		C4F176CB261D1543009D9F07 /* ChatFileDownloadContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatFileDownloadContentView.swift; sourceTree = "<group>"; };
 		C4F176CC261D1543009D9F07 /* ChatFileDownloadContentStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatFileDownloadContentStyle.swift; sourceTree = "<group>"; };
+		EB22C25F27C53F0E00FD307F /* FileUploaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploaderTests.swift; sourceTree = "<group>"; };
+		EB22C26127CB870100FD307F /* FileUploader.Environment.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploader.Environment.Failing.swift; sourceTree = "<group>"; };
 		EB750F52273BA9BB00BE5FBD /* GliaError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GliaError.swift; sourceTree = "<group>"; };
 		F08274A374F775EE39BFBDB1 /* Pods-GliaWidgetsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GliaWidgetsTests.debug.xcconfig"; path = "Target Support Files/Pods-GliaWidgetsTests/Pods-GliaWidgetsTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1513,6 +1517,7 @@
 		9A3E1D8527B6B668005634EB /* Lib */ = {
 			isa = PBXGroup;
 			children = (
+				EB22C25E27C53EFA00FD307F /* Upload */,
 				9A3E1D9E27BA7B80005634EB /* Storage */,
 			);
 			path = Lib;
@@ -1625,6 +1630,15 @@
 				C4F176CC261D1543009D9F07 /* ChatFileDownloadContentStyle.swift */,
 			);
 			path = Download;
+			sourceTree = "<group>";
+		};
+		EB22C25E27C53EFA00FD307F /* Upload */ = {
+			isa = PBXGroup;
+			children = (
+				EB22C25F27C53F0E00FD307F /* FileUploaderTests.swift */,
+				EB22C26127CB870100FD307F /* FileUploader.Environment.Failing.swift */,
+			);
+			path = Upload;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -2146,6 +2160,8 @@
 				9A3E1DA227BA7D00005634EB /* FileSystemStorage.Environment.Failing.swift in Sources */,
 				9A3E1DA027BA7B9F005634EB /* FileSystemStorageTests.swift in Sources */,
 				9ACC25D227B4727500BC5335 /* CoreSDKClient.Failing.swift in Sources */,
+				EB22C26027C53F0E00FD307F /* FileUploaderTests.swift in Sources */,
+				EB22C26227CB870100FD307F /* FileUploader.Environment.Failing.swift in Sources */,
 				9A3E1D9D27BA7741005634EB /* FoundationBased.Failing.swift in Sources */,
 				9A3E1D8427B67F1B005634EB /* Helper.swift in Sources */,
 			);

--- a/GliaWidgets/Coordinator/Chat/ChatCoordinator.swift
+++ b/GliaWidgets/Coordinator/Chat/ChatCoordinator.swift
@@ -75,7 +75,8 @@ class ChatCoordinator: SubFlowCoordinator, FlowCoordinator {
                 uploadFileToEngagement: environment.uploadFileToEngagement,
                 fileManager: environment.fileManager,
                 data: environment.data,
-                date: environment.date
+                date: environment.date,
+                uuid: environment.uuid
             )
         )
         viewModel.engagementDelegate = { [weak self] event in
@@ -185,5 +186,6 @@ extension ChatCoordinator {
         var fileManager: FoundationBased.FileManager
         var data: FoundationBased.Data
         var date: () -> Date
+        var uuid: () -> UUID
     }
 }

--- a/GliaWidgets/Coordinator/RootCoordinator.swift
+++ b/GliaWidgets/Coordinator/RootCoordinator.swift
@@ -163,7 +163,8 @@ class RootCoordinator: SubFlowCoordinator, FlowCoordinator {
                 uploadFileToEngagement: environment.uploadFileToEngagement,
                 fileManager: environment.fileManager,
                 data: environment.data,
-                date: environment.date
+                date: environment.date,
+                uuid: environment.uuid
             )
         )
         coordinator.delegate = { [weak self] event in

--- a/GliaWidgets/Lib/Upload/FileUpload.swift
+++ b/GliaWidgets/Lib/Upload/FileUpload.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 class FileUpload {
     enum Error {
         case fileTooBig
@@ -53,6 +55,7 @@ class FileUpload {
 
     private let storage: DataStorage
     private let environment: Environment
+    private let uuid = UUID()
 
     init(with localFile: LocalFile, storage: DataStorage, environment: Environment) {
         self.localFile = localFile
@@ -94,7 +97,7 @@ class FileUpload {
 
 extension FileUpload: Equatable {
     static func == (lhs: FileUpload, rhs: FileUpload) -> Bool {
-        return lhs.localFile == rhs.localFile
+        return lhs.uuid == rhs.uuid
     }
 }
 

--- a/GliaWidgets/Lib/Upload/FileUpload.swift
+++ b/GliaWidgets/Lib/Upload/FileUpload.swift
@@ -53,9 +53,10 @@ class FileUpload {
     let state = ObservableValue<State>(with: .none)
     let localFile: LocalFile
 
+    lazy var uuid = environment.uuid()
+
     private let storage: DataStorage
     private let environment: Environment
-    private let uuid = UUID()
 
     init(with localFile: LocalFile, storage: DataStorage, environment: Environment) {
         self.localFile = localFile
@@ -95,14 +96,9 @@ class FileUpload {
     }
 }
 
-extension FileUpload: Equatable {
-    static func == (lhs: FileUpload, rhs: FileUpload) -> Bool {
-        return lhs.uuid == rhs.uuid
-    }
-}
-
 extension FileUpload {
     struct Environment {
         var uploadFileToEngagement: CoreSdkClient.UploadFileToEngagement
+        var uuid: () -> UUID
     }
 }

--- a/GliaWidgets/Lib/Upload/FileUploader.swift
+++ b/GliaWidgets/Lib/Upload/FileUploader.swift
@@ -45,8 +45,8 @@ class FileUploader {
     var count: Int { return uploads.count }
     let state = ObservableValue<State>(with: .idle)
     let limitReached = ObservableValue<Bool>(with: false)
+    var uploads = [FileUpload]()
 
-    private var uploads = [FileUpload]()
     private var storage: FileSystemStorage
     private let maximumUploads: Int
     private let environment: Environment
@@ -67,8 +67,17 @@ class FileUploader {
 
     func addUpload(with url: URL) -> FileUpload? {
         guard !limitReached.value else { return nil }
+
         let localFile = LocalFile(with: url)
-        let upload = FileUpload(with: localFile, storage: storage, environment: .init(uploadFileToEngagement: environment.uploadFileToEngagement))
+        let upload = FileUpload(
+            with: localFile,
+            storage: storage,
+            environment: .init(
+                uploadFileToEngagement: environment.uploadFileToEngagement,
+                uuid: environment.uuid
+            )
+        )
+
         upload.state.addObserver(self) { [weak self] _, _ in
             self?.updateState()
         }
@@ -97,7 +106,7 @@ class FileUploader {
     }
 
     func removeUpload(_ upload: FileUpload) {
-        uploads.removeAll(where: { $0 == upload })
+        uploads.removeAll(where: { $0.uuid == upload.uuid })
         upload.removeLocalFile()
         updateState()
         updateLimitReached()
@@ -143,5 +152,6 @@ extension FileUploader {
         var fileManager: FoundationBased.FileManager
         var data: FoundationBased.Data
         var date: () -> Date
+        var uuid: () -> UUID
     }
 }

--- a/GliaWidgets/View/Chat/Entry/Upload/FileUploadListView.swift
+++ b/GliaWidgets/View/Chat/Entry/Upload/FileUploadListView.swift
@@ -31,7 +31,10 @@ class FileUploadListView: UIView {
     }
 
     func removeUploadView(with upload: FileUpload) {
-        guard let uploadView = uploadViews.first(where: { $0.upload == upload }) else { return }
+        guard
+            let uploadView = uploadViews.first(where: { $0.upload.uuid == upload.uuid })
+        else { return }
+
         stackView.removeArrangedSubview(uploadView)
         uploadView.removeFromSuperview()
         updateHeight()

--- a/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
@@ -119,7 +119,8 @@ class ChatViewModel: EngagementViewModel, ViewModel {
                 uploadFileToEngagement: environment.uploadFileToEngagement,
                 fileManager: environment.fileManager,
                 data: environment.data,
-                date: environment.date
+                date: environment.date,
+                uuid: environment.uuid
             )
         )
         self.downloader = FileDownloader(
@@ -810,5 +811,6 @@ extension ChatViewModel {
         var fileManager: FoundationBased.FileManager
         var data: FoundationBased.Data
         var date: () -> Date
+        var uuid: () -> UUID
     }
 }

--- a/GliaWidgetsTests/Lib/Storage/FileSystemStorage.Environment.Failing.swift
+++ b/GliaWidgetsTests/Lib/Storage/FileSystemStorage.Environment.Failing.swift
@@ -1,4 +1,5 @@
 @testable import GliaWidgets
+
 extension FileSystemStorage.Environment {
     static let failing = Self(
         fileManager: .failing,

--- a/GliaWidgetsTests/Lib/Upload/FileUploader.Environment.Failing.swift
+++ b/GliaWidgetsTests/Lib/Upload/FileUploader.Environment.Failing.swift
@@ -1,4 +1,5 @@
 @testable import GliaWidgets
+
 extension FileUploader.Environment {
     static let failing = Self(
         uploadFileToEngagement: CoreSdkClient.failing.uploadFileToEngagement,

--- a/GliaWidgetsTests/Lib/Upload/FileUploader.Environment.Failing.swift
+++ b/GliaWidgetsTests/Lib/Upload/FileUploader.Environment.Failing.swift
@@ -1,0 +1,16 @@
+@testable import GliaWidgets
+extension FileUploader.Environment {
+    static let failing = Self(
+        uploadFileToEngagement: CoreSdkClient.failing.uploadFileToEngagement,
+        fileManager: .failing,
+        data: FoundationBased.Data.failing,
+        date: {
+            fail("\(Self.self).date")
+            return .mock
+        },
+        uuid: {
+            fail("\(Self.self)uuid")
+            return .mock
+        }
+    )
+}

--- a/GliaWidgetsTests/Lib/Upload/FileUploaderTests.swift
+++ b/GliaWidgetsTests/Lib/Upload/FileUploaderTests.swift
@@ -1,0 +1,38 @@
+@testable import GliaWidgets
+import XCTest
+
+class FileUploaderTests: XCTestCase {
+    func test_matchingUrlFileUploadsAreUnique() {
+        var fileManager = FoundationBased.FileManager.failing
+        let expectedDirUrl = URL.mockFilePath
+        fileManager.urlsForDirectoryInDomainMask = { _, _ in
+            [expectedDirUrl]
+        }
+        fileManager.createDirectoryAtUrlWithIntermediateDirectories = { _, _, _ in }
+
+        var env: FileUploader.Environment = .failing
+        env.uploadFileToEngagement = { _, _, _ in }
+        env.uuid = { UUID() }
+        env.fileManager = fileManager
+
+        let fileUploder = FileUploader(
+            maximumUploads: 25,
+            environment: env
+        )
+
+        let uploadFileUrl: URL = .mock
+
+        guard
+            let fileUpload = fileUploder.addUpload(with: uploadFileUrl)
+        else {
+            XCTFail("Failed to add file uploads")
+            return
+        }
+
+        // add second upload with same url
+        _ = fileUploder.addUpload(with: uploadFileUrl)
+
+        fileUploder.removeUpload(fileUpload)
+        XCTAssertFalse(fileUploder.uploads.contains(where: { $0.uuid == fileUpload.uuid }))
+    }
+}


### PR DESCRIPTION
This PR fixes issue, where removing the file would remove all of the uploads where the local file is the same, which messes up the file count. Add UUID to each individual upload for them to be different.