### PR TITLE
Fix restoration of engagement after app restart

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -260,6 +260,8 @@
 		9AB196EA27C5390100FD60AB /* ChatAttachment.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AB196E927C5390100FD60AB /* ChatAttachment.Mock.swift */; };
 		9ACC25D227B4727500BC5335 /* CoreSDKClient.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACC25D127B4727500BC5335 /* CoreSDKClient.Failing.swift */; };
 		9ACC25D427B474E800BC5335 /* Glia.Environment.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACC25D327B474E800BC5335 /* Glia.Environment.Failing.swift */; };
+		9AE05CB32805C9D900871321 /* ChatViewModel.Environment.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE05CB22805C9D900871321 /* ChatViewModel.Environment.Failing.swift */; };
+		9AE05CB62805D2CB00871321 /* Interactor.Environment.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE05CB52805D2CB00871321 /* Interactor.Environment.Failing.swift */; };
 		9AE9E4B127E0E45200BFE239 /* CallViewController.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE9E4B027E0E45200BFE239 /* CallViewController.Mock.swift */; };
 		9AE9E4B327E0E60F00BFE239 /* CallViewModel.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE9E4B227E0E60F00BFE239 /* CallViewModel.Mock.swift */; };
 		9AE9E4B527E0EE2E00BFE239 /* CallViewControllerVoiceOverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE9E4B427E0EE2E00BFE239 /* CallViewControllerVoiceOverTests.swift */; };
@@ -599,6 +601,8 @@
 		9AB196E927C5390100FD60AB /* ChatAttachment.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachment.Mock.swift; sourceTree = "<group>"; };
 		9ACC25D127B4727500BC5335 /* CoreSDKClient.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSDKClient.Failing.swift; sourceTree = "<group>"; };
 		9ACC25D327B474E800BC5335 /* Glia.Environment.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Glia.Environment.Failing.swift; sourceTree = "<group>"; };
+		9AE05CB22805C9D900871321 /* ChatViewModel.Environment.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.Environment.Failing.swift; sourceTree = "<group>"; };
+		9AE05CB52805D2CB00871321 /* Interactor.Environment.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Interactor.Environment.Failing.swift; sourceTree = "<group>"; };
 		9AE9E4B027E0E45200BFE239 /* CallViewController.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallViewController.Mock.swift; sourceTree = "<group>"; };
 		9AE9E4B227E0E60F00BFE239 /* CallViewModel.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallViewModel.Mock.swift; sourceTree = "<group>"; };
 		9AE9E4B427E0EE2E00BFE239 /* CallViewControllerVoiceOverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallViewControllerVoiceOverTests.swift; sourceTree = "<group>"; };
@@ -898,6 +902,7 @@
 		1A205D6525655CB2003AA3CD /* GliaWidgetsTests */ = {
 			isa = PBXGroup;
 			children = (
+				9AE05CB42805D29F00871321 /* Interactor */,
 				9A8130C727D90DD300220BBD /* ViewModel */,
 				7512A57B27BFA36900319DF1 /* Mocks */,
 				7512A57827BF9FB800319DF1 /* Sources */,
@@ -1762,8 +1767,25 @@
 		9A8130C727D90DD300220BBD /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
+				9AE05CB12805C87C00871321 /* Chat */,
 			);
 			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		9AE05CB12805C87C00871321 /* Chat */ = {
+			isa = PBXGroup;
+			children = (
+				9AE05CB22805C9D900871321 /* ChatViewModel.Environment.Failing.swift */,
+			);
+			path = Chat;
+			sourceTree = "<group>";
+		};
+		9AE05CB42805D29F00871321 /* Interactor */ = {
+			isa = PBXGroup;
+			children = (
+				9AE05CB52805D2CB00871321 /* Interactor.Environment.Failing.swift */,
+			);
+			path = Interactor;
 			sourceTree = "<group>";
 		};
 		C42463722673ABCD0082C135 /* Screensharing */ = {
@@ -2496,6 +2518,8 @@
 				7512A57F27BFA39700319DF1 /* GliaWidgets.Mock.swift in Sources */,
 				9ACC25D227B4727500BC5335 /* CoreSDKClient.Failing.swift in Sources */,
 				9A1992E727D66C7400161AAE /* UIKitBased.Failing.swift in Sources */,
+				9AE05CB62805D2CB00871321 /* Interactor.Environment.Failing.swift in Sources */,
+				9AE05CB32805C9D900871321 /* ChatViewModel.Environment.Failing.swift in Sources */,
 				9A3E1D9D27BA7741005634EB /* FoundationBased.Failing.swift in Sources */,
 				9A3E1D8427B67F1B005634EB /* Helper.swift in Sources */,
 				9A8130C627D90B3800220BBD /* FileSystemStorage.Failing.swift in Sources */,

--- a/GliaWidgets/Interactor/Interactor.swift
+++ b/GliaWidgets/Interactor/Interactor.swift
@@ -98,7 +98,7 @@ class Interactor {
             }
     }
 
-    private func withConfiguration(_ action: @escaping () -> Void) {
+    func withConfiguration(_ action: @escaping () -> Void) {
 
         environment.coreSdk.configureWithInteractor(self)
         environment.coreSdk.configureWithConfiguration(sdkConfiguration) {

--- a/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
@@ -140,20 +140,26 @@ class ChatViewModel: EngagementViewModel, ViewModel {
         super.start()
 
         loadHistory()
+        // At this point we need to be sure that CoreSDK is configured.
+        // This will restore engagement if one was not completed earlier.
+        // Otherwise in case of ongoing engagement, visitor will not receive
+        // messages from operator until message is sent from visitor.
+        interactor.withConfiguration { [weak self] in
+            guard let self = self else { return }
+            if case .startEngagement = self.startAction, self.environment.chatStorage.isEmpty() {
+                let item = ChatItem(kind: .queueOperator)
 
-        if case .startEngagement = startAction, environment.chatStorage.isEmpty() {
-            let item = ChatItem(kind: .queueOperator)
+                self.appendItem(
+                    item,
+                    to: self.queueOperatorSection,
+                    animated: false
+                )
 
-            appendItem(
-                item,
-                to: queueOperatorSection,
-                animated: false
-            )
+                self.enqueue(mediaType: .text)
+            }
 
-            enqueue(mediaType: .text)
+            self.update(for: self.interactor.state)
         }
-
-        update(for: interactor.state)
     }
 
     override func update(for state: InteractorState) {

--- a/GliaWidgets/ViewModel/Chat/Data/ChatMessage.Mock.swift
+++ b/GliaWidgets/ViewModel/Chat/Data/ChatMessage.Mock.swift
@@ -1,13 +1,13 @@
 #if DEBUG
 extension ChatMessage {
     static func mock(
-        id: String,
-        queueID: String?,
-        `operator`: ChatOperator?,
-        sender: ChatMessageSender,
-        content: String,
-        attachment: ChatAttachment?,
-        downloads: [FileDownload]
+        id: String = "",
+        queueID: String? = nil,
+        `operator`: ChatOperator? = nil,
+        sender: ChatMessageSender = .visitor,
+        content: String = "",
+        attachment: ChatAttachment? = nil,
+        downloads: [FileDownload] = []
     ) -> ChatMessage {
         .init(
             id: id,

--- a/GliaWidgetsTests/Interactor/Interactor.Environment.Failing.swift
+++ b/GliaWidgetsTests/Interactor/Interactor.Environment.Failing.swift
@@ -1,0 +1,4 @@
+@testable import GliaWidgets
+extension Interactor.Environment {
+    static let failing = Self(coreSdk: .failing)
+}

--- a/GliaWidgetsTests/Sources/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModelTests.swift
@@ -1,6 +1,6 @@
-import XCTest
-
 @testable import GliaWidgets
+import SalemoveSDK
+import XCTest
 
 class ChatViewModelTests: XCTestCase {
 
@@ -52,9 +52,30 @@ class ChatViewModelTests: XCTestCase {
 
         XCTAssertEqual(calls, [.sendSelectedOptionValue])
     }
-}
 
-import SalemoveSDK
+    func test__startCallsSDKConfigureWithInteractorAndСonfigureWithConfiguration() throws {
+        var interactorEnv = Interactor.Environment.init(coreSdk: .failing)
+        enum Calls {
+            case configureWithConfiguration, configureWithInteractor
+        }
+        var calls: [Calls] = []
+        interactorEnv.coreSdk.configureWithConfiguration = { _, _ in
+            calls.append(.configureWithConfiguration)
+        }
+        interactorEnv.coreSdk.configureWithInteractor = { _ in
+            calls.append(.configureWithInteractor)
+        }
+        let interactor = Interactor.mock(environment: interactorEnv)
+        var viewModelEnv = ChatViewModel.Environment.failing
+        viewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
+        viewModelEnv.fileManager.createDirectoryAtUrlWithIntermediateDirectories = { _, _, _ in }
+        viewModelEnv.chatStorage.messages = { _ in [] }
+        viewModelEnv.fromHistory = { true }
+        let viewModel = ChatViewModel.mock(interactor: interactor, environment: viewModelEnv)
+        viewModel.start()
+        XCTAssertEqual(calls, [.configureWithInteractor, .configureWithConfiguration])
+    }
+}
 
 extension ChatChoiceCardOption {
     static let mock: ChatChoiceCardOption = {

--- a/GliaWidgetsTests/ViewModel/Chat/ChatViewModel.Environment.Failing.swift
+++ b/GliaWidgetsTests/ViewModel/Chat/ChatViewModel.Environment.Failing.swift
@@ -1,0 +1,33 @@
+@testable import GliaWidgets
+
+extension ChatViewModel.Environment {
+    static let failing = Self(
+        chatStorage: .failing,
+        fetchFile: { _, _, _ in
+            fail("\(Self.self).fetchFile")
+        },
+        sendSelectedOptionValue: { _, _ in
+            fail("\(Self.self).sendSelectedOptionValue")
+        },
+        uploadFileToEngagement: { _, _, _ in
+            fail("\(Self.self).uploadFileToEngagement")
+        },
+        fileManager: .failing,
+        data: .failing,
+        date: {
+            fail("\(Self.self).date")
+            return .mock
+        },
+        gcd: .failing,
+        localFileThumbnailQueue: .failing,
+        uiImage: .failing,
+        createFileDownload: { _, _, _ in
+            fail("\(Self.self).createFileDownload")
+            return .failing
+        },
+        fromHistory: {
+            fail("\(Self.self).fromHistory")
+            return true
+        }
+    )
+}


### PR DESCRIPTION
Provide fix by calling 'Interactor.withConfiguration' which will restore ongoing engagement if there is one.

MOB-1220