### PR TITLE
Implement engagement transfer in Interactor

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -289,6 +289,7 @@
 		C4F176CD261D1543009D9F07 /* ChatFileDownloadContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4F176CB261D1543009D9F07 /* ChatFileDownloadContentView.swift */; };
 		C4F176CE261D1543009D9F07 /* ChatFileDownloadContentStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4F176CC261D1543009D9F07 /* ChatFileDownloadContentStyle.swift */; };
 		EB750F53273BA9BB00BE5FBD /* GliaError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB750F52273BA9BB00BE5FBD /* GliaError.swift */; };
+		EB9ADB51280EBD4E00FAE8A4 /* InteractorStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9ADB50280EBD4E00FAE8A4 /* InteractorStateTests.swift */; };
 		FD01A52B483418AB02DCFBFC /* Pods_GliaWidgets.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85639A838514258D976E1B2A /* Pods_GliaWidgets.framework */; };
 /* End PBXBuildFile section */
 
@@ -636,6 +637,7 @@
 		C4F176CC261D1543009D9F07 /* ChatFileDownloadContentStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatFileDownloadContentStyle.swift; sourceTree = "<group>"; };
 		E8AC4FC1B06236D5EE552DEA /* Pods-SnapshotTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SnapshotTests.debug.xcconfig"; path = "Target Support Files/Pods-SnapshotTests/Pods-SnapshotTests.debug.xcconfig"; sourceTree = "<group>"; };
 		EB750F52273BA9BB00BE5FBD /* GliaError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GliaError.swift; sourceTree = "<group>"; };
+		EB9ADB50280EBD4E00FAE8A4 /* InteractorStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractorStateTests.swift; sourceTree = "<group>"; };
 		F08274A374F775EE39BFBDB1 /* Pods-GliaWidgetsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GliaWidgetsTests.debug.xcconfig"; path = "Target Support Files/Pods-GliaWidgetsTests/Pods-GliaWidgetsTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1695,6 +1697,7 @@
 				7512A57627BE8A6700319DF1 /* InteractorTests.swift */,
 				7512A57927BF9FCD00319DF1 /* ChatViewModelTests.swift */,
 				7512A5A627C3926500319DF1 /* GliaTests.swift */,
+				EB9ADB50280EBD4E00FAE8A4 /* InteractorStateTests.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -2517,6 +2520,7 @@
 				7512A57D27BFA37D00319DF1 /* CoreSdkClient.Salemove.swift in Sources */,
 				7512A57F27BFA39700319DF1 /* GliaWidgets.Mock.swift in Sources */,
 				9ACC25D227B4727500BC5335 /* CoreSDKClient.Failing.swift in Sources */,
+				EB9ADB51280EBD4E00FAE8A4 /* InteractorStateTests.swift in Sources */,
 				9A1992E727D66C7400161AAE /* UIKitBased.Failing.swift in Sources */,
 				9AE05CB62805D2CB00871321 /* Interactor.Environment.Failing.swift in Sources */,
 				9AE05CB32805C9D900871321 /* ChatViewModel.Environment.Failing.swift in Sources */,

--- a/GliaWidgets/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -1,5 +1,6 @@
 #if DEBUG
 import Foundation
+import SalemoveSDK
 
 extension CoreSdkClient {
     static let mock = Self(
@@ -22,6 +23,22 @@ extension CoreSdkClient {
         fetchFile: { _, _, _ in },
         getCurrentEngagement: { return nil }
     )
+}
+
+extension CoreSdkClient.Operator {
+    static func mock(
+        id: String = "mockId",
+        name: String = "Mock Operator",
+        picture: SalemoveSDK.OperatorPicture? = nil,
+        availableMedia: [CoreSdkClient.MediaType]? = [.text, .audio, .video]
+    ) -> CoreSdkClient.Operator {
+        CoreSdkClient.Operator(
+            id: id,
+            name: name,
+            picture: picture,
+            availableMedia: availableMedia
+        )
+    }
 }
 
 extension CoreSdkClient.PushNotifications {

--- a/GliaWidgets/GCD.Interface.swift
+++ b/GliaWidgets/GCD.Interface.swift
@@ -1,10 +1,15 @@
 struct GCD {
-    var mainQueue: DispatchQueue
+    var mainQueue: MainQueue
     var globalQueue: DispatchQueue
 }
 
 extension GCD {
     struct DispatchQueue {
         var async: (@escaping () -> Void) -> Void
+    }
+
+    struct MainQueue {
+        var async: (@escaping () -> Void) -> Void
+        var asyncIfNeeded: (@escaping () -> Void) -> Void
     }
 }

--- a/GliaWidgets/GCD.Live.swift
+++ b/GliaWidgets/GCD.Live.swift
@@ -5,8 +5,17 @@ extension GCD {
         mainQueue: .init(
             async: { callback in
                 Dispatch.DispatchQueue.main.async {
-                    callback()
+                  callback()
                 }
+            },
+            asyncIfNeeded: { callback in
+                if Thread.isMainThread {
+                    callback()
+                } else {
+                    Dispatch.DispatchQueue.main.async {
+                      callback()
+                    }
+                 }
             }
         ),
         globalQueue: .init(

--- a/GliaWidgets/GCD.Mock.swift
+++ b/GliaWidgets/GCD.Mock.swift
@@ -12,3 +12,14 @@ extension GCD.DispatchQueue {
         }
     )
 }
+
+extension GCD.MainQueue {
+    static let mock = Self(
+        async: { callback in
+            callback()
+        },
+        asyncIfNeeded: { callback in
+            callback()
+        }
+    )
+}

--- a/GliaWidgets/Glia.swift
+++ b/GliaWidgets/Glia.swift
@@ -72,7 +72,10 @@ public class Glia {
             with: sdkConfiguration,
             queueID: queueId,
             visitorContext: visitorContext,
-            environment: .init(coreSdk: environment.coreSdk)
+            environment: .init(
+                coreSdk: environment.coreSdk,
+                gcd: environment.gcd
+            )
         )
     }
 

--- a/GliaWidgets/Interactor/Interactor.Environment.Interface.swift
+++ b/GliaWidgets/Interactor/Interactor.Environment.Interface.swift
@@ -1,5 +1,6 @@
 extension Interactor {
     struct Environment {
         var coreSdk: CoreSdkClient
+        var gcd: GCD
     }
 }

--- a/GliaWidgets/Interactor/Interactor.Environment.Mock.swift
+++ b/GliaWidgets/Interactor/Interactor.Environment.Mock.swift
@@ -1,5 +1,8 @@
 #if DEBUG
 extension Interactor.Environment {
-    static let mock = Self(coreSdk: .mock)
+    static let mock = Self(
+        coreSdk: .mock,
+        gcd: .mock
+    )
 }
 #endif

--- a/GliaWidgets/Interactor/Interactor.swift
+++ b/GliaWidgets/Interactor/Interactor.swift
@@ -28,6 +28,7 @@ enum InteractorEvent {
     case screenShareError(error: CoreSdkClient.SalemoveError)
     case screenSharingStateChanged(to: CoreSdkClient.VisitorScreenSharingState)
     case error(CoreSdkClient.SalemoveError)
+    case engagementTransferred(CoreSdkClient.Operator?)
 }
 
 class Interactor {
@@ -92,7 +93,8 @@ class Interactor {
             .filter { $0.0 != nil }
             .forEach {
                 let handler = $0.1
-                DispatchQueue.main.async {
+
+                environment.gcd.mainQueue.asyncIfNeeded {
                     handler(event)
                 }
             }
@@ -274,7 +276,12 @@ extension Interactor: CoreSdkClient.Interactable {
     }
 
     var onEngagementTransfer: CoreSdkClient.EngagementTransferBlock {
-        return { _ in }
+        return { [weak self] operators in
+            let engagedOperator = operators?.first
+
+            self?.state = .engaged(engagedOperator)
+            self?.notify(.engagementTransferred(engagedOperator))
+        }
     }
 
     var onOperatorTypingStatusUpdate: CoreSdkClient.OperatorTypingStatusUpdate {
@@ -352,10 +359,13 @@ extension InteractorState: Equatable {
         switch (lhs, rhs) {
         case (.none, .none),
              (.enqueueing, .enqueueing),
-             (.engaged, .engaged),
              (.enqueued, .enqueued),
              (.ended, .ended):
             return true
+
+        case (.engaged(let lhsOperator), .engaged(let rhsOperator)):
+            return lhsOperator == rhsOperator
+
         default:
             return false
         }

--- a/GliaWidgets/ViewController/Chat/ChatViewController.Mock.swift
+++ b/GliaWidgets/ViewController/Chat/ChatViewController.Mock.swift
@@ -44,7 +44,7 @@ extension ChatViewController {
             var localFileEnv = LocalFile.Environment.mock
             localFileEnv.localFileThumbnailQueue.addOperation = { $0() }
             localFileEnv.gcd.globalQueue = .init(async: { $0() })
-            localFileEnv.gcd.mainQueue = .init(async: { $0() })
+            localFileEnv.gcd.mainQueue = .init(async: { $0() }, asyncIfNeeded: { $0() })
             localFileEnv.uiImage.imageWithContentsOfFileAtPath = { _ in .mock }
             fileDownload.state.value = .downloaded(
                 .mock(

--- a/GliaWidgetsTests/GCD.Failing.swift
+++ b/GliaWidgetsTests/GCD.Failing.swift
@@ -2,7 +2,10 @@
 
 extension GCD {
     static let failing = Self(
-        mainQueue: .init(async: { _ in fail("\(Self.self).mainQueue.async") }),
+        mainQueue: .init(
+            async: { _ in fail("\(Self.self).mainQueue.async") },
+            asyncIfNeeded: { _ in fail("\(Self.self).mainQueue.asyncIfNeeded") }
+        ),
         globalQueue: .init(async: { _ in fail("\(Self.self).globalQueue.async") })
     )
 }

--- a/GliaWidgetsTests/Interactor/Interactor.Environment.Failing.swift
+++ b/GliaWidgetsTests/Interactor/Interactor.Environment.Failing.swift
@@ -1,4 +1,7 @@
 @testable import GliaWidgets
 extension Interactor.Environment {
-    static let failing = Self(coreSdk: .failing)
+    static let failing = Self(
+        coreSdk: .failing,
+        gcd: .failing
+    )
 }

--- a/GliaWidgetsTests/Mocks/GliaWidgets.Mock.swift
+++ b/GliaWidgetsTests/Mocks/GliaWidgets.Mock.swift
@@ -9,7 +9,10 @@ extension Interactor {
             with: try .mock(),
             queueID: "4CC83BDF-1C04-4B05-87B3-4D558B8F6999",
             visitorContext: .mock(),
-            environment: .init(coreSdk: .failing)
+            environment: .init(
+                coreSdk: .failing,
+                gcd: .mock
+            )
         )
     }
 }

--- a/GliaWidgetsTests/Sources/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModelTests.swift
@@ -54,7 +54,10 @@ class ChatViewModelTests: XCTestCase {
     }
 
     func test__startCallsSDKConfigureWithInteractorAndСonfigureWithConfiguration() throws {
-        var interactorEnv = Interactor.Environment.init(coreSdk: .failing)
+        var interactorEnv = Interactor.Environment.init(
+            coreSdk: .failing,
+            gcd: .failing
+        )
         enum Calls {
             case configureWithConfiguration, configureWithInteractor
         }

--- a/GliaWidgetsTests/Sources/InteractorStateTests.swift
+++ b/GliaWidgetsTests/Sources/InteractorStateTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+
+@testable import GliaWidgets
+
+class InteractorStateTests: XCTestCase {
+    func test_engagedWithSameOperatorIsEqualState() throws {
+        let engagedOperator: CoreSdkClient.Operator = .mock()
+        let state1: InteractorState = .engaged(engagedOperator)
+        let state2: InteractorState = .engaged(engagedOperator)
+
+        XCTAssertEqual(state1, state2)
+    }
+    
+    func test_engagedWithDifferentOperatorIsNotEqualState() throws {
+        let state1: InteractorState = .engaged(.mock())
+        let state2: InteractorState = .engaged(.mock())
+
+        XCTAssertNotEqual(state1, state2)
+    }
+}

--- a/GliaWidgetsTests/Sources/InteractorTests.swift
+++ b/GliaWidgetsTests/Sources/InteractorTests.swift
@@ -38,7 +38,7 @@ class InteractorTests: XCTestCase {
             with: mock.config,
             queueID: mock.queueId,
             visitorContext: mock.visitorContext,
-            environment: .init(coreSdk: coreSdk)
+            environment: .init(coreSdk: coreSdk, gcd: .failing)
         )
 
         interactor.enqueueForEngagement(mediaType: .text) {} failure: {
@@ -49,6 +49,43 @@ class InteractorTests: XCTestCase {
             .configureWithInteractor,
             .configureWithConfiguration,
             .queueForEngagement
+        ])
+    }
+    
+    func test_onEngagementTransfer() throws {
+        enum Call: Equatable {
+            case stateChanged(InteractorState)
+            case engagementTransferred(CoreSdkClient.Operator?)
+        }
+    
+        var calls = [Call]()
+        let mockOperator: CoreSdkClient.Operator = .mock()
+
+        interactor = .init(
+            with: mock.config,
+            queueID: mock.queueId,
+            visitorContext: mock.visitorContext,
+            environment: .init(coreSdk: .failing, gcd: .mock)
+        )
+
+        interactor.addObserver(self, handler: { event in
+            switch event {
+            case .stateChanged(let state):
+                calls.append(.stateChanged(state))
+                    
+            case .engagementTransferred(let engagedOperator):
+                calls.append(.engagementTransferred(engagedOperator))
+                
+            default:
+                break
+            }
+        })
+        
+        interactor.onEngagementTransfer([mockOperator])
+        
+        XCTAssertEqual(calls, [
+            .stateChanged(.engaged(mockOperator)),
+            .engagementTransferred(mockOperator)
         ])
     }
 }


### PR DESCRIPTION
This PR implements engagement transfer callback in Interactor.
Engagement transfer callback changes the state to being engaged with a new first available operator and notifies all listening parties of the change.

MUIC-244