### PR TITLE
Visitor transfer in call views

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -312,6 +312,7 @@
 		EB2CBB1527D8DB95004F178E /* OnHoldOverlayVisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB2CBB1427D8DB95004F178E /* OnHoldOverlayVisualEffectView.swift */; };
 		EB750F53273BA9BB00BE5FBD /* GliaError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB750F52273BA9BB00BE5FBD /* GliaError.swift */; };
 		EB9ADB51280EBD4E00FAE8A4 /* InteractorStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9ADB50280EBD4E00FAE8A4 /* InteractorStateTests.swift */; };
+		EB9ADB552828E66B00FAE8A4 /* CallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9ADB542828E66B00FAE8A4 /* CallTests.swift */; };
 		FD01A52B483418AB02DCFBFC /* Pods_GliaWidgets.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85639A838514258D976E1B2A /* Pods_GliaWidgets.framework */; };
 /* End PBXBuildFile section */
 
@@ -682,6 +683,7 @@
 		EB2CBB1427D8DB95004F178E /* OnHoldOverlayVisualEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnHoldOverlayVisualEffectView.swift; sourceTree = "<group>"; };
 		EB750F52273BA9BB00BE5FBD /* GliaError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GliaError.swift; sourceTree = "<group>"; };
 		EB9ADB50280EBD4E00FAE8A4 /* InteractorStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractorStateTests.swift; sourceTree = "<group>"; };
+		EB9ADB542828E66B00FAE8A4 /* CallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallTests.swift; sourceTree = "<group>"; };
 		F08274A374F775EE39BFBDB1 /* Pods-GliaWidgetsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GliaWidgetsTests.debug.xcconfig"; path = "Target Support Files/Pods-GliaWidgetsTests/Pods-GliaWidgetsTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1746,6 +1748,7 @@
 				EB9ADB50280EBD4E00FAE8A4 /* InteractorStateTests.swift */,
 				EB27E71C27FEBB620090B895 /* CallViewModelTests.swift */,
 				EB03B00D27FFF6DD0058F6B1 /* CallViewTests.swift */,
+				EB9ADB542828E66B00FAE8A4 /* CallTests.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -2643,6 +2646,7 @@
 				7512A5A727C3926500319DF1 /* GliaTests.swift in Sources */,
 				9A3E1DA227BA7D00005634EB /* FileSystemStorage.Environment.Failing.swift in Sources */,
 				9A1992E127D6313500161AAE /* ImageView.Cache.Failing.swift in Sources */,
+				EB9ADB552828E66B00FAE8A4 /* CallTests.swift in Sources */,
 				9A3E1DA027BA7B9F005634EB /* FileSystemStorageTests.swift in Sources */,
 				7512A57D27BFA37D00319DF1 /* CoreSdkClient.Salemove.swift in Sources */,
 				EB27E71D27FEBB620090B895 /* CallViewModelTests.swift in Sources */,

--- a/GliaWidgets/Interactor/Interactor.swift
+++ b/GliaWidgets/Interactor/Interactor.swift
@@ -92,7 +92,7 @@ class Interactor {
         observers.removeAll(where: { $0().0 === observer })
     }
 
-    private func notify(_ event: InteractorEvent) {
+    func notify(_ event: InteractorEvent) {
         observers
             .compactMap { $0() }
             .filter { $0.0 != nil }

--- a/GliaWidgets/ViewModel/Call/CallViewModel.swift
+++ b/GliaWidgets/ViewModel/Call/CallViewModel.swift
@@ -254,6 +254,8 @@ class CallViewModel: EngagementViewModel, ViewModel {
             handleVideoStreamError(error)
         case .upgradeOffer(let offer, answer: let answer):
             offerMediaUpgrade(offer, answer: answer)
+        case .engagementTransferred:
+            call.transfer()
         default:
             break
         }
@@ -351,7 +353,7 @@ extension CallViewModel {
                 guard self.call.state.value == .started else { return }
                 self.call.duration.value = duration
             }
-        case .upgrading:
+        case .connecting:
             action?(.switchToUpgradeMode)
             showConnecting()
         case .ended:

--- a/GliaWidgetsTests/Sources/CallTests.swift
+++ b/GliaWidgetsTests/Sources/CallTests.swift
@@ -1,0 +1,63 @@
+@testable import GliaWidgets
+import XCTest
+
+class CallTests: XCTestCase {
+    func test_transfer() throws {
+        let call: Call = .mock(kind: .video(direction: .twoWay), environment: .mock)
+        let remoteAudioStream = CoreSdkClient.MockAudioStreamable.mock(
+            muteFunc: {},
+            unmuteFunc: {},
+            getIsMutedFunc: { false },
+            setIsMutedFunc: { _ in },
+            getIsRemoteFunc: { true },
+            setIsRemoteFunc: { _ in }
+        )
+        let remoteVideoStream = CoreSdkClient.MockVideoStreamable.mock(
+            getStreamViewFunc: { .init() },
+            playVideoFunc: {},
+            pauseFunc: {},
+            resumeFunc: {},
+            stopFunc: {},
+            getIsPausedFunc: { false },
+            setIsPausedFunc: { _ in },
+            getIsRemoteFunc: { true },
+            setIsRemoteFunc: { _ in }
+        )
+        let localAudioStream = CoreSdkClient.MockAudioStreamable.mock(
+            muteFunc: {},
+            unmuteFunc: {},
+            getIsMutedFunc: { false },
+            setIsMutedFunc: { _ in },
+            getIsRemoteFunc: { false },
+            setIsRemoteFunc: { _ in }
+        )
+        let localVideoStream = CoreSdkClient.MockVideoStreamable.mock(
+            getStreamViewFunc: { .init() },
+            playVideoFunc: {},
+            pauseFunc: {},
+            resumeFunc: {},
+            stopFunc: {},
+            getIsPausedFunc: { false },
+            setIsPausedFunc: { _ in },
+            getIsRemoteFunc: { false },
+            setIsRemoteFunc: { _ in }
+        )
+
+        XCTAssertEqual(call.state.value, .none)
+
+        call.updateAudioStream(with: localAudioStream)
+        call.updateAudioStream(with: remoteAudioStream)
+        call.updateVideoStream(with: localVideoStream)
+        call.updateVideoStream(with: remoteVideoStream)
+
+        XCTAssertEqual(call.state.value, .started)
+        XCTAssertFalse(call.audio.stream.value.isNone)
+        XCTAssertFalse(call.video.stream.value.isNone)
+
+        call.transfer()
+
+        XCTAssertEqual(call.state.value, .connecting)
+        XCTAssertTrue(call.audio.stream.value.isNone)
+        XCTAssertTrue(call.video.stream.value.isNone)
+    }
+}

--- a/GliaWidgetsTests/Sources/CallViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/CallViewModelTests.swift
@@ -183,11 +183,7 @@ class CallViewModelTests: XCTestCase {
     }
     
     func test_engagementTransferredReleasesRemoteAndLocalVideoAndShowsConnectingState() throws {
-        enum Calls {
-            case setLocalVideoNil
-            case setRemoteVideoNil
-            case showConnecting
-        }
+        enum Calls { case showConnecting }
         var calls: [Calls] = []
 
         var interactorEnv: Interactor.Environment = .failing
@@ -212,16 +208,6 @@ class CallViewModelTests: XCTestCase {
 
         viewModel.action = { action in
             switch action {
-            case .setLocalVideo(let video):
-                if video == nil {
-                    calls.append(.setLocalVideoNil)
-                }
-                
-            case .setRemoteVideo(let video):
-                if video == nil {
-                    calls.append(.setRemoteVideoNil)
-                }
-                
             case .connecting:
                 calls.append(.showConnecting)
                 
@@ -232,6 +218,84 @@ class CallViewModelTests: XCTestCase {
 
         interactor.notify(.engagementTransferred(mockOperator))
 
-        XCTAssertEqual([.setRemoteVideoNil, .setLocalVideoNil, .showConnecting], calls)
+        XCTAssertEqual([.showConnecting], calls)
+    }
+    
+    func test_engagementTransferReleasesStreams() throws {
+        var interactorEnv: Interactor.Environment = .failing
+        interactorEnv.gcd.mainQueue.asyncIfNeeded = { $0() }
+        let interactor: Interactor = .mock(environment: interactorEnv)
+        let mockOperator: CoreSdkClient.Operator = .mock()
+        let remoteAudioStream = CoreSdkClient.MockAudioStreamable.mock(
+            muteFunc: {},
+            unmuteFunc: {},
+            getIsMutedFunc: { false },
+            setIsMutedFunc: { _ in },
+            getIsRemoteFunc: { true },
+            setIsRemoteFunc: { _ in }
+        )
+        let remoteVideoStream = CoreSdkClient.MockVideoStreamable.mock(
+            getStreamViewFunc: { .init() },
+            playVideoFunc: {},
+            pauseFunc: {},
+            resumeFunc: {},
+            stopFunc: {},
+            getIsPausedFunc: { false },
+            setIsPausedFunc: { _ in },
+            getIsRemoteFunc: { true },
+            setIsRemoteFunc: { _ in }
+        )
+        let localAudioStream = CoreSdkClient.MockAudioStreamable.mock(
+            muteFunc: {},
+            unmuteFunc: {},
+            getIsMutedFunc: { false },
+            setIsMutedFunc: { _ in },
+            getIsRemoteFunc: { false },
+            setIsRemoteFunc: { _ in }
+        )
+        let localVideoStream = CoreSdkClient.MockVideoStreamable.mock(
+            getStreamViewFunc: { .init() },
+            playVideoFunc: {},
+            pauseFunc: {},
+            resumeFunc: {},
+            stopFunc: {},
+            getIsPausedFunc: { false },
+            setIsPausedFunc: { _ in },
+            getIsRemoteFunc: { false },
+            setIsRemoteFunc: { _ in }
+        )
+
+        call = .init(
+            .video(direction: .twoWay),
+            environment: .mock
+        )
+
+        viewModel = .init(
+            interactor: interactor,
+            alertConfiguration: .mock(),
+            screenShareHandler: ScreenShareHandler(),
+            environment: .mock,
+            call: call,
+            unreadMessages: .init(with: 0),
+            startWith: .engagement(mediaType: .video)
+        )
+
+        call.updateVideoStream(with: localVideoStream)
+        call.updateVideoStream(with: remoteVideoStream)
+        call.updateAudioStream(with: localAudioStream)
+        call.updateAudioStream(with: remoteAudioStream)
+
+        XCTAssertEqual(call.state.value, .started)
+        XCTAssertFalse(call.audio.stream.value.localStream == nil)
+        XCTAssertFalse(call.audio.stream.value.remoteStream == nil)
+        XCTAssertFalse(call.video.stream.value.localStream == nil)
+        XCTAssertFalse(call.video.stream.value.remoteStream == nil)
+        
+        interactor.notify(.engagementTransferred(mockOperator))
+
+        XCTAssertNil(call.video.stream.value.localStream)
+        XCTAssertNil(call.video.stream.value.remoteStream)
+        XCTAssertNil(call.audio.stream.value.localStream)
+        XCTAssertNil(call.audio.stream.value.remoteStream)
     }
 }

--- a/GliaWidgetsTests/Sources/CallViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/CallViewModelTests.swift
@@ -211,6 +211,12 @@ class CallViewModelTests: XCTestCase {
             case .connecting:
                 calls.append(.showConnecting)
                 
+            case .setRemoteVideo(let video):
+                XCTAssertNil(video)
+                
+            case .setLocalVideo(let video):
+                XCTAssertNil(video)
+
             default:
                 break
             }


### PR DESCRIPTION
Implement operator-to-operator engagement transfer for call views. The main idea is to reset Call to state where we wait for video/audio streams to come.