### PR TITLE
Chat/Audio/Video - Tapping 15 digits long phone number crashes a call

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -312,6 +312,7 @@
 		EB2CBB1227D89F7D004F178E /* OnHoldOverlayStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB2CBB1127D89F7D004F178E /* OnHoldOverlayStyle.swift */; };
 		EB2CBB1527D8DB95004F178E /* OnHoldOverlayVisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB2CBB1427D8DB95004F178E /* OnHoldOverlayVisualEffectView.swift */; };
 		EB750F53273BA9BB00BE5FBD /* GliaError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB750F52273BA9BB00BE5FBD /* GliaError.swift */; };
+		EB95491C2850757400F567F0 /* ChatTextContentViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB95491B2850757400F567F0 /* ChatTextContentViewTests.swift */; };
 		FD01A52B483418AB02DCFBFC /* Pods_GliaWidgets.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85639A838514258D976E1B2A /* Pods_GliaWidgets.framework */; };
 /* End PBXBuildFile section */
 
@@ -682,6 +683,7 @@
 		EB2CBB1127D89F7D004F178E /* OnHoldOverlayStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnHoldOverlayStyle.swift; sourceTree = "<group>"; };
 		EB2CBB1427D8DB95004F178E /* OnHoldOverlayVisualEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnHoldOverlayVisualEffectView.swift; sourceTree = "<group>"; };
 		EB750F52273BA9BB00BE5FBD /* GliaError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GliaError.swift; sourceTree = "<group>"; };
+		EB95491B2850757400F567F0 /* ChatTextContentViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTextContentViewTests.swift; sourceTree = "<group>"; };
 		F08274A374F775EE39BFBDB1 /* Pods-GliaWidgetsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GliaWidgetsTests.debug.xcconfig"; path = "Target Support Files/Pods-GliaWidgetsTests/Pods-GliaWidgetsTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1745,6 +1747,7 @@
 				7512A5A627C3926500319DF1 /* GliaTests.swift */,
 				EB27E71C27FEBB620090B895 /* CallViewModelTests.swift */,
 				EB03B00D27FFF6DD0058F6B1 /* CallViewTests.swift */,
+				EB95491B2850757400F567F0 /* ChatTextContentViewTests.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -2640,6 +2643,7 @@
 				9A8130C227D9095200220BBD /* FileDownload.Failing.swift in Sources */,
 				9A19927027D3BCAE00161AAE /* GCD.Failing.swift in Sources */,
 				9A8130C427D9099F00220BBD /* FileDownload.Environment.Failing.swift in Sources */,
+				EB95491C2850757400F567F0 /* ChatTextContentViewTests.swift in Sources */,
 				7512A5A727C3926500319DF1 /* GliaTests.swift in Sources */,
 				9A3E1DA227BA7D00005634EB /* FileSystemStorage.Environment.Failing.swift in Sources */,
 				9A1992E127D6313500161AAE /* ImageView.Cache.Failing.swift in Sources */,

--- a/GliaWidgets/Factory/ViewFactory.Environment.Interface.swift
+++ b/GliaWidgets/Factory/ViewFactory.Environment.Interface.swift
@@ -7,5 +7,6 @@ extension ViewFactory {
         var gcd: GCD
         var imageViewCache: ImageView.Cache
         var timerProviding: FoundationBased.Timer.Providing
+        var uiApplication: UIKitBased.UIApplication
     }
 }

--- a/GliaWidgets/Factory/ViewFactory.Environment.Mock.swift
+++ b/GliaWidgets/Factory/ViewFactory.Environment.Mock.swift
@@ -5,7 +5,8 @@ extension ViewFactory.Environment {
         uuid: { .mock },
         gcd: .mock,
         imageViewCache: .mock,
-        timerProviding: .mock
+        timerProviding: .mock,
+        uiApplication: .mock
     )
 }
 #endif

--- a/GliaWidgets/Factory/ViewFactory.swift
+++ b/GliaWidgets/Factory/ViewFactory.swift
@@ -20,7 +20,8 @@ class ViewFactory {
                 uuid: environment.uuid,
                 gcd: environment.gcd,
                 imageViewCache: environment.imageViewCache,
-                timerProviding: environment.timerProviding
+                timerProviding: environment.timerProviding,
+                uiApplication: environment.uiApplication
             )
         )
     }
@@ -33,7 +34,8 @@ class ViewFactory {
                 uuid: environment.uuid,
                 gcd: environment.gcd,
                 imageViewCache: environment.imageViewCache,
-                timerProviding: environment.timerProviding
+                timerProviding: environment.timerProviding,
+                uiApplication: environment.uiApplication
             )
         )
     }

--- a/GliaWidgets/Glia.Environment.Interface.swift
+++ b/GliaWidgets/Glia.Environment.Interface.swift
@@ -17,6 +17,7 @@ extension Glia {
         var createFileDownload: FileDownloader.CreateFileDownload
         var fromHistory: () -> Bool
         var timerProviding: FoundationBased.Timer.Providing
+        var uiApplication: UIKitBased.UIApplication
     }
 }
 

--- a/GliaWidgets/Glia.Environment.Live.swift
+++ b/GliaWidgets/Glia.Environment.Live.swift
@@ -20,7 +20,8 @@ extension Glia.Environment {
         uiImage: .live,
         createFileDownload: FileDownload.init(with:storage:environment:),
         fromHistory: { true },
-        timerProviding: .live
+        timerProviding: .live,
+        uiApplication: .live
     )
 }
 

--- a/GliaWidgets/Glia.Environment.Mock.swift
+++ b/GliaWidgets/Glia.Environment.Mock.swift
@@ -16,7 +16,8 @@ extension Glia.Environment {
         uiImage: .mock,
         createFileDownload: { _, _, _ in .mock() },
         fromHistory: { true },
-        timerProviding: .mock
+        timerProviding: .mock,
+        uiApplication: .mock
     )
 }
 

--- a/GliaWidgets/Glia.swift
+++ b/GliaWidgets/Glia.swift
@@ -116,7 +116,8 @@ public class Glia {
                 uuid: environment.uuid,
                 gcd: environment.gcd,
                 imageViewCache: environment.imageViewCache,
-                timerProviding: environment.timerProviding
+                timerProviding: environment.timerProviding,
+                uiApplication: environment.uiApplication
             )
         )
         startRootCoordinator(

--- a/GliaWidgets/UIKitBased.Interface.swift
+++ b/GliaWidgets/UIKitBased.Interface.swift
@@ -4,4 +4,9 @@ enum UIKitBased {
     struct UIImage {
         var imageWithContentsOfFileAtPath: (String) -> UIKit.UIImage?
     }
+
+    struct UIApplication {
+        var open: (URL) -> Void
+        var canOpenURL: (URL) -> Bool
+    }
 }

--- a/GliaWidgets/UIKitBased.Live.swift
+++ b/GliaWidgets/UIKitBased.Live.swift
@@ -3,3 +3,10 @@ import UIKit
 extension UIKitBased.UIImage {
     static let live = Self(imageWithContentsOfFileAtPath: UIKit.UIImage.init(contentsOfFile:))
 }
+
+extension UIKitBased.UIApplication {
+    static let live = Self(
+        open: { UIApplication.shared.open($0) },
+        canOpenURL: UIApplication.shared.canOpenURL
+    )
+}

--- a/GliaWidgets/UIKitBased.Mock.swift
+++ b/GliaWidgets/UIKitBased.Mock.swift
@@ -7,6 +7,13 @@ extension UIKitBased.UIImage {
     )
 }
 
+extension UIKitBased.UIApplication {
+    static let mock = Self(
+        open: { _ in },
+        canOpenURL: { _ in false }
+    )
+}
+
 extension UIImage {
     static let mock = UIImage(
         named: "mock-image",

--- a/GliaWidgets/View/Call/CallView.swift
+++ b/GliaWidgets/View/Call/CallView.swift
@@ -109,7 +109,8 @@ class CallView: EngagementView {
                 uuid: environment.uuid,
                 gcd: environment.gcd,
                 imageViewCache: environment.imageViewCache,
-                timerProviding: environment.timerProviding
+                timerProviding: environment.timerProviding,
+                uiApplication: environment.uiApplication
             )
         )
         setup()
@@ -427,5 +428,6 @@ extension CallView {
         var gcd: GCD
         var imageViewCache: ImageView.Cache
         var timerProviding: FoundationBased.Timer.Providing
+        var uiApplication: UIKitBased.UIApplication
     }
 }

--- a/GliaWidgets/View/Chat/ChatView.swift
+++ b/GliaWidgets/View/Chat/ChatView.swift
@@ -66,7 +66,8 @@ class ChatView: EngagementView {
                 uuid: environment.uuid,
                 gcd: environment.gcd,
                 imageViewCache: environment.imageViewCache,
-                timerProviding: environment.timerProviding
+                timerProviding: environment.timerProviding,
+                uiApplication: environment.uiApplication
             )
         )
         setup()
@@ -255,7 +256,12 @@ extension ChatView {
         case .queueOperator:
             return .queueOperator(connectView)
         case .outgoingMessage(let message):
-            let view = VisitorChatMessageView(with: style.visitorMessage)
+            let view = VisitorChatMessageView(
+                with: style.visitorMessage,
+                environment: .init(
+                    uiApplication: environment.uiApplication
+                )
+            )
             view.appendContent(.text(message.content, accessibility: Self.visitorAccessibilityOutgoingMessage(for: message)), animated: false)
             view.appendContent(
                 .files(
@@ -268,7 +274,12 @@ extension ChatView {
             view.linkTapped = { [weak self] in self?.linkTapped?($0) }
             return .outgoingMessage(view)
         case .visitorMessage(let message, let status):
-            let view = VisitorChatMessageView(with: style.visitorMessage)
+            let view = VisitorChatMessageView(
+                with: style.visitorMessage,
+                environment: .init(
+                    uiApplication: environment.uiApplication
+                )
+            )
             view.appendContent(.text(message.content, accessibility: Self.visitorAccessibilityMessage(for: message)), animated: false)
             view.appendContent(.downloads(message.downloads,
                                           accessibility: .init(from: .visitor)), animated: false)
@@ -283,7 +294,8 @@ extension ChatView {
                     data: environment.data,
                     uuid: environment.uuid,
                     gcd: environment.gcd,
-                    imageViewCache: environment.imageViewCache
+                    imageViewCache: environment.imageViewCache,
+                    uiApplication: environment.uiApplication
                 )
             )
             view.appendContent(.text(message.content, accessibility: Self.operatorAccessibilityMessage(for: message)), animated: false)
@@ -307,7 +319,8 @@ extension ChatView {
                     data: environment.data,
                     uuid: environment.uuid,
                     gcd: environment.gcd,
-                    imageViewCache: environment.imageViewCache
+                    imageViewCache: environment.imageViewCache,
+                    uiApplication: environment.uiApplication
                 )
             )
             let choiceCard = ChoiceCard(with: message, isActive: isActive)

--- a/GliaWidgets/View/Chat/Message/ChatMessageView.swift
+++ b/GliaWidgets/View/Chat/Message/ChatMessageView.swift
@@ -8,10 +8,16 @@ class ChatMessageView: UIView {
     var linkTapped: ((URL) -> Void)?
 
     private let contentAlignment: ChatMessageContentAlignment
+    private let environment: Environment
 
-    init(with style: ChatMessageStyle, contentAlignment: ChatMessageContentAlignment) {
+    init(
+        with style: ChatMessageStyle,
+        contentAlignment: ChatMessageContentAlignment,
+        environment: Environment
+    ) {
         self.style = style
         self.contentAlignment = contentAlignment
+        self.environment = environment
         super.init(frame: .zero)
         setup()
     }
@@ -23,7 +29,13 @@ class ChatMessageView: UIView {
     func appendContent(_ content: ChatMessageContent, animated: Bool) {
         switch content {
         case let .text(text, accProperties):
-            let contentView = ChatTextContentView(with: style.text, contentAlignment: contentAlignment)
+            let contentView = ChatTextContentView(
+                with: style.text,
+                contentAlignment: contentAlignment,
+                environment: .init(
+                    uiApplication: environment.uiApplication
+                )
+            )
             contentView.text = text
             contentView.linkTapped = { [weak self] in self?.linkTapped?($0) }
             contentView.accessibilityProperties = .init(label: accProperties.label, value: accProperties.value)
@@ -121,5 +133,11 @@ class ChatMessageView: UIView {
                 )
             }
         }
+    }
+}
+
+extension ChatMessageView {
+    struct Environment {
+        var uiApplication: UIKitBased.UIApplication
     }
 }

--- a/GliaWidgets/View/Chat/Message/Content/ChoiceCard/ChoiceCardView.swift
+++ b/GliaWidgets/View/Chat/Message/Content/ChoiceCard/ChoiceCardView.swift
@@ -18,7 +18,8 @@ final class ChoiceCardView: OperatorChatMessageView {
                 data: environment.data,
                 uuid: environment.uuid,
                 gcd: environment.gcd,
-                imageViewCache: environment.imageViewCache
+                imageViewCache: environment.imageViewCache,
+                uiApplication: environment.uiApplication
             )
         )
     }
@@ -74,6 +75,9 @@ final class ChoiceCardView: OperatorChatMessageView {
         let textView = ChatTextContentView(
             with: style.text,
             contentAlignment: .left,
+            environment: .init(
+                uiApplication: environment.uiApplication
+            ),
             insets: .zero
         )
         textView.text = choiceCard.text
@@ -109,6 +113,7 @@ extension ChoiceCardView {
         var uuid: () -> UUID
         var gcd: GCD
         var imageViewCache: ImageView.Cache
+        var uiApplication: UIKitBased.UIApplication
     }
 }
 

--- a/GliaWidgets/View/Chat/Message/Content/Text/ChatTextContentView.swift
+++ b/GliaWidgets/View/Chat/Message/Content/Text/ChatTextContentView.swift
@@ -104,10 +104,8 @@ extension ChatTextContentView: UITextViewDelegate {
         in characterRange: NSRange,
         interaction: UITextItemInteraction
     ) -> Bool {
-        if URL.scheme == "tel" {
-            openPhoneDialer(url: URL)
-        } else if URL.scheme == "mailto" {
-            openEmailClient(url: URL)
+        if URL.scheme == "tel" || URL.scheme == "mailto" {
+            openUrl(url: URL)
         } else {
             linkTapped?(URL)
         }
@@ -115,20 +113,10 @@ extension ChatTextContentView: UITextViewDelegate {
         return false
     }
 
-    private func openPhoneDialer(url: URL) {
-        let phone = url.absoluteString.replacingOccurrences(of: "tel:", with: "")
+    private func openUrl(url: URL) {
+        guard environment.uiApplication.canOpenURL(url) else { return }
 
-        if let callUrl = URL(string: "tel://\(phone)"), environment.uiApplication.canOpenURL(callUrl) {
-            environment.uiApplication.open(callUrl)
-        }
-    }
-
-    private func openEmailClient(url: URL) {
-        let email = url.absoluteString.replacingOccurrences(of: "mailto:", with: "")
-
-        if let emailUrl = URL(string: "mailto://\(email)"), environment.uiApplication.canOpenURL(emailUrl) {
-            environment.uiApplication.open(emailUrl)
-        }
+        environment.uiApplication.open(url)
     }
 }
 

--- a/GliaWidgets/View/Chat/Message/Content/Text/ChatTextContentView.swift
+++ b/GliaWidgets/View/Chat/Message/Content/Text/ChatTextContentView.swift
@@ -109,12 +109,21 @@ extension ChatTextContentView: UITextViewDelegate {
     }
 
     func handleUrl(url: URL) {
-        if url.scheme == "tel" || url.scheme == "mailto" {
-            guard environment.uiApplication.canOpenURL(url) else { return }
+        switch url.scheme?.lowercased() {
+        case "tel",
+            "mailto":
+            guard
+                environment.uiApplication.canOpenURL(url)
+            else { return }
 
             environment.uiApplication.open(url)
-        } else {
+
+        case "http",
+            "https":
             linkTapped?(url)
+
+        default:
+            return
         }
     }
 }

--- a/GliaWidgets/View/Chat/Message/Content/Text/ChatTextContentView.swift
+++ b/GliaWidgets/View/Chat/Message/Content/Text/ChatTextContentView.swift
@@ -58,7 +58,7 @@ class ChatTextContentView: UIView {
         textView.isEditable = false
         textView.textContainerInset = .zero
         textView.textContainer.lineFragmentPadding = 0
-        textView.dataDetectorTypes = .all
+        textView.dataDetectorTypes = [.link, .phoneNumber]
         textView.linkTextAttributes = [.underlineStyle: NSUnderlineStyle.single.rawValue]
         textView.font = style.textFont
         textView.backgroundColor = .clear
@@ -101,11 +101,30 @@ extension ChatTextContentView: UITextViewDelegate {
         in characterRange: NSRange,
         interaction: UITextItemInteraction
     ) -> Bool {
-        if URL.scheme == "tel" || URL.scheme == "mailto" {
-            return true
+        if URL.scheme == "tel" {
+            openPhoneDialer(url: URL)
+        } else if URL.scheme == "mailto" {
+            openEmailClient(url: URL)
         } else {
             linkTapped?(URL)
-            return false
+        }
+
+        return false
+    }
+
+    private func openPhoneDialer(url: URL) {
+        let phone = url.absoluteString.replacingOccurrences(of: "tel:", with: "")
+
+        if let callUrl = URL(string: "tel://\(phone)"), UIApplication.shared.canOpenURL(callUrl) {
+            UIApplication.shared.open(callUrl)
+        }
+    }
+
+    private func openEmailClient(url: URL) {
+        let email = url.absoluteString.replacingOccurrences(of: "mailto:", with: "")
+
+        if let emailUrl = URL(string: "mailto://\(email)"), UIApplication.shared.canOpenURL(emailUrl) {
+            UIApplication.shared.open(emailUrl)
         }
     }
 }

--- a/GliaWidgets/View/Chat/Message/Content/Text/ChatTextContentView.swift
+++ b/GliaWidgets/View/Chat/Message/Content/Text/ChatTextContentView.swift
@@ -30,14 +30,17 @@ class ChatTextContentView: UIView {
     private let contentAlignment: ChatMessageContentAlignment
     private let contentView = UIView()
     private let kTextInsets: UIEdgeInsets
+    private let environment: Environment
 
     init(
         with style: ChatTextContentStyle,
         contentAlignment: ChatMessageContentAlignment,
+        environment: Environment,
         insets: UIEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
     ) {
         self.style = style
         self.contentAlignment = contentAlignment
+        self.environment = environment
         self.kTextInsets = insets
         super.init(frame: .zero)
         setup()
@@ -115,17 +118,23 @@ extension ChatTextContentView: UITextViewDelegate {
     private func openPhoneDialer(url: URL) {
         let phone = url.absoluteString.replacingOccurrences(of: "tel:", with: "")
 
-        if let callUrl = URL(string: "tel://\(phone)"), UIApplication.shared.canOpenURL(callUrl) {
-            UIApplication.shared.open(callUrl)
+        if let callUrl = URL(string: "tel://\(phone)"), environment.uiApplication.canOpenURL(callUrl) {
+            environment.uiApplication.open(callUrl)
         }
     }
 
     private func openEmailClient(url: URL) {
         let email = url.absoluteString.replacingOccurrences(of: "mailto:", with: "")
 
-        if let emailUrl = URL(string: "mailto://\(email)"), UIApplication.shared.canOpenURL(emailUrl) {
-            UIApplication.shared.open(emailUrl)
+        if let emailUrl = URL(string: "mailto://\(email)"), environment.uiApplication.canOpenURL(emailUrl) {
+            environment.uiApplication.open(emailUrl)
         }
+    }
+}
+
+extension ChatTextContentView {
+    struct Environment {
+        var uiApplication: UIKitBased.UIApplication
     }
 }
 

--- a/GliaWidgets/View/Chat/Message/Content/Text/ChatTextContentView.swift
+++ b/GliaWidgets/View/Chat/Message/Content/Text/ChatTextContentView.swift
@@ -104,19 +104,18 @@ extension ChatTextContentView: UITextViewDelegate {
         in characterRange: NSRange,
         interaction: UITextItemInteraction
     ) -> Bool {
-        if URL.scheme == "tel" || URL.scheme == "mailto" {
-            openUrl(url: URL)
-        } else {
-            linkTapped?(URL)
-        }
-
+        handleUrl(url: URL)
         return false
     }
 
-    private func openUrl(url: URL) {
-        guard environment.uiApplication.canOpenURL(url) else { return }
+    func handleUrl(url: URL) {
+        if url.scheme == "tel" || url.scheme == "mailto" {
+            guard environment.uiApplication.canOpenURL(url) else { return }
 
-        environment.uiApplication.open(url)
+            environment.uiApplication.open(url)
+        } else {
+            linkTapped?(url)
+        }
     }
 }
 
@@ -132,3 +131,20 @@ extension ChatTextContentView {
         var value: String?
     }
 }
+
+#if DEBUG
+extension ChatTextContentView {
+    static func mock(environment: Environment) -> ChatTextContentView {
+        ChatTextContentView(
+            with: ChatTextContentStyle(
+                textFont: .systemFont(ofSize: 10),
+                textColor: .black,
+                backgroundColor: .black
+            ),
+            contentAlignment: .left,
+            environment: environment,
+            insets: .zero
+        )
+    }
+}
+#endif

--- a/GliaWidgets/View/Chat/Message/OperatorChatMessageView.swift
+++ b/GliaWidgets/View/Chat/Message/OperatorChatMessageView.swift
@@ -37,7 +37,13 @@ class OperatorChatMessageView: ChatMessageView {
     ) {
         viewStyle = style
         self.environment = environment
-        super.init(with: style, contentAlignment: .left)
+        super.init(
+            with: style,
+            contentAlignment: .left,
+            environment: .init(
+                uiApplication: environment.uiApplication
+            )
+        )
         setup()
         layout()
     }
@@ -74,5 +80,6 @@ extension OperatorChatMessageView {
         var uuid: () -> UUID
         var gcd: GCD
         var imageViewCache: ImageView.Cache
+        var uiApplication: UIKitBased.UIApplication
     }
 }

--- a/GliaWidgets/View/Chat/Message/VisitorChatMessageView.swift
+++ b/GliaWidgets/View/Chat/Message/VisitorChatMessageView.swift
@@ -9,8 +9,16 @@ class VisitorChatMessageView: ChatMessageView {
     private let statusLabel = UILabel()
     private let kInsets = UIEdgeInsets(top: 2, left: 88, bottom: 2, right: 16)
 
-    init(with style: VisitorChatMessageStyle) {
-        super.init(with: style, contentAlignment: .right)
+    init(
+        with style: VisitorChatMessageStyle,
+        environment: Environment
+    ) {
+        super.init(
+            with: style,
+            contentAlignment: .right,
+            environment: environment
+        )
+
         setup(style: style)
         layout()
     }

--- a/GliaWidgets/View/EngagementView.swift
+++ b/GliaWidgets/View/EngagementView.swift
@@ -44,5 +44,6 @@ extension EngagementView {
         var gcd: GCD
         var imageViewCache: ImageView.Cache
         var timerProviding: FoundationBased.Timer.Providing
+        var uiApplication: UIKitBased.UIApplication
     }
 }

--- a/GliaWidgetsTests/Glia.Environment.Failing.swift
+++ b/GliaWidgetsTests/Glia.Environment.Failing.swift
@@ -23,7 +23,8 @@ extension Glia.Environment {
             fail("\(Self.self).fromHistory")
             return true
         },
-        timerProviding: .failing
+        timerProviding: .failing,
+        uiApplication: .failing
     )
 }
 

--- a/GliaWidgetsTests/Sources/ChatTextContentViewTests.swift
+++ b/GliaWidgetsTests/Sources/ChatTextContentViewTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+
+@testable import GliaWidgets
+
+class ChatTextContentViewTests: XCTestCase {
+    var view: ChatTextContentView!
+
+    func test_handleUrlWithPhoneOpensURLWithUIApplication() throws {
+        enum Call: Equatable { case openUrl(URL) }
+
+        var calls: [Call] = []
+        var environment = ChatTextContentView.Environment(
+            uiApplication: .failing
+        )
+
+        environment.uiApplication.canOpenURL = { _ in true }
+        environment.uiApplication.open = {
+            calls.append(.openUrl($0))
+        }
+
+        view = .mock(environment: environment)
+
+        let telUrl = URL(string: "tel:12345678")!
+        view.handleUrl(url: telUrl)
+
+        XCTAssertEqual(calls, [.openUrl(telUrl)])
+    }
+    
+    func test_handleUrlWithEmailOpensURLWithUIApplication() throws {
+        enum Call: Equatable { case openUrl(URL) }
+
+        var calls: [Call] = []
+        var environment = ChatTextContentView.Environment(
+            uiApplication: .failing
+        )
+
+        environment.uiApplication.canOpenURL = { _ in true }
+        environment.uiApplication.open = {
+            calls.append(.openUrl($0))
+        }
+
+        view = .mock(environment: environment)
+
+        let mailUrl = URL(string: "mailto:mock@mock.mock")!
+        view.handleUrl(url: mailUrl)
+
+        XCTAssertEqual(calls, [.openUrl(mailUrl)])
+    }
+    
+    func test_handleUrlWithLinkOpensCalsLinkTapped() throws {
+        enum Call: Equatable { case linkTapped(URL) }
+        var calls: [Call] = []
+
+        let environment = ChatTextContentView.Environment(
+            uiApplication: .failing
+        )
+
+        view = .mock(environment: environment)
+        view.linkTapped = {
+            calls.append(.linkTapped($0))
+        }
+
+        let linkUrl = URL(string: "https://mock.mock")!
+        view.handleUrl(url: linkUrl)
+
+        XCTAssertEqual(calls, [.linkTapped(linkUrl)])
+    }
+}

--- a/GliaWidgetsTests/Sources/ChatTextContentViewTests.swift
+++ b/GliaWidgetsTests/Sources/ChatTextContentViewTests.swift
@@ -65,4 +65,32 @@ class ChatTextContentViewTests: XCTestCase {
 
         XCTAssertEqual(calls, [.linkTapped(linkUrl)])
     }
+    
+    func test_handleUrlWithRandomSchemeDoesNothing() throws {
+        enum Call: Equatable {
+            case linkTapped(URL)
+            case openUrl(URL)
+        }
+    
+        var calls: [Call] = []
+
+        var environment = ChatTextContentView.Environment(
+            uiApplication: .failing
+        )
+    
+        environment.uiApplication.canOpenURL = { _ in true }
+        environment.uiApplication.open = {
+            calls.append(.openUrl($0))
+        }
+
+        view = .mock(environment: environment)
+        view.linkTapped = {
+            calls.append(.linkTapped($0))
+        }
+
+        let linkUrl = URL(string: "mock:mock")!
+        view.handleUrl(url: linkUrl)
+
+        XCTAssertEqual(calls, [])
+    }
 }

--- a/GliaWidgetsTests/Sources/ChatTextContentViewTests.swift
+++ b/GliaWidgetsTests/Sources/ChatTextContentViewTests.swift
@@ -88,8 +88,8 @@ class ChatTextContentViewTests: XCTestCase {
             calls.append(.linkTapped($0))
         }
 
-        let linkUrl = URL(string: "mock:mock")!
-        view.handleUrl(url: linkUrl)
+        let mockUrl = URL(string: "mock:mock")!
+        view.handleUrl(url: mockUrl)
 
         XCTAssertEqual(calls, [])
     }

--- a/GliaWidgetsTests/UIKitBased.Failing.swift
+++ b/GliaWidgetsTests/UIKitBased.Failing.swift
@@ -8,3 +8,15 @@ extension UIKitBased.UIImage {
         }
     )
 }
+
+extension UIKitBased.UIApplication {
+    static let failing = Self(
+        open: { _ in
+            fail("\(Self.self).open")
+        },
+        canOpenURL: { _ in
+            fail("\(Self.self).canOpenURL")
+            return false
+        }
+    )
+}


### PR DESCRIPTION
This PR fixes issue, where tapping a 15 digit code would crash the app.
15 digit code was detected as a shipping number and therefore the linkTapped closure would be called.
Instead of this, we only track links and phone numbers so 15 digit long text won't be highlighted at all.
We also have an issue where in certain cases Messages app would open instead of phone dialer. 
Instead of letting TextView handle the URL managing we now compose and call the UIApplication to handle URL ourselves to tackle this issue.
MUIC-841