### PR TITLE
Audio - Upgrading an audio call to a video call from chat view crashes the app

### DIFF
--- a/GliaWidgets/Coordinator/RootCoordinator.swift
+++ b/GliaWidgets/Coordinator/RootCoordinator.swift
@@ -407,7 +407,10 @@ extension RootCoordinator {
 
         case .call(let callViewController, _, _, let call):
             call.upgrade(to: offer)
-            navigationPresenter.push(callViewController, animated: true)
+            navigationPresenter.setViewControllers(
+                [callViewController],
+                animated: true
+            )
             answer(true, nil)
 
         case .none:


### PR DESCRIPTION
This PR fixes issue created with another PR (#302). It appears, if you start call-first engagement instead of chat, that the call is in navigation stack in that case. Therefore we can't push another call into the stack. 
Correct solution is to reset the whole navigation stack again starting from with the newly upgraded call.
MUIC-828