### PR TITLE
Video - upgrading an audio call to video does not change call status in chat view

### DIFF
--- a/GliaWidgets/View/Chat/ChatView.swift
+++ b/GliaWidgets/View/Chat/ChatView.swift
@@ -324,7 +324,7 @@ extension ChatView {
             )
             kind.addObserver(self) { [weak self] kind, _ in
                 guard let self = self else { return }
-    
+
                 view.style = self.callUpgradeStyle(for: kind)
                 self.tableView.reloadData()
             }


### PR DESCRIPTION
This PR fixes issue happening on devices < iOS target version 15.

What would happen is that if the tableview is not scrolled to the very bottom (eg. if you add a file upload), then doing chat -> upgrade to audio -> chat -> upgrade to video -> chat would not update the chat item from "upgraded to audio call" to "upgraded to video call". I don't know why this happens exactly (possibly some UIKit quirk since the chat is not presented at the moment it updates?) since the item get's updates from the observable to update the view, but it just won't show up until you scroll up and down to re-dequeue the cell. 

The sure fix is to just reload tableview cells when the call kind value changes, meaning, when the upgrade happened.

MUIC-794