### PR TITLE
Add URL scheme support for quick SDK configuration

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -199,6 +199,9 @@
 		7529F2B427E1D503004D3581 /* Survey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7529F2B327E1D503004D3581 /* Survey.swift */; };
 		7529F2B627E1EB9A004D3581 /* Survey.ButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7529F2B527E1EB9A004D3581 /* Survey.ButtonView.swift */; };
 		753A56B927CFEB730050D8E6 /* ChatViewModel.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AB196DF27C401F600FD60AB /* ChatViewModel.Mock.swift */; };
+		754313CB2870A65400C9C1C6 /* SettingsViewController.Props.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754313CA2870A65400C9C1C6 /* SettingsViewController.Props.swift */; };
+		754313CD2870B1C400C9C1C6 /* UserDefaultsStored.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754313CC2870B1C400C9C1C6 /* UserDefaultsStored.swift */; };
+		754313CF2870E64600C9C1C6 /* Configuration.Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754313CE2870E64600C9C1C6 /* Configuration.Extensions.swift */; };
 		754CC61227E2767A005676E9 /* Survey.BooleanQuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75AF8D0827DD0DE1009EEE2C /* Survey.BooleanQuestionView.swift */; };
 		754CC61327E27BE2005676E9 /* Survey.SingleChoiceQuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75AF8D0A27DD1DD3009EEE2C /* Survey.SingleChoiceQuestionView.swift */; };
 		754CC61527E27C42005676E9 /* Survey.Checkbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754CC61427E27C42005676E9 /* Survey.Checkbox.swift */; };
@@ -367,11 +370,10 @@
 		EB2CBB1227D89F7D004F178E /* OnHoldOverlayStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB2CBB1127D89F7D004F178E /* OnHoldOverlayStyle.swift */; };
 		EB2CBB1527D8DB95004F178E /* OnHoldOverlayVisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB2CBB1427D8DB95004F178E /* OnHoldOverlayVisualEffectView.swift */; };
 		EB750F53273BA9BB00BE5FBD /* GliaError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB750F52273BA9BB00BE5FBD /* GliaError.swift */; };
+		EB95491C2850757400F567F0 /* ChatTextContentViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB95491B2850757400F567F0 /* ChatTextContentViewTests.swift */; };
 		EB9ADB51280EBD4E00FAE8A4 /* InteractorStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9ADB50280EBD4E00FAE8A4 /* InteractorStateTests.swift */; };
 		EB9ADB552828E66B00FAE8A4 /* CallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9ADB542828E66B00FAE8A4 /* CallTests.swift */; };
 		EB9ADB5A2829089F00FAE8A4 /* ChatItem+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9ADB592829089F00FAE8A4 /* ChatItem+Equatable.swift */; };
-		FD01A52B483418AB02DCFBFC /* Pods_GliaWidgets.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85639A838514258D976E1B2A /* Pods_GliaWidgets.framework */; };
-		EB95491C2850757400F567F0 /* ChatTextContentViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB95491B2850757400F567F0 /* ChatTextContentViewTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -622,6 +624,9 @@
 		7529F2B327E1D503004D3581 /* Survey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Survey.swift; sourceTree = "<group>"; };
 		7529F2B527E1EB9A004D3581 /* Survey.ButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Survey.ButtonView.swift; sourceTree = "<group>"; };
 		75348B236C84EBF420D0F082 /* Pods-SnapshotTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SnapshotTests.release.xcconfig"; path = "Target Support Files/Pods-SnapshotTests/Pods-SnapshotTests.release.xcconfig"; sourceTree = "<group>"; };
+		754313CA2870A65400C9C1C6 /* SettingsViewController.Props.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.Props.swift; sourceTree = "<group>"; };
+		754313CC2870B1C400C9C1C6 /* UserDefaultsStored.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsStored.swift; sourceTree = "<group>"; };
+		754313CE2870E64600C9C1C6 /* Configuration.Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.Extensions.swift; sourceTree = "<group>"; };
 		754CC61427E27C42005676E9 /* Survey.Checkbox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Survey.Checkbox.swift; sourceTree = "<group>"; };
 		756087E027837EC000158604 /* BundleManaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleManaging.swift; sourceTree = "<group>"; };
 		75A985425A950FFA1C13EACE /* Pods-GliaWidgets.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GliaWidgets.debug.xcconfig"; path = "Target Support Files/Pods-GliaWidgets/Pods-GliaWidgets.debug.xcconfig"; sourceTree = "<group>"; };
@@ -796,11 +801,10 @@
 		EB2CBB1127D89F7D004F178E /* OnHoldOverlayStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnHoldOverlayStyle.swift; sourceTree = "<group>"; };
 		EB2CBB1427D8DB95004F178E /* OnHoldOverlayVisualEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnHoldOverlayVisualEffectView.swift; sourceTree = "<group>"; };
 		EB750F52273BA9BB00BE5FBD /* GliaError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GliaError.swift; sourceTree = "<group>"; };
+		EB95491B2850757400F567F0 /* ChatTextContentViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTextContentViewTests.swift; sourceTree = "<group>"; };
 		EB9ADB50280EBD4E00FAE8A4 /* InteractorStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractorStateTests.swift; sourceTree = "<group>"; };
 		EB9ADB542828E66B00FAE8A4 /* CallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallTests.swift; sourceTree = "<group>"; };
 		EB9ADB592829089F00FAE8A4 /* ChatItem+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatItem+Equatable.swift"; sourceTree = "<group>"; };
-		F08274A374F775EE39BFBDB1 /* Pods-GliaWidgetsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GliaWidgetsTests.debug.xcconfig"; path = "Target Support Files/Pods-GliaWidgetsTests/Pods-GliaWidgetsTests.debug.xcconfig"; sourceTree = "<group>"; };
-		EB95491B2850757400F567F0 /* ChatTextContentViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTextContentViewTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1234,6 +1238,7 @@
 			isa = PBXGroup;
 			children = (
 				1A4AD3D5256FE7F800468BFB /* UIColor+Extensions.swift */,
+				754313CE2870E64600C9C1C6 /* Configuration.Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1573,6 +1578,8 @@
 			children = (
 				1A4AD3CC256E8E6500468BFB /* Cells */,
 				1A60AFF42567CE1300E53F53 /* SettingsViewController.swift */,
+				754313CA2870A65400C9C1C6 /* SettingsViewController.Props.swift */,
+				754313CC2870B1C400C9C1C6 /* UserDefaultsStored.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -2951,7 +2958,6 @@
 				9A1992E127D6313500161AAE /* ImageView.Cache.Failing.swift in Sources */,
 				EB9ADB552828E66B00FAE8A4 /* CallTests.swift in Sources */,
 				9A3E1DA027BA7B9F005634EB /* FileSystemStorageTests.swift in Sources */,
-				7512A57D27BFA37D00319DF1 /* CoreSdkClient.Salemove.swift in Sources */,
 				EB9ADB5A2829089F00FAE8A4 /* ChatItem+Equatable.swift in Sources */,
 				EB27E71D27FEBB620090B895 /* CallViewModelTests.swift in Sources */,
 				9ACC25D227B4727500BC5335 /* CoreSDKClient.Failing.swift in Sources */,
@@ -2963,7 +2969,6 @@
 				9A3E1D9D27BA7741005634EB /* FoundationBased.Failing.swift in Sources */,
 				9A3E1D8427B67F1B005634EB /* Helper.swift in Sources */,
 				9A8130C627D90B3800220BBD /* FileSystemStorage.Failing.swift in Sources */,
-				845E2F6A28365AD000C04D56 /* CoreSDKClient.Operator.Mock.swift in Sources */,
 				7512A57A27BF9FCD00319DF1 /* ChatViewModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2976,7 +2981,10 @@
 				1A4AD3DC256FF67200468BFB /* SettingsFontCell.swift in Sources */,
 				1A205D7F25655CEC003AA3CD /* ViewController.swift in Sources */,
 				1A4AD3D6256FE7F800468BFB /* UIColor+Extensions.swift in Sources */,
+				754313CD2870B1C400C9C1C6 /* UserDefaultsStored.swift in Sources */,
 				1A205D7B25655CEC003AA3CD /* AppDelegate.swift in Sources */,
+				754313CB2870A65400C9C1C6 /* SettingsViewController.Props.swift in Sources */,
+				754313CF2870E64600C9C1C6 /* Configuration.Extensions.swift in Sources */,
 				1A4AD3D1256E92F300468BFB /* SettingsColorCell.swift in Sources */,
 				1A4AD3CE256E8F5500468BFB /* SettingsCell.swift in Sources */,
 				6B2BFCE2274297F100B68506 /* SettingsSwitchCell.swift in Sources */,

--- a/GliaWidgets/Configuration.swift
+++ b/GliaWidgets/Configuration.swift
@@ -8,6 +8,8 @@ public enum Environment {
     case usa
     /// Beta environment. For development use.
     case beta
+    /// Custom environment. For development use.
+    case custom(URL)
 
     var region: CoreSdkClient.Salemove.Region {
         switch self {
@@ -19,6 +21,8 @@ public enum Environment {
             // swiftlint:disable force_unwrapping
             return .custom(URL(string: "https://api.beta.salemove.com/")!)
             // swiftlint:enable force_unwrapping
+        case .custom(let url):
+            return .custom(url)
         }
     }
 }

--- a/TestingApp/AppDelegate.swift
+++ b/TestingApp/AppDelegate.swift
@@ -34,7 +34,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         if components.host == "configure" {
-            root.updateConf(with: queryItems)
+            root.updateConfiguration(with: queryItems)
         }
         return true
     }

--- a/TestingApp/AppDelegate.swift
+++ b/TestingApp/AppDelegate.swift
@@ -23,18 +23,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         guard
             let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-            let queryItems = components.queryItems,
-            components.host == "configure"
+            let queryItems = components.queryItems
         else {
-            debugPrint("URL is not supported. url='\(url.absoluteString)'.")
+            debugPrint("URL is not valid. url='\(url.absoluteString)'.")
             return false
         }
 
-        guard let root = (window?.rootViewController as? ViewController) else {
+        guard let root = window?.rootViewController as? ViewController else {
             return false
         }
 
-        root.updateConf(with: queryItems)
+        if components.host == "configure" {
+            root.updateConf(with: queryItems)
+        }
         return true
     }
 

--- a/TestingApp/AppDelegate.swift
+++ b/TestingApp/AppDelegate.swift
@@ -11,6 +11,30 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             application,
             didFinishLaunchingWithOptions: launchOptions
         )
+        Salemove.sharedInstance.pushNotifications.enable(true)
+        return true
+    }
+
+    func application(
+        _ app: UIApplication,
+        open url: URL,
+        options: [UIApplication.OpenURLOptionsKey : Any] = [:]
+    ) -> Bool {
+
+        guard
+            let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+            let queryItems = components.queryItems,
+            components.host == "configure"
+        else {
+            debugPrint("URL is not supported. url='\(url.absoluteString)'.")
+            return false
+        }
+
+        guard let root = (window?.rootViewController as? ViewController) else {
+            return false
+        }
+
+        root.updateConf(with: queryItems)
         return true
     }
 

--- a/TestingApp/Extensions/Configuration.Extensions.swift
+++ b/TestingApp/Extensions/Configuration.Extensions.swift
@@ -13,17 +13,12 @@ extension Configuration {
 
 extension Configuration {
     init?(queryItems: [URLQueryItem]) {
-
-        guard let siteId = queryItems.first(where: { $0.name == "site_id"})?.value else {
-            return nil
-        }
-        guard let siteApiKeyId = queryItems.first(where: { $0.name == "api_key_id"})?.value else {
-            return nil
-        }
-        guard let siteApiKeySecret = queryItems.first(where: { $0.name == "api_key_secret"})?.value else {
-            return nil
-        }
-        guard let envName = queryItems.first(where: { $0.name == "env"})?.value else {
+        guard
+            let siteId = queryItems.first(where: { $0.name == "site_id"})?.value,
+            let siteApiKeyId = queryItems.first(where: { $0.name == "api_key_id"})?.value,
+            let siteApiKeySecret = queryItems.first(where: { $0.name == "api_key_secret"})?.value,
+            let envName = queryItems.first(where: { $0.name == "env"})?.value
+        else {
             return nil
         }
 

--- a/TestingApp/Extensions/Configuration.Extensions.swift
+++ b/TestingApp/Extensions/Configuration.Extensions.swift
@@ -53,7 +53,6 @@ private extension Environment {
 }
 
 extension Configuration: Codable {
-
     enum CodingKeys: String, CodingKey {
         case authorizationMethod, environment, site, visitorContext
     }
@@ -78,7 +77,6 @@ extension Configuration: Codable {
 }
 
 extension Configuration.AuthorizationMethod: Codable {
-
     enum CodingKeys: String, CodingKey {
         case id, secret, appToken
     }

--- a/TestingApp/Extensions/Configuration.Extensions.swift
+++ b/TestingApp/Extensions/Configuration.Extensions.swift
@@ -119,7 +119,7 @@ extension Environment: Codable {
             self = .europe
         default:
             guard let custom = URL(string: rawValue) else {
-                throw NSError(domain: "not-valid-env", code: -33)
+                throw NSError(domain: "not-valid-env", code: 0)
             }
             self = .custom(custom)
         }

--- a/TestingApp/Extensions/Configuration.Extensions.swift
+++ b/TestingApp/Extensions/Configuration.Extensions.swift
@@ -17,7 +17,8 @@ extension Configuration {
             let siteId = queryItems.first(where: { $0.name == "site_id"})?.value,
             let siteApiKeyId = queryItems.first(where: { $0.name == "api_key_id"})?.value,
             let siteApiKeySecret = queryItems.first(where: { $0.name == "api_key_secret"})?.value,
-            let envName = queryItems.first(where: { $0.name == "env"})?.value
+            let envName = queryItems.first(where: { $0.name == "env"})?.value,
+            let environment = Environment(rawValue: envName)
         else {
             return nil
         }
@@ -28,7 +29,7 @@ extension Configuration {
 
         self = .init(
             authorizationMethod: .siteApiKey(id: siteApiKeyId, secret: siteApiKeySecret),
-            environment: .init(rawValue: envName) ?? .beta,
+            environment: environment,
             site: siteId,
             visitorContext: visitorContext
         )

--- a/TestingApp/Extensions/Configuration.Extensions.swift
+++ b/TestingApp/Extensions/Configuration.Extensions.swift
@@ -1,0 +1,159 @@
+import Foundation
+import GliaWidgets
+
+extension Configuration {
+    static func empty(with env: Environment = .beta) -> Self {
+        .init(
+            authorizationMethod: .siteApiKey(id: "", secret: ""),
+            environment: env,
+            site: ""
+        )
+    }
+}
+
+extension Configuration {
+    init?(queryItems: [URLQueryItem]) {
+
+        guard let siteId = queryItems.first(where: { $0.name == "site_id"})?.value else {
+            return nil
+        }
+        guard let siteApiKeyId = queryItems.first(where: { $0.name == "api_key_id"})?.value else {
+            return nil
+        }
+        guard let siteApiKeySecret = queryItems.first(where: { $0.name == "api_key_secret"})?.value else {
+            return nil
+        }
+        guard let envName = queryItems.first(where: { $0.name == "env"})?.value else {
+            return nil
+        }
+
+        let visitorAssetId = queryItems.first(where: { $0.name == "visitor_context_asset_id" })?.value ?? ""
+        let visitorContext = UUID(uuidString: visitorAssetId)
+            .map(Configuration.VisitorContext.init(assetId:))
+
+        self = .init(
+            authorizationMethod: .siteApiKey(id: siteApiKeyId, secret: siteApiKeySecret),
+            environment: .init(rawValue: envName) ?? .beta,
+            site: siteId,
+            visitorContext: visitorContext
+        )
+    }
+}
+
+private extension Environment {
+    init?(rawValue: String) {
+        switch rawValue {
+        case "beta":
+            self = .beta
+        case "us":
+            self = .usa
+        case "eu":
+            self = .europe
+        default:
+            guard let url = URL(string: rawValue) else { return nil }
+            self = .custom(url)
+        }
+    }
+}
+
+extension Configuration: Codable {
+
+    enum CodingKeys: String, CodingKey {
+        case authorizationMethod, environment, site, visitorContext
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self = try .init(
+            authorizationMethod: container.decode(Configuration.AuthorizationMethod.self, forKey: .authorizationMethod),
+            environment: container.decode(Environment.self, forKey: .environment),
+            site: container.decode(String.self, forKey: .site),
+            visitorContext: container.decodeIfPresent(VisitorContext.self, forKey: .visitorContext)
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(authorizationMethod, forKey: .authorizationMethod)
+        try container.encode(environment, forKey: .environment)
+        try container.encode(site, forKey: .site)
+        try container.encode(visitorContext, forKey: .visitorContext)
+    }
+}
+
+extension Configuration.AuthorizationMethod: Codable {
+
+    enum CodingKeys: String, CodingKey {
+        case id, secret, appToken
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        if container.contains(.appToken) {
+            self = try .appToken(container.decode(String.self, forKey: .appToken))
+        } else {
+            self = try .siteApiKey(
+                id: container.decode(String.self, forKey: .id),
+                secret: container.decode(String.self, forKey: .secret)
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .appToken(let appToken):
+            try container.encode(appToken, forKey: .appToken)
+        case let .siteApiKey(id, secret):
+            try container.encode(id, forKey: .id)
+            try container.encode(secret, forKey: .secret)
+        }
+    }
+}
+
+extension Environment: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+        switch rawValue {
+        case "beta":
+            self = .beta
+        case "us":
+            self = .usa
+        case "eu":
+            self = .europe
+        default:
+            guard let custom = URL(string: rawValue) else {
+                throw NSError(domain: "not-valid-env", code: -33)
+            }
+            self = .custom(custom)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .europe:
+            try container.encode("eu")
+        case .usa:
+            try container.encode("us")
+        case .beta:
+            try container.encode("beta")
+        case .custom(let url):
+            try container.encode(url.absoluteString)
+        }
+    }
+}
+
+extension Configuration.VisitorContext: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self = try .init(assetId: container.decode(UUID.self))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(assetId)
+    }
+}

--- a/TestingApp/Info.plist
+++ b/TestingApp/Info.plist
@@ -16,6 +16,17 @@
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
 	<string>0.9.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>glia</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/TestingApp/Main.storyboard
+++ b/TestingApp/Main.storyboard
@@ -22,6 +22,7 @@
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FAP-5O-GCi">
                                         <rect key="frame" x="164.5" y="0.0" width="85" height="30"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="button_settings"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="F8f-dQ-RxV"/>
                                         </constraints>
@@ -32,6 +33,7 @@
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zmv-pl-N2H">
                                         <rect key="frame" x="173" y="50" width="68" height="30"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="button_chat"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="9bb-ZJ-g4f"/>
                                         </constraints>
@@ -42,6 +44,7 @@
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="USF-zD-dZ5">
                                         <rect key="frame" x="173.5" y="100" width="67" height="30"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="button_audio_call"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="PFk-Yr-vcD"/>
                                         </constraints>
@@ -52,6 +55,7 @@
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tG2-uU-gYf">
                                         <rect key="frame" x="173.5" y="150" width="67" height="30"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="button_video_call"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="Hga-kH-fOK"/>
                                         </constraints>
@@ -62,6 +66,7 @@
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="P9U-ba-KVy">
                                         <rect key="frame" x="179.5" y="200" width="55" height="30"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="button_resume"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="mbg-qw-hCC"/>
                                         </constraints>
@@ -72,6 +77,7 @@
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0wb-9L-Csn">
                                         <rect key="frame" x="161" y="250" width="92" height="30"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="button_clear_session"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="wht-81-BI4"/>
                                         </constraints>
@@ -82,6 +88,7 @@
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3Ys-xS-zdq">
                                         <rect key="frame" x="126" y="300" width="162" height="30"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="button_end_active_engagement"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="QkV-yj-Sti"/>
                                         </constraints>
@@ -95,6 +102,7 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <accessibility key="accessibilityConfiguration" identifier="screen_main"/>
                         <constraints>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="A3Y-Xf-Ufg" secondAttribute="trailing" id="8pF-OV-n0R"/>
                             <constraint firstItem="A3Y-Xf-Ufg" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="A7O-6m-VGg"/>

--- a/TestingApp/Main.storyboard
+++ b/TestingApp/Main.storyboard
@@ -22,7 +22,7 @@
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FAP-5O-GCi">
                                         <rect key="frame" x="164.5" y="0.0" width="85" height="30"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="button_settings"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="main_settings_button"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="F8f-dQ-RxV"/>
                                         </constraints>
@@ -33,7 +33,7 @@
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zmv-pl-N2H">
                                         <rect key="frame" x="173" y="50" width="68" height="30"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="button_chat"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="main_chat_button"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="9bb-ZJ-g4f"/>
                                         </constraints>
@@ -44,7 +44,7 @@
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="USF-zD-dZ5">
                                         <rect key="frame" x="173.5" y="100" width="67" height="30"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="button_audio_call"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="main_audio_button"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="PFk-Yr-vcD"/>
                                         </constraints>
@@ -55,7 +55,7 @@
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tG2-uU-gYf">
                                         <rect key="frame" x="173.5" y="150" width="67" height="30"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="button_video_call"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="main_video_button"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="Hga-kH-fOK"/>
                                         </constraints>
@@ -66,7 +66,7 @@
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="P9U-ba-KVy">
                                         <rect key="frame" x="179.5" y="200" width="55" height="30"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="button_resume"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="main_resume_button"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="mbg-qw-hCC"/>
                                         </constraints>
@@ -77,7 +77,7 @@
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0wb-9L-Csn">
                                         <rect key="frame" x="161" y="250" width="92" height="30"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="button_clear_session"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="main_clearSession_button"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="wht-81-BI4"/>
                                         </constraints>
@@ -88,7 +88,7 @@
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3Ys-xS-zdq">
                                         <rect key="frame" x="126" y="300" width="162" height="30"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="button_end_active_engagement"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="main_endEngagement_button"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="QkV-yj-Sti"/>
                                         </constraints>

--- a/TestingApp/Settings/SettingsViewController.Props.swift
+++ b/TestingApp/Settings/SettingsViewController.Props.swift
@@ -1,0 +1,18 @@
+import GliaWidgets
+import Foundation
+
+extension SettingsViewController {
+    struct Props {
+        let config: Configuration
+        let changeConfig: (Configuration) -> Void
+
+        let queueId: String
+        let changeQueueId: (String) -> Void
+
+        let theme: Theme
+        let changeTheme: (Theme) -> Void
+        
+        let features: Features
+        let changeFeatures: (Features) -> Void
+    }
+}

--- a/TestingApp/Settings/SettingsViewController.swift
+++ b/TestingApp/Settings/SettingsViewController.swift
@@ -49,10 +49,13 @@ class SettingsViewController: UIViewController {
         title = "Settings"
         view.backgroundColor = .white
 
-        let doneItem = UIBarButtonItem(title: "Done",
-                                       style: .done,
-                                       target: self,
-                                       action: #selector(doneTapped))
+        let doneItem = UIBarButtonItem(
+            title: "Done",
+            style: .done,
+            target: self,
+            action: #selector(doneTapped)
+        )
+        doneItem.accessibilityIdentifier = "barButtonItem_done"
         navigationItem.rightBarButtonItem = doneItem
 
         tableView.dataSource = self
@@ -90,18 +93,22 @@ private extension SettingsViewController {
             title: "Identifier:",
             text: conf.siteApiKeyId
         )
+        siteApiKeyIdCell.textField.accessibilityIdentifier = "textField_site_api_key_id"
         siteApiKeySecretCell = SettingsTextCell(
             title: "Secret:",
             text: conf.siteApiKeySecret
         )
+        siteApiKeySecretCell.textField.accessibilityIdentifier = "textField_site_api_key_secret"
         siteCell = SettingsTextCell(
             title: "Site:",
             text: conf.site
         )
+        siteCell.textField.accessibilityIdentifier = "textField_site_id"
         queueIDCell = SettingsTextCell(
             title: "Queue ID:",
             text: queueID
         )
+        queueIDCell.accessibilityIdentifier = "textField_queue_id"
         visitorContextAssedIdCell = SettingsTextCell(
             title: "Visitor Context Asset ID:",
             text: visitorContextAssetId

--- a/TestingApp/Settings/SettingsViewController.swift
+++ b/TestingApp/Settings/SettingsViewController.swift
@@ -55,7 +55,7 @@ class SettingsViewController: UIViewController {
             target: self,
             action: #selector(doneTapped)
         )
-        doneItem.accessibilityIdentifier = "barButtonItem_done"
+        doneItem.accessibilityIdentifier = "screen_settings_barButtonItem_done"
         navigationItem.rightBarButtonItem = doneItem
 
         tableView.dataSource = self
@@ -93,22 +93,22 @@ private extension SettingsViewController {
             title: "Identifier:",
             text: conf.siteApiKeyId
         )
-        siteApiKeyIdCell.textField.accessibilityIdentifier = "textField_site_api_key_id"
+        siteApiKeyIdCell.textField.accessibilityIdentifier = "settings_siteApiKeyId_textfield"
         siteApiKeySecretCell = SettingsTextCell(
             title: "Secret:",
             text: conf.siteApiKeySecret
         )
-        siteApiKeySecretCell.textField.accessibilityIdentifier = "textField_site_api_key_secret"
+        siteApiKeySecretCell.textField.accessibilityIdentifier = "settings_siteApiKeySecret_textfield"
         siteCell = SettingsTextCell(
             title: "Site:",
             text: conf.site
         )
-        siteCell.textField.accessibilityIdentifier = "textField_site_id"
+        siteCell.textField.accessibilityIdentifier = "settings_siteId_textfield"
         queueIDCell = SettingsTextCell(
             title: "Queue ID:",
             text: queueID
         )
-        queueIDCell.accessibilityIdentifier = "textField_queue_id"
+        queueIDCell.accessibilityIdentifier = "settings_queueId_textfield"
         visitorContextAssedIdCell = SettingsTextCell(
             title: "Visitor Context Asset ID:",
             text: visitorContextAssetId

--- a/TestingApp/Settings/SettingsViewController.swift
+++ b/TestingApp/Settings/SettingsViewController.swift
@@ -40,9 +40,7 @@ final class SettingsViewController: UIViewController {
 
     private var props: Props
 
-    init(
-        props: Props
-    ) {
+    init(props: Props) {
         self.props = props
         super.init(nibName: nil, bundle: nil)
     }
@@ -253,7 +251,7 @@ private extension SettingsViewController {
         let uuid = UUID(uuidString: visitorContextAssedIdCell.textField.text ?? "")
         props.changeConfig(
             .init(
-                authorizationMethod: .siteApiKey(id: siteApiKeyIdCell.textField.text ?? "", secret: siteApiKeySecretCell.textField.text ?? ""),
+                authorizationMethod: siteApiKey,
                 environment: .beta,
                 site: siteCell.textField.text ?? "",
                 visitorContext: uuid == nil ? nil : .init(assetId: uuid!)
@@ -265,6 +263,13 @@ private extension SettingsViewController {
             features.remove(.bubbleView)
         }
         props.changeFeatures(features)
+    }
+
+    private var siteApiKey: Configuration.AuthorizationMethod {
+        .siteApiKey(
+            id: siteApiKeyIdCell.textField.text ?? "",
+            secret: siteApiKeySecretCell.textField.text ?? ""
+        )
     }
 
     private func makeTheme() -> Theme {

--- a/TestingApp/Settings/SettingsViewController.swift
+++ b/TestingApp/Settings/SettingsViewController.swift
@@ -6,7 +6,7 @@ private struct Section {
     let cells: [SettingsCell]
 }
 
-class SettingsViewController: UIViewController {
+final class SettingsViewController: UIViewController {
     private let tableView = UITableView(frame: .zero, style: .grouped)
     private var sections = [Section]()
     private var siteApiKeyIdCell: SettingsTextCell!
@@ -38,11 +38,18 @@ class SettingsViewController: UIViewController {
         cells: []
     )
 
-    var theme: Theme = Theme()
-    var conf: Configuration { loadConf() }
-    var queueID: String { loadQueueID() }
-    var visitorContextAssetId: String { loadVisitorContextAssetId() }
-    var features: Features { loadFeatures() }
+    private var props: Props
+
+    init(
+        props: Props
+    ) {
+        self.props = props
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -79,8 +86,8 @@ class SettingsViewController: UIViewController {
 
     @objc
     private func doneTapped() {
-        saveConf()
-        theme = makeTheme()
+        updateConfiguration()
+        props.changeTheme(makeTheme())
         dismiss(animated: true, completion: nil)
     }
 }
@@ -91,53 +98,69 @@ private extension SettingsViewController {
     private func createCells() {
         siteApiKeyIdCell = SettingsTextCell(
             title: "Identifier:",
-            text: conf.siteApiKeyId
+            text: props.config.siteApiKeyId
         )
         siteApiKeyIdCell.textField.accessibilityIdentifier = "settings_siteApiKeyId_textfield"
         siteApiKeySecretCell = SettingsTextCell(
             title: "Secret:",
-            text: conf.siteApiKeySecret
+            text: props.config.siteApiKeySecret
         )
         siteApiKeySecretCell.textField.accessibilityIdentifier = "settings_siteApiKeySecret_textfield"
         siteCell = SettingsTextCell(
             title: "Site:",
-            text: conf.site
+            text: props.config.site
         )
         siteCell.textField.accessibilityIdentifier = "settings_siteId_textfield"
         queueIDCell = SettingsTextCell(
             title: "Queue ID:",
-            text: queueID
+            text: props.queueId
         )
         queueIDCell.accessibilityIdentifier = "settings_queueId_textfield"
         visitorContextAssedIdCell = SettingsTextCell(
             title: "Visitor Context Asset ID:",
-            text: visitorContextAssetId
+            text: props.config.visitorContext?.assetId.uuidString ?? ""
         )
         bubbleFeatureCell = SettingsSwitchCell(
             title: "Present \"Bubble\" overlay in engagement time",
-            isOn: features ~= .bubbleView
+            isOn: props.features ~= .bubbleView
         )
         let featuresSection = Section(
             title: "Features",
             cells: [bubbleFeatureCell]
         )
 
-        primaryColorCell = SettingsColorCell(title: "Primary:",
-                                             color: theme.color.primary)
-        secondaryColorCell = SettingsColorCell(title: "Secondary:",
-                                               color: theme.color.secondary)
-        baseNormalColorCell = SettingsColorCell(title: "Base normal:",
-                                                color: theme.color.baseNormal)
-        baseLightColorCell = SettingsColorCell(title: "Base light:",
-                                               color: theme.color.baseLight)
-        baseDarkColorCell = SettingsColorCell(title: "Base dark:",
-                                              color: theme.color.baseDark)
-        baseShadeColorCell = SettingsColorCell(title: "Base shade:",
-                                               color: theme.color.baseShade)
-        backgroundColorCell = SettingsColorCell(title: "Background:",
-                                                color: theme.color.background)
-        systemNegativeColorCell = SettingsColorCell(title: "System negative:",
-                                                    color: theme.color.systemNegative)
+        primaryColorCell = SettingsColorCell(
+            title: "Primary:",
+            color: props.theme.color.primary
+        )
+        secondaryColorCell = SettingsColorCell(
+            title: "Secondary:",
+            color: props.theme.color.secondary
+        )
+        baseNormalColorCell = SettingsColorCell(
+            title: "Base normal:",
+            color: props.theme.color.baseNormal
+        )
+        baseLightColorCell = SettingsColorCell(
+            title: "Base light:",
+            color: props.theme.color.baseLight
+        )
+        baseDarkColorCell = SettingsColorCell(
+            title: "Base dark:",
+            color: props.theme.color.baseDark
+        )
+        baseShadeColorCell = SettingsColorCell(
+            title: "Base shade:",
+            color: props.theme.color.baseShade
+        )
+        backgroundColorCell = SettingsColorCell(
+            title: "Background:",
+            color: props.theme.color.background
+        )
+        systemNegativeColorCell = SettingsColorCell(
+            title: "System negative:",
+            color: props.theme.color.systemNegative
+        )
         var colorCells = [SettingsCell]()
         colorCells.append(primaryColorCell)
         colorCells.append(secondaryColorCell)
@@ -148,27 +171,47 @@ private extension SettingsViewController {
         colorCells.append(backgroundColorCell)
         colorCells.append(systemNegativeColorCell)
 
-        let colorSection = Section(title: "Theme colors (RRGGBB Alpha)",
-                                   cells: colorCells)
+        let colorSection = Section(
+            title: "Theme colors (RRGGBB Alpha)",
+            cells: colorCells
+        )
 
-        header1FontCell = SettingsFontCell(title: "Header1",
-                                           defaultFont: theme.font.header1)
-        header2FontCell = SettingsFontCell(title: "Header2",
-                                           defaultFont: theme.font.header2)
-        header3FontCell = SettingsFontCell(title: "Header3",
-                                           defaultFont: theme.font.header3)
-        bodyTextFontCell = SettingsFontCell(title: "Body text",
-                                            defaultFont: theme.font.bodyText)
-        subtitleFontCell = SettingsFontCell(title: "Subtitle",
-                                            defaultFont: theme.font.subtitle)
-        mediumSubtitle1FontCell = SettingsFontCell(title: "Medium subtitle1",
-                                                   defaultFont: theme.font.mediumSubtitle1)
-        mediumSubtitle2FontCell = SettingsFontCell(title: "Medium subtitle2",
-                                                   defaultFont: theme.font.mediumSubtitle2)
-        captionFontCell = SettingsFontCell(title: "Caption",
-                                           defaultFont: theme.font.caption)
-        buttonLabelFontCell = SettingsFontCell(title: "Button label",
-                                               defaultFont: theme.font.buttonLabel)
+        header1FontCell = SettingsFontCell(
+            title: "Header1",
+            defaultFont: props.theme.font.header1
+        )
+        header2FontCell = SettingsFontCell(
+            title: "Header2",
+            defaultFont: props.theme.font.header2
+        )
+        header3FontCell = SettingsFontCell(
+            title: "Header3",
+            defaultFont: props.theme.font.header3
+        )
+        bodyTextFontCell = SettingsFontCell(
+            title: "Body text",
+            defaultFont: props.theme.font.bodyText
+        )
+        subtitleFontCell = SettingsFontCell(
+            title: "Subtitle",
+            defaultFont: props.theme.font.subtitle
+        )
+        mediumSubtitle1FontCell = SettingsFontCell(
+            title: "Medium subtitle1",
+            defaultFont: props.theme.font.mediumSubtitle1
+        )
+        mediumSubtitle2FontCell = SettingsFontCell(
+            title: "Medium subtitle2",
+            defaultFont: props.theme.font.mediumSubtitle2
+        )
+        captionFontCell = SettingsFontCell(
+            title: "Caption",
+            defaultFont: props.theme.font.caption
+        )
+        buttonLabelFontCell = SettingsFontCell(
+            title: "Button label",
+            defaultFont: props.theme.font.buttonLabel
+        )
         var fontCells = [SettingsCell]()
         fontCells.append(header1FontCell)
         fontCells.append(header2FontCell)
@@ -206,79 +249,54 @@ private extension SettingsViewController {
         sections[0] = configurationSection
     }
 
-    private func loadConf() -> Configuration {
-        let siteApiKeyId = UserDefaults.standard.string(forKey: "conf.siteApiKeyId") ?? ""
-        let siteApiKeySecret = UserDefaults.standard.string(forKey: "conf.siteApiKeySecret") ?? ""
-        let site = UserDefaults.standard.string(forKey: "conf.site") ?? ""
-        let visitorAssetId = loadVisitorContextAssetId()
-        let visitorContext = UUID(uuidString: visitorAssetId)
-            .map(Configuration.VisitorContext.init(assetId:))
-        return Configuration(
-            authorizationMethod: .siteApiKey(
-                id: siteApiKeyId,
-                secret: siteApiKeySecret
-            ),
-            environment: .beta,
-            site: site,
-            visitorContext: visitorContext
+    private func updateConfiguration() {
+        let uuid = UUID(uuidString: visitorContextAssedIdCell.textField.text ?? "")
+        props.changeConfig(
+            .init(
+                authorizationMethod: .siteApiKey(id: siteApiKeyIdCell.textField.text ?? "", secret: siteApiKeySecretCell.textField.text ?? ""),
+                environment: .beta,
+                site: siteCell.textField.text ?? "",
+                visitorContext: uuid == nil ? nil : .init(assetId: uuid!)
+            )
         )
-    }
-
-    private func loadQueueID() -> String {
-        let queueID = UserDefaults.standard.string(forKey: "conf.queueID") ?? ""
-        return queueID
-    }
-
-    private func loadVisitorContextAssetId() -> String {
-        let visitorContextAssetId = UserDefaults.standard.string(forKey: "conf.visitorContextAssetId") ?? ""
-        return visitorContextAssetId
-    }
-
-    private func loadFeatures() -> Features {
-        guard let savedValue = UserDefaults.standard.value(forKey: "conf.features") as? Int else {
-            return .all
-        }
-        return Features(rawValue: savedValue)
-    }
-
-    private func saveConf() {
-        UserDefaults.standard.setValue(siteApiKeyIdCell.textField.text ?? "", forKey: "conf.siteApiKeyId")
-        UserDefaults.standard.setValue(siteApiKeySecretCell.textField.text ?? "", forKey: "conf.siteApiKeySecret")
-        UserDefaults.standard.setValue(siteCell.textField.text ?? "", forKey: "conf.site")
-        UserDefaults.standard.setValue(queueIDCell.textField.text ?? "", forKey: "conf.queueID")
-        UserDefaults.standard.setValue(visitorContextAssedIdCell.textField.text ?? "", forKey: "conf.visitorContextAssetId")
 
         var features = Features.all
         if !bubbleFeatureCell.switcher.isOn {
             features.remove(.bubbleView)
         }
-        UserDefaults.standard.setValue(features.rawValue, forKey: "conf.features")
+        props.changeFeatures(features)
     }
 
     private func makeTheme() -> Theme {
-        let color = ThemeColor(primary: primaryColorCell.color,
-                               secondary: secondaryColorCell.color,
-                               baseNormal: baseNormalColorCell.color,
-                               baseLight: baseLightColorCell.color,
-                               baseDark: baseDarkColorCell.color,
-                               baseShade: baseShadeColorCell.color,
-                               background: backgroundColorCell.color,
-                               systemNegative: systemNegativeColorCell.color)
-        let font = ThemeFont(header1: header1FontCell.selectedFont,
-                             header2: header2FontCell.selectedFont,
-                             header3: header3FontCell.selectedFont,
-                             bodyText: bodyTextFontCell.selectedFont,
-                             subtitle: subtitleFontCell.selectedFont,
-                             mediumSubtitle1: mediumSubtitle1FontCell.selectedFont,
-                             mediumSubtitle2: mediumSubtitle2FontCell.selectedFont,
-                             caption: captionFontCell.selectedFont,
-                             buttonLabel: buttonLabelFontCell.selectedFont)
+        let color = ThemeColor(
+            primary: primaryColorCell.color,
+            secondary: secondaryColorCell.color,
+            baseNormal: baseNormalColorCell.color,
+            baseLight: baseLightColorCell.color,
+            baseDark: baseDarkColorCell.color,
+            baseShade: baseShadeColorCell.color,
+            background: backgroundColorCell.color,
+            systemNegative: systemNegativeColorCell.color
+        )
+        let font = ThemeFont(
+            header1: header1FontCell.selectedFont,
+            header2: header2FontCell.selectedFont,
+            header3: header3FontCell.selectedFont,
+            bodyText: bodyTextFontCell.selectedFont,
+            subtitle: subtitleFontCell.selectedFont,
+            mediumSubtitle1: mediumSubtitle1FontCell.selectedFont,
+            mediumSubtitle2: mediumSubtitle2FontCell.selectedFont,
+            caption: captionFontCell.selectedFont,
+            buttonLabel: buttonLabelFontCell.selectedFont
+        )
 
         let colorStyle: ThemeColorStyle = .custom(color)
         let fontStyle: ThemeFontStyle = .custom(font)
 
-        return Theme(colorStyle: colorStyle,
-                     fontStyle: fontStyle)
+        return Theme(
+            colorStyle: colorStyle,
+            fontStyle: fontStyle
+        )
     }
 }
 

--- a/TestingApp/Settings/UserDefaultsStored.swift
+++ b/TestingApp/Settings/UserDefaultsStored.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+@propertyWrapper struct UserDefaultsStored<Value> {
+    var wrappedValue: Value {
+        get {
+            coder.decode(
+                userDefaults.value(forKey: key)
+            ) ?? defaultValue
+        }
+        set {
+            userDefaults.set(
+                coder.encode(newValue),
+                forKey: key
+            )
+        }
+    }
+
+    init(
+        key: String,
+        defaultValue: Value,
+        coder: Coder<Value> = .casting(),
+        userDefaults: UserDefaults = .standard
+    ) {
+        self.key = key
+        self.userDefaults = userDefaults
+        self.defaultValue = defaultValue
+        self.coder = coder
+    }
+
+    // MARK: - Private
+
+    private var coder: Coder<Value>
+    private let defaultValue: Value
+    private let key: String
+    private let userDefaults: UserDefaults
+}
+
+extension UserDefaultsStored {
+    struct Coder<Value> {
+        var decode: (Any?) -> Value?
+        var encode: (Value?) -> Any?
+    }
+}
+
+extension UserDefaultsStored.Coder {
+    static func casting() -> UserDefaultsStored.Coder<Value> {
+        UserDefaultsStored.Coder { $0 as? Value }
+            encode: {
+                $0
+            }
+    }
+    
+    static func jsonCoding() -> UserDefaultsStored.Coder<Value> where Value: Codable {
+        let decoder = JSONDecoder()
+        let encoder = JSONEncoder()
+        return UserDefaultsStored.Coder(
+            decode: { try? decoder.decode(Value.self, from: ($0 as? Data) ?? Data()) },
+            encode: { try? encoder.encode($0) }
+        )
+    }
+
+    static func rawRepresentable() -> UserDefaultsStored.Coder<Value> where Value: RawRepresentable {
+        UserDefaultsStored.Coder {
+            guard let rawValue = $0 as? Value.RawValue else { return nil }
+            return Value(rawValue: rawValue)
+        } encode: {
+            $0?.rawValue
+        }
+    }
+}

--- a/TestingApp/ViewController.swift
+++ b/TestingApp/ViewController.swift
@@ -74,7 +74,6 @@ extension ViewController {
     }
 
     func presentGlia(_ engagementKind: EngagementKind) {
-
         let visitorContext: SalemoveSDK.VisitorContext? = configuration.visitorContext
             .map(\.assetId)
             .map(SalemoveSDK.VisitorContext.AssetId.init(rawValue:))
@@ -121,7 +120,7 @@ extension ViewController {
         present(alert, animated: true, completion: nil)
     }
 
-    func updateConf(with queryItems: [URLQueryItem]) {
+    func updateConfiguration(with queryItems: [URLQueryItem]) {
         Configuration(queryItems: queryItems).map { configuration = $0 }
         queryItems.first(where: { $0.name == "queue_id"})?.value.map {
             queueId = $0


### PR DESCRIPTION
- reworked SettingsViewController for TestingApp to avoid retaining it from ViewController
- added URL scheme support for quick SDK configuration

```
glia://configure?site_id=#{site_id}&api_key_secret=#{api_key_secret}&api_key_id=#{api_key_id}&queue_id=#{queue_id}&env=#{env}&visitor_context_asset_id=${visitor_context_asset_id}
```
* visitor_context_asset_id is optional