### PR TITLE
Add accessibility label for audio upgrades

### DIFF
--- a/GliaWidgets/Component/CallButtonBar/Button/CallButton.swift
+++ b/GliaWidgets/Component/CallButtonBar/Button/CallButton.swift
@@ -132,6 +132,9 @@ class CallButton: UIView {
         )
         accessibilityValue = properties.value
         accessibilityLabel = properties.label
+
+        let buttonAccessibilityIdentifier = "audio_\(properties.value.lowercased())_button"
+        accessibilityIdentifier = isUserInteractionEnabled ? buttonAccessibilityIdentifier : ""
     }
 
     private func style(for state: State) -> CallButtonStyle.StateStyle {

--- a/GliaWidgets/ViewController/Common/Alert/AlertViewController+SingleMediaUpgrade.swift
+++ b/GliaWidgets/ViewController/Common/Alert/AlertViewController+SingleMediaUpgrade.swift
@@ -14,6 +14,7 @@ extension AlertViewController {
 
         let declineButton = ActionButton(with: viewFactory.theme.alert.negativeAction)
         declineButton.title = conf.decline
+        declineButton.accessibilityIdentifier = "alert_negative_button"
         declineButton.tap = { [weak self] in
             self?.dismiss(animated: true) {
                 declined()
@@ -21,6 +22,7 @@ extension AlertViewController {
         }
         let acceptButton = ActionButton(with: viewFactory.theme.alert.positiveAction)
         acceptButton.title = conf.accept
+        acceptButton.accessibilityIdentifier = "alert_positive_button"
         acceptButton.tap = { [weak self] in
             self?.dismiss(animated: true) {
                 accepted()


### PR DESCRIPTION
In order to detect if an engagement has been upgraded to audio, new
accessibility identifiers have been added to the buttons in the audio
call view, and the alert that appears when the operator requests an
audio call from the visitor. For the audio call view, the
accessibility identifier is only set when the button is enabled.

MOB-1400