### PR TITLE
Change accessibility identifier prefix to `media`

### DIFF
--- a/GliaWidgets/Component/CallButtonBar/Button/CallButton.swift
+++ b/GliaWidgets/Component/CallButtonBar/Button/CallButton.swift
@@ -133,7 +133,7 @@ class CallButton: UIView {
         accessibilityValue = properties.value
         accessibilityLabel = properties.label
 
-        let buttonAccessibilityIdentifier = "audio_\(properties.value.lowercased())_button"
+        let buttonAccessibilityIdentifier = "media_\(properties.value.lowercased())_button"
         accessibilityIdentifier = isUserInteractionEnabled ? buttonAccessibilityIdentifier : ""
     }
 


### PR DESCRIPTION
Because the CallButton class is used in both audio and video, then it
makes more sense to have the accessibility identifier's prefix to be
`media` rather than `audio`.

MOB-1400