### PR TITLE
Add unit tests for default parameters of deprecated Glia.start

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -342,6 +342,17 @@
 		9AE9E4B327E0E60F00BFE239 /* CallViewModel.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE9E4B227E0E60F00BFE239 /* CallViewModel.Mock.swift */; };
 		9AE9E4B527E0EE2E00BFE239 /* CallViewControllerVoiceOverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE9E4B427E0EE2E00BFE239 /* CallViewControllerVoiceOverTests.swift */; };
 		9AE9E4B727E1E30500BFE239 /* MockHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE9E4B627E1E30500BFE239 /* MockHelpers.swift */; };
+		AF9DB22E2890571A00A0C442 /* RootCoordinator.Environment.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9DB22D2890571A00A0C442 /* RootCoordinator.Environment.Failing.swift */; };
+		AF9DB23128905A1D00A0C442 /* ViewFactory.Environment.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9DB23028905A1D00A0C442 /* ViewFactory.Environment.Failing.swift */; };
+		AFA2FDEC28907D7C00428E6D /* RootCoordinator.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA2FDEB28907D7C00428E6D /* RootCoordinator.Environment.swift */; };
+		AFA2FDEE28907DDB00428E6D /* RootCoordinator.Environment.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA2FDED28907DDB00428E6D /* RootCoordinator.Environment.Mock.swift */; };
+		AFA2FDF028907E3900428E6D /* RootCoordinator.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA2FDEF28907E3900428E6D /* RootCoordinator.Mock.swift */; };
+		AFA2FDF228907E9D00428E6D /* GliaViewController.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA2FDF128907E9D00428E6D /* GliaViewController.Mock.swift */; };
+		AFA2FDF428907F0C00428E6D /* BubbleView.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA2FDF328907F0C00428E6D /* BubbleView.Mock.swift */; };
+		AFA2FDF628907FC800428E6D /* BubbleStyle.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA2FDF528907FC800428E6D /* BubbleStyle.Mock.swift */; };
+		AFA2FDF8289080FA00428E6D /* UserImageStyle.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA2FDF7289080FA00428E6D /* UserImageStyle.Mock.swift */; };
+		AFA2FDFA2890827E00428E6D /* BadgeStyle.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA2FDF92890827E00428E6D /* BadgeStyle.Mock.swift */; };
+		AFA2FDFC289082F500428E6D /* OnHoldOverlayStyle.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA2FDFB289082F500428E6D /* OnHoldOverlayStyle.Mock.swift */; };
 		AFBBF5782851C391004993B3 /* Glia.Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBBF5772851C391004993B3 /* Glia.Deprecated.swift */; };
 		AFBBF57A28522591004993B3 /* Configuration.Unavailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBBF57928522591004993B3 /* Configuration.Unavailable.swift */; };
 		C4119E06268F41D1004DFEFB /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C4119E05268F41D1004DFEFB /* Main.storyboard */; };
@@ -774,6 +785,17 @@
 		9AE9E4B227E0E60F00BFE239 /* CallViewModel.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallViewModel.Mock.swift; sourceTree = "<group>"; };
 		9AE9E4B427E0EE2E00BFE239 /* CallViewControllerVoiceOverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallViewControllerVoiceOverTests.swift; sourceTree = "<group>"; };
 		9AE9E4B627E1E30500BFE239 /* MockHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHelpers.swift; sourceTree = "<group>"; };
+		AF9DB22D2890571A00A0C442 /* RootCoordinator.Environment.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootCoordinator.Environment.Failing.swift; sourceTree = "<group>"; };
+		AF9DB23028905A1D00A0C442 /* ViewFactory.Environment.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewFactory.Environment.Failing.swift; sourceTree = "<group>"; };
+		AFA2FDEB28907D7C00428E6D /* RootCoordinator.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootCoordinator.Environment.swift; sourceTree = "<group>"; };
+		AFA2FDED28907DDB00428E6D /* RootCoordinator.Environment.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootCoordinator.Environment.Mock.swift; sourceTree = "<group>"; };
+		AFA2FDEF28907E3900428E6D /* RootCoordinator.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootCoordinator.Mock.swift; sourceTree = "<group>"; };
+		AFA2FDF128907E9D00428E6D /* GliaViewController.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GliaViewController.Mock.swift; sourceTree = "<group>"; };
+		AFA2FDF328907F0C00428E6D /* BubbleView.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BubbleView.Mock.swift; sourceTree = "<group>"; };
+		AFA2FDF528907FC800428E6D /* BubbleStyle.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BubbleStyle.Mock.swift; sourceTree = "<group>"; };
+		AFA2FDF7289080FA00428E6D /* UserImageStyle.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserImageStyle.Mock.swift; sourceTree = "<group>"; };
+		AFA2FDF92890827E00428E6D /* BadgeStyle.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeStyle.Mock.swift; sourceTree = "<group>"; };
+		AFA2FDFB289082F500428E6D /* OnHoldOverlayStyle.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnHoldOverlayStyle.Mock.swift; sourceTree = "<group>"; };
 		AFBBF5772851C391004993B3 /* Glia.Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Glia.Deprecated.swift; sourceTree = "<group>"; };
 		AFBBF57928522591004993B3 /* Configuration.Unavailable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.Unavailable.swift; sourceTree = "<group>"; };
 		C1B1D31D2A8244728847B885 /* Pods_GliaWidgetsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GliaWidgetsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1102,6 +1124,8 @@
 				9A3E1D8527B6B668005634EB /* Lib */,
 				1A205D6825655CB2003AA3CD /* Info.plist */,
 				9ACC25D127B4727500BC5335 /* CoreSDKClient.Failing.swift */,
+				AF9DB22F2890599700A0C442 /* Factory */,
+				AF9DB22C289056F600A0C442 /* Coordinator */,
 				9ACC25D327B474E800BC5335 /* Glia.Environment.Failing.swift */,
 				9A1992E027D6313500161AAE /* ImageView.Cache.Failing.swift */,
 				9A19926F27D3BCAE00161AAE /* GCD.Failing.swift */,
@@ -1219,6 +1243,7 @@
 			children = (
 				1A475BB225DE831F00296D55 /* BadgeView.swift */,
 				1A475BB625DE833200296D55 /* BadgeStyle.swift */,
+				AFA2FDF92890827E00428E6D /* BadgeStyle.Mock.swift */,
 			);
 			path = Badge;
 			sourceTree = "<group>";
@@ -1344,6 +1369,7 @@
 			children = (
 				1A6075DF2582209100569B0E /* UserImageView.swift */,
 				1A6075E6258220E300569B0E /* UserImageStyle.swift */,
+				AFA2FDF7289080FA00428E6D /* UserImageStyle.Mock.swift */,
 			);
 			path = User;
 			sourceTree = "<group>";
@@ -1356,6 +1382,7 @@
 				1A0C143D25B85DA300B00695 /* Call */,
 				1A63B2EF257A3EF100508478 /* Common */,
 				1AC7A7472582237500567FF8 /* GliaViewController.swift */,
+				AFA2FDF128907E9D00428E6D /* GliaViewController.Mock.swift */,
 				1A0C142825B84E5500B00695 /* EngagementViewController.swift */,
 			);
 			path = ViewController;
@@ -1367,6 +1394,9 @@
 				1A60AFE225669AF800E53F53 /* Chat */,
 				1A0C144225B868ED00B00695 /* Call */,
 				1A60AFC92566943F00E53F53 /* RootCoordinator.swift */,
+				AFA2FDEF28907E3900428E6D /* RootCoordinator.Mock.swift */,
+				AFA2FDEB28907D7C00428E6D /* RootCoordinator.Environment.swift */,
+				AFA2FDED28907DDB00428E6D /* RootCoordinator.Environment.Mock.swift */,
 			);
 			path = Coordinator;
 			sourceTree = "<group>";
@@ -1804,7 +1834,9 @@
 			children = (
 				1ABD6C5C25B59D1C00D56EFA /* BubbleWindow.swift */,
 				1ABD6C5425B574FF00D56EFA /* BubbleView.swift */,
+				AFA2FDF328907F0C00428E6D /* BubbleView.Mock.swift */,
 				1ABD6C5825B5758000D56EFA /* BubbleStyle.swift */,
+				AFA2FDF528907FC800428E6D /* BubbleStyle.Mock.swift */,
 				9A186A4427F6F88F0055886D /* BubbleStyle.Accessibility.swift */,
 			);
 			path = Bubble;
@@ -2124,6 +2156,22 @@
 			path = Interactor;
 			sourceTree = "<group>";
 		};
+		AF9DB22C289056F600A0C442 /* Coordinator */ = {
+			isa = PBXGroup;
+			children = (
+				AF9DB22D2890571A00A0C442 /* RootCoordinator.Environment.Failing.swift */,
+			);
+			path = Coordinator;
+			sourceTree = "<group>";
+		};
+		AF9DB22F2890599700A0C442 /* Factory */ = {
+			isa = PBXGroup;
+			children = (
+				AF9DB23028905A1D00A0C442 /* ViewFactory.Environment.Failing.swift */,
+			);
+			path = Factory;
+			sourceTree = "<group>";
+		};
 		C42463722673ABCD0082C135 /* Screensharing */ = {
 			isa = PBXGroup;
 			children = (
@@ -2227,6 +2275,7 @@
 				EB2CBB1427D8DB95004F178E /* OnHoldOverlayVisualEffectView.swift */,
 				EB2CBB0F27D89F74004F178E /* OnHoldOverlayView.swift */,
 				EB2CBB1127D89F7D004F178E /* OnHoldOverlayStyle.swift */,
+				AFA2FDFB289082F500428E6D /* OnHoldOverlayStyle.Mock.swift */,
 			);
 			path = OnHoldOverlay;
 			sourceTree = "<group>";
@@ -2726,6 +2775,7 @@
 				1A7CA81D2574D6370047CBBE /* ConnectView.swift in Sources */,
 				1ABD6C5525B574FF00D56EFA /* BubbleView.swift in Sources */,
 				C43D7A1525FF9A590064B1DA /* ChatChoiceCardOption.swift in Sources */,
+				AFA2FDF8289080FA00428E6D /* UserImageStyle.Mock.swift in Sources */,
 				845E2F8B283FB53500C04D56 /* Theme.Survey.InputQuestion.Accessibility.swift in Sources */,
 				9A3E1D9427B6C29C005634EB /* ChatEngagementFile.Mock.swift in Sources */,
 				1A2DA73B25EFC00500032611 /* FileUploadListStyle.swift in Sources */,
@@ -2733,6 +2783,7 @@
 				C4F176CE261D1543009D9F07 /* ChatFileDownloadContentStyle.swift in Sources */,
 				845876A5282A9015007AC3DF /* ScaleQuestionView.Props.Accessibility.swift in Sources */,
 				C43D7A0D25FF92530064B1DA /* ChoiceCardView.swift in Sources */,
+				AFA2FDFC289082F500428E6D /* OnHoldOverlayStyle.Mock.swift in Sources */,
 				1A0C142925B84E5500B00695 /* EngagementViewController.swift in Sources */,
 				1A60AFE425669B0400E53F53 /* ChatCoordinator.swift in Sources */,
 				EB2CBB1027D89F74004F178E /* OnHoldOverlayView.swift in Sources */,
@@ -2839,6 +2890,7 @@
 				754CC61527E27C42005676E9 /* Survey.Checkbox.swift in Sources */,
 				AFBBF57A28522591004993B3 /* Configuration.Unavailable.swift in Sources */,
 				1A4AD3CA256E864800468BFB /* ThemeColorStyle.swift in Sources */,
+				AFA2FDF228907E9D00428E6D /* GliaViewController.Mock.swift in Sources */,
 				9AB196DE27C3FFF400FD60AB /* Call.Environment.Mock.swift in Sources */,
 				1A0C143125B8547200B00695 /* EngagementStyle.swift in Sources */,
 				9A186A3727F5D38D0055886D /* ChatMessageEntryStyle.Accessibility.swift in Sources */,
@@ -2865,6 +2917,7 @@
 				1A2DA72D25EF9DD900032611 /* FileUpload.swift in Sources */,
 				C499A57E26382FAA009962AC /* UnreadMessageIndicatorView.swift in Sources */,
 				31DB0C01287C2EFC00FB288E /* StaticValues.swift in Sources */,
+				AFA2FDFA2890827E00428E6D /* BadgeStyle.Mock.swift in Sources */,
 				9AB3402527FCBEB4006E0FE2 /* CallButtonStyle.Accessibility.swift in Sources */,
 				1A8B61D225C974A1000D780E /* ChatCallUpgradeView.swift in Sources */,
 				845E2F88283FB49F00C04D56 /* Theme.Survey.BooleanQuestion.Accessibility.swift in Sources */,
@@ -2878,6 +2931,7 @@
 				1A5F814D2588C0B800A605DA /* KeyboardObserver.swift in Sources */,
 				9A66172C27A94A4B001C8E03 /* CoreSDKClient.Mock.swift in Sources */,
 				1A5F8182258B4F0E00A605DA /* OutgoingMessage.swift in Sources */,
+				AFA2FDF428907F0C00428E6D /* BubbleView.Mock.swift in Sources */,
 				9A19926E27D3BB7800161AAE /* Theme.Mock.swift in Sources */,
 				9AE9E4B127E0E45200BFE239 /* CallViewController.Mock.swift in Sources */,
 				9AE0A7642822B02C00725946 /* FontScaling.Environment.Mock.swift in Sources */,
@@ -2895,6 +2949,7 @@
 				845876AB282A959C007AC3DF /* SingleChoiceQuestionView.Props.Accessibility.swift in Sources */,
 				9AB3402327FC859E006E0FE2 /* CallButtonStyle.StateStyle.Accessibility.swift in Sources */,
 				6E9C01AD26D3B8B500EBE1D4 /* OperatorTypingIndicatorView.swift in Sources */,
+				AFA2FDF628907FC800428E6D /* BubbleStyle.Mock.swift in Sources */,
 				7529F2B427E1D503004D3581 /* Survey.swift in Sources */,
 				1A5F494B25CA86CA003E3678 /* Call.swift in Sources */,
 				9A1992ED27D6C19E00161AAE /* FileSystemStorage.Environment.Mock.swift in Sources */,
@@ -2910,6 +2965,7 @@
 				9A8130BF27D7AEF700220BBD /* FileUpload.Mock.swift in Sources */,
 				9A8130BD27D7A53300220BBD /* FileUpload.Environment.Mock.swift in Sources */,
 				1A60AFB22566821B00E53F53 /* Asset.swift in Sources */,
+				AFA2FDEC28907D7C00428E6D /* RootCoordinator.Environment.swift in Sources */,
 				75FF151727F4E13900FE7BE2 /* Theme.Survey.BooleanQuestion.swift in Sources */,
 				1A1E309625F8CA4400850E68 /* FileDownload.swift in Sources */,
 				EB2CBB1527D8DB95004F178E /* OnHoldOverlayVisualEffectView.swift in Sources */,
@@ -2926,6 +2982,7 @@
 				1A1E30C725F9FDAB00850E68 /* ChatImageFileContentView.swift in Sources */,
 				756087E127837EC000158604 /* BundleManaging.swift in Sources */,
 				1A60AF90256674F000E53F53 /* Font.swift in Sources */,
+				AFA2FDEE28907DDB00428E6D /* RootCoordinator.Environment.Mock.swift in Sources */,
 				9A41B66A27E2439000CF9F69 /* Call.Mock.swift in Sources */,
 				1A4674C225E92A710078FA1C /* AtttachmentSourceItemKind.swift in Sources */,
 				9A1992EB27D6C0F000161AAE /* FileSystemStorage.Mock.swift in Sources */,
@@ -2943,6 +3000,7 @@
 				1A2DA73125EFA77E00032611 /* FileUploader.swift in Sources */,
 				1A60B0272568070800E53F53 /* UIStackView+Extensions.swift in Sources */,
 				9AB3401D27FB4F3C006E0FE2 /* ConnectOperatorStyle.Accessibility.swift in Sources */,
+				AFA2FDF028907E3900428E6D /* RootCoordinator.Mock.swift in Sources */,
 				9A1992E527D6679300161AAE /* UIKitBased.Live.swift in Sources */,
 				1A60B0232567FD2D00E53F53 /* CloseButtonProperties.swift in Sources */,
 				1ABD6C8725B6EFD000D56EFA /* SingleMediaUpgradeAlertConfiguration.swift in Sources */,
@@ -2976,6 +3034,8 @@
 				9A3E1DA227BA7D00005634EB /* FileSystemStorage.Environment.Failing.swift in Sources */,
 				9A1992E127D6313500161AAE /* ImageView.Cache.Failing.swift in Sources */,
 				EB9ADB552828E66B00FAE8A4 /* CallTests.swift in Sources */,
+				AF9DB22E2890571A00A0C442 /* RootCoordinator.Environment.Failing.swift in Sources */,
+				AF9DB23128905A1D00A0C442 /* ViewFactory.Environment.Failing.swift in Sources */,
 				9A3E1DA027BA7B9F005634EB /* FileSystemStorageTests.swift in Sources */,
 				EB9ADB5A2829089F00FAE8A4 /* ChatItem+Equatable.swift in Sources */,
 				EB7A150A286D98270035AC62 /* FileUploaderTests.swift in Sources */,

--- a/GliaWidgets/Component/Badge/BadgeStyle.Mock.swift
+++ b/GliaWidgets/Component/Badge/BadgeStyle.Mock.swift
@@ -1,0 +1,17 @@
+#if DEBUG
+import UIKit
+
+extension BadgeStyle {
+    static func mock(
+        font: UIFont = .systemFont(ofSize: 10),
+        fontColor: UIColor = .red,
+        backgroundColor: UIColor = .red
+    ) -> BadgeStyle {
+        .init(
+            font: font,
+            fontColor: fontColor,
+            backgroundColor: backgroundColor
+        )
+    }
+}
+#endif

--- a/GliaWidgets/Component/Bubble/BubbleStyle.Mock.swift
+++ b/GliaWidgets/Component/Bubble/BubbleStyle.Mock.swift
@@ -1,0 +1,17 @@
+#if DEBUG
+extension BubbleStyle {
+    static func mock(
+        userImage: UserImageStyle = .mock(),
+        badge: BadgeStyle = .mock(),
+        onHoldOverlay: OnHoldOverlayStyle = .mock(),
+        accessibility: Accessibility = .unsupported
+    ) -> BubbleStyle {
+        .init(
+            userImage: userImage,
+            badge: badge,
+            onHoldOverlay: onHoldOverlay,
+            accessibility: accessibility
+        )
+    }
+}
+#endif

--- a/GliaWidgets/Component/Bubble/BubbleView.Mock.swift
+++ b/GliaWidgets/Component/Bubble/BubbleView.Mock.swift
@@ -1,0 +1,13 @@
+#if DEBUG
+extension BubbleView {
+    static func mock(
+        with bubbleStyle: BubbleStyle,
+        environment: Environment
+    ) -> BubbleView {
+        .init(
+            with: bubbleStyle,
+            environment: environment
+        )
+    }
+}
+#endif

--- a/GliaWidgets/Component/ImageView/User/UserImageStyle.Mock.swift
+++ b/GliaWidgets/Component/ImageView/User/UserImageStyle.Mock.swift
@@ -1,0 +1,21 @@
+#if DEBUG
+import UIKit
+
+extension UserImageStyle {
+    static func mock(
+        placeholderImage: UIImage? = nil,
+        placeholderColor: UIColor = .red,
+        placeholderBackgroundColor: UIColor = .red,
+        imageBackgroundColor: UIColor = .red,
+        transferringImage: UIImage? = nil
+    ) -> UserImageStyle {
+        .init(
+            placeholderImage: placeholderImage,
+            placeholderColor: placeholderColor,
+            placeholderBackgroundColor: placeholderBackgroundColor,
+            imageBackgroundColor: imageBackgroundColor,
+            transferringImage: transferringImage
+        )
+    }
+}
+#endif

--- a/GliaWidgets/Component/OnHoldOverlay/OnHoldOverlayStyle.Mock.swift
+++ b/GliaWidgets/Component/OnHoldOverlay/OnHoldOverlayStyle.Mock.swift
@@ -1,0 +1,17 @@
+#if DEBUG
+import UIKit
+
+extension OnHoldOverlayStyle {
+    static func mock(
+        image: UIImage = .init(),
+        imageColor: UIColor = .red,
+        imageSize: CGSize = .zero
+    ) -> OnHoldOverlayStyle {
+        .init(
+            image: image,
+            imageColor: imageColor,
+            imageSize: imageSize
+        )
+    }
+}
+#endif

--- a/GliaWidgets/Coordinator/Call/CallCoordinator.swift
+++ b/GliaWidgets/Coordinator/Call/CallCoordinator.swift
@@ -69,7 +69,7 @@ class CallCoordinator: SubFlowCoordinator, FlowCoordinator {
                 localFileThumbnailQueue: environment.localFileThumbnailQueue,
                 uiImage: environment.uiImage,
                 createFileDownload: environment.createFileDownload,
-                fromHistory: environment.fromHistory,
+                loadChatMessagesFromHistory: environment.fromHistory,
                 fetchSiteConfigurations: environment.fetchSiteConfigurations,
                 getCurrentEngagement: environment.getCurrentEngagement,
                 timerProviding: environment.timerProviding,

--- a/GliaWidgets/Coordinator/Chat/ChatCoordinator.swift
+++ b/GliaWidgets/Coordinator/Chat/ChatCoordinator.swift
@@ -81,7 +81,7 @@ class ChatCoordinator: SubFlowCoordinator, FlowCoordinator {
                 localFileThumbnailQueue: environment.localFileThumbnailQueue,
                 uiImage: environment.uiImage,
                 createFileDownload: environment.createFileDownload,
-                fromHistory: environment.fromHistory,
+                loadChatMessagesFromHistory: environment.fromHistory,
                 fetchSiteConfigurations: environment.fetchSiteConfigurations,
                 getCurrentEngagement: environment.getCurrentEngagement,
                 timerProviding: .live,

--- a/GliaWidgets/Coordinator/RootCoordinator.Environment.Mock.swift
+++ b/GliaWidgets/Coordinator/RootCoordinator.Environment.Mock.swift
@@ -1,0 +1,25 @@
+#if DEBUG
+extension RootCoordinator.Environment {
+    static let mock = Self.init(
+        chatStorage: .mock,
+        fetchFile: { _, _, _ in },
+        sendSelectedOptionValue: { _, _ in },
+        uploadFileToEngagement: { _, _, _ in },
+        audioSession: .mock,
+        uuid: { .mock },
+        fileManager: .mock,
+        data: .mock,
+        date: { .mock },
+        gcd: .mock,
+        localFileThumbnailQueue: .mock(),
+        uiImage: .mock,
+        createFileDownload: { _, _, _ in .mock() },
+        loadChatMessagesFromHistory: { false },
+        timerProviding: .mock,
+        fetchSiteConfigurations: { _ in },
+        getCurrentEngagement: { nil },
+        submitSurveyAnswer: { _, _, _, _ in },
+        uiApplication: .mock
+    )
+}
+#endif

--- a/GliaWidgets/Coordinator/RootCoordinator.Environment.swift
+++ b/GliaWidgets/Coordinator/RootCoordinator.Environment.swift
@@ -1,11 +1,11 @@
-import Foundation
-
-extension EngagementViewModel {
+extension RootCoordinator {
     struct Environment {
         var chatStorage: Glia.Environment.ChatStorage
         var fetchFile: CoreSdkClient.FetchFile
         var sendSelectedOptionValue: CoreSdkClient.SendSelectedOptionValue
         var uploadFileToEngagement: CoreSdkClient.UploadFileToEngagement
+        var audioSession: Glia.Environment.AudioSession
+        var uuid: () -> UUID
         var fileManager: FoundationBased.FileManager
         var data: FoundationBased.Data
         var date: () -> Date
@@ -14,10 +14,10 @@ extension EngagementViewModel {
         var uiImage: UIKitBased.UIImage
         var createFileDownload: FileDownloader.CreateFileDownload
         var loadChatMessagesFromHistory: () -> Bool
+        var timerProviding: FoundationBased.Timer.Providing
         var fetchSiteConfigurations: CoreSdkClient.FetchSiteConfigurations
         var getCurrentEngagement: CoreSdkClient.GetCurrentEngagement
-        var timerProviding: FoundationBased.Timer.Providing
-        var uuid: () -> UUID
+        var submitSurveyAnswer: CoreSdkClient.SubmitSurveyAnswer
         var uiApplication: UIKitBased.UIApplication
     }
 }

--- a/GliaWidgets/Coordinator/RootCoordinator.Mock.swift
+++ b/GliaWidgets/Coordinator/RootCoordinator.Mock.swift
@@ -1,0 +1,21 @@
+#if DEBUG
+extension RootCoordinator {
+    static func mock(
+        interactor: Interactor = .mock(),
+        viewFactory: ViewFactory = .mock(),
+        sceneProvider: SceneProvider? = nil,
+        engagementKind: EngagementKind = .audioCall,
+        features: Features = .all,
+        environment: Environment = .mock
+    ) -> RootCoordinator {
+        RootCoordinator(
+            interactor: interactor,
+            viewFactory: viewFactory,
+            sceneProvider: sceneProvider,
+            engagementKind: engagementKind,
+            features: features,
+            environment: environment
+        )
+    }
+}
+#endif

--- a/GliaWidgets/Coordinator/RootCoordinator.swift
+++ b/GliaWidgets/Coordinator/RootCoordinator.swift
@@ -206,7 +206,7 @@ extension RootCoordinator {
                 localFileThumbnailQueue: environment.localFileThumbnailQueue,
                 uiImage: environment.uiImage,
                 createFileDownload: environment.createFileDownload,
-                fromHistory: environment.fromHistory,
+                fromHistory: environment.loadChatMessagesFromHistory,
                 fetchSiteConfigurations: environment.fetchSiteConfigurations,
                 getCurrentEngagement: environment.getCurrentEngagement,
                 submitSurveyAnswer: environment.submitSurveyAnswer,
@@ -290,7 +290,7 @@ extension RootCoordinator {
                 localFileThumbnailQueue: environment.localFileThumbnailQueue,
                 uiImage: environment.uiImage,
                 createFileDownload: environment.createFileDownload,
-                fromHistory: environment.fromHistory,
+                fromHistory: environment.loadChatMessagesFromHistory,
                 fetchSiteConfigurations: environment.fetchSiteConfigurations,
                 getCurrentEngagement: environment.getCurrentEngagement,
                 timerProviding: environment.timerProviding,
@@ -468,30 +468,6 @@ extension EngagementKind {
         case .video:
             self = .videoCall
         }
-    }
-}
-
-extension RootCoordinator {
-    struct Environment {
-        var chatStorage: Glia.Environment.ChatStorage
-        var fetchFile: CoreSdkClient.FetchFile
-        var sendSelectedOptionValue: CoreSdkClient.SendSelectedOptionValue
-        var uploadFileToEngagement: CoreSdkClient.UploadFileToEngagement
-        var audioSession: Glia.Environment.AudioSession
-        var uuid: () -> UUID
-        var fileManager: FoundationBased.FileManager
-        var data: FoundationBased.Data
-        var date: () -> Date
-        var gcd: GCD
-        var localFileThumbnailQueue: FoundationBased.OperationQueue
-        var uiImage: UIKitBased.UIImage
-        var createFileDownload: FileDownloader.CreateFileDownload
-        var fromHistory: () -> Bool
-        var timerProviding: FoundationBased.Timer.Providing
-        var fetchSiteConfigurations: CoreSdkClient.FetchSiteConfigurations
-        var getCurrentEngagement: CoreSdkClient.GetCurrentEngagement
-        var submitSurveyAnswer: CoreSdkClient.SubmitSurveyAnswer
-        var uiApplication: UIKitBased.UIApplication
     }
 }
 

--- a/GliaWidgets/Glia.Environment.Interface.swift
+++ b/GliaWidgets/Glia.Environment.Interface.swift
@@ -2,7 +2,24 @@ import AVFoundation
 import Foundation
 
 extension Glia {
+    /// `Environment` is a dependency container that solves the problem exchanging live dependencies to mocked ones during unit testing.
+    /// So regarding particular naming of things like `var date: () -> Date` and `var uuid: () -> UUID` is a way of saying is that
+    /// there is going to be used `Date()` and `UUID()` accordingly. In case of using some type that has several initializers that expect specific
+    /// arguments, there will be used wrapper struct instead of simple closure, like `var data: FoundationBased.Data`for example.
+    /// But the idea stays the same - for using 3rd party frameworks like `Core SDK` and 1st party like `Foundation.FileManager` we will have
+    /// closures and structs-wrappers that mimic actual types provided by frameworks.
+    /// Child `Environment` that is going to use `Foundation.Date` for some very specific case will get this type injected from parent `Environment`
+    /// that may not use it explicitly (or use it for some very different case), so there's no sense to give to parent `Environment` property specific name,
+    /// but very general one like var date: `() -> Date`.
     struct Environment {
+        typealias CreateRootCoordinator = (
+            _ interactor: Interactor,
+            _ viewFactory: ViewFactory,
+            _ sceneProvider: SceneProvider?,
+            _ engagementKind: EngagementKind,
+            _ features: Features,
+            _ environment: RootCoordinator.Environment
+        ) -> RootCoordinator
         var coreSdk: CoreSdkClient
         var chatStorage: ChatStorage
         var audioSession: AudioSession
@@ -15,9 +32,30 @@ extension Glia {
         var localFileThumbnailQueue: FoundationBased.OperationQueue
         var uiImage: UIKitBased.UIImage
         var createFileDownload: FileDownloader.CreateFileDownload
-        var fromHistory: () -> Bool
+        var loadChatMessagesFromHistory: () -> Bool
         var timerProviding: FoundationBased.Timer.Providing
         var uiApplication: UIKitBased.UIApplication
+        var createRootCoordinator: CreateRootCoordinator
+    }
+}
+
+extension Glia.Environment {
+    func rootCoordinator(
+        interactor: Interactor,
+        viewFactory: ViewFactory,
+        sceneProvider: SceneProvider?,
+        engagementKind: EngagementKind,
+        features: Features,
+        environment: RootCoordinator.Environment
+    ) -> RootCoordinator {
+        self.createRootCoordinator(
+            interactor,
+            viewFactory,
+            sceneProvider,
+            engagementKind,
+            features,
+            environment
+        )
     }
 }
 

--- a/GliaWidgets/Glia.Environment.Live.swift
+++ b/GliaWidgets/Glia.Environment.Live.swift
@@ -19,9 +19,10 @@ extension Glia.Environment {
         }(),
         uiImage: .live,
         createFileDownload: FileDownload.init(with:storage:environment:),
-        fromHistory: { true },
+        loadChatMessagesFromHistory: { true },
         timerProviding: .live,
-        uiApplication: .live
+        uiApplication: .live,
+        createRootCoordinator: RootCoordinator.init(interactor: viewFactory:sceneProvider:engagementKind:features:environment:)
     )
 }
 

--- a/GliaWidgets/Glia.Environment.Mock.swift
+++ b/GliaWidgets/Glia.Environment.Mock.swift
@@ -15,9 +15,10 @@ extension Glia.Environment {
         localFileThumbnailQueue: .mock(),
         uiImage: .mock,
         createFileDownload: { _, _, _ in .mock() },
-        fromHistory: { true },
+        loadChatMessagesFromHistory: { true },
         timerProviding: .mock,
-        uiApplication: .mock
+        uiApplication: .mock,
+        createRootCoordinator: RootCoordinator.mock
     )
 }
 

--- a/GliaWidgets/Glia.swift
+++ b/GliaWidgets/Glia.swift
@@ -187,7 +187,7 @@ public class Glia {
         engagementKind: EngagementKind,
         features: Features
     ) {
-        rootCoordinator = RootCoordinator(
+        rootCoordinator = self.environment.rootCoordinator(
             interactor: interactor,
             viewFactory: viewFactory,
             sceneProvider: sceneProvider,
@@ -207,7 +207,7 @@ public class Glia {
                 localFileThumbnailQueue: environment.localFileThumbnailQueue,
                 uiImage: environment.uiImage,
                 createFileDownload: environment.createFileDownload,
-                fromHistory: environment.fromHistory,
+                loadChatMessagesFromHistory: environment.loadChatMessagesFromHistory,
                 timerProviding: environment.timerProviding,
                 fetchSiteConfigurations: environment.coreSdk.fetchSiteConfigurations,
                 getCurrentEngagement: environment.coreSdk.getCurrentEngagement,

--- a/GliaWidgets/ViewController/Chat/ChatViewController.Mock.swift
+++ b/GliaWidgets/ViewController/Chat/ChatViewController.Mock.swift
@@ -314,7 +314,7 @@ extension ChatViewController {
     static func mockChoiceCard() throws -> ChatViewController {
         var chatViewModelEnv = ChatViewModel.Environment.mock
         chatViewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
-        chatViewModelEnv.fromHistory = {
+        chatViewModelEnv.loadChatMessagesFromHistory = {
             true
         }
         let messageUuid = UUID.incrementing

--- a/GliaWidgets/ViewController/GliaViewController.Mock.swift
+++ b/GliaWidgets/ViewController/GliaViewController.Mock.swift
@@ -1,0 +1,15 @@
+#if DEBUG
+extension GliaViewController {
+    static func mock(
+        bubbleView: BubbleView,
+        delegate: GliaViewControllerDelegate?,
+        features: Features
+    ) -> GliaViewController {
+        .init(
+            bubbleView: bubbleView,
+            delegate: delegate,
+            features: features
+        )
+    }
+}
+#endif

--- a/GliaWidgets/ViewModel/Chat/ChatViewModel.Environment.Mock.swift
+++ b/GliaWidgets/ViewModel/Chat/ChatViewModel.Environment.Mock.swift
@@ -18,7 +18,7 @@ extension ChatViewModel.Environment {
                     environment: env
                 )
         },
-        fromHistory: { true },
+        loadChatMessagesFromHistory: { true },
         fetchSiteConfigurations: { _ in },
         getCurrentEngagement: { return nil },
         timerProviding: .mock,

--- a/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
@@ -307,7 +307,7 @@ extension ChatViewModel {
 extension ChatViewModel {
     private func loadHistory() {
         let messages = environment.chatStorage.messages(interactor.queueID)
-        let items = messages.compactMap { ChatItem(with: $0, fromHistory: environment.fromHistory()) }
+        let items = messages.compactMap { ChatItem(with: $0, fromHistory: environment.loadChatMessagesFromHistory()) }
         historySection.set(items)
         action?(.refreshSection(historySection.index))
         action?(.scrollToBottom(animated: false))

--- a/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
+++ b/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
@@ -1,7 +1,7 @@
 @testable import GliaWidgets
 
-extension ChatViewModel.Environment {
-    static let failing = Self(
+extension RootCoordinator.Environment {
+    static let failing = Self.init(
         chatStorage: .failing,
         fetchFile: { _, _, _ in
             fail("\(Self.self).fetchFile")
@@ -12,6 +12,11 @@ extension ChatViewModel.Environment {
         uploadFileToEngagement: { _, _, _ in
             fail("\(Self.self).uploadFileToEngagement")
         },
+        audioSession: .failing,
+        uuid: {
+            fail("\(Self.self).uuid")
+            return .mock
+        },
         fileManager: .failing,
         data: .failing,
         date: {
@@ -21,23 +26,22 @@ extension ChatViewModel.Environment {
         gcd: .failing,
         localFileThumbnailQueue: .failing,
         uiImage: .failing,
-        createFileDownload: { _, _, _ in
-            fail("\(Self.self).createFileDownload")
-            return .failing
-        },
+        createFileDownload: { _, _, _ in .failing },
         loadChatMessagesFromHistory: {
             fail("\(Self.self).loadChatMessagesFromHistory")
             return true
         },
+        timerProviding: .failing,
         fetchSiteConfigurations: { _ in
             fail("\(Self.self).fetchSiteConfigurations")
         },
-        getCurrentEngagement: { nil },
-        timerProviding: .mock,
-        uuid: {
-            fail("\(Self.self).uuid")
-            return .mock
+        getCurrentEngagement: {
+            fail("\(Self.self).getCurrentEngagement")
+            return nil
         },
-        uiApplication: .mock
+        submitSurveyAnswer: { _, _, _, _ in
+            fail("\(Self.self).submitSurveyAnswer")
+        },
+        uiApplication: .failing
     )
 }

--- a/GliaWidgetsTests/Factory/ViewFactory.Environment.Failing.swift
+++ b/GliaWidgetsTests/Factory/ViewFactory.Environment.Failing.swift
@@ -1,0 +1,15 @@
+@testable import GliaWidgets
+
+extension ViewFactory.Environment {
+    static let failing = Self(
+        data: .failing,
+        uuid: {
+            fail("\(Self.self).uuid")
+            return .mock
+        },
+        gcd: .failing,
+        imageViewCache: .failing,
+        timerProviding: .failing,
+        uiApplication: .failing
+    )
+}

--- a/GliaWidgetsTests/Glia.Environment.Failing.swift
+++ b/GliaWidgetsTests/Glia.Environment.Failing.swift
@@ -19,12 +19,23 @@ extension Glia.Environment {
         localFileThumbnailQueue: .failing,
         uiImage: .failing,
         createFileDownload: { _, _, _ in .failing },
-        fromHistory: {
-            fail("\(Self.self).fromHistory")
+        loadChatMessagesFromHistory: {
+            fail("\(Self.self).loadChatMessagesFromHistory")
             return true
         },
         timerProviding: .failing,
-        uiApplication: .failing
+        uiApplication: .failing,
+        createRootCoordinator: { _, _, _, _, _, _ in
+            fail("\(Self.self).createRootCoordinator")
+            return .mock(
+                interactor: .mock(environment: .failing),
+                viewFactory: .mock(environment: .failing),
+                sceneProvider: nil,
+                engagementKind: .none,
+                features: [],
+                environment: .failing
+            )
+        }
     )
 }
 

--- a/GliaWidgetsTests/Sources/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModelTests.swift
@@ -44,7 +44,7 @@ class ChatViewModelTests: XCTestCase {
                         environment: .failing
                     )
                 },
-                fromHistory: { true },
+                loadChatMessagesFromHistory: { true },
                 fetchSiteConfigurations: { _ in },
                 getCurrentEngagement: { nil },
                 timerProviding: .mock,
@@ -79,7 +79,7 @@ class ChatViewModelTests: XCTestCase {
         viewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
         viewModelEnv.fileManager.createDirectoryAtUrlWithIntermediateDirectories = { _, _, _ in }
         viewModelEnv.chatStorage.messages = { _ in [] }
-        viewModelEnv.fromHistory = { true }
+        viewModelEnv.loadChatMessagesFromHistory = { true }
         let viewModel = ChatViewModel.mock(interactor: interactor, environment: viewModelEnv)
         viewModel.start()
         XCTAssertEqual(calls, [.configureWithInteractor, .configureWithConfiguration])
@@ -110,7 +110,7 @@ class ChatViewModelTests: XCTestCase {
         viewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
         viewModelEnv.fileManager.createDirectoryAtUrlWithIntermediateDirectories = { _, _, _ in }
         viewModelEnv.chatStorage.messages = { _ in [] }
-        viewModelEnv.fromHistory = { true }
+        viewModelEnv.loadChatMessagesFromHistory = { true }
         viewModelEnv.fetchSiteConfigurations = { _ in }
         
         let interactor: Interactor = .mock(environment: interactorEnv)
@@ -132,7 +132,7 @@ class ChatViewModelTests: XCTestCase {
         viewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
         viewModelEnv.fileManager.createDirectoryAtUrlWithIntermediateDirectories = { _, _, _ in }
         viewModelEnv.chatStorage.messages = { _ in [] }
-        viewModelEnv.fromHistory = { true }
+        viewModelEnv.loadChatMessagesFromHistory = { true }
         viewModelEnv.fetchSiteConfigurations = { _ in }
 
         let interactor: Interactor = .mock(environment: interactorEnv)
@@ -159,7 +159,7 @@ class ChatViewModelTests: XCTestCase {
         viewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
         viewModelEnv.fileManager.createDirectoryAtUrlWithIntermediateDirectories = { _, _, _ in }
         viewModelEnv.chatStorage.messages = { _ in [] }
-        viewModelEnv.fromHistory = { true }
+        viewModelEnv.loadChatMessagesFromHistory = { true }
         viewModelEnv.fetchSiteConfigurations = { _ in }
 
         let interactor: Interactor = .mock(environment: interactorEnv)


### PR DESCRIPTION
Accompanying unit test to make sure that passed parameters from deprecated `start` method are passed further.

MOB-1464