### PR TITLE
Removed applying frames to tested controllers

### DIFF
--- a/GliaWidgets/View/Call/CallView.swift
+++ b/GliaWidgets/View/Call/CallView.swift
@@ -126,6 +126,8 @@ class CallView: EngagementView {
     }
 
     override func setup() {
+        accessibilityIdentifier = "call_root_view"
+
         topStackView.axis = .vertical
         topStackView.spacing = 8
         topStackView.addArrangedSubviews([operatorNameLabel, secondLabel])

--- a/GliaWidgets/ViewController/Call/CallViewController.Mock.swift
+++ b/GliaWidgets/ViewController/Call/CallViewController.Mock.swift
@@ -45,7 +45,6 @@ extension CallViewController {
             environment: viewFactEnv
         )
         let viewController = CallViewController.mock(viewModel: viewModel, viewFactory: viewFactory)
-        viewController.view.frame = UIScreen.main.bounds
         viewModel.action?(.queue)
         return viewController
     }
@@ -83,7 +82,6 @@ extension CallViewController {
             environment: viewFactEnv
         )
         let viewController = CallViewController.mock(viewModel: viewModel, viewFactory: viewFactory)
-        viewController.view.frame = UIScreen.main.bounds
         viewModel.action?(.connecting(name: "Blob The Operator", imageUrl: nil))
         return viewController
     }
@@ -140,7 +138,6 @@ extension CallViewController {
             environment: viewFactEnv
         )
         let viewController = CallViewController.mock(viewModel: viewModel, viewFactory: viewFactory)
-        viewController.view.frame = UIScreen.main.bounds
         call.updateAudioStream(with: remoteAudioStream)
         call.updateAudioStream(with: localAudioStream)
         viewModel.action?(.connected(name: "Blob The Operator", imageUrl: nil))
@@ -188,7 +185,6 @@ extension CallViewController {
             environment: viewFactEnv
         )
         let viewController = CallViewController.mock(viewModel: viewModel, viewFactory: viewFactory)
-        viewController.view.frame = UIScreen.main.bounds
         let operatorImageURL = URL.mock
             .appendingPathComponent("operator")
             .appendingPathComponent("123")
@@ -231,7 +227,6 @@ extension CallViewController {
             environment: viewFactEnv
         )
         let viewController = CallViewController.mock(viewModel: viewModel, viewFactory: viewFactory)
-        viewController.view.frame = UIScreen.main.bounds
         viewModel.action?(.queue)
         return viewController
     }
@@ -275,7 +270,6 @@ extension CallViewController {
             environment: viewFactEnv
         )
         let viewController = CallViewController.mock(viewModel: viewModel, viewFactory: viewFactory)
-        viewController.view.frame = UIScreen.main.bounds
 
         call.updateVideoStream(with: CoreSdkClient.MockVideoStreamable.mock())
         call.state.value = .started

--- a/GliaWidgets/ViewController/Chat/ChatViewController.Mock.swift
+++ b/GliaWidgets/ViewController/Chat/ChatViewController.Mock.swift
@@ -205,7 +205,6 @@ extension ChatViewController {
         let interactor = Interactor.mock(environment: interEnv)
         let chatViewModel = ChatViewModel.mock(interactor: interactor, environment: chatViewModelEnv)
         let controller: ChatViewController = .mock(chatViewModel: chatViewModel)
-        controller.view.frame = UIScreen.main.bounds
         chatViewModel.action?(.setMessageText("Input Message Mock"))
         let localFileURL = URL.mockFilePath.appendingPathComponent("image").appendingPathExtension("png")
         var fileManager = FoundationBased.FileManager.mock

--- a/SnapshotTests/SurveyViewControllerVoiceOverTests.swift
+++ b/SnapshotTests/SurveyViewControllerVoiceOverTests.swift
@@ -6,7 +6,6 @@ import XCTest
 class SurveyViewControllerVoiceOverTests: SnapshotTestCase {
     func test_emptySurvey() {
         let viewController = Survey.ViewController(viewFactory: .mock(), props: .emptyPropsMock())
-        viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
             as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),
@@ -16,7 +15,6 @@ class SurveyViewControllerVoiceOverTests: SnapshotTestCase {
 
     func test_filledSurvey() {
         let viewController = Survey.ViewController(viewFactory: .mock(), props: .filledPropsMock())
-        viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
             as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),
@@ -26,7 +24,6 @@ class SurveyViewControllerVoiceOverTests: SnapshotTestCase {
 
     func test_emptySurveyErrorState() {
         let viewController = Survey.ViewController(viewFactory: .mock(), props: .errorPropsMock())
-        viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
             as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),


### PR DESCRIPTION
After removing SceneDelegate snapshot test were broken, but Testing app appearance hasn't been changed. 
It affected only snapshot tests. So after removing applying frames to tested controllers tests started to pass.

Maybe we will need to roll back this code when add SceneDelegate again in the future.