### PR TITLE
Bump Core SDK version after release

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -262,6 +262,16 @@ workflows:
     description: >-
       Workflow for creating builds of dev branch. Triggered on each push to dev
       branch, notifies over email + Slack (internal)
+  update_dependencies:
+    steps:
+    - activate-ssh-key@4: {}
+    - git-clone@6: {}
+    - cocoapods-install@2:
+        inputs:
+        - command: update
+    - fastlane@3:
+        inputs:
+        - lane: create_pr
 app:
   envs:
   - opts:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -42,4 +42,21 @@ platform :ios do
       value: "\"#{version}\""
     )
   end
+
+  desc "Creates a pull request in the repository with whatever changes have been made. "\
+    "Used in tandem with Bitrise to update dependencies. Named `create_pr` and not "\
+    "`create_pull_request` to avoid conflicting with the Fastlane action of the same name."
+  lane :create_pr do |options|
+    branch_name = 'dependencies-update'
+    message = "Update dependencies declared in `Podfile`"
+
+    sh "cd .. && scripts/create_pr.sh '#{branch_name}' '#{message}'"
+    create_pull_request(
+      repo: 'salemove/ios-sdk-widgets',
+      title: message,
+      head: branch_name,
+      base: 'master',
+      reviewers: [:gersonnoboa, :dukhovnyi, :igorkravchenko, :EgorovEI]
+    )
+  end
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -22,6 +22,7 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 ```
 
 Increments versions in Xcode projects and Podspec file according to given type.
+
 Usage:
 fastlane increment_project_version type:major - increments X.0.0
 fastlane increment_project_version type:minor - increments 0.X.0
@@ -35,6 +36,14 @@ fastlane increment_project_version type:patch - increments 0.0.X
 ```
 
 
+
+### ios create_pr
+
+```sh
+[bundle exec] fastlane ios create_pr
+```
+
+Creates a pull request in the repository with whatever changes have been made. Used in tandem with Bitrise to update dependencies. Named `create_pr` and not `create_pull_request` to avoid conflicting with the Fastlane action of the same name.
 
 ----
 

--- a/scripts/commit_unstaged_changes.sh
+++ b/scripts/commit_unstaged_changes.sh
@@ -1,0 +1,7 @@
+BRANCH_NAME=$1
+MESSAGE=$2
+
+git checkout -b "$BRANCH_NAME"
+git add -A
+git commit -m "$MESSAGE"
+git push origin "$BRANCH_NAME":"$BRANCH_NAME"


### PR DESCRIPTION
After the Core SDK is released, the Podfile.lock of the widgets should
be updated to reflect this. Thus, an update is triggered in Bitrise,
and then the `create_pr` lane is run in Fastlane in order to create
a PR with the new version.

MOB-1502