### PR TITLE
Set operator image to default on engagement termination

### DIFF
--- a/GliaWidgets/ViewModel/EngagementViewModel.swift
+++ b/GliaWidgets/ViewModel/EngagementViewModel.swift
@@ -135,13 +135,6 @@ class EngagementViewModel {
             engagementDelegate?(.finished)
 
         case .ended(let reason) where reason == .byOperator:
-
-            self.engagementDelegate?(
-                .engaged(
-                    operatorImageUrl: nil
-                )
-            )
-
             interactor.currentEngagement?.getSurvey(completion: { [weak self] result in
 
                 guard let self = self else { return }
@@ -156,6 +149,11 @@ class EngagementViewModel {
                         self.alertConfiguration.operatorEndedEngagement,
                         actionTapped: { [weak self] in
                             self?.endSession()
+                            self?.engagementDelegate?(
+                                .engaged(
+                                    operatorImageUrl: nil
+                                )
+                            )
                         }
                     )
                 )


### PR DESCRIPTION
When operator ended the engagement, the chat bubble, on the client side, was set to generic silhouette placeholder.

This fix keeps the default operator image until the user has ended the engagement on their side.

MOB-1428