### PR TITLE
Add Bitrise workflow to upgrade project version

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -66,6 +66,17 @@ workflows:
     description: >-
       Workflow for checking and building pull requests. Does not notify
       anywhere, but shows on the pull request itself.
+  increment_project_version:
+    steps:
+    - activate-ssh-key@4: {}
+    - git-clone@6: {}
+    - fastlane@3:
+        inputs:
+        - lane: 'create_pr_for_increment_project_version type:$VERSION_INCREMENT_TYPE'
+    envs:
+    - opts:
+        is_expand: false
+      VERSION_INCREMENT_TYPE: minor
   integration-spm:
     steps:
     - script@1:
@@ -271,7 +282,7 @@ workflows:
         - command: update
     - fastlane@3:
         inputs:
-        - lane: create_pr
+        - lane: create_pr_for_dependencies_update
 app:
   envs:
   - opts:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -8,6 +8,24 @@ PATH_GLIA_PROJECT_DIR = "#{PATH_ROOT}/#{PRODUCT_NAME_GLIA_WIDGETS}"
 PATH_GLIA_STATIC_VALUES = "#{PATH_GLIA_PROJECT_DIR}/StaticValues.swift"
 
 platform :ios do
+  desc "Creates a pull request in the repository with the required files to increment "\
+    "the project version."
+  lane :create_pr_for_increment_project_version do |options|
+    type = options[:type]
+    new_version = increment_project_version(type: type)
+    branch_name = 'increment-project-version'
+    message = "Update project version to #{new_version}"
+
+    sh "cd .. && scripts/commit_unstaged_changes.sh '#{branch_name}' '#{message}'"
+    create_pull_request(
+      repo: 'salemove/ios-sdk-widgets',
+      title: message,
+      head: branch_name,
+      base: 'master',
+      team_reviewers: ["tm-mobile-ios"]
+    )
+  end
+
   desc "Increments versions in Xcode projects and Podspec file "\
     "according to given type.\n\n"\
     "Usage:\n"\
@@ -27,9 +45,11 @@ platform :ios do
       file_path: PATH_GLIA_STATIC_VALUES,
       version: new_version
     )
+
+    new_version
   end
 
-  lane :increment_static_version do |options|
+  private_lane :increment_static_version do |options|
     file_path = options[:file_path]
     UI.user_error!("No filepath specified") unless !file_path.nil?
 
@@ -44,19 +64,18 @@ platform :ios do
   end
 
   desc "Creates a pull request in the repository with whatever changes have been made. "\
-    "Used in tandem with Bitrise to update dependencies. Named `create_pr` and not "\
-    "`create_pull_request` to avoid conflicting with the Fastlane action of the same name."
-  lane :create_pr do |options|
+    "Used in tandem with Bitrise to update dependencies."
+  lane :create_pr_for_dependencies_update do |options|
     branch_name = 'dependencies-update'
     message = "Update dependencies declared in `Podfile`"
 
-    sh "cd .. && scripts/create_pr.sh '#{branch_name}' '#{message}'"
+    sh "cd .. && scripts/commit_unstaged_changes.sh '#{branch_name}' '#{message}'"
     create_pull_request(
       repo: 'salemove/ios-sdk-widgets',
       title: message,
       head: branch_name,
       base: 'master',
-      reviewers: [:gersonnoboa, :dukhovnyi, :igorkravchenko, :EgorovEI]
+      team_reviewers: ["tm-mobile-ios"]
     )
   end
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -15,6 +15,14 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 ## iOS
 
+### ios create_pr_for_incremented_project_version
+
+```sh
+[bundle exec] fastlane ios create_pr_for_incremented_project_version
+```
+
+
+
 ### ios increment_project_version
 
 ```sh
@@ -27,14 +35,6 @@ Usage:
 fastlane increment_project_version type:major - increments X.0.0
 fastlane increment_project_version type:minor - increments 0.X.0
 fastlane increment_project_version type:patch - increments 0.0.X
-
-
-### ios increment_static_version
-
-```sh
-[bundle exec] fastlane ios increment_static_version
-```
-
 
 
 ### ios create_pr


### PR DESCRIPTION
A new lane is added that increments the project version using the
already available lane. Also, a new workflow in `bitrise.yml` is
added that uses this lane along with an EnvVar that one can control
by sending `major`, `minor`, or `patch`. Some changes to naming were
done, as the previous names were not appropriate with the current
changes.

MOB-1507