### PR TITLE
Add to gitignore .bundle folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ project.xcworkspace
 xcuserdata
 *.xctimeline
 .swiftpm
+.bundle
 
 # Xcode
 #


### PR DESCRIPTION
.bundle folder creates automatically during CI
update dependencies workflow and this file appears in PR. Since this folder is unnecessary for us, added to .gitignore.