### PR TITLE
Fixed ongoing message text after selecting option on AI custom card

### DIFF
--- a/GliaWidgets/ViewModel/Chat/ChatViewModel+CustomCard.swift
+++ b/GliaWidgets/ViewModel/Chat/ChatViewModel+CustomCard.swift
@@ -18,7 +18,7 @@ extension ChatViewModel {
         )
 
         let outgoingMessage = OutgoingMessage(
-            content: option.value,
+            content: option.text,
             files: []
         )
 


### PR DESCRIPTION
Displayed ongoing message text should be set from the `selectedOption.text` instead of the `value` property. Before fixing this caused displaying `value`, that is replaced by correct text after receiving the `sendMessage` response.

MOB-1242