### PR TITLE
Fetch chat history for authenticated visitor

### DIFF
--- a/GliaWidgets/Coordinator/Call/CallCoordinator.swift
+++ b/GliaWidgets/Coordinator/Call/CallCoordinator.swift
@@ -74,7 +74,8 @@ class CallCoordinator: SubFlowCoordinator, FlowCoordinator {
                 getCurrentEngagement: environment.getCurrentEngagement,
                 timerProviding: environment.timerProviding,
                 uuid: environment.uuid,
-                uiApplication: environment.uiApplication
+                uiApplication: environment.uiApplication,
+                fetchChatHistory: environment.fetchChatHistory
             ),
             call: call,
             unreadMessages: unreadMessages,
@@ -127,5 +128,6 @@ extension CallCoordinator {
         var submitSurveyAnswer: CoreSdkClient.SubmitSurveyAnswer
         var uuid: () -> UUID
         var uiApplication: UIKitBased.UIApplication
+        var fetchChatHistory: CoreSdkClient.FetchChatHistory
     }
 }

--- a/GliaWidgets/Coordinator/Chat/ChatCoordinator.swift
+++ b/GliaWidgets/Coordinator/Chat/ChatCoordinator.swift
@@ -91,7 +91,8 @@ class ChatCoordinator: SubFlowCoordinator, FlowCoordinator {
                 getCurrentEngagement: environment.getCurrentEngagement,
                 timerProviding: .live,
                 uuid: environment.uuid,
-                uiApplication: environment.uiApplication
+                uiApplication: environment.uiApplication,
+                fetchChatHistory: environment.fetchChatHistory
             )
         )
         viewModel.isInteractableCard = viewFactory.messageRenderer?.isInteractable
@@ -215,5 +216,6 @@ extension ChatCoordinator {
         var submitSurveyAnswer: CoreSdkClient.SubmitSurveyAnswer
         var uuid: () -> UUID
         var uiApplication: UIKitBased.UIApplication
+        var fetchChatHistory: CoreSdkClient.FetchChatHistory
     }
 }

--- a/GliaWidgets/Coordinator/RootCoordinator.Environment.Mock.swift
+++ b/GliaWidgets/Coordinator/RootCoordinator.Environment.Mock.swift
@@ -19,7 +19,8 @@ extension RootCoordinator.Environment {
         fetchSiteConfigurations: { _ in },
         getCurrentEngagement: { nil },
         submitSurveyAnswer: { _, _, _, _ in },
-        uiApplication: .mock
+        uiApplication: .mock,
+        fetchChatHistory: { _ in }
     )
 }
 #endif

--- a/GliaWidgets/Coordinator/RootCoordinator.Environment.swift
+++ b/GliaWidgets/Coordinator/RootCoordinator.Environment.swift
@@ -21,5 +21,6 @@ extension RootCoordinator {
         var getCurrentEngagement: CoreSdkClient.GetCurrentEngagement
         var submitSurveyAnswer: CoreSdkClient.SubmitSurveyAnswer
         var uiApplication: UIKitBased.UIApplication
+        var fetchChatHistory: CoreSdkClient.FetchChatHistory
     }
 }

--- a/GliaWidgets/Coordinator/RootCoordinator.swift
+++ b/GliaWidgets/Coordinator/RootCoordinator.swift
@@ -229,7 +229,8 @@ extension RootCoordinator {
                 getCurrentEngagement: environment.getCurrentEngagement,
                 submitSurveyAnswer: environment.submitSurveyAnswer,
                 uuid: environment.uuid,
-                uiApplication: environment.uiApplication
+                uiApplication: environment.uiApplication,
+                fetchChatHistory: environment.fetchChatHistory
             )
         )
         coordinator.delegate = { [weak self] event in
@@ -314,7 +315,8 @@ extension RootCoordinator {
                 timerProviding: environment.timerProviding,
                 submitSurveyAnswer: environment.submitSurveyAnswer,
                 uuid: environment.uuid,
-                uiApplication: environment.uiApplication
+                uiApplication: environment.uiApplication,
+                fetchChatHistory: environment.fetchChatHistory
             )
         )
         coordinator.delegate = { [weak self] event in

--- a/GliaWidgets/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -102,6 +102,9 @@ struct CoreSdkClient {
     var submitSurveyAnswer: SubmitSurveyAnswer
     typealias CreateAuthentication = (_ behaviour: AuthenticationBehavior) throws -> Authentication
     var authentication: CreateAuthentication
+
+    typealias FetchChatHistory = (_ completion: @escaping (Result<[Self.Message], SalemoveSDK.SalemoveError>) -> Void) -> Void
+    var fetchChatHistory: FetchChatHistory
 }
 
 extension CoreSdkClient {

--- a/GliaWidgets/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/CoreSDKClient/CoreSDKClient.Live.swift
@@ -24,7 +24,8 @@ extension CoreSdkClient {
             getCurrentEngagement: Salemove.sharedInstance.getCurrentEngagement,
             fetchSiteConfigurations: Salemove.sharedInstance.fetchSiteConfiguration(_:),
             submitSurveyAnswer: Salemove.sharedInstance.submitSurveyAnswer(_:surveyId:engagementId:completion:),
-            authentication: Salemove.sharedInstance.authentication
+            authentication: Salemove.sharedInstance.authentication,
+            fetchChatHistory: Salemove.sharedInstance.fetchChatTranscript
         )
     }()
 }

--- a/GliaWidgets/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -24,7 +24,8 @@ extension CoreSdkClient {
         getCurrentEngagement: { return nil },
         fetchSiteConfigurations: { _ in },
         submitSurveyAnswer: { _, _, _, _ in },
-        authentication: { _ in .mock }
+        authentication: { _ in .mock },
+        fetchChatHistory: { _ in }
     )
 }
 

--- a/GliaWidgets/Glia.swift
+++ b/GliaWidgets/Glia.swift
@@ -250,7 +250,8 @@ public class Glia {
                 fetchSiteConfigurations: environment.coreSdk.fetchSiteConfigurations,
                 getCurrentEngagement: environment.coreSdk.getCurrentEngagement,
                 submitSurveyAnswer: environment.coreSdk.submitSurveyAnswer,
-                uiApplication: environment.uiApplication
+                uiApplication: environment.uiApplication,
+                fetchChatHistory: environment.coreSdk.fetchChatHistory
             )
         )
         rootCoordinator?.delegate = { [weak self] event in

--- a/GliaWidgets/ViewModel/Chat/ChatViewModel.Environment.Interface.swift
+++ b/GliaWidgets/ViewModel/Chat/ChatViewModel.Environment.Interface.swift
@@ -19,5 +19,6 @@ extension EngagementViewModel {
         var timerProviding: FoundationBased.Timer.Providing
         var uuid: () -> UUID
         var uiApplication: UIKitBased.UIApplication
+        var fetchChatHistory: CoreSdkClient.FetchChatHistory
     }
 }

--- a/GliaWidgets/ViewModel/Chat/ChatViewModel.Environment.Mock.swift
+++ b/GliaWidgets/ViewModel/Chat/ChatViewModel.Environment.Mock.swift
@@ -26,7 +26,8 @@ extension ChatViewModel.Environment {
         getCurrentEngagement: { return nil },
         timerProviding: .mock,
         uuid: { UUID.mock },
-        uiApplication: .mock
+        uiApplication: .mock,
+        fetchChatHistory: { _ in }
     )
 }
 #endif

--- a/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
@@ -150,15 +150,16 @@ class ChatViewModel: EngagementViewModel, ViewModel {
     override func start() {
         super.start()
 
-        loadHistory()
-        // At this point we need to be sure that CoreSDK is configured.
-        // This will restore engagement if one was not completed earlier.
-        // Otherwise in case of ongoing engagement, visitor will not receive
-        // messages from operator until message is sent from visitor.
-        interactor.withConfiguration { [weak self] in
-            guard let self = self else { return }
-            if case .startEngagement = self.startAction, self.chatStorageState().isEmpty() {
-                self.enqueue(mediaType: .text)
+        loadHistory { [weak self] in
+            // At this point we need to be sure that CoreSDK is configured.
+            // This will restore engagement if one was not completed earlier.
+            // Otherwise in case of ongoing engagement, visitor will not receive
+            // messages from operator until message is sent from visitor.
+            self?.interactor.withConfiguration { [weak self] in
+                guard let self = self else { return }
+                if case .startEngagement = self.startAction, self.chatStorageState().isEmpty() {
+                    self.enqueue(mediaType: .text)
+                }
             }
         }
     }
@@ -317,18 +318,26 @@ extension ChatViewModel {
 // MARK: History
 
 extension ChatViewModel {
-    private func loadHistory() {
-        let messages = environment.chatStorage.messages(interactor.queueID)
-        let items = messages.compactMap {
-            ChatItem(
-                with: $0,
-                isCustomCardSupported: isCustomCardSupported,
-                fromHistory: environment.loadChatMessagesFromHistory()
-            )
+    private func loadHistory(_ completion: @escaping () -> Void) {
+        environment.fetchChatHistory { [weak self] result in
+            defer { completion() }
+            guard let self = self else { return }
+            if case .success(let messages) = result {
+                self.chatStorageState().storeMessages(messages, "", nil)
+            }
+
+            let messages = self.chatStorageState().messages(self.interactor.queueID)
+            let items = messages.compactMap {
+                ChatItem(
+                    with: $0,
+                    isCustomCardSupported: self.isCustomCardSupported,
+                    fromHistory: self.environment.loadChatMessagesFromHistory()
+                )
+            }
+            self.historySection.set(items)
+            self.action?(.refreshSection(self.historySection.index))
+            self.action?(.scrollToBottom(animated: false))
         }
-        historySection.set(items)
-        action?(.refreshSection(historySection.index))
-        action?(.scrollToBottom(animated: false))
     }
 }
 

--- a/GliaWidgets/ViewModel/Chat/Storage/AuthenticatedChatStorage.Interface.swift
+++ b/GliaWidgets/ViewModel/Chat/Storage/AuthenticatedChatStorage.Interface.swift
@@ -40,7 +40,6 @@ extension AuthenticatedChatStorage {
         typealias QueueId = AuthenticatedChatStorage.QueueId
         typealias MessageId = AuthenticatedChatStorage.MessageId
 
-        var messageIdsForQueue: [QueueId: [MessageId]] = [:]
-        var messageForMessageId: [MessageId: ChatMessage] = [:]
+        var messages: [ChatMessage] = []
     }
 }

--- a/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
+++ b/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
@@ -42,6 +42,7 @@ extension RootCoordinator.Environment {
         submitSurveyAnswer: { _, _, _, _ in
             fail("\(Self.self).submitSurveyAnswer")
         },
-        uiApplication: .failing
+        uiApplication: .failing,
+        fetchChatHistory: { _ in }
     )
 }

--- a/GliaWidgetsTests/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/CoreSDKClient.Failing.swift
@@ -25,7 +25,8 @@ extension CoreSdkClient {
         authentication: { _ in
             fail("\(Self.self).authentication")
             return .mock
-        }
+        },
+        fetchChatHistory: { _ in }
     )
 }
 

--- a/GliaWidgetsTests/Sources/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModelTests.swift
@@ -51,7 +51,8 @@ class ChatViewModelTests: XCTestCase {
                 getCurrentEngagement: { nil },
                 timerProviding: .mock,
                 uuid: { .mock },
-                uiApplication: .mock
+                uiApplication: .mock,
+                fetchChatHistory: { _ in }
             )
         )
 
@@ -77,7 +78,7 @@ class ChatViewModelTests: XCTestCase {
             calls.append(.configureWithInteractor)
         }
         let interactor = Interactor.mock(environment: interactorEnv)
-        var viewModelEnv = ChatViewModel.Environment.failing
+        var viewModelEnv = ChatViewModel.Environment.failing(fetchChatHistory: { $0(.success([]))})
         viewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
         viewModelEnv.fileManager.createDirectoryAtUrlWithIntermediateDirectories = { _, _, _ in }
         viewModelEnv.chatStorage.messages = { _ in [] }
@@ -88,7 +89,7 @@ class ChatViewModelTests: XCTestCase {
     }
     
     func test_onInteractorStateEngagedClearsChatQueueSection() throws {
-        var viewModelEnv = ChatViewModel.Environment.failing
+        var viewModelEnv = ChatViewModel.Environment.failing()
         viewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
         viewModelEnv.fileManager.createDirectoryAtUrlWithIntermediateDirectories = { _, _, _ in }
         viewModelEnv.fetchSiteConfigurations = { _ in }
@@ -108,7 +109,7 @@ class ChatViewModelTests: XCTestCase {
     func test_onEngagementTransferringAddsTransferringItemToTheEndOfChat() throws {
         var interactorEnv: Interactor.Environment = .failing
         interactorEnv.gcd.mainQueue.asyncIfNeeded = { $0() }
-        var viewModelEnv = ChatViewModel.Environment.failing
+        var viewModelEnv = ChatViewModel.Environment.failing()
         viewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
         viewModelEnv.fileManager.createDirectoryAtUrlWithIntermediateDirectories = { _, _, _ in }
         viewModelEnv.chatStorage.messages = { _ in [] }
@@ -130,7 +131,7 @@ class ChatViewModelTests: XCTestCase {
     func test_onEngagementTransferRemovesTransferringItemFromChat() throws {
         var interactorEnv: Interactor.Environment = .failing
         interactorEnv.gcd.mainQueue.asyncIfNeeded = { $0() }
-        var viewModelEnv = ChatViewModel.Environment.failing
+        var viewModelEnv = ChatViewModel.Environment.failing()
         viewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
         viewModelEnv.fileManager.createDirectoryAtUrlWithIntermediateDirectories = { _, _, _ in }
         viewModelEnv.chatStorage.messages = { _ in [] }
@@ -157,7 +158,7 @@ class ChatViewModelTests: XCTestCase {
     func test_onEngagementTransferAddsOperatorConnectedChatItemToTheEndOfChat() throws {
         var interactorEnv: Interactor.Environment = .failing
         interactorEnv.gcd.mainQueue.asyncIfNeeded = { $0() }
-        var viewModelEnv = ChatViewModel.Environment.failing
+        var viewModelEnv = ChatViewModel.Environment.failing()
         viewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
         viewModelEnv.fileManager.createDirectoryAtUrlWithIntermediateDirectories = { _, _, _ in }
         viewModelEnv.chatStorage.messages = { _ in [] }
@@ -184,7 +185,7 @@ class ChatViewModelTests: XCTestCase {
         var calls: [Calls] = []
         let interactorEnv = Interactor.Environment(coreSdk: .failing, gcd: .mock)
         let interactor = Interactor.mock(environment: interactorEnv)
-        var viewModelEnv = ChatViewModel.Environment.failing
+        var viewModelEnv = ChatViewModel.Environment.failing()
         viewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
         viewModelEnv.fileManager.createDirectoryAtUrlWithIntermediateDirectories = { _, _, _ in }
         viewModelEnv.fetchSiteConfigurations = { _ in
@@ -205,7 +206,7 @@ class ChatViewModelTests: XCTestCase {
         var calls: [Calls] = []
         let interactorEnv = Interactor.Environment.init(coreSdk: .failing, gcd: .mock)
         let interactor = Interactor.mock(environment: interactorEnv)
-        var viewModelEnv = ChatViewModel.Environment.failing
+        var viewModelEnv = ChatViewModel.Environment.failing()
         viewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
         viewModelEnv.fileManager.createDirectoryAtUrlWithIntermediateDirectories = { _, _, _ in }
         viewModelEnv.fetchSiteConfigurations = { _ in
@@ -224,7 +225,7 @@ class ChatViewModelTests: XCTestCase {
         enum Call: Equatable { case openUrl(URL) }
 
         var calls: [Call] = []
-        var viewModelEnv = ChatViewModel.Environment.failing
+        var viewModelEnv = ChatViewModel.Environment.failing()
         viewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
         viewModelEnv.fileManager.createDirectoryAtUrlWithIntermediateDirectories = { _, _, _ in }
         viewModelEnv.uiApplication.canOpenURL = { _ in true }
@@ -243,7 +244,7 @@ class ChatViewModelTests: XCTestCase {
         enum Call: Equatable { case openUrl(URL) }
 
         var calls: [Call] = []
-        var viewModelEnv = ChatViewModel.Environment.failing
+        var viewModelEnv = ChatViewModel.Environment.failing()
         viewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
         viewModelEnv.fileManager.createDirectoryAtUrlWithIntermediateDirectories = { _, _, _ in }
         viewModelEnv.uiApplication.canOpenURL = { _ in true }
@@ -261,7 +262,7 @@ class ChatViewModelTests: XCTestCase {
     func test_handleUrlWithLinkOpensCalsLinkTapped() throws {
         enum Call: Equatable { case linkTapped(URL) }
         var calls: [Call] = []
-        var viewModelEnv = ChatViewModel.Environment.failing
+        var viewModelEnv = ChatViewModel.Environment.failing()
         viewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
         viewModelEnv.fileManager.createDirectoryAtUrlWithIntermediateDirectories = { _, _, _ in }
         let viewModel: ChatViewModel = .mock(
@@ -292,7 +293,7 @@ class ChatViewModelTests: XCTestCase {
         }
     
         var calls: [Call] = []
-        var viewModelEnv = ChatViewModel.Environment.failing
+        var viewModelEnv = ChatViewModel.Environment.failing()
         viewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
         viewModelEnv.fileManager.createDirectoryAtUrlWithIntermediateDirectories = { _, _, _ in }
         viewModelEnv.uiApplication.canOpenURL = { _ in true }

--- a/GliaWidgetsTests/ViewModel/Chat/ChatViewModel.Environment.Failing.swift
+++ b/GliaWidgetsTests/ViewModel/Chat/ChatViewModel.Environment.Failing.swift
@@ -1,43 +1,50 @@
 @testable import GliaWidgets
 
 extension ChatViewModel.Environment {
-    static let failing = Self(
-        chatStorage: .failing,
-        fetchFile: { _, _, _ in
-            fail("\(Self.self).fetchFile")
-        },
-        sendSelectedOptionValue: { _, _ in
-            fail("\(Self.self).sendSelectedOptionValue")
-        },
-        uploadFileToEngagement: { _, _, _ in
-            fail("\(Self.self).uploadFileToEngagement")
-        },
-        fileManager: .failing,
-        data: .failing,
-        date: {
-            fail("\(Self.self).date")
-            return .mock
-        },
-        gcd: .failing,
-        localFileThumbnailQueue: .failing,
-        uiImage: .failing,
-        createFileDownload: { _, _, _ in
-            fail("\(Self.self).createFileDownload")
-            return .failing
-        },
-        loadChatMessagesFromHistory: {
-            fail("\(Self.self).loadChatMessagesFromHistory")
-            return true
-        },
-        fetchSiteConfigurations: { _ in
-            fail("\(Self.self).fetchSiteConfigurations")
-        },
-        getCurrentEngagement: { nil },
-        timerProviding: .mock,
-        uuid: {
-            fail("\(Self.self).uuid")
-            return .mock
-        },
-        uiApplication: .mock
-    )
+    static func failing(
+        fetchChatHistory: CoreSdkClient.FetchChatHistory? = nil
+    ) -> Self {
+        .init(
+            chatStorage: .failing,
+            fetchFile: { _, _, _ in
+                fail("\(Self.self).fetchFile")
+            },
+            sendSelectedOptionValue: { _, _ in
+                fail("\(Self.self).sendSelectedOptionValue")
+            },
+            uploadFileToEngagement: { _, _, _ in
+                fail("\(Self.self).uploadFileToEngagement")
+            },
+            fileManager: .failing,
+            data: .failing,
+            date: {
+                fail("\(Self.self).date")
+                return .mock
+            },
+            gcd: .failing,
+            localFileThumbnailQueue: .failing,
+            uiImage: .failing,
+            createFileDownload: { _, _, _ in
+                fail("\(Self.self).createFileDownload")
+                return .failing
+            },
+            loadChatMessagesFromHistory: {
+                fail("\(Self.self).loadChatMessagesFromHistory")
+                return true
+            },
+            fetchSiteConfigurations: { _ in
+                fail("\(Self.self).fetchSiteConfigurations")
+            },
+            getCurrentEngagement: { nil },
+            timerProviding: .mock,
+            uuid: {
+                fail("\(Self.self).uuid")
+                return .mock
+            },
+            uiApplication: .mock,
+            fetchChatHistory: fetchChatHistory ?? { _ in
+                fail("\(Self.self).fetchChatHistory")
+            }
+        )
+    }
 }

--- a/GliaWidgetsTests/ViewModel/Chat/Storage/AuthenticatedChatStorage.StorageRefTests.swift
+++ b/GliaWidgetsTests/ViewModel/Chat/Storage/AuthenticatedChatStorage.StorageRefTests.swift
@@ -24,7 +24,7 @@ class AuthenticatedChatStorageStorageRefTests: XCTestCase {
             message,
             for: queueId
         )
-        XCTAssertEqual(ref.messageIdsForQueue, [queueId: [messageId]])
+        XCTAssertEqual(ref.messages.map(\.id), [message.id])
     }
 
     func test_messagesForQueueReturnsMessages() {
@@ -76,7 +76,7 @@ class AuthenticatedChatStorageStorageRefTests: XCTestCase {
 
         ref.updateMessage(newMessage)
 
-        XCTAssertEqual(ref.messageForMessageId[message.id]?.content, otherContent)
+        XCTAssertEqual(ref.messages.map(\.content), [otherContent])
     }
 
     func test_isNewMessageReturnsTrueForNotStoredMessage() {

--- a/GliaWidgetsTests/ViewModel/Chat/Storage/AuthenticatedChatStorageTests.swift
+++ b/GliaWidgetsTests/ViewModel/Chat/Storage/AuthenticatedChatStorageTests.swift
@@ -15,7 +15,7 @@ class AuthenticatedChatStorageTests: XCTestCase {
         let message = CoreSdkClient.Message.mock(id: messageId)
         storage = .inMemory(ref)
         storage.storeMessage(message, queueId, .mock())
-        XCTAssertEqual(ref.messageIdsForQueue, [queueId: [messageId]])
+        XCTAssertEqual(ref.messages.map(\.id), [message.id])
 
     }
 


### PR DESCRIPTION
Introduced mechanism for fetching chat history
from API. This approach guarantees to provide
the up-to-date history for an authenticated visitor.

MOB-1557