### PR TITLE
Change version increment type from minor to patch

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -102,7 +102,7 @@ workflows:
     envs:
     - opts:
         is_expand: false
-      VERSION_INCREMENT_TYPE: minor
+      VERSION_INCREMENT_TYPE: patch
   integration-spm:
     steps:
     - script@1:


### PR DESCRIPTION
Currently, the release process will update the project version to minor, but before we were doing it with patch, so now it's changed to be consistent with how we did things before.

MOB-1589