### PR TITLE
Fix incorrect changelogs being generated on release

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -34,7 +34,9 @@ workflows:
   deployment:
     steps:
     - activate-ssh-key@4: {}
-    - git-clone@6: {}
+    - git-clone:
+        inputs:
+        - fetch_tags: 'yes'
     - cache-pull@2: {}
     - cocoapods-install@2: {}
     - xcode-test@4:


### PR DESCRIPTION
The `git-clone` step was fetching the repository without tags. This made the changelog step not know what is the latest tag, thus generating a changelog with all commits in the repo. By fetching the tag, Bitrise will be able to generate a changelog from the latest tag to the most recent commit.

MOB-1610