### PR TITLE
Snapshot tests fixes

### DIFF
--- a/GliaWidgets/ViewController/Survey/SurveyViewController.View.swift
+++ b/GliaWidgets/ViewController/Survey/SurveyViewController.View.swift
@@ -92,7 +92,7 @@ extension Survey {
                 buttonContainer.leadingAnchor.constraint(equalTo: leadingAnchor),
                 buttonContainer.trailingAnchor.constraint(equalTo: trailingAnchor),
 
-                buttonStackView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -Self.contentPadding),
+                buttonStackView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: 0),
                 buttonStackView.topAnchor.constraint(equalTo: buttonContainer.topAnchor, constant: Self.contentPadding),
                 buttonStackView.leadingAnchor.constraint(equalTo: buttonContainer.leadingAnchor, constant: Self.contentPadding),
                 buttonStackView.trailingAnchor.constraint(equalTo: buttonContainer.trailingAnchor, constant: -Self.contentPadding),

--- a/SnapshotTests/AlertViewControllerTests.swift
+++ b/SnapshotTests/AlertViewControllerTests.swift
@@ -56,9 +56,11 @@ class AlertViewControllerTests: SnapshotTestCase {
     }
 
     private func alert(ofKind kind: AlertViewController.Kind) -> AlertViewController {
-        AlertViewController(
+        let viewController = AlertViewController(
             kind: kind,
             viewFactory: .mock()
         )
+        viewController.view.frame = UIScreen.main.bounds
+        return viewController
     }
 }

--- a/SnapshotTests/CallViewControllerVoiceOverTests.swift
+++ b/SnapshotTests/CallViewControllerVoiceOverTests.swift
@@ -6,6 +6,7 @@ import XCTest
 class CallViewControllerVoiceOverTests: SnapshotTestCase {
     func test_audioCallQueueState() throws {
         let viewController = try CallViewController.mockAudioCallQueueState()
+        viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
             as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),
@@ -15,6 +16,7 @@ class CallViewControllerVoiceOverTests: SnapshotTestCase {
 
     func test_audioCallConnectingState() throws {
         let viewController = try CallViewController.mockAudioCallConnectingState()
+        viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
             as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),
@@ -24,6 +26,7 @@ class CallViewControllerVoiceOverTests: SnapshotTestCase {
 
     func test_audioCallConnectedState() throws {
         let viewController = try CallViewController.mockAudioCallConnectedState()
+        viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
             as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),
@@ -33,6 +36,7 @@ class CallViewControllerVoiceOverTests: SnapshotTestCase {
 
     func test_mockVideoCallConnectingState() throws {
         let viewController = try CallViewController.mockVideoCallConnectingState()
+        viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
             as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),
@@ -42,6 +46,7 @@ class CallViewControllerVoiceOverTests: SnapshotTestCase {
 
     func test_mockVideoCallQueueState() throws {
         let viewController = try CallViewController.mockVideoCallQueueState()
+        viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
             as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),
@@ -51,6 +56,7 @@ class CallViewControllerVoiceOverTests: SnapshotTestCase {
 
     func test_mockVideoCallConnectedState() throws {
         let viewController = try CallViewController.mockVideoCallConnectedState()
+        viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
             as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),

--- a/SnapshotTests/ChatViewControllerVoiceOverTests.swift
+++ b/SnapshotTests/ChatViewControllerVoiceOverTests.swift
@@ -16,6 +16,7 @@ class ChatViewControllerVoiceOverTests: SnapshotTestCase {
 
     func test_visitorUploadedFileStates() throws {
         let viewController = try ChatViewController.mockVisitorFileUploadStates()
+        viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
             as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),
@@ -25,6 +26,7 @@ class ChatViewControllerVoiceOverTests: SnapshotTestCase {
 
     func test_choiceCard() throws {
         let viewController = try ChatViewController.mockChoiceCard()
+        viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
             as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),
@@ -34,9 +36,10 @@ class ChatViewControllerVoiceOverTests: SnapshotTestCase {
 
     func test_visitorFileDownloadStates() throws {
         var chatMessages: [ChatMessage] = []
-        let viewController = try ChatViewController.mockVisitorFileDownloadStates() { messages in
+        let viewController = try ChatViewController.mockVisitorFileDownloadStates { messages in
             chatMessages = messages
         }
+        viewController.view.frame = UIScreen.main.bounds
         viewController.view.setNeedsLayout()
         viewController.view.layoutIfNeeded()
         XCTAssertEqual(chatMessages.count, 4)

--- a/SnapshotTests/SurveyViewControllerVoiceOverTests.swift
+++ b/SnapshotTests/SurveyViewControllerVoiceOverTests.swift
@@ -6,6 +6,7 @@ import XCTest
 class SurveyViewControllerVoiceOverTests: SnapshotTestCase {
     func test_emptySurvey() {
         let viewController = Survey.ViewController(viewFactory: .mock(), props: .emptyPropsMock())
+        viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
             as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),
@@ -15,6 +16,7 @@ class SurveyViewControllerVoiceOverTests: SnapshotTestCase {
 
     func test_filledSurvey() {
         let viewController = Survey.ViewController(viewFactory: .mock(), props: .filledPropsMock())
+        viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
             as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),
@@ -24,6 +26,7 @@ class SurveyViewControllerVoiceOverTests: SnapshotTestCase {
 
     func test_emptySurveyErrorState() {
         let viewController = Survey.ViewController(viewFactory: .mock(), props: .errorPropsMock())
+        viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
             as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),


### PR DESCRIPTION
Since tests were broken previously by deleting applying frame to tested view, I returned it back. If the frame for the tested view is not set and the reference for the test already exists, test will pass, but this is not correct. 
Also fixed mocks for chat screen tests.
Also fixed bottom padding between buttons and safeAreaLayoutGuide on the survey screen