### PR TITLE
AssetsBuilder for font customization

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -217,6 +217,7 @@
 		75FF151B27F4F52D00FE7BE2 /* Theme.Survey.SingleQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FF151A27F4F52D00FE7BE2 /* Theme.Survey.SingleQuestion.swift */; };
 		75FF151D27F4F8E000FE7BE2 /* Theme.Survey.InputQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FF151C27F4F8E000FE7BE2 /* Theme.Survey.InputQuestion.swift */; };
 		844D3C6C29142C17002887A9 /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844D3C6B29142C17002887A9 /* Optional+Extensions.swift */; };
+		844D3C6E291BD890002887A9 /* RemoteConfiguration+AssetsBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844D3C6D291BD890002887A9 /* RemoteConfiguration+AssetsBuilder.swift */; };
 		8454122B28E2FE8400F59DE2 /* RemoteConfiguration+Chat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8454122A28E2FE8400F59DE2 /* RemoteConfiguration+Chat.swift */; };
 		8458769F2823FD18007AC3DF /* SurveyViewControllerVoiceOverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8458769E2823FD18007AC3DF /* SurveyViewControllerVoiceOverTests.swift */; };
 		845876A22823FF34007AC3DF /* Survey.ViewController.Props.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845876A12823FF34007AC3DF /* Survey.ViewController.Props.Mock.swift */; };
@@ -683,6 +684,7 @@
 		75FF151C27F4F8E000FE7BE2 /* Theme.Survey.InputQuestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.Survey.InputQuestion.swift; sourceTree = "<group>"; };
 		8325AC4B1189635C079F02C9 /* Pods-SnapshotTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SnapshotTests.release.xcconfig"; path = "Target Support Files/Pods-SnapshotTests/Pods-SnapshotTests.release.xcconfig"; sourceTree = "<group>"; };
 		844D3C6B29142C17002887A9 /* Optional+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+Extensions.swift"; sourceTree = "<group>"; };
+		844D3C6D291BD890002887A9 /* RemoteConfiguration+AssetsBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteConfiguration+AssetsBuilder.swift"; sourceTree = "<group>"; };
 		8454122A28E2FE8400F59DE2 /* RemoteConfiguration+Chat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteConfiguration+Chat.swift"; sourceTree = "<group>"; };
 		8458769E2823FD18007AC3DF /* SurveyViewControllerVoiceOverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyViewControllerVoiceOverTests.swift; sourceTree = "<group>"; };
 		845876A12823FF34007AC3DF /* Survey.ViewController.Props.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Survey.ViewController.Props.Mock.swift; sourceTree = "<group>"; };
@@ -1119,7 +1121,6 @@
 		1A205D5A25655CB1003AA3CD /* GliaWidgets */ = {
 			isa = PBXGroup;
 			children = (
-				7562B2E728CBD7150040C784 /* RemoteConfiguration */,
 				84EFB05E28AB90610005E270 /* MessageRenderer */,
 				7562B2E728CBD7150040C784 /* RemoteConfiguration */,
 				75AF8CF227DBB3BE009EEE2C /* Layout */,
@@ -2027,6 +2028,7 @@
 			children = (
 				7562B2EA28CBD7E20040C784 /* RemoteConfiguration.swift */,
 				8454122A28E2FE8400F59DE2 /* RemoteConfiguration+Chat.swift */,
+				844D3C6D291BD890002887A9 /* RemoteConfiguration+AssetsBuilder.swift */,
 			);
 			path = RemoteConfiguration;
 			sourceTree = "<group>";
@@ -2734,23 +2736,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		845BD16F28EC80C100978E67 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "find -L ${SRCROOT}/TestingApp \\\n    -type f \\\n    -name \"*.json\" \\\n    | xargs -t -I {} \\\n    cp {} ${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/\n";
-		};
 		845BD16F28EC80C100978E67 /* Copy Remote Configuration Files */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -3176,6 +3161,7 @@
 				6EA3516926E139DA00BF5941 /* GliaViewTransitionController.swift in Sources */,
 				AF11F31328C274BC002ACEB4 /* AuthenticatedChatStorage.Implementation.swift in Sources */,
 				1A1E30C725F9FDAB00850E68 /* ChatImageFileContentView.swift in Sources */,
+				844D3C6E291BD890002887A9 /* RemoteConfiguration+AssetsBuilder.swift in Sources */,
 				756087E127837EC000158604 /* BundleManaging.swift in Sources */,
 				AF11F30B28C145FF002ACEB4 /* ChatStorageState.swift in Sources */,
 				AFA2FDEE28907DDB00428E6D /* RootCoordinator.Environment.Mock.swift in Sources */,

--- a/GliaWidgets/Component/AttachmentList/AttachmentSourceListStyle.swift
+++ b/GliaWidgets/Component/AttachmentList/AttachmentSourceListStyle.swift
@@ -27,7 +27,10 @@ public class AttachmentSourceListStyle {
         self.backgroundColor = backgroundColor
     }
 
-    func apply(configuration: RemoteConfiguration.AttachmentSourceList?) {
+    func apply(
+        configuration: RemoteConfiguration.AttachmentSourceList?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
         configuration?.separator?.value
             .map { UIColor(hex: $0) }
             .first
@@ -41,7 +44,10 @@ public class AttachmentSourceListStyle {
         configuration?.items?.forEach { item in
             let sourceType = AttachmentSourceItemKind(rawValue: item.type.rawValue)
             items.first(where: { $0.kind == sourceType })?
-                .apply(configuration: item)
+                .apply(
+                    configuration: item,
+                    assetsBuilder: assetsBuilder
+                )
         }
     }
 }

--- a/GliaWidgets/Component/AttachmentList/Item/AttachmentSourceItemStyle.swift
+++ b/GliaWidgets/Component/AttachmentList/Item/AttachmentSourceItemStyle.swift
@@ -57,7 +57,10 @@ public class AttachmentSourceItemStyle {
         self.accessibility = accessibility
     }
 
-    func apply(configuration: RemoteConfiguration.AttachmentSource?) {
+    func apply(
+        configuration: RemoteConfiguration.AttachmentSource?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
         configuration?.tintColor?.value
             .map { UIColor(hex: $0) }
             .first
@@ -69,7 +72,7 @@ public class AttachmentSourceItemStyle {
             .unwrap { titleColor = $0 }
 
         UIFont.convertToFont(
-            font: configuration?.text?.font,
+            uiFont: assetsBuilder.fontBuilder(configuration?.text?.font),
             textStyle: titleTextStyle
         ).unwrap { titleFont = $0 }
     }

--- a/GliaWidgets/Component/Badge/BadgeStyle.swift
+++ b/GliaWidgets/Component/Badge/BadgeStyle.swift
@@ -34,9 +34,12 @@ public struct BadgeStyle {
     }
 
     /// Apply badge remote configuration
-    mutating func apply(configuration: RemoteConfiguration.Button?) {
+    mutating func apply(
+        configuration: RemoteConfiguration.Button?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
         UIFont.convertToFont(
-            font: configuration?.text?.font,
+            uiFont: assetsBuilder.fontBuilder(configuration?.text?.font),
             textStyle: textStyle
         ).unwrap { font = $0 }
 

--- a/GliaWidgets/Component/Bubble/BubbleStyle.swift
+++ b/GliaWidgets/Component/Bubble/BubbleStyle.swift
@@ -33,9 +33,15 @@ public class BubbleStyle {
     }
 
     /// Apply bubble remote configuration
-    func apply(configuration: RemoteConfiguration.Bubble?) {
+    func apply(
+        configuration: RemoteConfiguration.Bubble?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
         onHoldOverlay.apply(configuration: configuration?.onHoldOverlay)
-        badge?.apply(configuration: configuration?.badge)
+        badge?.apply(
+            configuration: configuration?.badge,
+            assetsBuilder: assetsBuilder
+        )
         userImage.apply(configuration: configuration?.userImage)
     }
 }

--- a/GliaWidgets/Component/Button/Action/ActionButtonStyle.swift
+++ b/GliaWidgets/Component/Button/Action/ActionButtonStyle.swift
@@ -87,9 +87,12 @@ public struct ActionButtonStyle {
     }
 
     /// Apply Button from remote configuration
-    mutating func apply(configuration: RemoteConfiguration.Button?) {
+    mutating func apply(
+        configuration: RemoteConfiguration.Button?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
         UIFont.convertToFont(
-            font: configuration?.text?.font,
+            uiFont: assetsBuilder.fontBuilder(configuration?.text?.font),
             textStyle: textStyle
         ).unwrap { titleFont = $0 }
 

--- a/GliaWidgets/Component/CallButtonBar/Button/CallButtonStyle.swift
+++ b/GliaWidgets/Component/CallButtonBar/Button/CallButtonStyle.swift
@@ -42,16 +42,31 @@ public struct CallButtonStyle {
     public var accessibility: Accessibility
 
     /// Apply bar button from remote configuration
-    mutating func applyBarButtonConfig(button: RemoteConfiguration.BarButtonStates?) {
-        active.apply(configuration: button?.active)
-        inactive.apply(configuration: button?.inactive)
-        selected.apply(configuration: button?.selected)
+    mutating func applyBarButtonConfig(
+        button: RemoteConfiguration.BarButtonStates?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
+        active.apply(
+            configuration: button?.active,
+            assetsBuilder: assetsBuilder
+        )
+        inactive.apply(
+            configuration: button?.inactive,
+            assetsBuilder: assetsBuilder
+        )
+        selected.apply(
+            configuration: button?.selected,
+            assetsBuilder: assetsBuilder
+        )
     }
 }
 
 extension CallButtonStyle.StateStyle {
 
-    mutating func apply(configuration: RemoteConfiguration.BarButtonStyle?) {
+    mutating func apply(
+        configuration: RemoteConfiguration.BarButtonStyle?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
         configuration?.background.unwrap {
             switch $0.type {
             case .fill:
@@ -87,7 +102,7 @@ extension CallButtonStyle.StateStyle {
         }
 
         UIFont.convertToFont(
-            font: configuration?.title?.font,
+            uiFont: assetsBuilder.fontBuilder(configuration?.title?.font),
             textStyle: textStyle
         ).unwrap { titleFont = $0 }
 

--- a/GliaWidgets/Component/CallButtonBar/CallButtonBarStyle.swift
+++ b/GliaWidgets/Component/CallButtonBar/CallButtonBarStyle.swift
@@ -19,11 +19,29 @@ public struct CallButtonBarStyle {
     public var badge: BadgeStyle
 
     /// Apply button bar from remote configuration
-    mutating func applyBarConfiguration(_ bar: RemoteConfiguration.ButtonBar?) {
-        minimizeButton.applyBarButtonConfig(button: bar?.minimizeButton)
-        chatButton.applyBarButtonConfig(button: bar?.chatButton)
-        videoButton.applyBarButtonConfig(button: bar?.videoButton)
-        muteButton.applyBarButtonConfig(button: bar?.muteButton)
-        speakerButton.applyBarButtonConfig(button: bar?.speakerButton)
+    mutating func applyBarConfiguration(
+        _ bar: RemoteConfiguration.ButtonBar?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
+        minimizeButton.applyBarButtonConfig(
+            button: bar?.minimizeButton,
+            assetsBuilder: assetsBuilder
+        )
+        chatButton.applyBarButtonConfig(
+            button: bar?.chatButton,
+            assetsBuilder: assetsBuilder
+        )
+        videoButton.applyBarButtonConfig(
+            button: bar?.videoButton,
+            assetsBuilder: assetsBuilder
+        )
+        muteButton.applyBarButtonConfig(
+            button: bar?.muteButton,
+            assetsBuilder: assetsBuilder
+        )
+        speakerButton.applyBarButtonConfig(
+            button: bar?.speakerButton,
+            assetsBuilder: assetsBuilder
+        )
     }
 }

--- a/GliaWidgets/Component/Connect/ConnectStyle.swift
+++ b/GliaWidgets/Component/Connect/ConnectStyle.swift
@@ -45,12 +45,30 @@ public struct ConnectStyle {
         self.onHold = onHold
     }
 
-    mutating func apply(configuration: RemoteConfiguration.EngagementStates?) {
+    mutating func apply(
+        configuration: RemoteConfiguration.EngagementStates?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
         connectOperator.apply(configuration: configuration?.operator)
-        queue.apply(configuration: configuration?.queue)
-        connecting.apply(configuration: configuration?.connecting)
-        connected.apply(configuration: configuration?.connected)
-        transferring.apply(configuration: configuration?.transferring)
-        onHold.apply(configuration: configuration?.onHold)
+        queue.apply(
+            configuration: configuration?.queue,
+            assetsBuilder: assetsBuilder
+        )
+        connecting.apply(
+            configuration: configuration?.connecting,
+            assetsBuilder: assetsBuilder
+        )
+        connected.apply(
+            configuration: configuration?.connected,
+            assetsBuilder: assetsBuilder
+        )
+        transferring.apply(
+            configuration: configuration?.transferring,
+            assetsBuilder: assetsBuilder
+        )
+        onHold.apply(
+            configuration: configuration?.onHold,
+            assetsBuilder: assetsBuilder
+        )
     }
 }

--- a/GliaWidgets/Component/Connect/Status/ConnectStatusStyle.swift
+++ b/GliaWidgets/Component/Connect/Status/ConnectStatusStyle.swift
@@ -63,9 +63,12 @@ public struct ConnectStatusStyle {
         self.accessibility = accessibility
     }
 
-    mutating func apply(configuration: RemoteConfiguration.EngagementState?) {
+    mutating func apply(
+        configuration: RemoteConfiguration.EngagementState?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
         UIFont.convertToFont(
-            font: configuration?.title?.font,
+            uiFont: assetsBuilder.fontBuilder(configuration?.title?.font),
             textStyle: firstTextStyle
         ).unwrap { firstTextFont = $0 }
 
@@ -75,7 +78,7 @@ public struct ConnectStatusStyle {
             .unwrap { firstTextFontColor = $0 }
 
         UIFont.convertToFont(
-            font: configuration?.description?.font,
+            uiFont: assetsBuilder.fontBuilder(configuration?.description?.font),
             textStyle: secondTextStyle
         ).unwrap { secondTextFont = $0 }
 

--- a/GliaWidgets/Component/Header/HeaderStyle.swift
+++ b/GliaWidgets/Component/Header/HeaderStyle.swift
@@ -62,7 +62,10 @@ public struct HeaderStyle {
         self.accessibility = accessibility
     }
 
-    mutating func apply(configuration: RemoteConfiguration.Header?) {
+    mutating func apply(
+        configuration: RemoteConfiguration.Header?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
         configuration?.background?.color.unwrap {
             switch $0.type {
             case .fill:
@@ -77,7 +80,7 @@ public struct HeaderStyle {
         }
 
         UIFont.convertToFont(
-            font: configuration?.text?.font,
+            uiFont: assetsBuilder.fontBuilder(configuration?.text?.font),
             textStyle: textStyle
         ).unwrap { titleFont = $0 }
 
@@ -108,7 +111,10 @@ public struct HeaderStyle {
 
         backButton.apply(configuration: configuration?.backButton)
         closeButton.apply(configuration: configuration?.closeButton)
-        endButton.apply(configuration: configuration?.endButton)
+        endButton.apply(
+            configuration: configuration?.endButton,
+            assetsBuilder: assetsBuilder
+        )
         endScreenShareButton.apply(configuration: configuration?.endScreenSharingButton)
     }
 }

--- a/GliaWidgets/Component/ImageView/File/FilePreviewStyle.swift
+++ b/GliaWidgets/Component/ImageView/File/FilePreviewStyle.swift
@@ -65,7 +65,10 @@ public class FilePreviewStyle {
         self.accessibility = accessibility
     }
 
-    func apply(configuration: RemoteConfiguration.FilePreview?) {
+    func apply(
+        configuration: RemoteConfiguration.FilePreview?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
         configuration?.background?.cornerRadius
             .unwrap { cornerRadius = $0 }
 
@@ -85,7 +88,7 @@ public class FilePreviewStyle {
             .unwrap { fileColor = $0 }
 
         UIFont.convertToFont(
-            font: configuration?.text?.font,
+            uiFont: assetsBuilder.fontBuilder(configuration?.text?.font),
             textStyle: fileTextStyle
         ).unwrap { fileFont = $0 }
 

--- a/GliaWidgets/Component/UnreadMessageIndicator/UnreadMessageIndicatorStyle.swift
+++ b/GliaWidgets/Component/UnreadMessageIndicator/UnreadMessageIndicatorStyle.swift
@@ -50,8 +50,14 @@ public struct UnreadMessageIndicatorStyle {
         self.accessibility = accessibility
     }
 
-    mutating func apply(configuration: RemoteConfiguration.Bubble?) {
-        badge.apply(configuration: configuration?.badge)
+    mutating func apply(
+        configuration: RemoteConfiguration.Bubble?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
+        badge.apply(
+            configuration: configuration?.badge,
+            assetsBuilder: assetsBuilder
+        )
         userImage.apply(configuration: configuration?.userImage)
     }
 }

--- a/GliaWidgets/Glia.RemoteConfiguration.swift
+++ b/GliaWidgets/Glia.RemoteConfiguration.swift
@@ -23,13 +23,17 @@ extension Glia {
     public func startEngagementWithConfig(
         engagement: EngagementKind,
         uiConfig: RemoteConfiguration,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder = .standard,
         features: Features = .all,
         sceneProvider: SceneProvider? = nil
     ) throws {
 
         // Apply remote configuration
         let theme = Theme()
-        theme.applyRemoteConfiguration(uiConfig)
+        theme.applyRemoteConfiguration(
+            uiConfig,
+            assetsBuilder: assetsBuilder
+        )
 
         try startEngagement(
             engagementKind: engagement,

--- a/GliaWidgets/Lib/Extensions/UIFont+Extensions.swift
+++ b/GliaWidgets/Lib/Extensions/UIFont+Extensions.swift
@@ -2,28 +2,25 @@ import Foundation
 import UIKit
 
 extension UIFont {
-    static func convertToFont(font: RemoteConfiguration.Font?, textStyle: UIFont.TextStyle) -> UIFont? {
-        let fontScaling = FontScaling.theme
-        if let fontSize = font?.size, let fontStyle = font?.style {
-            let weight = UIFont.Weight(fontStyle: fontStyle)
-            let font = fontStyle == .italic ? Self.italicFont(weight:size:) : Self.font(weight:size:)
-            return fontScaling.uiFont(
-                with: textStyle,
-                font: font(weight, fontSize)
-            )
-        } else {
-            return nil
-        }
+
+    static func convertToFont(
+        uiFont: UIFont?,
+        textStyle: UIFont.TextStyle
+    ) -> UIFont? {
+        FontScaling.theme.uiFont(
+            with: textStyle,
+            font: uiFont
+        )
     }
 
-    private static func font(
+    static func font(
         weight: UIFont.Weight,
         size: CGFloat
     ) -> UIFont {
         return .systemFont(ofSize: size, weight: weight)
     }
 
-    private static func italicFont(
+    static func italicFont(
         weight: UIFont.Weight = .regular,
         size: CGFloat
     ) -> UIFont {

--- a/GliaWidgets/RemoteConfiguration/RemoteConfiguration+AssetsBuilder.swift
+++ b/GliaWidgets/RemoteConfiguration/RemoteConfiguration+AssetsBuilder.swift
@@ -1,0 +1,34 @@
+import UIKit
+
+public extension RemoteConfiguration {
+    /// Provides assets for remote configuration.
+    struct AssetsBuilder {
+        /// The font builder provides the UIFont instance for appropriate Font configururation structure.
+        public var fontBuilder: (RemoteConfiguration.Font?) -> UIFont?
+
+        /// The default implementation of the AssetsBuilder.
+        /// Transforms `RemoteConfiguration.Font` to SF font family `UIFont`
+        public static let standard: Self = .init(
+            fontBuilder: { font in
+                guard
+                    let fontSize = font?.size,
+                    let fontStyle = font?.style
+                else {
+                    return nil
+                }
+                let weight = UIFont.Weight(fontStyle: fontStyle)
+
+                let font = fontStyle == .italic ? UIFont.italicFont(weight:size:) : UIFont.font(weight:size:)
+                return font(weight, fontSize)
+            }
+        )
+
+        /// Initilizes the assets builder with font-building closure.
+        ///
+        /// - Parameter fontBuilder: Closure that provides the UIFont instance for appropriate Font configururation structure.
+        ///
+        public init(fontBuilder: @escaping (RemoteConfiguration.Font?) -> UIFont?) {
+            self.fontBuilder = fontBuilder
+        }
+    }
+}

--- a/GliaWidgets/Theme/Survey/Theme+Survey.swift
+++ b/GliaWidgets/Theme/Survey/Theme+Survey.swift
@@ -84,14 +84,38 @@ extension Theme.SurveyStyle {
     }
 
     /// Apply survey remote configuration
-    mutating func apply(configuration: RemoteConfiguration.Survey?) {
+    mutating func apply(
+        configuration: RemoteConfiguration.Survey?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
         layer.apply(configuration: configuration?.layer)
-        title.apply(configuration: configuration?.title)
-        submitButton.apply(configuration: configuration?.submitButton)
-        cancellButton.apply(configuration: configuration?.cancelButton)
-        booleanQuestion.apply(configuration: configuration?.booleanQuestion)
-        scaleQuestion.apply(configuration: configuration?.scaleQuestion)
-        singleQuestion.apply(configuration: configuration?.singleQuestion)
-        inputQuestion.apply(configuration: configuration?.inputQuestion)
+        title.apply(
+            configuration: configuration?.title,
+            assetsBuilder: assetsBuilder
+        )
+        submitButton.apply(
+            configuration: configuration?.submitButton,
+            assetsBuilder: assetsBuilder
+        )
+        cancellButton.apply(
+            configuration: configuration?.cancelButton,
+            assetsBuilder: assetsBuilder
+        )
+        booleanQuestion.apply(
+            configuration: configuration?.booleanQuestion,
+            assetsBuilder: assetsBuilder
+        )
+        scaleQuestion.apply(
+            configuration: configuration?.scaleQuestion,
+            assetsBuilder: assetsBuilder
+        )
+        singleQuestion.apply(
+            configuration: configuration?.singleQuestion,
+            assetsBuilder: assetsBuilder
+        )
+        inputQuestion.apply(
+            configuration: configuration?.inputQuestion,
+            assetsBuilder: assetsBuilder
+        )
     }
 }

--- a/GliaWidgets/Theme/Survey/Theme.Survey.BooleanQuestion.swift
+++ b/GliaWidgets/Theme/Survey/Theme.Survey.BooleanQuestion.swift
@@ -63,9 +63,18 @@ public extension Theme.SurveyStyle {
         }
 
         /// Apply boolean question from remote configuration
-        mutating func apply(configuration: RemoteConfiguration.SurveyBooleanQuestion?) {
-            title.apply(configuration: configuration?.title)
-            option.apply(configuration: configuration?.optionButton)
+        mutating func apply(
+            configuration: RemoteConfiguration.SurveyBooleanQuestion?,
+            assetsBuilder: RemoteConfiguration.AssetsBuilder
+        ) {
+            title.apply(
+                configuration: configuration?.title,
+                assetsBuilder: assetsBuilder
+            )
+            option.apply(
+                configuration: configuration?.optionButton,
+                assetsBuilder: assetsBuilder
+            )
         }
     }
 }

--- a/GliaWidgets/Theme/Survey/Theme.Survey.InputQuestion.swift
+++ b/GliaWidgets/Theme/Survey/Theme.Survey.InputQuestion.swift
@@ -79,11 +79,23 @@ public extension Theme.SurveyStyle {
         }
 
         /// Apply input question from remote configuration
-        mutating func apply(configuration: RemoteConfiguration.SurveyInputQuestion?) {
-            title.apply(configuration: configuration?.title)
-            text.apply(configuration: configuration?.text)
+        mutating func apply(
+            configuration: RemoteConfiguration.SurveyInputQuestion?,
+            assetsBuilder: RemoteConfiguration.AssetsBuilder
+        ) {
+            title.apply(
+                configuration: configuration?.title,
+                assetsBuilder: assetsBuilder
+            )
+            text.apply(
+                configuration: configuration?.text,
+                assetsBuilder: assetsBuilder
+            )
             background.apply(configuration: configuration?.background)
-            option.apply(configuration: configuration?.option)
+            option.apply(
+                configuration: configuration?.option,
+                assetsBuilder: assetsBuilder
+            )
         }
     }
 }

--- a/GliaWidgets/Theme/Survey/Theme.Survey.OptionButton.swift
+++ b/GliaWidgets/Theme/Survey/Theme.Survey.OptionButton.swift
@@ -45,20 +45,38 @@ extension Theme.SurveyStyle {
         }
 
         /// Apply option button from remote configuration
-        mutating func apply(configuration: RemoteConfiguration.OptionButton?) {
-            applyFontConfiguration(configuration?.font)
-            normalText.apply(configuration: configuration?.normalText)
+        mutating func apply(
+            configuration: RemoteConfiguration.OptionButton?,
+            assetsBuilder: RemoteConfiguration.AssetsBuilder
+        ) {
+            applyFontConfiguration(
+                configuration?.font,
+                assetsBuilder: assetsBuilder
+            )
+            normalText.apply(
+                configuration: configuration?.normalText,
+                assetsBuilder: assetsBuilder
+            )
             normalLayer.apply(configuration: configuration?.normalLayer)
-            selectedText.apply(configuration: configuration?.selectedText)
+            selectedText.apply(
+                configuration: configuration?.selectedText,
+                assetsBuilder: assetsBuilder
+            )
             selectedLayer.apply(configuration: configuration?.selectedLayer)
-            highlightedText.apply(configuration: configuration?.highlightedText)
+            highlightedText.apply(
+                configuration: configuration?.highlightedText,
+                assetsBuilder: assetsBuilder
+            )
             highlightedLayer.apply(configuration: configuration?.highlightedLayer)
         }
 
         /// Apply option button title font from remote configuration
-        private mutating func applyFontConfiguration(_ font: RemoteConfiguration.Font?) {
+        private mutating func applyFontConfiguration(
+            _ font: RemoteConfiguration.Font?,
+            assetsBuilder: RemoteConfiguration.AssetsBuilder
+        ) {
             UIFont.convertToFont(
-                font: font,
+                uiFont: assetsBuilder.fontBuilder(font),
                 textStyle: textStyle
             ).unwrap { self.font = $0 }
         }

--- a/GliaWidgets/Theme/Survey/Theme.Survey.ScaleQuestion.swift
+++ b/GliaWidgets/Theme/Survey/Theme.Survey.ScaleQuestion.swift
@@ -63,9 +63,18 @@ public extension Theme.SurveyStyle {
         }
 
         /// Apply scale question from remote configuration
-        mutating func apply(configuration: RemoteConfiguration.SurveyScaleQuestion?) {
-            title.apply(configuration: configuration?.title)
-            option.apply(configuration: configuration?.optionButton)
+        mutating func apply(
+            configuration: RemoteConfiguration.SurveyScaleQuestion?,
+            assetsBuilder: RemoteConfiguration.AssetsBuilder
+        ) {
+            title.apply(
+                configuration: configuration?.title,
+                assetsBuilder: assetsBuilder
+            )
+            option.apply(
+                configuration: configuration?.optionButton,
+                assetsBuilder: assetsBuilder
+            )
         }
     }
 }

--- a/GliaWidgets/Theme/Survey/Theme.Survey.SingleQuestion.swift
+++ b/GliaWidgets/Theme/Survey/Theme.Survey.SingleQuestion.swift
@@ -38,9 +38,18 @@ public extension Theme.SurveyStyle {
         }
 
         /// Apply single question from remote configuration
-        mutating func apply(configuration: RemoteConfiguration.SurveySingleQuestion?) {
-            option.title.apply(configuration: configuration?.option)
-            title.apply(configuration: configuration?.title)
+        mutating func apply(
+            configuration: RemoteConfiguration.SurveySingleQuestion?,
+            assetsBuilder: RemoteConfiguration.AssetsBuilder
+        ) {
+            option.title.apply(
+                configuration: configuration?.option,
+                assetsBuilder: assetsBuilder
+            )
+            title.apply(
+                configuration: configuration?.title,
+                assetsBuilder: assetsBuilder
+            )
             applyTintColorConfiguration(configuration?.tintColor)
         }
 

--- a/GliaWidgets/Theme/Theme+Button.swift
+++ b/GliaWidgets/Theme/Theme+Button.swift
@@ -63,9 +63,15 @@ extension Theme {
         }
 
         /// Apply default question button from remote configuration
-        mutating func apply(configuration: RemoteConfiguration.Button?) {
+        mutating func apply(
+            configuration: RemoteConfiguration.Button?,
+            assetsBuilder: RemoteConfiguration.AssetsBuilder
+        ) {
             applyBackground(configuration?.background)
-            title.apply(configuration: configuration?.text)
+            title.apply(
+                configuration: configuration?.text,
+                assetsBuilder: assetsBuilder
+            )
             shadow.apply(configuration: configuration?.shadow)
         }
     }

--- a/GliaWidgets/Theme/Theme+Text.swift
+++ b/GliaWidgets/Theme/Theme+Text.swift
@@ -28,7 +28,10 @@ extension Theme {
         }
 
         /// Apply text from remote configuration
-        mutating func apply(configuration: RemoteConfiguration.Text?) {
+        mutating func apply(
+            configuration: RemoteConfiguration.Text?,
+            assetsBuilder: RemoteConfiguration.AssetsBuilder
+        ) {
             configuration?.alignment.unwrap { alignment in
                 switch alignment {
                 case .center:
@@ -45,7 +48,7 @@ extension Theme {
             }
 
             UIFont.convertToFont(
-                font: configuration?.font,
+                uiFont: assetsBuilder.fontBuilder(configuration?.font),
                 textStyle: textStyle
             ).unwrap { font = $0 }
 

--- a/GliaWidgets/Theme/Theme.swift
+++ b/GliaWidgets/Theme/Theme.swift
@@ -65,11 +65,29 @@ public class Theme {
     }
 
     /// Apply remote configuration
-    func applyRemoteConfiguration(_ config: RemoteConfiguration) {
-        call.apply(configuration: config.callScreen)
-        survey.apply(configuration: config.surveyScreen)
-        alert.apply(configuration: config.alertScreen)
-        minimizedBubble.apply(configuration: config.bubble)
-        chat.apply(configuration: config.chatScreen)
+    func applyRemoteConfiguration(
+        _ config: RemoteConfiguration,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
+        call.apply(
+            configuration: config.callScreen,
+            assetsBuilder: assetsBuilder
+        )
+        survey.apply(
+            configuration: config.surveyScreen,
+            assetsBuilder: assetsBuilder
+        )
+        alert.apply(
+            configuration: config.alertScreen,
+            assetsBuilder: assetsBuilder
+        )
+        minimizedBubble.apply(
+            configuration: config.bubble,
+            assetsBuilder: assetsBuilder
+        )
+        chat.apply(
+            configuration: config.chatScreen,
+            assetsBuilder: assetsBuilder
+        )
     }
 }

--- a/GliaWidgets/View/Call/CallStyle.swift
+++ b/GliaWidgets/View/Call/CallStyle.swift
@@ -185,25 +185,49 @@ extension CallStyle {
     }
 
     /// Apply call configuration from remote configuration
-    func apply(configuration: RemoteConfiguration.Call?) {
-        applyBarConfiguration(configuration?.buttonBar)
+    func apply(
+        configuration: RemoteConfiguration.Call?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
+        applyBarConfiguration(
+            configuration?.buttonBar,
+            assetsBuilder: assetsBuilder
+        )
         applyBackgroundConfiguration(configuration?.background)
-        applyOperatorConfiguration(configuration?.callOperator)
-        header.apply(configuration: configuration?.header)
-        applyDurationConfiguration(configuration?.duration)
-        applyTopTextConfiguration(configuration?.topText)
-        applyBottomTextConfiguration(configuration?.bottomText)
+        applyOperatorConfiguration(
+            configuration?.callOperator,
+            assetsBuilder: assetsBuilder
+        )
+        header.apply(
+            configuration: configuration?.header,
+            assetsBuilder: assetsBuilder
+        )
+        applyDurationConfiguration(
+            configuration?.duration,
+            assetsBuilder: assetsBuilder
+        )
+        applyTopTextConfiguration(
+            configuration?.topText,
+            assetsBuilder: assetsBuilder
+        )
+        applyBottomTextConfiguration(
+            configuration?.bottomText,
+            assetsBuilder: assetsBuilder
+        )
     }
 
     /// Apply bottomText from remote configuration
-    private func applyBottomTextConfiguration(_ bottomText: RemoteConfiguration.Text?) {
+    private func applyBottomTextConfiguration(
+        _ bottomText: RemoteConfiguration.Text?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
 
         bottomText?.alignment.unwrap { _ in
             // The logic for bottomText alignment has not been implemented
         }
 
         UIFont.convertToFont(
-            font: bottomText?.font,
+            uiFont: assetsBuilder.fontBuilder(bottomText?.font),
             textStyle: bottomTextStyle
         ).unwrap { bottomTextFont = $0 }
 
@@ -214,7 +238,10 @@ extension CallStyle {
     }
 
     /// Apply topText from remote configuration
-    private func applyTopTextConfiguration(_ topText: RemoteConfiguration.Text?) {
+    private func applyTopTextConfiguration(
+        _ topText: RemoteConfiguration.Text?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
 
         topText?.alignment.unwrap { _ in
             // The logic for topText alignment has not been implemented
@@ -225,7 +252,7 @@ extension CallStyle {
         }
 
         UIFont.convertToFont(
-            font: topText?.font,
+            uiFont: assetsBuilder.fontBuilder(topText?.font),
             textStyle: topTextStyle
         ).unwrap { topTextFont = $0 }
 
@@ -236,7 +263,10 @@ extension CallStyle {
     }
 
     /// Apply duration from remote configuration
-    private func applyDurationConfiguration(_ duration: RemoteConfiguration.Text?) {
+    private func applyDurationConfiguration(
+        _ duration: RemoteConfiguration.Text?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
 
         duration?.alignment.unwrap { _ in
             // The logic for duration alignment has not been implemented
@@ -247,7 +277,7 @@ extension CallStyle {
         }
 
         UIFont.convertToFont(
-            font: duration?.font,
+            uiFont: assetsBuilder.fontBuilder(duration?.font),
             textStyle: durationTextStyle
         ).unwrap { durationFont = $0 }
 
@@ -257,94 +287,18 @@ extension CallStyle {
             .unwrap { durationColor = $0 }
     }
 
-    /// Apply end button from remote configuration
-    private func applyEndButtonConfiguration(_ endButton: RemoteConfiguration.Button?) {
-        endButton?.background?.color.unwrap {
-            switch $0.type {
-            case .fill:
-                $0.value
-                    .map { UIColor(hex: $0) }
-                    .first
-                    .unwrap { header.endButton.backgroundColor = .fill(color: $0) }
-            case .gradient:
-                let colors = $0.value.convertToCgColors()
-                header.endButton.backgroundColor = .gradient(colors: colors)
-            }
-        }
-
-        endButton?.text?.alignment.unwrap { _ in
-            // The logic for duration alignment has not been implemented
-        }
-
-        endButton?.text?.background.unwrap { _ in
-            // The logic for duration background has not been implemented
-        }
-        UIFont.convertToFont(
-            font: endButton?.text?.font,
-            textStyle: header.endButton.textStyle
-        ).unwrap { header.endButton.titleFont = $0 }
-
-        endButton?.text?.foreground?.value
-            .map { UIColor(hex: $0) }
-            .first
-            .unwrap { header.endButton.titleColor = $0 }
-    }
-
-    /// Apply header from remote configuration
-    private func applyHeaderConfiguration(_ header: RemoteConfiguration.Header?) {
-        header?.background?.border.unwrap { _ in
-            // The logic for header border has not been implemented
-        }
-
-        header?.background?.borderWidth.unwrap { _ in
-            // The logic for header borderWidth has not been implemented
-        }
-
-        header?.background?.cornerRadius.unwrap { _ in
-            // The logic for header cornerRadius has not been implemented
-        }
-
-        header?.background?.color.unwrap {
-            switch $0.type {
-            case .fill:
-                $0.value
-                    .map { UIColor(hex: $0) }
-                    .first
-                    .unwrap { self.header.backgroundColor = .fill(color: $0) }
-            case .gradient:
-                let colors = $0.value.convertToCgColors()
-                self.header.backgroundColor = .gradient(colors: colors)
-            }
-        }
-
-        header?.text?.alignment.unwrap { _ in
-            // The logic for title alignment has not been implemented
-        }
-
-        header?.text?.background.unwrap { _ in
-            // The logic for title background has not been implemented
-        }
-
-        UIFont.convertToFont(
-            font: header?.text?.font,
-            textStyle: self.header.textStyle
-        ).unwrap { self.header.titleFont = $0 }
-
-        header?.text?.foreground?.value
-            .map { UIColor(hex: $0) }
-            .first
-            .unwrap { self.header.titleColor = $0 }
-    }
-
     /// Apply operator from remote configuration
-    private func applyOperatorConfiguration(_ callOperator: RemoteConfiguration.Text?) {
+    private func applyOperatorConfiguration(
+        _ callOperator: RemoteConfiguration.Text?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
         callOperator?.foreground?.value
             .map { UIColor(hex: $0) }
             .first
             .unwrap { self.operatorNameColor = $0 }
 
         UIFont.convertToFont(
-            font: callOperator?.font,
+            uiFont: assetsBuilder.fontBuilder(callOperator?.font),
             textStyle: operatorNameTextStyle
         ).unwrap { operatorNameFont = $0 }
     }
@@ -366,7 +320,13 @@ extension CallStyle {
     }
 
     /// Apply bar buttons from remote configuration
-    private func applyBarConfiguration(_ bar: RemoteConfiguration.ButtonBar?) {
-        buttonBar.applyBarConfiguration(bar)
+    private func applyBarConfiguration(
+        _ bar: RemoteConfiguration.ButtonBar?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
+        buttonBar.applyBarConfiguration(
+            bar,
+            assetsBuilder: assetsBuilder
+        )
     }
 }

--- a/GliaWidgets/View/Chat/ChatStyle.swift
+++ b/GliaWidgets/View/Chat/ChatStyle.swift
@@ -95,18 +95,54 @@ public class ChatStyle: EngagementStyle {
         )
     }
 
-    func apply(configuration: RemoteConfiguration.Chat?) {
-        header.apply(configuration: configuration?.header)
-        connect.apply(configuration: configuration?.connect)
-        visitorMessage.apply(configuration: configuration?.visitorMessage)
-        operatorMessage.apply(configuration: configuration?.operatorMessage)
-        messageEntry.apply(configuration: configuration?.input)
-        choiceCard.apply(configuration: configuration?.responseCard)
-        audioUpgrade.apply(configuration: configuration?.audioUpgrade)
-        videoUpgrade.apply(configuration: configuration?.videoUpgrade)
-        callBubble.apply(configuration: configuration?.bubble)
-        pickMedia.apply(configuration: configuration?.attachmentSourceList)
-        unreadMessageIndicator.apply(configuration: configuration?.unreadIndicator)
+    func apply(
+        configuration: RemoteConfiguration.Chat?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
+        header.apply(
+            configuration: configuration?.header,
+            assetsBuilder: assetsBuilder
+        )
+        connect.apply(
+            configuration: configuration?.connect,
+            assetsBuilder: assetsBuilder
+        )
+        visitorMessage.apply(
+            configuration: configuration?.visitorMessage,
+            assetsBuilder: assetsBuilder
+        )
+        operatorMessage.apply(
+            configuration: configuration?.operatorMessage,
+            assetsBuilder: assetsBuilder
+        )
+        messageEntry.apply(
+            configuration: configuration?.input,
+            assetsBuilder: assetsBuilder
+        )
+        choiceCard.apply(
+            configuration: configuration?.responseCard,
+            assetsBuilder: assetsBuilder
+        )
+        audioUpgrade.apply(
+            configuration: configuration?.audioUpgrade,
+            assetsBuilder: assetsBuilder
+        )
+        videoUpgrade.apply(
+            configuration: configuration?.videoUpgrade,
+            assetsBuilder: assetsBuilder
+        )
+        callBubble.apply(
+            configuration: configuration?.bubble,
+            assetsBuilder: assetsBuilder
+        )
+        pickMedia.apply(
+            configuration: configuration?.attachmentSourceList,
+            assetsBuilder: assetsBuilder
+        )
+        unreadMessageIndicator.apply(
+            configuration: configuration?.unreadIndicator,
+            assetsBuilder: assetsBuilder
+        )
         operatorTypingIndicator.apply(configuration: configuration?.typingIndicator)
 
         configuration?.background?.color.unwrap {

--- a/GliaWidgets/View/Chat/Entry/ChatMessageEntryStyle.swift
+++ b/GliaWidgets/View/Chat/Entry/ChatMessageEntryStyle.swift
@@ -99,7 +99,10 @@ public struct ChatMessageEntryStyle {
         self.accessibility = accessibility
     }
 
-    mutating func apply(configuration: RemoteConfiguration.Input?) {
+    mutating func apply(
+        configuration: RemoteConfiguration.Input?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
         configuration?.background?.color?.value
             .map { UIColor(hex: $0) }
             .first
@@ -111,7 +114,7 @@ public struct ChatMessageEntryStyle {
             .unwrap { messageColor = $0 }
 
         UIFont.convertToFont(
-            font: configuration?.text?.font,
+            uiFont: assetsBuilder.fontBuilder(configuration?.text?.font),
             textStyle: messageTextStyle
         ).unwrap { messageFont = $0 }
 
@@ -121,7 +124,7 @@ public struct ChatMessageEntryStyle {
             .unwrap { placeholderColor = $0 }
 
         UIFont.convertToFont(
-            font: configuration?.placeholder?.font,
+            uiFont: assetsBuilder.fontBuilder(configuration?.placeholder?.font),
             textStyle: placeholderTextStyle
         ).unwrap { placeholderFont = $0 }
 
@@ -140,6 +143,9 @@ public struct ChatMessageEntryStyle {
             .first
             .unwrap { sendButton.color = $0 }
 
-        uploadList.apply(configuration: configuration?.fileUploadBar)
+        uploadList.apply(
+            configuration: configuration?.fileUploadBar,
+            assetsBuilder: assetsBuilder
+        )
     }
 }

--- a/GliaWidgets/View/Chat/Entry/Upload/FileUploadListStyle.swift
+++ b/GliaWidgets/View/Chat/Entry/Upload/FileUploadListStyle.swift
@@ -13,7 +13,13 @@ public class FileUploadListStyle {
         self.item = item
     }
 
-    func apply(configuration: RemoteConfiguration.FileUploadBar?) {
-        item.apply(configuration: configuration)
+    func apply(
+        configuration: RemoteConfiguration.FileUploadBar?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
+        item.apply(
+            configuration: configuration,
+            assetsBuilder: assetsBuilder
+        )
     }
 }

--- a/GliaWidgets/View/Chat/Entry/Upload/FileUploadStyle.swift
+++ b/GliaWidgets/View/Chat/Entry/Upload/FileUploadStyle.swift
@@ -68,11 +68,26 @@ public class FileUploadStyle {
         self.accessibility = accessibility
     }
 
-    func apply(configuration: RemoteConfiguration.FileUploadBar?) {
-        filePreview.apply(configuration: configuration?.filePreview)
-        uploading.apply(configuration: configuration?.uploading)
-        uploaded.apply(configuration: configuration?.uploaded)
-        error.apply(configuration: configuration?.error)
+    func apply(
+        configuration: RemoteConfiguration.FileUploadBar?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
+        filePreview.apply(
+            configuration: configuration?.filePreview,
+            assetsBuilder: assetsBuilder
+        )
+        uploading.apply(
+            configuration: configuration?.uploading,
+            assetsBuilder: assetsBuilder
+        )
+        uploaded.apply(
+            configuration: configuration?.uploaded,
+            assetsBuilder: assetsBuilder
+        )
+        error.apply(
+            configuration: configuration?.error,
+            assetsBuilder: assetsBuilder
+        )
 
         configuration?.progress?.value
             .map { UIColor(hex: $0) }
@@ -147,14 +162,17 @@ public class FileUploadStateStyle {
         self.infoTextStyle = infoTextStyle
     }
 
-    func apply(configuration: RemoteConfiguration.FileState?) {
+    func apply(
+        configuration: RemoteConfiguration.FileState?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
         configuration?.text?.foreground?.value
             .map { UIColor(hex: $0) }
             .first
             .unwrap { textColor = $0 }
 
         UIFont.convertToFont(
-            font: configuration?.text?.font,
+            uiFont: assetsBuilder.fontBuilder(configuration?.text?.font),
             textStyle: textStyle
         ).unwrap { font = $0 }
 
@@ -164,7 +182,7 @@ public class FileUploadStateStyle {
             .unwrap { infoColor = $0 }
 
         UIFont.convertToFont(
-            font: configuration?.info?.font,
+            uiFont: assetsBuilder.fontBuilder(configuration?.info?.font),
             textStyle: infoTextStyle
         ).unwrap { infoFont = $0 }
     }
@@ -251,14 +269,17 @@ public class FileUploadErrorStateStyle {
         self.infoGenericError = infoGenericError
     }
 
-    func apply(configuration: RemoteConfiguration.FileState?) {
+    func apply(
+        configuration: RemoteConfiguration.FileState?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
         configuration?.text?.foreground?.value
             .map { UIColor(hex: $0) }
             .first
             .unwrap { textColor = $0 }
 
         UIFont.convertToFont(
-            font: configuration?.text?.font,
+            uiFont: assetsBuilder.fontBuilder(configuration?.text?.font),
             textStyle: textStyle
         ).unwrap { font = $0 }
 
@@ -268,7 +289,7 @@ public class FileUploadErrorStateStyle {
             .unwrap { infoColor = $0 }
 
         UIFont.convertToFont(
-            font: configuration?.info?.font,
+            uiFont: assetsBuilder.fontBuilder(configuration?.info?.font),
             textStyle: infoTextStyle
         ).unwrap { infoFont = $0 }
     }

--- a/GliaWidgets/View/Chat/Message/Content/ChoiceCard/ChoiceCardOptionStateStyle.swift
+++ b/GliaWidgets/View/Chat/Message/Content/ChoiceCard/ChoiceCardOptionStateStyle.swift
@@ -33,7 +33,10 @@ public final class ChoiceCardOptionStateStyle: ChatTextContentStyle {
         )
     }
 
-    func apply(configuration: RemoteConfiguration.Button?) {
+    func apply(
+        configuration: RemoteConfiguration.Button?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
         configuration?.background?.color?.value
             .map { UIColor(hex: $0) }
             .first
@@ -53,7 +56,7 @@ public final class ChoiceCardOptionStateStyle: ChatTextContentStyle {
             .unwrap { textColor = $0 }
 
         UIFont.convertToFont(
-            font: configuration?.text?.font,
+            uiFont: assetsBuilder.fontBuilder(configuration?.text?.font),
             textStyle: textStyle
         ).unwrap { textFont = $0 }
     }

--- a/GliaWidgets/View/Chat/Message/Content/ChoiceCard/ChoiceCardOptionStyle.swift
+++ b/GliaWidgets/View/Chat/Message/Content/ChoiceCard/ChoiceCardOptionStyle.swift
@@ -27,9 +27,21 @@ public final class ChoiceCardOptionStyle {
         self.disabled = disabled
     }
 
-    func apply(configuration: RemoteConfiguration.ResponseCardOption?) {
-        normal.apply(configuration: configuration?.normal)
-        selected.apply(configuration: configuration?.selected)
-        disabled.apply(configuration: configuration?.disabled)
+    func apply(
+        configuration: RemoteConfiguration.ResponseCardOption?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
+        normal.apply(
+            configuration: configuration?.normal,
+            assetsBuilder: assetsBuilder
+        )
+        selected.apply(
+            configuration: configuration?.selected,
+            assetsBuilder: assetsBuilder
+        )
+        disabled.apply(
+            configuration: configuration?.disabled,
+            assetsBuilder: assetsBuilder
+        )
     }
 }

--- a/GliaWidgets/View/Chat/Message/Content/ChoiceCard/ChoiceCardStyle.swift
+++ b/GliaWidgets/View/Chat/Message/Content/ChoiceCard/ChoiceCardStyle.swift
@@ -55,7 +55,10 @@ public final class ChoiceCardStyle: OperatorChatMessageStyle {
         )
     }
 
-    func apply(configuration: RemoteConfiguration.ResponseCard?) {
+    func apply(
+        configuration: RemoteConfiguration.ResponseCard?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
         configuration?.background?.color?.value
             .map { UIColor(hex: $0) }
             .first
@@ -72,7 +75,13 @@ public final class ChoiceCardStyle: OperatorChatMessageStyle {
         configuration?.background?.borderWidth
             .unwrap { borderWidth = $0 }
 
-        choiceOption.apply(configuration: configuration?.option)
-        apply(configuration: configuration?.message)
+        choiceOption.apply(
+            configuration: configuration?.option,
+            assetsBuilder: assetsBuilder
+        )
+        apply(
+            configuration: configuration?.message,
+            assetsBuilder: assetsBuilder
+        )
     }
 }

--- a/GliaWidgets/View/Chat/Message/Content/File/Download/ChatFileDownloadContentStyle.swift
+++ b/GliaWidgets/View/Chat/Message/Content/File/Download/ChatFileDownloadContentStyle.swift
@@ -77,12 +77,30 @@ public class ChatFileDownloadStyle: ChatFileContentStyle {
         )
     }
 
-    func apply(configuration: RemoteConfiguration.FileMessage?) {
-        filePreview.apply(configuration: configuration?.preview)
-        download.apply(configuration: configuration?.download)
-        downloading.apply(configuration: configuration?.downloading)
-        open.apply(configuration: configuration?.downloaded)
-        error.apply(configuration: configuration?.error)
+    func apply(
+        configuration: RemoteConfiguration.FileMessage?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
+        filePreview.apply(
+            configuration: configuration?.preview,
+            assetsBuilder: assetsBuilder
+        )
+        download.apply(
+            configuration: configuration?.download,
+            assetsBuilder: assetsBuilder
+        )
+        downloading.apply(
+            configuration: configuration?.downloading,
+            assetsBuilder: assetsBuilder
+        )
+        open.apply(
+            configuration: configuration?.downloaded,
+            assetsBuilder: assetsBuilder
+        )
+        error.apply(
+            configuration: configuration?.error,
+            assetsBuilder: assetsBuilder
+        )
 
         configuration?.progress?.value
             .map { UIColor(hex: $0) }
@@ -162,9 +180,12 @@ public class ChatFileDownloadStateStyle {
         self.infoTextStyle = infoTextStyle
     }
 
-    func apply(configuration: RemoteConfiguration.FileState?) {
+    func apply(
+        configuration: RemoteConfiguration.FileState?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
         UIFont.convertToFont(
-            font: configuration?.text?.font,
+            uiFont: assetsBuilder.fontBuilder(configuration?.text?.font),
             textStyle: textStyle
         ).unwrap { font = $0 }
 
@@ -174,7 +195,7 @@ public class ChatFileDownloadStateStyle {
             .unwrap { textColor = $0 }
 
         UIFont.convertToFont(
-            font: configuration?.info?.font,
+            uiFont: assetsBuilder.fontBuilder(configuration?.info?.font),
             textStyle: infoTextStyle
         ).unwrap { infoFont = $0 }
 
@@ -284,9 +305,12 @@ public class ChatFileDownloadErrorStateStyle {
         self.retryTextStyle = retryTextStyle
     }
 
-    func apply(configuration: RemoteConfiguration.FileErrorState?) {
+    func apply(
+        configuration: RemoteConfiguration.FileErrorState?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
         UIFont.convertToFont(
-            font: configuration?.text?.font,
+            uiFont: assetsBuilder.fontBuilder(configuration?.text?.font),
             textStyle: textStyle
         ).unwrap { font = $0 }
 
@@ -296,7 +320,7 @@ public class ChatFileDownloadErrorStateStyle {
             .unwrap { textColor = $0 }
 
         UIFont.convertToFont(
-            font: configuration?.info?.font,
+            uiFont: assetsBuilder.fontBuilder(configuration?.info?.font),
             textStyle: infoTextStyle
         ).unwrap { infoFont = $0 }
 
@@ -306,7 +330,7 @@ public class ChatFileDownloadErrorStateStyle {
             .unwrap { infoColor = $0 }
 
         UIFont.convertToFont(
-            font: configuration?.separator?.font,
+            uiFont: assetsBuilder.fontBuilder(configuration?.separator?.font),
             textStyle: separatorTextStyle
         ).unwrap { separatorFont = $0 }
 
@@ -316,7 +340,7 @@ public class ChatFileDownloadErrorStateStyle {
             .unwrap { separatorTextColor = $0 }
 
         UIFont.convertToFont(
-            font: configuration?.retry?.font,
+            uiFont: assetsBuilder.fontBuilder(configuration?.retry?.font),
             textStyle: retryTextStyle
         ).unwrap { retryFont = $0 }
 

--- a/GliaWidgets/View/Chat/Message/OperatorChatMessageStyle.swift
+++ b/GliaWidgets/View/Chat/Message/OperatorChatMessageStyle.swift
@@ -26,7 +26,10 @@ public class OperatorChatMessageStyle: ChatMessageStyle {
         )
     }
 
-    func apply(configuration: RemoteConfiguration.MessageBalloon?) {
+    func apply(
+        configuration: RemoteConfiguration.MessageBalloon?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
         configuration?.background?.cornerRadius
             .unwrap { text.cornerRadius = $0 }
 
@@ -39,7 +42,7 @@ public class OperatorChatMessageStyle: ChatMessageStyle {
             }
 
         UIFont.convertToFont(
-            font: configuration?.text?.font,
+            uiFont: assetsBuilder.fontBuilder(configuration?.text?.font),
             textStyle: text.textStyle
         ).unwrap { text.textFont = $0 }
 
@@ -48,7 +51,10 @@ public class OperatorChatMessageStyle: ChatMessageStyle {
             .first
             .unwrap { text.textColor = $0 }
 
-        fileDownload.apply(configuration: configuration?.file)
+        fileDownload.apply(
+            configuration: configuration?.file,
+            assetsBuilder: assetsBuilder
+        )
         operatorImage.apply(configuration: configuration?.userImage)
     }
 }

--- a/GliaWidgets/View/Chat/Message/VisitorChatMessageStyle.swift
+++ b/GliaWidgets/View/Chat/Message/VisitorChatMessageStyle.swift
@@ -50,7 +50,10 @@ public class VisitorChatMessageStyle: ChatMessageStyle {
         )
     }
 
-    func apply(configuration: RemoteConfiguration.MessageBalloon?) {
+    func apply(
+        configuration: RemoteConfiguration.MessageBalloon?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
         configuration?.background?.cornerRadius
             .unwrap { text.cornerRadius = $0 }
 
@@ -63,7 +66,7 @@ public class VisitorChatMessageStyle: ChatMessageStyle {
             }
 
         UIFont.convertToFont(
-            font: configuration?.text?.font,
+            uiFont: assetsBuilder.fontBuilder(configuration?.text?.font),
             textStyle: text.textStyle
         ).unwrap { text.textFont = $0 }
 
@@ -73,7 +76,7 @@ public class VisitorChatMessageStyle: ChatMessageStyle {
             .unwrap { text.textColor = $0 }
 
         UIFont.convertToFont(
-            font: configuration?.status?.font,
+            uiFont: assetsBuilder.fontBuilder(configuration?.status?.font),
             textStyle: statusTextStyle
         ).unwrap { statusFont = $0 }
 
@@ -82,6 +85,9 @@ public class VisitorChatMessageStyle: ChatMessageStyle {
             .first
             .unwrap { statusColor = $0 }
 
-        fileDownload.apply(configuration: configuration?.file)
+        fileDownload.apply(
+            configuration: configuration?.file,
+            assetsBuilder: assetsBuilder
+        )
     }
 }

--- a/GliaWidgets/View/Chat/Upgrade/ChatCallUpgradeStyle.swift
+++ b/GliaWidgets/View/Chat/Upgrade/ChatCallUpgradeStyle.swift
@@ -87,14 +87,17 @@ public class ChatCallUpgradeStyle {
         self.accessibility = accessibility
     }
 
-    func apply(configuration: RemoteConfiguration.Upgrade?) {
+    func apply(
+        configuration: RemoteConfiguration.Upgrade?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
         configuration?.iconColor?.value
             .map { UIColor(hex: $0) }
             .first
             .unwrap { iconColor = $0 }
 
         UIFont.convertToFont(
-            font: configuration?.text?.font,
+            uiFont: assetsBuilder.fontBuilder(configuration?.text?.font),
             textStyle: textStyle
         ).unwrap { textFont = $0 }
 
@@ -104,7 +107,7 @@ public class ChatCallUpgradeStyle {
             .unwrap { textColor = $0 }
 
         UIFont.convertToFont(
-            font: configuration?.description?.font,
+            uiFont: assetsBuilder.fontBuilder(configuration?.description?.font),
             textStyle: durationTextStyle
         ).unwrap { durationFont = $0 }
 

--- a/GliaWidgets/View/Common/Alert/AlertStyle.swift
+++ b/GliaWidgets/View/Common/Alert/AlertStyle.swift
@@ -94,12 +94,27 @@ public struct AlertStyle {
     }
 
     /// Apply alert customization from remote configuration
-    mutating func apply(configuration: RemoteConfiguration.Alert?) {
-        positiveAction.apply(configuration: configuration?.positiveButton)
-        negativeAction.apply(configuration: configuration?.negativeButton)
-        applyTitleConfiguration(configuration?.title)
+    mutating func apply(
+        configuration: RemoteConfiguration.Alert?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
+        positiveAction.apply(
+            configuration: configuration?.positiveButton,
+            assetsBuilder: assetsBuilder
+        )
+        negativeAction.apply(
+            configuration: configuration?.negativeButton,
+            assetsBuilder: assetsBuilder
+        )
+        applyTitleConfiguration(
+            configuration?.title,
+            assetsBuilder: assetsBuilder
+        )
         applyTitleImageConfiguration(configuration?.titleImageColor)
-        applyMessageConfiguration(configuration?.message)
+        applyMessageConfiguration(
+            configuration?.message,
+            assetsBuilder: assetsBuilder
+        )
     }
 }
 
@@ -107,9 +122,12 @@ public struct AlertStyle {
 
 private extension AlertStyle {
 
-    mutating func applyTitleConfiguration(_ configuration: RemoteConfiguration.Text?) {
+    mutating func applyTitleConfiguration(
+        _ configuration: RemoteConfiguration.Text?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
         UIFont.convertToFont(
-            font: configuration?.font,
+            uiFont: assetsBuilder.fontBuilder(configuration?.font),
             textStyle: titleTextStyle
         ).unwrap { titleFont = $0 }
 
@@ -126,9 +144,12 @@ private extension AlertStyle {
             .unwrap { titleImageColor = $0 }
     }
 
-    mutating func applyMessageConfiguration(_ configuration: RemoteConfiguration.Text?) {
+    mutating func applyMessageConfiguration(
+        _ configuration: RemoteConfiguration.Text?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
         UIFont.convertToFont(
-            font: configuration?.font,
+            uiFont: assetsBuilder.fontBuilder(configuration?.font),
             textStyle: messageTextStyle
         ).unwrap { messageFont = $0 }
 


### PR DESCRIPTION
Since we decided to not provide the ability to configure the SDK with RemoteConfiguration and Theme through one method, we decided to add AssetsBuilder structure that will transform RemoteConfiguration.Font structure to UIFont. 
Added default implementation for AssetsBuilder that returns UIFont based on SF font family. 
The main goal is that integrator can pass to SDK configuration method their own AssetsBuilder that will return their custom font.