### PR TITLE
Change screen sharing end button accessibility label

### DIFF
--- a/GliaWidgets/Resources/en.lproj/Localizable.strings
+++ b/GliaWidgets/Resources/en.lproj/Localizable.strings
@@ -113,7 +113,7 @@
 "chat.accessibility.header.endButton.label" = "End";
 "chat.accessibility.header.closeButton.label" = "Close";
 "chat.accessibility.header.closeButton.hint" = "";
-"chat.accessibility.header.endScreenShareButton.label" = "End";
+"chat.accessibility.header.endScreenShareButton.label" = "End screen share";
 "chat.accessibility.header.endScreenShareButton.hint" = "";
 "chat.accessibility.message.choiceCard.image.label" = "Choice card";
 "chat.accessibility.message.unreadMessagesIndicator.label" = "Unread messages";


### PR DESCRIPTION
When screen sharing is activated, the green button to end the screen sharing on the app has accessibility label "End". Meanwhile, the red button for finishing engagement also has accessibility label "End", which makes it complicated to assert that the screen sharing end button has appeared. With this pull request, the end engagement button will retain its "End" label, but the screen share end button will have "End screen share".

MOB-1406