### PR TITLE
Fix memory leak in Chat and Call views

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -376,6 +376,8 @@
 		AFA2FDFC289082F500428E6D /* OnHoldOverlayStyle.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA2FDFB289082F500428E6D /* OnHoldOverlayStyle.Mock.swift */; };
 		AFBBF5782851C391004993B3 /* Glia.Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBBF5772851C391004993B3 /* Glia.Deprecated.swift */; };
 		AFBBF57A28522591004993B3 /* Configuration.Unavailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBBF57928522591004993B3 /* Configuration.Unavailable.swift */; };
+		C03A8047292BA76D00DDECA6 /* ChatViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03A8046292BA76D00DDECA6 /* ChatViewControllerTests.swift */; };
+		C03A8049292BC8DB00DDECA6 /* CallViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03A8048292BC8DB00DDECA6 /* CallViewControllerTests.swift */; };
 		C4119E06268F41D1004DFEFB /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C4119E05268F41D1004DFEFB /* Main.storyboard */; };
 		C42463742673ABE10082C135 /* ScreenShareHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42463732673ABE10082C135 /* ScreenShareHandler.swift */; };
 		C43C12F92694B14900C37E1B /* GliaPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C43C12F82694B14900C37E1B /* GliaPresenter.swift */; };
@@ -841,6 +843,8 @@
 		AFA2FDFB289082F500428E6D /* OnHoldOverlayStyle.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnHoldOverlayStyle.Mock.swift; sourceTree = "<group>"; };
 		AFBBF5772851C391004993B3 /* Glia.Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Glia.Deprecated.swift; sourceTree = "<group>"; };
 		AFBBF57928522591004993B3 /* Configuration.Unavailable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.Unavailable.swift; sourceTree = "<group>"; };
+		C03A8046292BA76D00DDECA6 /* ChatViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewControllerTests.swift; sourceTree = "<group>"; };
+		C03A8048292BC8DB00DDECA6 /* CallViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallViewControllerTests.swift; sourceTree = "<group>"; };
 		C4119E05268F41D1004DFEFB /* Main.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		C42463732673ABE10082C135 /* ScreenShareHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenShareHandler.swift; sourceTree = "<group>"; };
 		C43C12F82694B14900C37E1B /* GliaPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GliaPresenter.swift; sourceTree = "<group>"; };
@@ -1994,6 +1998,8 @@
 				EB9ADB542828E66B00FAE8A4 /* CallTests.swift */,
 				847A7642285A1914004044D1 /* FileUploadListViewTests.swift */,
 				EB7A1509286D98270035AC62 /* FileUploaderTests.swift */,
+				C03A8046292BA76D00DDECA6 /* ChatViewControllerTests.swift */,
+				C03A8048292BC8DB00DDECA6 /* CallViewControllerTests.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -3118,6 +3124,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C03A8049292BC8DB00DDECA6 /* CallViewControllerTests.swift in Sources */,
 				EB03B00E27FFF6DD0058F6B1 /* CallViewTests.swift in Sources */,
 				7512A57727BE8A6700319DF1 /* InteractorTests.swift in Sources */,
 				9ACC25D427B474E800BC5335 /* Glia.Environment.Failing.swift in Sources */,
@@ -3128,6 +3135,7 @@
 				9A3E1DA227BA7D00005634EB /* FileSystemStorage.Environment.Failing.swift in Sources */,
 				9A1992E127D6313500161AAE /* ImageView.Cache.Failing.swift in Sources */,
 				AF11F31628C31E4A002ACEB4 /* AuthenticatedChatStorageTests.swift in Sources */,
+				C03A8047292BA76D00DDECA6 /* ChatViewControllerTests.swift in Sources */,
 				EB9ADB552828E66B00FAE8A4 /* CallTests.swift in Sources */,
 				AF9DB22E2890571A00A0C442 /* RootCoordinator.Environment.Failing.swift in Sources */,
 				AF9DB23128905A1D00A0C442 /* ViewFactory.Environment.Failing.swift in Sources */,

--- a/GliaWidgets/FoundationBased.Mock.swift
+++ b/GliaWidgets/FoundationBased.Mock.swift
@@ -3,7 +3,7 @@ import Foundation
 
 extension FoundationBased.FileManager {
     static let mock = Self(
-        urlsForDirectoryInDomainMask: { _, _ in [] },
+        urlsForDirectoryInDomainMask: { _, _ in [.mock] },
         fileExistsAtPath: { _ in false },
         createDirectoryAtUrlWithIntermediateDirectories: { _, _, _ in },
         removeItemAtUrl: { _ in },

--- a/GliaWidgets/ViewController/Call/CallViewController.swift
+++ b/GliaWidgets/ViewController/Call/CallViewController.swift
@@ -55,9 +55,11 @@ class CallViewController: EngagementViewController, MediaUpgradePresenter {
         view.header.showBackButton()
         view.header.showCloseButton()
 
-        view.callButtonTapped = { viewModel.event(.callButtonTapped(.init(with: $0))) }
+        view.callButtonTapped = { [weak viewModel] button in
+            viewModel?.event(.callButtonTapped(.init(with: button)))
+        }
 
-        viewModel.action = { action in
+        self.viewModel.action = { [weak self] action in
             switch action {
             case .queue:
                 view.setConnectState(.queue, animated: false)
@@ -96,7 +98,7 @@ class CallViewController: EngagementViewController, MediaUpgradePresenter {
                 let button = CallButton.Kind(with: button)
                 view.buttonBar.setButton(button, badgeItemCount: itemCount)
             case .offerMediaUpgrade(let conf, accepted: let accepted, declined: let declined):
-                self.offerMediaUpgrade(with: conf, accepted: accepted, declined: declined)
+                self?.offerMediaUpgrade(with: conf, accepted: accepted, declined: declined)
             case .setRemoteVideo(let streamView):
                 view.remoteVideoView.streamView = streamView
             case .setLocalVideo(let streamView):

--- a/GliaWidgets/ViewController/Chat/ChatViewController.swift
+++ b/GliaWidgets/ViewController/Chat/ChatViewController.swift
@@ -52,27 +52,50 @@ class ChatViewController: EngagementViewController, MediaUpgradePresenter,
         view.header.showBackButton()
         view.header.showCloseButton()
 
-        view.numberOfSections = { viewModel.numberOfSections }
-        view.numberOfRows = { viewModel.numberOfItems(in: $0) }
-        view.itemForRow = { viewModel.item(for: $0, in: $1) }
-        view.messageEntryView.textChanged = { viewModel.event(.messageTextChanged($0)) }
-        view.messageEntryView.sendTapped = { viewModel.event(.sendTapped) }
-        view.messageEntryView.pickMediaTapped = { viewModel.event(.pickMediaTapped) }
-        view.messageEntryView.uploadListView.removeTapped = { viewModel.event(.removeUploadTapped($0)) }
-        view.fileTapped = { viewModel.event(.fileTapped($0)) }
-        view.downloadTapped = { viewModel.event(.downloadTapped($0)) }
-        view.callBubbleTapped = { viewModel.event(.callBubbleTapped) }
-        view.choiceOptionSelected = { viewModel.event(.choiceOptionSelected($0, $1)) }
-        view.chatScrolledToBottom = { viewModel.event(.chatScrolled(bottomReached: $0)) }
-        view.linkTapped = { viewModel.event(.linkTapped($0)) }
-        view.selectCustomCardOption = { viewModel.event(
-            .customCardOptionSelected(
-                option: $0,
-                messageId: $1
-            )
-        ) }
+        view.numberOfSections = { [weak viewModel] in
+            viewModel?.numberOfSections
+        }
+        view.numberOfRows = { [weak viewModel] rows in
+            viewModel?.numberOfItems(in: rows)
+        }
+        view.itemForRow = { [weak viewModel] row, section in
+            viewModel?.item(for: row, in: section)
+        }
+        view.messageEntryView.textChanged = { [weak viewModel] text in
+            viewModel?.event(.messageTextChanged(text))
+        }
+        view.messageEntryView.sendTapped = { [weak viewModel] in
+            viewModel?.event(.sendTapped)
+        }
+        view.messageEntryView.pickMediaTapped = { [weak viewModel] in
+            viewModel?.event(.pickMediaTapped)
+        }
+        view.messageEntryView.uploadListView.removeTapped = { [weak viewModel] upload in
+            viewModel?.event(.removeUploadTapped(upload))
+        }
+        view.fileTapped = { [weak viewModel] file in
+            viewModel?.event(.fileTapped(file))
+        }
+        view.downloadTapped = { [weak viewModel] download in
+            viewModel?.event(.downloadTapped(download))
+        }
+        view.callBubbleTapped = { [weak viewModel] in
+            viewModel?.event(.callBubbleTapped)
+        }
+        view.choiceOptionSelected = { [weak viewModel] option, messageId in
+            viewModel?.event(.choiceOptionSelected(option, messageId))
+        }
+        view.chatScrolledToBottom = { [weak viewModel] bottomReached in
+            viewModel?.event(.chatScrolled(bottomReached: bottomReached))
+        }
+        view.linkTapped = { [weak viewModel] url in
+            viewModel?.event(.linkTapped(url))
+        }
+        view.selectCustomCardOption = { [weak viewModel] option, messageId in
+            viewModel?.event(.customCardOptionSelected(option: option, messageId: messageId))
+        }
 
-        viewModel.action = { action in
+        viewModel.action = { [weak self] action in
             switch action {
             case .queue:
                 view.setConnectState(.queue, animated: false)
@@ -111,12 +134,12 @@ class ChatViewController: EngagementViewController, MediaUpgradePresenter,
             case .removeAllUploads:
                 view.messageEntryView.uploadListView.removeAllUploadViews()
             case .presentMediaPicker(let itemSelected):
-                self.presentMediaPicker(
+                self?.presentMediaPicker(
                     from: view.messageEntryView.pickMediaButton,
                     itemSelected: itemSelected
                 )
             case .offerMediaUpgrade(let conf, let accepted, let declined):
-                self.offerMediaUpgrade(with: conf, accepted: accepted, declined: declined)
+                self?.offerMediaUpgrade(with: conf, accepted: accepted, declined: declined)
             case .showCallBubble(let imageUrl):
                 view.showCallBubble(with: imageUrl, animated: true)
             case .updateUnreadMessageIndicator(let count):

--- a/GliaWidgets/ViewController/EngagementViewController.swift
+++ b/GliaWidgets/ViewController/EngagementViewController.swift
@@ -42,7 +42,8 @@ class EngagementViewController: ViewController, AlertPresenter {
         view.header.backButton.tap = { [weak self] in self?.viewModel.event(.backTapped) }
         view.header.closeButton.tap = { [weak self] in self?.viewModel.event(.closeTapped) }
 
-        viewModel.engagementAction = { action in
+        viewModel.engagementAction = { [weak self] action in
+            guard let self = self else { return }
             switch action {
             case .confirm(let conf, let accessibilityIdentifier, confirmed: let confirmed):
                 self.presentConfirmation(

--- a/GliaWidgets/ViewModel/Call/CallViewModel.swift
+++ b/GliaWidgets/ViewModel/Call/CallViewModel.swift
@@ -38,22 +38,22 @@ class CallViewModel: EngagementViewModel, ViewModel {
         unreadMessages.addObserver(self) { [weak self] unreadCount, _ in
             self?.action?(.setButtonBadge(.chat, itemCount: unreadCount))
         }
-        call.kind.addObserver(self) { [weak self] kind, _ in
+        self.call.kind.addObserver(self) { [weak self] kind, _ in
             self?.onKindChanged(kind)
         }
-        call.state.addObserver(self) { [weak self] state, _ in
+        self.call.state.addObserver(self) { [weak self] state, _ in
             self?.onStateChanged(state)
         }
-        call.video.stream.addObserver(self) { [weak self] audio, _ in
+        self.call.video.stream.addObserver(self) { [weak self] audio, _ in
             self?.onVideoChanged(audio)
         }
-        call.audio.stream.addObserver(self) { [weak self] audio, _ in
+        self.call.audio.stream.addObserver(self) { [weak self] audio, _ in
             self?.onAudioChanged(audio)
         }
-        call.duration.addObserver(self) { [weak self] duration, _ in
+        self.call.duration.addObserver(self) { [weak self] duration, _ in
             self?.onDurationChanged(duration)
         }
-        call.isVisitorOnHold.addObserver(self) { [weak self] isOnHold, oldValue in
+        self.call.isVisitorOnHold.addObserver(self) { [weak self] isOnHold, oldValue in
             guard isOnHold != oldValue else { return }
 
             self?.setVisitorOnHold(isOnHold)
@@ -362,9 +362,9 @@ extension CallViewModel {
             break
         case .started:
             showConnected()
-            durationCounter.start { duration in
-                guard self.call.state.value == .started else { return }
-                self.call.duration.value = duration
+            durationCounter.start { [weak self] duration in
+                guard self?.call.state.value == .started else { return }
+                self?.call.duration.value = duration
             }
         case .connecting:
             action?(.switchToUpgradeMode)

--- a/GliaWidgets/ViewModel/EngagementViewModel.swift
+++ b/GliaWidgets/ViewModel/EngagementViewModel.swift
@@ -24,7 +24,9 @@ class EngagementViewModel {
         self.alertConfiguration = alertConfiguration
         self.screenShareHandler = screenShareHandler
         self.environment = environment
-        interactor.addObserver(self, handler: interactorEvent)
+        self.interactor.addObserver(self) { [weak self] event in
+            self?.interactorEvent(event)
+        }
         screenShareHandler.status.addObserver(self) { [weak self] status, _ in
             self?.onScreenSharingStatusChange(status)
         }

--- a/GliaWidgetsTests/Sources/CallViewControllerTests.swift
+++ b/GliaWidgetsTests/Sources/CallViewControllerTests.swift
@@ -1,0 +1,17 @@
+@testable import GliaWidgets
+import SalemoveSDK
+import XCTest
+
+class CallViewControllerTests: XCTestCase {
+    func test_call_deinit() {
+        weak var weakViewController: CallViewController?
+        autoreleasepool {
+            let viewController: CallViewController? = CallViewController(
+                viewModel: CallViewModel.mock(environment: CallViewModel.Environment.mock),
+                viewFactory: ViewFactory.mock()
+            )
+            weakViewController = viewController
+        }
+        XCTAssertNil(weakViewController, "CallViewController not deinitilized")
+    }
+}

--- a/GliaWidgetsTests/Sources/ChatViewControllerTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewControllerTests.swift
@@ -1,0 +1,34 @@
+@testable import GliaWidgets
+import SalemoveSDK
+import XCTest
+
+class ChatViewControllerTests: XCTestCase {
+    // This test is not specific to `ChatViewController`, however it
+    // shows specifics of `UIViewController` life cycle.
+    // In particular: once UIViewController.view referred, view controller
+    // will not get deallocated immediately, but with some delay due to being
+    // held in `autoreleasepool`. In order to ensure that it really
+    // gets deallocated, it has to be created within separate `autoreleasepool`.
+    // Once `viewController` leaves `autoreleasepool` scope, it gets deallocated.
+    func test_vc_deinit() {
+        weak var weakViewController: UIViewController?
+        autoreleasepool {
+            let viewController: UIViewController? = UIViewController()
+            _ = viewController?.view
+            weakViewController = viewController
+        }
+        XCTAssertNil(weakViewController, "UIViewController not deinitilized")
+    }
+
+    func test_chat_deinit() {
+        weak var weakViewController: ChatViewController?
+        autoreleasepool {
+            let viewController: ChatViewController? = ChatViewController(
+                viewModel: ChatViewModel.mock(environment: ChatViewModel.Environment.mock),
+                viewFactory: ViewFactory.mock()
+            )
+            weakViewController = viewController
+        }
+        XCTAssertNil(weakViewController, "ChatViewController not deinitilized")
+    }
+}


### PR DESCRIPTION
Currently when engagement had ended, the following objects were not deallocated from the memory:
1. EngagementViewModel
2. EngagementViewController
3. ChatView
4. ChatViewController
5. ChatViewModel
6. CallView
7. CallViewController
8. CallViewModel
9. RootCoordinator

This PR fixes the memory leaks.

MOB-1559