### PR TITLE
Update the release process for publishing GliaWidgets to Cocoapods

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -92,12 +92,10 @@ workflows:
         - draft: 'no'
         - tag: $NEW_VERSION
         - commit: $GIT_CLONE_COMMIT_HASH
-    - trigger-bitrise-workflow@0:
+    - script:
         inputs:
-        - api_token: $GLIA_IOS_PODSPECS_API_TOKEN
-        - workflow_id: upload_widgets_sdk_podspec
-        - exported_environment_variable_names: NEW_VERSION
-        - app_slug: $GLIA_IOS_PODSPECS_APP_SLUG
+        - content: |-
+            pod trunk push GliaWidgets.podspec --verbose
     - cache-push@2: {}
     after_run:
     - _increment_project_version
@@ -359,9 +357,6 @@ app:
   - opts:
       is_expand: false
     BROWSERSTACK_APP_ID: WidgetsSdkIosTestApp
-  - opts:
-      is_expand: false
-    GLIA_IOS_PODSPECS_APP_SLUG: 02d9069f03b494d0
   - opts:
       is_expand: false
     CORTEX_DEMO_APP_SLUG: 2e5eb3394ea5598e

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -24,6 +24,10 @@ platform :ios do
       base: 'master',
       team_reviewers: ["tm-mobile-ios"]
     )
+
+    sh("cp ../templates/GliaWidgets.podspec ../GliaWidgets.podspec")
+    sh("sed -i '' 's/\${WIDGETS_SDK_VERSION_SEMVER}/#{new_version}/' ../GliaWidgets.podspec")
+    
   end
 
   desc "Increments versions in Xcode projects and Podspec file "\

--- a/templates/GliaWidgets.podspec
+++ b/templates/GliaWidgets.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = 'GliaWidgets'
-  s.version               = '0.10.2'
+  s.version               = '${WIDGETS_SDK_VERSION_SEMVER}'
   s.summary               = 'The Glia iOS Widgets library'
   s.description           = 'The Glia Widgets library allows to integrate easily a UI/UX for Glia\'s Digital Customer Service platform'
   s.homepage              = 'https://github.com/salemove/ios-sdk-widgets'


### PR DESCRIPTION
Created template podspec file for automating the release process. A new release flow will not trigger pospec repo but publish podspec file directly from this repo.