### PR TITLE
Fixed bottom padding on Survey screen

### DIFF
--- a/GliaWidgets/Component/Bubble/BubbleView.swift
+++ b/GliaWidgets/Component/Bubble/BubbleView.swift
@@ -11,9 +11,11 @@ class BubbleView: UIView {
 
     var isVisitorOnHold: Bool = false {
         didSet {
-            isVisitorOnHold
-                ? showOnHoldView()
-                : hideOnHoldView()
+            if isVisitorOnHold {
+                showOnHoldView()
+            } else {
+                hideOnHoldView()
+            }
 
             setAccessibilityIdentifier()
         }

--- a/GliaWidgets/Component/Connect/ConnectView.swift
+++ b/GliaWidgets/Component/Connect/ConnectView.swift
@@ -45,6 +45,7 @@ class ConnectView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // swiftlint:disable function_body_length
     func setState(_ state: State, animated: Bool) {
         self.state = state
 
@@ -100,6 +101,7 @@ class ConnectView: UIView {
             show(animated: animated)
         }
     }
+    // swiftlint:enable function_body_length
 
     private func show(animated: Bool) {
         guard !isShowing else { return }

--- a/GliaWidgets/Component/Connect/Operator/ConnectOperatorView.swift
+++ b/GliaWidgets/Component/Connect/Operator/ConnectOperatorView.swift
@@ -28,9 +28,11 @@ class ConnectOperatorView: UIView {
 
     var isVisitorOnHold: Bool = false {
         didSet {
-            isVisitorOnHold
-                ? showOnHoldView()
-                : hideOnHoldView()
+            if isVisitorOnHold {
+                showOnHoldView()
+            } else {
+                hideOnHoldView()
+            }
         }
     }
 

--- a/GliaWidgets/Coordinator/Call/CallCoordinator.swift
+++ b/GliaWidgets/Coordinator/Call/CallCoordinator.swift
@@ -48,8 +48,12 @@ class CallCoordinator: SubFlowCoordinator, FlowCoordinator {
         )
         return viewController
     }
+}
 
-    private func makeCallViewController(
+// MARK: - Private
+
+private extension CallCoordinator {
+    func makeCallViewController(
         call: Call,
         startAction: CallViewModel.StartAction
     ) -> CallViewController {
@@ -82,29 +86,37 @@ class CallCoordinator: SubFlowCoordinator, FlowCoordinator {
             startWith: startAction
         )
         viewModel.engagementDelegate = { [weak self] event in
-            switch event {
-            case .back:
-                self?.delegate?(.back)
-            case .engaged(operatorImageUrl: let url):
-                self?.delegate?(.engaged(operatorImageUrl: url))
-            case .finished:
-                self?.delegate?(.finished)
-            }
+            self?.handleEngagementViewModelEvent(event)
         }
         viewModel.delegate = { [weak self] event in
-            switch event {
-            case .chat:
-                self?.delegate?(.chat)
-            case .minimize:
-                self?.delegate?(.minimize)
-            case .visitorOnHoldUpdated(let isOnHold):
-                self?.delegate?(.visitorOnHoldUpdated(isOnHold: isOnHold))
-            }
+            self?.handleCallViewModelEvent(event)
         }
         return CallViewController(
             viewModel: viewModel,
             viewFactory: viewFactory
         )
+    }
+
+    func handleEngagementViewModelEvent(_ event: EngagementViewModel.DelegateEvent) {
+        switch event {
+        case .back:
+            delegate?(.back)
+        case .engaged(let url):
+            delegate?(.engaged(operatorImageUrl: url))
+        case .finished:
+            delegate?(.finished)
+        }
+    }
+
+    func handleCallViewModelEvent(_ event: CallViewModel.DelegateEvent) {
+        switch event {
+        case .chat:
+            delegate?(.chat)
+        case .minimize:
+            delegate?(.minimize)
+        case .visitorOnHoldUpdated(let isOnHold):
+            delegate?(.visitorOnHoldUpdated(isOnHold: isOnHold))
+        }
     }
 }
 

--- a/GliaWidgets/Coordinator/RootCoordinator.swift
+++ b/GliaWidgets/Coordinator/RootCoordinator.swift
@@ -50,6 +50,7 @@ class RootCoordinator: SubFlowCoordinator, FlowCoordinator {
         navigationController.isNavigationBarHidden = true
     }
 
+    // swiftlint:disable function_body_length
     func start() {
         switch engagementKind {
         case .none:
@@ -117,6 +118,7 @@ class RootCoordinator: SubFlowCoordinator, FlowCoordinator {
         event(.maximized)
         delegate?(.started)
     }
+    // swiftlint:enable function_body_length
 
     deinit {
         print("\(Self.self) is deallocated.")
@@ -124,6 +126,7 @@ class RootCoordinator: SubFlowCoordinator, FlowCoordinator {
 }
 
 extension RootCoordinator {
+    // swiftlint:disable function_body_length
     func end() {
         defer {
             // For now it is required that message history is cleared when engagement ends
@@ -196,6 +199,7 @@ extension RootCoordinator {
             presentSurvey(engagement.id, survey)
         }
     }
+    // swiftlint:enable function_body_length
 
     private func startChat(
         withAction startAction: ChatViewModel.StartAction,

--- a/GliaWidgets/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -168,7 +168,7 @@ extension CoreSdkClient {
 
         static func mock(
             onHold: CoreSdkClient.StreamableOnHoldHandler? = nil,
-            muteFunc: @escaping () -> Void = {} ,
+            muteFunc: @escaping () -> Void = {},
             unmuteFunc: @escaping () -> Void = {},
             getIsMutedFunc: @escaping () -> Bool = { false },
             setIsMutedFunc: @escaping (Bool) -> Void = { _ in },
@@ -266,7 +266,7 @@ extension CoreSdkClient {
             onHold: CoreSdkClient.StreamableOnHoldHandler? = nil,
             getStreamViewFunc: @escaping () -> CoreSdkClient.StreamView = { .init() },
             playVideoFunc: @escaping () -> Void = {},
-            pauseFunc: @escaping () -> Void = {} ,
+            pauseFunc: @escaping () -> Void = {},
             resumeFunc: @escaping () -> Void = {},
             stopFunc: @escaping () -> Void = {},
             getIsPausedFunc: @escaping () -> Bool = { false },

--- a/GliaWidgets/FoundationBased.Interface.swift
+++ b/GliaWidgets/FoundationBased.Interface.swift
@@ -7,9 +7,9 @@ enum FoundationBased {
             _ inDomainMask: Foundation.FileManager.SearchPathDomainMask
         ) -> [URL]
 
-        var fileExistsAtPath:(_ atPath: String) -> Bool
+        var fileExistsAtPath: (_ atPath: String) -> Bool
 
-        var createDirectoryAtUrlWithIntermediateDirectories:(
+        var createDirectoryAtUrlWithIntermediateDirectories: (
             _ atURL: URL,
             _ withIntermediateDirectories: Bool,
             _ attributes: [FileAttributeKey: Any]?

--- a/GliaWidgets/Glia.Deprecated.swift
+++ b/GliaWidgets/Glia.Deprecated.swift
@@ -16,9 +16,7 @@ extension Glia {
     }
 
     /// Deprecated.
-// swiftlint: disable line_length
     @available(*, deprecated, message: "Use start(_:configuration:queueID:visitorContext:theme:features:sceneProvider:) with Optional<VisitorContext> instead.")
-// swiftlint: enable line_length
     public func start(
         _ engagementKind: EngagementKind,
         configuration: Configuration,

--- a/GliaWidgets/Glia.swift
+++ b/GliaWidgets/Glia.swift
@@ -255,21 +255,25 @@ public class Glia {
             )
         )
         rootCoordinator?.delegate = { [weak self] event in
-            switch event {
-            case .started:
-                self?.onEvent?(.started)
-            case .engagementChanged(let engagementKind):
-                self?.onEvent?(.engagementChanged(engagementKind))
-            case .ended:
-                self?.rootCoordinator = nil
-                self?.onEvent?(.ended)
-            case .minimized:
-                self?.onEvent?(.minimized)
-            case .maximized:
-                self?.onEvent?(.maximized)
-            }
+            self?.handleCoordinatorEvent(event)
         }
         rootCoordinator?.start()
+    }
+
+    private func handleCoordinatorEvent(_ event: RootCoordinator.DelegateEvent) {
+        switch event {
+        case .started:
+            onEvent?(.started)
+        case .engagementChanged(let engagementKind):
+            onEvent?(.engagementChanged(engagementKind))
+        case .ended:
+            rootCoordinator = nil
+            onEvent?(.ended)
+        case .minimized:
+            onEvent?(.minimized)
+        case .maximized:
+            onEvent?(.maximized)
+        }
     }
 
     /// Clear visitor session

--- a/GliaWidgets/View/Call/CallView.swift
+++ b/GliaWidgets/View/Call/CallView.swift
@@ -125,6 +125,7 @@ class CallView: EngagementView {
         adjustLocalVideoFrameAfterLayout()
     }
 
+    // swiftlint:disable function_body_length
     override func setup() {
         accessibilityIdentifier = "call_root_view"
 
@@ -190,6 +191,7 @@ class CallView: EngagementView {
         header.backButton.accessibilityLabel = style.header.backButton.accessibility.label
         header.backButton.accessibilityHint = style.header.backButton.accessibility.hint
     }
+    // swiftlint:enable function_body_length
 
     func switchTo(_ mode: Mode) {
         self.mode = mode
@@ -253,6 +255,7 @@ class CallView: EngagementView {
         }
     }
 
+    // swiftlint:disable function_body_length
     private func layout() {
         let effect = UIBlurEffect(style: .dark)
         let effectView = UIVisualEffectView(effect: effect)
@@ -316,6 +319,7 @@ class CallView: EngagementView {
         adjustForCurrentOrientation()
         switchTo(mode)
     }
+    // swiftlint:enable function_body_length
 
     private func adjustForCurrentOrientation() {
         if currentOrientation.isLandscape {

--- a/GliaWidgets/View/Chat/Message/Content/ChoiceCard/ChoiceCardView.swift
+++ b/GliaWidgets/View/Chat/Message/Content/ChoiceCard/ChoiceCardView.swift
@@ -38,6 +38,7 @@ final class ChoiceCardView: OperatorChatMessageView {
         }
     }
 
+    // swiftlint:disable function_body_length
     private func contentView(for choiceCard: ChoiceCard) -> UIView {
         let containerView = UIView()
 
@@ -101,6 +102,7 @@ final class ChoiceCardView: OperatorChatMessageView {
 
         return containerView
     }
+    // swiftlint:enable function_body_length
 }
 
 extension ChoiceCardView {

--- a/GliaWidgets/View/Chat/Message/Content/File/Download/ChatFileDownloadContentView.swift
+++ b/GliaWidgets/View/Chat/Message/Content/File/Download/ChatFileDownloadContentView.swift
@@ -175,7 +175,6 @@ class ChatFileDownloadContentView: ChatFileContentView {
         }
         accessibilityLabel = sharedProperties.label
     }
-    // swiftlint:enable function_body_length
 
     private func stateText(for downloadState: FileDownload.State) -> NSAttributedString? {
         switch downloadState {
@@ -232,4 +231,5 @@ class ChatFileDownloadContentView: ChatFileContentView {
             return string
         }
     }
+    // swiftlint:enable function_body_length
 }

--- a/GliaWidgets/ViewController/Call/CallViewController.Mock.swift
+++ b/GliaWidgets/ViewController/Call/CallViewController.Mock.swift
@@ -86,6 +86,7 @@ extension CallViewController {
         return viewController
     }
 
+    // swiftlint:disable function_body_length
     static func mockAudioCallConnectedState() throws -> CallViewController {
         let conf = try CoreSdkClient.Salemove.Configuration.mock()
         let queueId = UUID.mock.uuidString
@@ -143,6 +144,7 @@ extension CallViewController {
         viewModel.action?(.connected(name: "Blob The Operator", imageUrl: nil))
         return viewController
     }
+    // swiftlint:enable function_body_length
 
     static func mockVideoCallConnectingState() throws -> CallViewController {
         let conf = try CoreSdkClient.Salemove.Configuration.mock()

--- a/GliaWidgets/ViewController/Survey/SurveyViewController.View.swift
+++ b/GliaWidgets/ViewController/Survey/SurveyViewController.View.swift
@@ -92,7 +92,7 @@ extension Survey {
                 buttonContainer.leadingAnchor.constraint(equalTo: leadingAnchor),
                 buttonContainer.trailingAnchor.constraint(equalTo: trailingAnchor),
 
-                buttonStackView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: 0),
+                buttonStackView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -Self.contentPadding),
                 buttonStackView.topAnchor.constraint(equalTo: buttonContainer.topAnchor, constant: Self.contentPadding),
                 buttonStackView.leadingAnchor.constraint(equalTo: buttonContainer.leadingAnchor, constant: Self.contentPadding),
                 buttonStackView.trailingAnchor.constraint(equalTo: buttonContainer.trailingAnchor, constant: -Self.contentPadding),

--- a/GliaWidgets/ViewController/Survey/SurveyViewController.swift
+++ b/GliaWidgets/ViewController/Survey/SurveyViewController.swift
@@ -72,7 +72,11 @@ extension Survey {
         func render() {
             contentView.header.text = props.header
             contentView.header.accessibilityLabel = props.header
-            props.questionsProps.count == contentView.surveyItemsStack.arrangedSubviews.count ? updateProps() : reloadProps()
+            if props.questionsProps.count == contentView.surveyItemsStack.arrangedSubviews.count {
+                updateProps()
+            } else {
+                reloadProps()
+            }
             contentView.updateUi(theme: theme)
             contentView.endEditing = props.endEditing
         }

--- a/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
@@ -40,6 +40,7 @@ class ChatViewModel: EngagementViewModel, ViewModel {
     private var pendingMessages: [OutgoingMessage] = []
     private var isViewLoaded: Bool = false
 
+    // swiftlint:disable function_body_length
     init(
         interactor: Interactor,
         alertConfiguration: AlertConfiguration,
@@ -108,6 +109,7 @@ class ChatViewModel: EngagementViewModel, ViewModel {
             self?.action?(.pickMediaButtonEnabled(!limitReached))
         }
     }
+    // swiftlint:enable function_body_length
 
     func event(_ event: Event) {
         switch event {
@@ -168,6 +170,7 @@ class ChatViewModel: EngagementViewModel, ViewModel {
         }
     }
 
+    // swiftlint:disable function_body_length
     override func update(for state: InteractorState) {
         super.update(for: state)
 
@@ -233,6 +236,7 @@ class ChatViewModel: EngagementViewModel, ViewModel {
             break
         }
     }
+    // swiftlint:enable function_body_length
 
     override func interactorEvent(_ event: InteractorEvent) {
         super.interactorEvent(event)

--- a/SnapshotTests/AlertViewControllerTests.swift
+++ b/SnapshotTests/AlertViewControllerTests.swift
@@ -38,7 +38,7 @@ class AlertViewControllerTests: SnapshotTestCase {
         ))
         assertSnapshot(
             matching: alert,
-            as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),
+            as: .accessibilityImage,
             named: nameForDevice()
         )
     }
@@ -50,7 +50,7 @@ class AlertViewControllerTests: SnapshotTestCase {
         ))
         assertSnapshot(
             matching: alert,
-            as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),
+            as: .accessibilityImage,
             named: nameForDevice()
         )
     }

--- a/SnapshotTests/CallViewControllerVoiceOverTests.swift
+++ b/SnapshotTests/CallViewControllerVoiceOverTests.swift
@@ -9,7 +9,7 @@ class CallViewControllerVoiceOverTests: SnapshotTestCase {
         viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
-            as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),
+            as: .accessibilityImage,
             named: nameForDevice()
         )
     }
@@ -19,7 +19,7 @@ class CallViewControllerVoiceOverTests: SnapshotTestCase {
         viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
-            as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),
+            as: .accessibilityImage,
             named: nameForDevice()
         )
     }
@@ -29,7 +29,7 @@ class CallViewControllerVoiceOverTests: SnapshotTestCase {
         viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
-            as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),
+            as: .accessibilityImage,
             named: nameForDevice()
         )
     }
@@ -39,7 +39,7 @@ class CallViewControllerVoiceOverTests: SnapshotTestCase {
         viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
-            as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),
+            as: .accessibilityImage,
             named: nameForDevice()
         )
     }
@@ -49,7 +49,7 @@ class CallViewControllerVoiceOverTests: SnapshotTestCase {
         viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
-            as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),
+            as: .accessibilityImage,
             named: nameForDevice()
         )
     }
@@ -59,7 +59,7 @@ class CallViewControllerVoiceOverTests: SnapshotTestCase {
         viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
-            as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),
+            as: .accessibilityImage,
             named: nameForDevice()
         )
     }

--- a/SnapshotTests/ChatCallUpgradeViewVoiceOverTests.swift
+++ b/SnapshotTests/ChatCallUpgradeViewVoiceOverTests.swift
@@ -7,12 +7,18 @@ class ChatCallUpgradeViewVoiceOverTests: SnapshotTestCase {
     func test_chatCallUpgradeViewToAudio() {
         let upgradeView = ChatCallUpgradeView(with: Theme.mock().chat.audioUpgrade, duration: .init(with: .zero))
         upgradeView.frame = .init(origin: .zero, size: .init(width: 300, height: 120))
-        assertSnapshot(matching: upgradeView, as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision))
+        assertSnapshot(
+            matching: upgradeView,
+            as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision)
+        )
     }
 
     func test_chatCallUpgradeViewToVideo() {
         let upgradeView = ChatCallUpgradeView(with: Theme.mock().chat.videoUpgrade, duration: .init(with: .zero))
         upgradeView.frame = .init(origin: .zero, size: .init(width: 300, height: 120))
-        assertSnapshot(matching: upgradeView, as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision))
+        assertSnapshot(
+            matching: upgradeView,
+            as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision)
+        )
     }
 }

--- a/SnapshotTests/ChatViewControllerVoiceOverTests.swift
+++ b/SnapshotTests/ChatViewControllerVoiceOverTests.swift
@@ -9,7 +9,7 @@ class ChatViewControllerVoiceOverTests: SnapshotTestCase {
         viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
-            as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),
+            as: .accessibilityImage,
             named: nameForDevice()
         )
     }
@@ -19,7 +19,7 @@ class ChatViewControllerVoiceOverTests: SnapshotTestCase {
         viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
-            as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),
+            as: .accessibilityImage,
             named: nameForDevice()
         )
     }
@@ -29,7 +29,7 @@ class ChatViewControllerVoiceOverTests: SnapshotTestCase {
         viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
-            as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),
+            as: .accessibilityImage,
             named: nameForDevice()
         )
     }
@@ -49,7 +49,7 @@ class ChatViewControllerVoiceOverTests: SnapshotTestCase {
         chatMessages[3].downloads[0].state.value = .error(.deleted)
         assertSnapshot(
             matching: viewController,
-            as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),
+            as: .accessibilityImage,
             named: self.nameForDevice()
         )
     }

--- a/SnapshotTests/SurveyViewControllerVoiceOverTests.swift
+++ b/SnapshotTests/SurveyViewControllerVoiceOverTests.swift
@@ -9,7 +9,7 @@ class SurveyViewControllerVoiceOverTests: SnapshotTestCase {
         viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
-            as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),
+            as: .accessibilityImage,
             named: nameForDevice()
         )
     }
@@ -19,7 +19,7 @@ class SurveyViewControllerVoiceOverTests: SnapshotTestCase {
         viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
-            as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),
+            as: .accessibilityImage,
             named: nameForDevice()
         )
     }
@@ -29,7 +29,7 @@ class SurveyViewControllerVoiceOverTests: SnapshotTestCase {
         viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
-            as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision),
+            as: .accessibilityImage,
             named: nameForDevice()
         )
     }


### PR DESCRIPTION
During fixing snapshot tests previously we deleted bottom padding for buttons on Survey screen. It was wrong and I added it back. possiblePrecision usage was removed for almost all tests because it was preventing tests from failing with small changes on UI.

MOB-1645