### PR TITLE
Update SalemoveSDK version in podspec

### DIFF
--- a/GliaWidgets.podspec
+++ b/GliaWidgets.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   }
   s.exclude_files         = ['GliaWidgets/Window/**']
 
-  s.dependency 'SalemoveSDK', '0.35.1'
+  s.dependency 'SalemoveSDK', '0.35.2'
   s.dependency 'PureLayout', '~>3.1'
   s.dependency 'lottie-ios', '3.2.3'
 end

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -95,7 +95,7 @@ workflows:
     - script:
         inputs:
         - content: |-
-            pod trunk push GliaWidgets.podspec --verbose
+            pod trunk push GliaWidgets.podspec --verbose --allow-warnings
     - cache-push@2: {}
     after_run:
     - _increment_project_version


### PR DESCRIPTION
`--allow-warnings` because our SDK has a lot of deprecation and these warnings block publishing to Cocoapdos repo.