### PR TITLE
Inserting task number into commit message

### DIFF
--- a/.git-hooks/prepare-commit-msg
+++ b/.git-hooks/prepare-commit-msg
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+#
+# Inspects branch name and checks if it contains a Jira ticket number (i.e. MOB-1234).
+# If yes, [MOB-123] will be added in the end of a commit message.
+#
+
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+
+# Ensure BRANCH_NAME is not empty and is not in a detached HEAD state (i.e. rebase).
+if [ ! -z "$BRANCH_NAME" ] && [ "$BRANCH_NAME" != "HEAD" ] && [ "$SHOULD_PREPARE_COMMIT_MSG" == 1 ]; then
+
+	SUFFIX_PATTERN='MOB-[0-9]{4,5}'
+
+	[[ $BRANCH_NAME =~ $SUFFIX_PATTERN ]]
+
+	SUFFIX=${BASH_REMATCH[0]}
+
+	SUFFIX_IN_COMMIT=$(grep -c "\[$SUFFIX\]" $1)
+
+	# Ensure SUFFIX exists in BRANCH_NAME and is not already present in the commit message
+	if [[ -n "$SUFFIX" ]] && ! [[ $SUFFIX_IN_COMMIT -ge 1 ]]; then
+		echo "" >>$1
+  	echo "$SUFFIX" >>$1
+  fi
+fi

--- a/scripts/swiftlint.sh
+++ b/scripts/swiftlint.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+if [ "$SHOULD_LINT_ON_PRECOMMIT" != 1 ]; then
+    exit 0
+fi
+
 # Checks and sets the appropriate SwiftLint path for M1 or Intel CPU
 if [[ $(uname -m) == 'arm64' ]]; then
     SWIFT_LINT=/opt/homebrew/bin/swiftlint


### PR DESCRIPTION
`prepare-commit-msg` hook was added to custom `.git-hooks` folder. The script searches for task number in branch name and puts it to the end of the commit message. 
Also added checking `SHOULD_LINT_ON_PRECOMMIT` value before linting files on `pre-commit` hook