### PR TITLE
Fix incorrect changelog in release process

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -82,6 +82,29 @@ workflows:
     - xcode-test@4:
         inputs:
         - scheme: GliaWidgetsTests
+    - git-tag@1:
+        inputs:
+        - tag: $NEW_VERSION
+    - script@1:
+        inputs:
+        - content: >-
+            #!/usr/bin/env bash
+
+            # fail if any commands fails
+
+            set -e
+
+            # make pipelines' return status equal the last command to exit with
+            a non-zero status, or zero if all commands exit successfully
+
+            set -o pipefail
+
+            # debug log
+
+            set -x
+
+
+            git fetch --tags
     - generate-changelog@0: {}
     - github-release@0:
         inputs:
@@ -94,8 +117,7 @@ workflows:
         - commit: $GIT_CLONE_COMMIT_HASH
     - script:
         inputs:
-        - content: |-
-            pod trunk push GliaWidgets.podspec --verbose --allow-warnings
+        - content: pod trunk push GliaWidgets.podspec --verbose --allow-warnings
     - cache-push@2: {}
     after_run:
     - _increment_project_version


### PR DESCRIPTION
The changelog was incorrectly generated before the new tag was created, so the changelog showed old commits. Two new steps have been added: one generates a new tag according to the value saved in $NEW_VERSION on workflow trigger, and another after it fetches all tags. This makes the changelog generation step aware of the new tag and generates it correctly.

I don't really know why Bitrise decided to change the order of some workflows, but no changes have been done to them.

MOB-1680