### PR TITLE
Remote UI customization fixes.

### DIFF
--- a/GliaWidgets/Component/Badge/BadgeStyle.swift
+++ b/GliaWidgets/Component/Badge/BadgeStyle.swift
@@ -14,6 +14,12 @@ public struct BadgeStyle {
     /// Background color of the view.
     public var backgroundColor: ColorType
 
+    /// Border color of the view.
+    public var borderColor: ColorType
+
+    /// Border width of the view.
+    public var borderWidth: CGFloat
+
     ///
     /// - Parameters:
     ///   - font: Font of the text.
@@ -25,25 +31,29 @@ public struct BadgeStyle {
         font: UIFont,
         fontColor: UIColor,
         textStyle: UIFont.TextStyle = .caption1,
-        backgroundColor: ColorType
+        backgroundColor: ColorType,
+        borderColor: ColorType = .fill(color: .clear),
+        borderWidth: CGFloat = .zero
     ) {
         self.font = font
         self.fontColor = fontColor
         self.textStyle = textStyle
         self.backgroundColor = backgroundColor
+        self.borderColor = borderColor
+        self.borderWidth = borderWidth
     }
 
     /// Apply badge remote configuration
     mutating func apply(
-        configuration: RemoteConfiguration.Button?,
+        configuration: RemoteConfiguration.Badge?,
         assetsBuilder: RemoteConfiguration.AssetsBuilder
     ) {
         UIFont.convertToFont(
-            uiFont: assetsBuilder.fontBuilder(configuration?.text?.font),
+            uiFont: assetsBuilder.fontBuilder(configuration?.font),
             textStyle: textStyle
         ).unwrap { font = $0 }
 
-        configuration?.text?.foreground?.value
+        configuration?.fontColor?.value
             .map { UIColor(hex: $0) }
             .first
             .unwrap { fontColor = $0 }
@@ -60,5 +70,20 @@ public struct BadgeStyle {
                 backgroundColor = .gradient(colors: colors)
             }
         }
+
+        configuration?.background?.border.unwrap {
+            switch $0.type {
+            case .fill:
+                $0.value
+                    .map { UIColor(hex: $0) }
+                    .first
+                    .unwrap { borderColor = .fill(color: $0) }
+            case .gradient:
+                break
+            }
+        }
+
+        configuration?.background?.borderWidth
+            .unwrap { borderWidth = $0 }
     }
 }

--- a/GliaWidgets/Component/Badge/BadgeView.swift
+++ b/GliaWidgets/Component/Badge/BadgeView.swift
@@ -31,6 +31,11 @@ class BadgeView: UIView {
     private func setup() {
         clipsToBounds = true
         layer.cornerRadius = size / 2
+        layer.borderWidth = style.borderWidth
+        if case let .fill(color) = style.borderColor {
+            layer.borderColor = color.cgColor
+        }
+
         switch style.backgroundColor {
         case .fill(let color):
             backgroundColor = color

--- a/GliaWidgets/Component/CallButtonBar/CallButtonBarStyle.swift
+++ b/GliaWidgets/Component/CallButtonBar/CallButtonBarStyle.swift
@@ -43,5 +43,9 @@ public struct CallButtonBarStyle {
             button: bar?.speakerButton,
             assetsBuilder: assetsBuilder
         )
+        badge.apply(
+            configuration: bar?.badge,
+            assetsBuilder: assetsBuilder
+        )
     }
 }

--- a/GliaWidgets/Component/Connect/Operator/ConnectOperatorStyle.swift
+++ b/GliaWidgets/Component/Connect/Operator/ConnectOperatorStyle.swift
@@ -34,53 +34,12 @@ public struct ConnectOperatorStyle {
     }
 
     mutating func apply(configuration: RemoteConfiguration.Operator?) {
-        configuration?.image?.imageBackgroundColor.unwrap {
-            switch $0.type {
-            case .fill:
-                $0.value
-                    .map { UIColor(hex: $0) }
-                    .first
-                    .unwrap { operatorImage.imageBackgroundColor = .fill(color: $0) }
-            case .gradient:
-                let colors = $0.value.convertToCgColors()
-                operatorImage.imageBackgroundColor = .gradient(colors: colors)
-            }
-        }
-
-        configuration?.image?.placeholderBackgroundColor.unwrap {
-            switch $0.type {
-            case .fill:
-                $0.value
-                    .map { UIColor(hex: $0) }
-                    .first
-                    .unwrap { operatorImage.placeholderBackgroundColor = .fill(color: $0) }
-            case .gradient:
-                let colors = $0.value.convertToCgColors()
-                operatorImage.placeholderBackgroundColor = .gradient(colors: colors)
-            }
-        }
-
-        configuration?.image?.placeholderColor?.value
-            .map { UIColor(hex: $0) }
-            .first
-            .unwrap { operatorImage.placeholderColor = $0 }
-
         configuration?.animationColor?.value
             .map { UIColor(hex: $0) }
             .first
             .unwrap { animationColor = $0 }
 
-        configuration?.overlayColor.unwrap {
-            switch $0.type {
-            case .fill:
-                $0.value
-                    .map { UIColor(hex: $0) }
-                    .first
-                    .unwrap { onHoldOverlay.imageColor = .fill(color: $0) }
-            case .gradient:
-                let colors = $0.value.convertToCgColors()
-                onHoldOverlay.imageColor = .gradient(colors: colors)
-            }
-        }
+        operatorImage.apply(configuration: configuration?.image)
+        onHoldOverlay.apply(configuration: configuration?.onHoldOverlay)
     }
 }

--- a/GliaWidgets/Component/OnHoldOverlay/OnHoldOverlayStyle.swift
+++ b/GliaWidgets/Component/OnHoldOverlay/OnHoldOverlayStyle.swift
@@ -5,20 +5,23 @@ public struct OnHoldOverlayStyle {
     public var image: UIImage
     public var imageColor: ColorType
     public var imageSize: CGSize
+    public var backgroundColor: ColorType
 
     public init(
         image: UIImage,
         imageColor: ColorType,
-        imageSize: CGSize
+        imageSize: CGSize,
+        backgroundColor: ColorType = .fill(color: .clear)
     ) {
         self.image = image
         self.imageColor = imageColor
         self.imageSize = imageSize
+        self.backgroundColor = backgroundColor
     }
 
     /// Apply onHoldOverlay style remote configuration
     mutating func apply(configuration: RemoteConfiguration.OnHoldOverlayStyle?) {
-        configuration?.color.unwrap {
+        configuration?.tintColor.unwrap {
             switch $0.type {
             case .fill:
                 $0.value
@@ -28,6 +31,19 @@ public struct OnHoldOverlayStyle {
             case .gradient:
                 let colors = $0.value.convertToCgColors()
                 imageColor = .gradient(colors: colors)
+            }
+        }
+
+        configuration?.backgroundColor.unwrap {
+            switch $0.type {
+            case .fill:
+                $0.value
+                    .map { UIColor(hex: $0) }
+                    .first
+                    .unwrap { backgroundColor = .fill(color: $0) }
+            case .gradient:
+                let colors = $0.value.convertToCgColors()
+                backgroundColor = .gradient(colors: colors)
             }
         }
     }

--- a/GliaWidgets/Component/OnHoldOverlay/OnHoldOverlayView.swift
+++ b/GliaWidgets/Component/OnHoldOverlay/OnHoldOverlayView.swift
@@ -6,18 +6,26 @@ final class OnHoldOverlayView: UIView {
     private let blurEffectView = OnHoldOverlayVisualEffectView()
     private let imageView = UIImageView()
 
+    private var gradientLayer: CAGradientLayer?
+
     init(style: OnHoldOverlayStyle) {
         self.style = style
 
         super.init(frame: .zero)
 
-        setup()
         layout()
+        setup()
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        gradientLayer?.frame = bounds
     }
 
     private func setup() {
@@ -27,6 +35,13 @@ final class OnHoldOverlayView: UIView {
             imageView.tintColor = color
         case .gradient(let colors):
             imageView.makeGradientBackground(colors: colors)
+        }
+
+        switch style.backgroundColor {
+        case .fill(let color):
+            backgroundColor = color
+        case .gradient(let colors):
+            gradientLayer = makeGradientBackground(colors: colors)
         }
     }
 

--- a/GliaWidgets/Component/UnreadMessageIndicator/UnreadMessageIndicatorStyle.swift
+++ b/GliaWidgets/Component/UnreadMessageIndicator/UnreadMessageIndicatorStyle.swift
@@ -10,6 +10,9 @@ public struct UnreadMessageIndicatorStyle {
     /// Style of the operator's image that appears in the indicator's main frame.
     public var userImage: UserImageStyle
 
+    /// Color of the unread indicator image.
+    public var indicatorImageTintColor: UIColor
+
     /// Accessibility related properties.
     public var accessibility: Accessibility
 
@@ -22,7 +25,8 @@ public struct UnreadMessageIndicatorStyle {
     ///   - placeholderColor: Color of the placeholder's image if the operator has no picture set.
     ///   - placeholderBackgroundColor: Background color of the placeholder's image if the operator has no picture set.
     ///   - imageBackgroundColor: Background color of the operator's image. Visible when the operator's image contains transparent parts.
-    ///   - imageBackgroundColor: Background olor of the operator's image. Visible when the operator's image contains transparent parts.
+    ///   - imageBackgroundColor: Background color of the operator's image. Visible when the operator's image contains transparent parts.
+    ///   - indicatorImageTintColor: Color of the unread indicator image.
     ///   - accessibility: Accessibility related properties.
     public init(
         badgeFont: UIFont,
@@ -33,6 +37,7 @@ public struct UnreadMessageIndicatorStyle {
         placeholderBackgroundColor: ColorType,
         imageBackgroundColor: ColorType,
         transferringImage: UIImage,
+        indicatorImageTintColor: UIColor = .white,
         accessibility: Accessibility = .unsupported
     ) {
         self.badge = BadgeStyle(
@@ -47,17 +52,22 @@ public struct UnreadMessageIndicatorStyle {
             imageBackgroundColor: imageBackgroundColor,
             transferringImage: transferringImage
         )
+        self.indicatorImageTintColor = indicatorImageTintColor
         self.accessibility = accessibility
     }
 
     mutating func apply(
-        configuration: RemoteConfiguration.Bubble?,
+        configuration: RemoteConfiguration.UnreadIndicator?,
         assetsBuilder: RemoteConfiguration.AssetsBuilder
     ) {
         badge.apply(
-            configuration: configuration?.badge,
+            configuration: configuration?.bubble?.badge,
             assetsBuilder: assetsBuilder
         )
-        userImage.apply(configuration: configuration?.userImage)
+        userImage.apply(configuration: configuration?.bubble?.userImage)
+        configuration?.backgroundColor?.value
+            .first
+            .map { UIColor(hex: $0) }
+            .unwrap { indicatorImageTintColor = $0 }
     }
 }

--- a/GliaWidgets/Component/UnreadMessageIndicator/UnreadMessageIndicatorView.swift
+++ b/GliaWidgets/Component/UnreadMessageIndicator/UnreadMessageIndicatorView.swift
@@ -59,6 +59,8 @@ final class UnreadMessageIndicatorView: View {
         isHidden = true
 
         backgroundView.image = Asset.unreadMessageIndicator.image
+            .withRenderingMode(.alwaysTemplate)
+        backgroundView.tintColor = style.indicatorImageTintColor
 
         let tapRecognizer = UITapGestureRecognizer(
             target: self,

--- a/GliaWidgets/RemoteConfiguration/RemoteConfiguration+Chat.swift
+++ b/GliaWidgets/RemoteConfiguration/RemoteConfiguration+Chat.swift
@@ -13,7 +13,7 @@ extension RemoteConfiguration {
         let videoUpgrade: Upgrade?
         let bubble: Bubble?
         let attachmentSourceList: AttachmentSourceList?
-        let unreadIndicator: Bubble?
+        let unreadIndicator: UnreadIndicator?
         let typingIndicator: Color?
     }
 
@@ -141,5 +141,10 @@ extension RemoteConfiguration {
         let info: Text?
         let separator: Text?
         let retry: Text?
+    }
+
+    struct UnreadIndicator: Codable {
+        let backgroundColor: Color?
+        let bubble: Bubble?
     }
 }

--- a/GliaWidgets/RemoteConfiguration/RemoteConfiguration+Chat.swift
+++ b/GliaWidgets/RemoteConfiguration/RemoteConfiguration+Chat.swift
@@ -64,7 +64,7 @@ extension RemoteConfiguration {
     struct Operator: Codable {
         let image: UserImageStyle?
         let animationColor: Color?
-        let overlayColor: Color?
+        let onHoldOverlay: OnHoldOverlayStyle?
     }
 
     struct Input: Codable {

--- a/GliaWidgets/RemoteConfiguration/RemoteConfiguration.swift
+++ b/GliaWidgets/RemoteConfiguration/RemoteConfiguration.swift
@@ -48,7 +48,8 @@ extension RemoteConfiguration {
     }
 
     struct OnHoldOverlayStyle: Codable {
-        let color: Color?
+        let backgroundColor: Color?
+        let tintColor: Color?
     }
 
     struct UserImageStyle: Codable {

--- a/GliaWidgets/RemoteConfiguration/RemoteConfiguration.swift
+++ b/GliaWidgets/RemoteConfiguration/RemoteConfiguration.swift
@@ -42,9 +42,15 @@ extension RemoteConfiguration {
     }
 
     struct Bubble: Codable {
-        let badge: Button?
+        let badge: Badge?
         let onHoldOverlay: OnHoldOverlayStyle?
         let userImage: UserImageStyle?
+    }
+
+    struct Badge: Codable {
+        let background: Layer?
+        let font: Font?
+        let fontColor: Color?
     }
 
     struct OnHoldOverlayStyle: Codable {
@@ -113,6 +119,7 @@ extension RemoteConfiguration {
     struct ButtonBar: Codable {
         let chatButton, minimizeButton, muteButton, speakerButton: BarButtonStates?
         let videoButton: BarButtonStates?
+        let badge: Badge?
     }
 
     struct BarButtonStates: Codable {

--- a/GliaWidgets/RemoteConfiguration/RemoteConfiguration.swift
+++ b/GliaWidgets/RemoteConfiguration/RemoteConfiguration.swift
@@ -4,7 +4,7 @@ public struct RemoteConfiguration: Codable {
     let callScreen: Call?
     let chatScreen: Chat?
     let surveyScreen: Survey?
-    let alertScreen: Alert?
+    let alert: Alert?
     let bubble: Bubble?
 }
 

--- a/GliaWidgets/Theme/Theme.swift
+++ b/GliaWidgets/Theme/Theme.swift
@@ -78,7 +78,7 @@ public class Theme {
             assetsBuilder: assetsBuilder
         )
         alert.apply(
-            configuration: config.alertScreen,
+            configuration: config.alert,
             assetsBuilder: assetsBuilder
         )
         minimizedBubble.apply(

--- a/GliaWidgets/View/Call/CallStyle.swift
+++ b/GliaWidgets/View/Call/CallStyle.swift
@@ -189,10 +189,11 @@ extension CallStyle {
         configuration: RemoteConfiguration.Call?,
         assetsBuilder: RemoteConfiguration.AssetsBuilder
     ) {
-        applyBarConfiguration(
+        buttonBar.applyBarConfiguration(
             configuration?.buttonBar,
             assetsBuilder: assetsBuilder
         )
+
         applyBackgroundConfiguration(configuration?.background)
         applyOperatorConfiguration(
             configuration?.callOperator,
@@ -322,16 +323,5 @@ extension CallStyle {
                 backgroundColor = .gradient(colors: colors)
             }
         }
-    }
-
-    /// Apply bar buttons from remote configuration
-    private func applyBarConfiguration(
-        _ bar: RemoteConfiguration.ButtonBar?,
-        assetsBuilder: RemoteConfiguration.AssetsBuilder
-    ) {
-        buttonBar.applyBarConfiguration(
-            bar,
-            assetsBuilder: assetsBuilder
-        )
     }
 }


### PR DESCRIPTION
In this PR were fixed:
- Added `Badge`, `UnreadIndicator` configuration structures.
- Renamed `alertScreen` property to `alert` owned by RemoteConfiguration.
- `BadgeView`. Added customization for border.
- UnreadMessageIndicatorView. Added customization for image tintColor.
- Added customization for bubble on Chat button on Call screen.
- Added customization for `OnHoldOverLayView`