### PR TITLE
Change default enqueueing subtitle

### DIFF
--- a/GliaWidgets/L10n.swift
+++ b/GliaWidgets/L10n.swift
@@ -385,8 +385,8 @@ public enum L10n {
       public enum Queue {
         /// CompanyName
         public static let firstText = L10n.tr("Localizable", "call.connect.queue.firstText", fallback: "CompanyName")
-        /// An MSR will be with you shortly.
-        public static let secondText = L10n.tr("Localizable", "call.connect.queue.secondText", fallback: "An MSR will be with you shortly.")
+        /// We're here to help!
+        public static let secondText = L10n.tr("Localizable", "call.connect.queue.secondText", fallback: "We're here to help!")
       }
       public enum Transferring {
         /// Transferring
@@ -583,8 +583,8 @@ public enum L10n {
       public enum Queue {
         /// CompanyName
         public static let firstText = L10n.tr("Localizable", "chat.connect.queue.firstText", fallback: "CompanyName")
-        /// An MSR will be with you shortly.
-        public static let secondText = L10n.tr("Localizable", "chat.connect.queue.secondText", fallback: "An MSR will be with you shortly.")
+        /// We're here to help!
+        public static let secondText = L10n.tr("Localizable", "chat.connect.queue.secondText", fallback: "We're here to help!")
       }
       public enum Transferring {
         /// Transferring

--- a/GliaWidgets/Resources/en.lproj/Localizable.strings
+++ b/GliaWidgets/Resources/en.lproj/Localizable.strings
@@ -61,7 +61,7 @@
 "chat.title" = "Chat";
 "chat.endButton.title" = "End";
 "chat.connect.queue.firstText" = "CompanyName";
-"chat.connect.queue.secondText" = "An MSR will be with you shortly.";
+"chat.connect.queue.secondText" = "We're here to help!";
 "chat.connect.connecting.firstText" = "Connecting with {operatorName}";
 "chat.connect.connecting.secondText" = "";
 "chat.connect.connected.firstText" = "{operatorName}";
@@ -134,7 +134,7 @@
 "call.video.title" = "Video";
 "call.endButton.title" = "End";
 "call.connect.queue.firstText" = "CompanyName";
-"call.connect.queue.secondText" = "An MSR will be with you shortly.";
+"call.connect.queue.secondText" = "We're here to help!";
 "call.connect.connecting.firstText" = "Connecting with {operatorName}";
 "call.connect.connecting.secondText" = "";
 "call.connect.connected.firstText" = "{operatorName}";


### PR DESCRIPTION
The current default enqueueing subtitle text is confusing to clients and partners. That is why a a change was needed.

MOB-1642