### PR TITLE
Introduce Command - wrapper for closures used in Props for data-driven UI

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -370,6 +370,7 @@
 		AF11F31A28C60A28002ACEB4 /* AuthenticatedChatStorage.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF11F31928C60A28002ACEB4 /* AuthenticatedChatStorage.Mock.swift */; };
 		AF11F31C28C639A5002ACEB4 /* AuthenticatedChatStorage.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF11F31B28C639A5002ACEB4 /* AuthenticatedChatStorage.Failing.swift */; };
 		AF11F31E28C78E7F002ACEB4 /* AuthenticatedChatStorage.StorageRefTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF11F31D28C78E7F002ACEB4 /* AuthenticatedChatStorage.StorageRefTests.swift */; };
+		AF5762192948A608003C0ACE /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF5762182948A608003C0ACE /* Command.swift */; };
 		AF9DB22E2890571A00A0C442 /* RootCoordinator.Environment.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9DB22D2890571A00A0C442 /* RootCoordinator.Environment.Failing.swift */; };
 		AF9DB23128905A1D00A0C442 /* ViewFactory.Environment.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9DB23028905A1D00A0C442 /* ViewFactory.Environment.Failing.swift */; };
 		AFA2FDEC28907D7C00428E6D /* RootCoordinator.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA2FDEB28907D7C00428E6D /* RootCoordinator.Environment.swift */; };
@@ -844,6 +845,7 @@
 		AF11F31928C60A28002ACEB4 /* AuthenticatedChatStorage.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedChatStorage.Mock.swift; sourceTree = "<group>"; };
 		AF11F31B28C639A5002ACEB4 /* AuthenticatedChatStorage.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedChatStorage.Failing.swift; sourceTree = "<group>"; };
 		AF11F31D28C78E7F002ACEB4 /* AuthenticatedChatStorage.StorageRefTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedChatStorage.StorageRefTests.swift; sourceTree = "<group>"; };
+		AF5762182948A608003C0ACE /* Command.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
 		AF9DB22D2890571A00A0C442 /* RootCoordinator.Environment.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootCoordinator.Environment.Failing.swift; sourceTree = "<group>"; };
 		AF9DB23028905A1D00A0C442 /* ViewFactory.Environment.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewFactory.Environment.Failing.swift; sourceTree = "<group>"; };
 		AFA2FDEB28907D7C00428E6D /* RootCoordinator.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootCoordinator.Environment.swift; sourceTree = "<group>"; };
@@ -1553,6 +1555,7 @@
 		1A60AFC12566857200E53F53 /* Lib */ = {
 			isa = PBXGroup;
 			children = (
+				AF5762172948A608003C0ACE /* Command */,
 				84D2292C28C61DE000F64FE7 /* WKNavigationPolicyProvider */,
 				845A28FD28AFF2DC008558EA /* URLScheme */,
 				C4794E6E270673FC00F989F7 /* Animation */,
@@ -2308,6 +2311,14 @@
 			path = Storage;
 			sourceTree = "<group>";
 		};
+		AF5762172948A608003C0ACE /* Command */ = {
+			isa = PBXGroup;
+			children = (
+				AF5762182948A608003C0ACE /* Command.swift */,
+			);
+			path = Command;
+			sourceTree = "<group>";
+		};
 		AF9DB22C289056F600A0C442 /* Coordinator */ = {
 			isa = PBXGroup;
 			children = (
@@ -2979,6 +2990,7 @@
 				845E2F98283FC9A900C04D56 /* Theme.Survey.OptionButton.swift in Sources */,
 				9AB196DC27C3FFCC00FD60AB /* Call.Environment.Interface.swift in Sources */,
 				C49A29EA2614A32600819269 /* ChatMessageContent.swift in Sources */,
+				AF5762192948A608003C0ACE /* Command.swift in Sources */,
 				9AB3402727FCDD92006E0FE2 /* ChatStyle.Accessibility.swift in Sources */,
 				845E2F74283D43FA00C04D56 /* AlertStyle.Accessibility.swift in Sources */,
 				1A60B0082567F29900E53F53 /* HeaderStyle.swift in Sources */,

--- a/GliaWidgets/Lib/Command/Command.swift
+++ b/GliaWidgets/Lib/Command/Command.swift
@@ -1,0 +1,67 @@
+/// Developer-friendly wrapper around a closure.
+/// It makes debugging easier by providing callee information.
+/// Note: since closure does not conform to `Equatable`, it will
+/// also be ignored in `Equatable` and `Hashable` implementations
+/// of `Command`.
+///
+/// Example of declaration and execution:
+/// ```
+/// let validateEmail = Command<String> { email in /* email validation goes here */ }
+/// validateEmail("email@example.test")
+/// ```
+struct Command<T>: Hashable {
+    let tag: String
+    let file: String
+    let function: String
+    let line: UInt
+    let closure: (T) -> Void
+
+    init(
+        tag: String = "",
+        file: StaticString = #file,
+        function: StaticString = #function,
+        line: UInt = #line,
+        closure: @escaping (T) -> Void
+    ) {
+        self.tag = tag
+        self.file = "\(file)"
+        self.function = "\(function)"
+        self.line = line
+        self.closure = closure
+    }
+
+    func execute(with value: T) {
+        closure(value)
+    }
+
+    func callAsFunction(_ value: T) {
+        execute(with: value)
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.tag == rhs.tag &&
+        lhs.file == rhs.file &&
+        lhs.function == rhs.function &&
+        lhs.line == rhs.line
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(tag)
+        hasher.combine(file)
+        hasher.combine(function)
+        hasher.combine(line)
+    }
+}
+
+/// A shorthand for Command for closure with zero parameters.
+typealias Cmd = Command<Void>
+
+extension Cmd {
+    func execute() where T == Void {
+        self.execute(with: ())
+    }
+
+    func callAsFunction() {
+        execute()
+    }
+}


### PR DESCRIPTION
Add wrapper for closure to be used in `Props` of data-driven UI.
It makes closure conform `Equatable` and `Hashable`, providing info about callee.

MOB-1706