### PR TITLE
Handle call visualizer engagement request

### DIFF
--- a/GliaWidgets/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -105,6 +105,9 @@ struct CoreSdkClient {
 
     typealias FetchChatHistory = (_ completion: @escaping (Result<[Self.Message], SalemoveSDK.GliaCoreError>) -> Void) -> Void
     var fetchChatHistory: FetchChatHistory
+
+    typealias RequestVisitorCode = (_ completion: @escaping VisitorCodeBlock) -> GliaCore.Cancellable
+    var requestVisitorCode: RequestVisitorCode
 }
 
 extension CoreSdkClient {
@@ -165,6 +168,7 @@ extension CoreSdkClient {
     typealias QueueTicket = SalemoveSDK.QueueTicket
     typealias QueueTicketBlock = SalemoveSDK.QueueTicketBlock
     typealias RequestOfferBlock = SalemoveSDK.RequestOfferBlock
+    typealias RequestAnswerBlock = SalemoveSDK.RequestAnswerBlock
     typealias Salemove = SalemoveSDK.GliaCore
     typealias SalemoveError = SalemoveSDK.GliaCoreError
     typealias ScreenshareOfferBlock = SalemoveSDK.ScreenshareOfferBlock
@@ -185,4 +189,5 @@ extension CoreSdkClient {
     typealias SurveyAnswerContainer = SalemoveSDK.Survey.Answer.ValueContainer
     typealias Authentication = SalemoveSDK.GliaCore.Authentication
     typealias AuthenticationBehavior = SalemoveSDK.GliaCore.Authentication.Behavior
+    typealias VisitorCodeBlock = (Result<VisitorCode, Swift.Error>) -> Void
 }

--- a/GliaWidgets/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/CoreSDKClient/CoreSDKClient.Live.swift
@@ -25,7 +25,8 @@ extension CoreSdkClient {
             fetchSiteConfigurations: GliaCore.sharedInstance.fetchSiteConfiguration(_:),
             submitSurveyAnswer: GliaCore.sharedInstance.submitSurveyAnswer(_:surveyId:engagementId:completion:),
             authentication: GliaCore.sharedInstance.authentication,
-            fetchChatHistory: GliaCore.sharedInstance.fetchChatTranscript
+            fetchChatHistory: GliaCore.sharedInstance.fetchChatTranscript,
+            requestVisitorCode: GliaCore.sharedInstance.callVisualizer.requestVisitorCode(completion:)
         )
     }()
 }

--- a/GliaWidgets/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -1,6 +1,6 @@
 #if DEBUG
 import Foundation
-import SalemoveSDK
+@testable import SalemoveSDK
 
 extension CoreSdkClient {
     static let mock = Self(
@@ -25,7 +25,8 @@ extension CoreSdkClient {
         fetchSiteConfigurations: { _ in },
         submitSurveyAnswer: { _, _, _, _ in },
         authentication: { _ in .mock },
-        fetchChatHistory: { _ in }
+        fetchChatHistory: { _ in },
+        requestVisitorCode: { _ in .init() }
     )
 }
 

--- a/GliaWidgets/Glia.swift
+++ b/GliaWidgets/Glia.swift
@@ -374,4 +374,8 @@ public class Glia {
             }
         )
     }
+
+    public func requestVisitorCode(completion: @escaping (Result<VisitorCode, Swift.Error>) -> Void) {
+        environment.coreSdk.requestVisitorCode(completion)
+    }
 }

--- a/GliaWidgets/Interactor/Interactor.swift
+++ b/GliaWidgets/Interactor/Interactor.swift
@@ -31,6 +31,7 @@ enum InteractorEvent {
     case error(CoreSdkClient.SalemoveError)
     case engagementTransferred(CoreSdkClient.Operator?)
     case engagementTransferring
+    case engagementRequested(CoreSdkClient.RequestAnswerBlock)
 }
 
 class Interactor {
@@ -264,8 +265,16 @@ extension Interactor: CoreSdkClient.Interactable {
     }
 
     var onEngagementRequest: CoreSdkClient.RequestOfferBlock {
+        debugPrint("Engagement request received")
         return { [weak self] answer in
-            answer(self?.visitorContext, true) { _, _ in }
+            let completion: CoreSdkClient.SuccessBlock = { _, error in
+                if let reason = error?.reason {
+                    debugPrint(reason)
+                }
+
+            }
+            self?.notify(.engagementRequested(answer))
+            answer(self?.visitorContext, true, completion)
         }
     }
 

--- a/GliaWidgetsTests/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/CoreSDKClient.Failing.swift
@@ -26,7 +26,8 @@ extension CoreSdkClient {
             fail("\(Self.self).authentication")
             return .mock
         },
-        fetchChatHistory: { _ in }
+        fetchChatHistory: { _ in },
+        requestVisitorCode: { _ in fail("\(Self.self).requestVisitorCode") }
     )
 }
 

--- a/TestingApp/Main.storyboard
+++ b/TestingApp/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="A3Y-Xf-Ufg">
-                                <rect key="frame" x="0.0" y="258" width="414" height="380"/>
+                                <rect key="frame" x="0.0" y="183" width="414" height="530"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FAP-5O-GCi">
                                         <rect key="frame" x="164.5" y="0.0" width="85" height="30"/>
@@ -109,7 +109,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ezc-iY-PbB">
-                                        <rect key="frame" x="141" y="350" width="132" height="30"/>
+                                        <rect key="frame" x="141" y="400" width="132" height="30"/>
                                         <accessibility key="accessibilityConfiguration" identifier="main_endEngagement_button"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="Nef-0j-qW7"/>
@@ -117,6 +117,29 @@
                                         <state key="normal" title="Remote config.json"/>
                                         <connections>
                                             <action selector="remoteConfigTapped" destination="Y6W-OH-hqX" eventType="touchUpInside" id="9aa-P2-FLo"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oR8-dm-fet">
+                                        <rect key="frame" x="164.5" y="450" width="85" height="30"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="30" id="NCp-mB-WjL"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                        <state key="normal" title="Visitor Code"/>
+                                        <connections>
+                                            <action selector="visitorCodeTapped" destination="Y6W-OH-hqX" eventType="touchUpInside" id="zMe-CW-TCa"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4yC-lN-tH2">
+                                        <rect key="frame" x="156.5" y="500" width="101" height="30"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="30" id="qN6-sa-ywS"/>
+                                        </constraints>
+                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                        <state key="normal" title="Configure SDK"/>
+                                        <connections>
+                                            <action selector="configureSDKTapped" destination="Y6W-OH-hqX" eventType="touchUpInside" id="3UC-r4-Dv0"/>
                                         </connections>
                                     </button>
                                 </subviews>

--- a/TestingApp/ViewController.swift
+++ b/TestingApp/ViewController.swift
@@ -51,6 +51,14 @@ class ViewController: UIViewController {
         Glia.sharedInstance.clearVisitorSession()
     }
 
+    @IBAction private func visitorCodeTapped() {
+        requestVisitorCode()
+    }
+
+    @IBAction private func configureSDKTapped() {
+        configureSDK()
+    }
+
     @IBAction private func endEngagementTapped() {
         self.catchingError {
             // Since ending of engagement is possible
@@ -170,6 +178,27 @@ extension ViewController {
         } catch {
             alert(message: "Failed to start\nCheck Glia parameters in Settings")
         }
+    }
+
+    func requestVisitorCode() {
+        Glia.sharedInstance.requestVisitorCode { result in
+            switch result {
+            case .success(let visitorCode):
+                print("Visitor code is:", visitorCode.code)
+                print("Visitor code expires at:", visitorCode.expiresAt)
+            case .failure(let error):
+                print("Error getting visitor code.", error.localizedDescription)
+            }
+        }
+    }
+
+    func configureSDK() {
+        try? Glia.sharedInstance.configure(
+            with: configuration,
+            queueId: queueId,
+            visitorContext: nil) {
+                debugPrint("SDK has been configured")
+            }
     }
 
     func alert(message: String) {


### PR DESCRIPTION
After the operator has entered the visitor's code, the WidgetSDK should receive an engagement request. This request needs to be accepted, and handled, which in the future allows rendering adequate views. This PR makes this possible.