### PR TITLE
Make public interface for visitor code

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -370,6 +370,25 @@
 		AFBBF57A28522591004993B3 /* Configuration.Unavailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBBF57928522591004993B3 /* Configuration.Unavailable.swift */; };
 		C03A8047292BA76D00DDECA6 /* ChatViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03A8046292BA76D00DDECA6 /* ChatViewControllerTests.swift */; };
 		C03A8049292BC8DB00DDECA6 /* CallViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03A8048292BC8DB00DDECA6 /* CallViewControllerTests.swift */; };
+		C05AB01A295F177700AA381F /* CallVisualizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05AB019295F177700AA381F /* CallVisualizer.swift */; };
+		C05AB01C295F416700AA381F /* VisitorCodeCloseButtonProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05AB01B295F416700AA381F /* VisitorCodeCloseButtonProperties.swift */; };
+		C06A756129685232006B69A2 /* VisitorCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06A756029685232006B69A2 /* VisitorCodeView.swift */; };
+		C06A7565296852AF006B69A2 /* VisitorCodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06A7564296852AF006B69A2 /* VisitorCodeViewController.swift */; };
+		C06A756729685314006B69A2 /* TemporaryCommandFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06A756629685314006B69A2 /* TemporaryCommandFile.swift */; };
+		C06A7569296C3BE9006B69A2 /* VisitorCodeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06A7568296C3BE9006B69A2 /* VisitorCodeViewModel.swift */; };
+		C06A756B296C3C48006B69A2 /* CallVisualizer+Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06A756A296C3C48006B69A2 /* CallVisualizer+Environment.swift */; };
+		C06A756D296C3C77006B69A2 /* VisitorCodeViewModel+Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06A756C296C3C77006B69A2 /* VisitorCodeViewModel+Environment.swift */; };
+		C06A756F296C3CA4006B69A2 /* VisitorCodeViewModel+Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06A756E296C3CA4006B69A2 /* VisitorCodeViewModel+Delegate.swift */; };
+		C06A7571296C3EFA006B69A2 /* CallVisualizer+Presentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06A7570296C3EFA006B69A2 /* CallVisualizer+Presentation.swift */; };
+		C06A7573296C4B49006B69A2 /* VisitorCodeView+NumberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06A7572296C4B49006B69A2 /* VisitorCodeView+NumberView.swift */; };
+		C06A7576296D7951006B69A2 /* VisitorCodeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06A7575296D7951006B69A2 /* VisitorCodeCoordinator.swift */; };
+		C06A7578296D9BA1006B69A2 /* VisitorCodeCoordinator+Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06A7577296D9BA1006B69A2 /* VisitorCodeCoordinator+Environment.swift */; };
+		C06A757A296D9BD0006B69A2 /* VisitorCodeCoordinator+DelegateEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06A7579296D9BD0006B69A2 /* VisitorCodeCoordinator+DelegateEvent.swift */; };
+		C06A757F296EC76B006B69A2 /* VisitorCodeStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06A757E296EC76B006B69A2 /* VisitorCodeStyle.swift */; };
+		C06A7582296EC856006B69A2 /* NumberSlotStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06A7581296EC856006B69A2 /* NumberSlotStyle.swift */; };
+		C06A7584296EC9DC006B69A2 /* NumberSlotStyle.Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06A7583296EC9DC006B69A2 /* NumberSlotStyle.Accessibility.swift */; };
+		C06A7586296ECC57006B69A2 /* VisitorCodeStyle.Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06A7585296ECC57006B69A2 /* VisitorCodeStyle.Accessibility.swift */; };
+		C06A7588296ECD75006B69A2 /* Theme+VisitorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06A7587296ECD75006B69A2 /* Theme+VisitorCode.swift */; };
 		C0857DE528D470C1008D171D /* Theme+Shadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0857DE428D470C1008D171D /* Theme+Shadow.swift */; };
 		C0857DE728D470F2008D171D /* Theme+Layer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0857DE628D470F2008D171D /* Theme+Layer.swift */; };
 		C0857DEB28D482D0008D171D /* Theme+Button.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0857DEA28D482D0008D171D /* Theme+Button.swift */; };
@@ -837,6 +856,26 @@
 		AFBBF57928522591004993B3 /* Configuration.Unavailable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.Unavailable.swift; sourceTree = "<group>"; };
 		C03A8046292BA76D00DDECA6 /* ChatViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewControllerTests.swift; sourceTree = "<group>"; };
 		C03A8048292BC8DB00DDECA6 /* CallViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallViewControllerTests.swift; sourceTree = "<group>"; };
+		C05AB016295DA9FC00AA381F /* AlertViewController+VisitorCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AlertViewController+VisitorCode.swift"; sourceTree = "<group>"; };
+		C05AB019295F177700AA381F /* CallVisualizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallVisualizer.swift; sourceTree = "<group>"; };
+		C05AB01B295F416700AA381F /* VisitorCodeCloseButtonProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitorCodeCloseButtonProperties.swift; sourceTree = "<group>"; };
+		C06A756029685232006B69A2 /* VisitorCodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitorCodeView.swift; sourceTree = "<group>"; };
+		C06A7564296852AF006B69A2 /* VisitorCodeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitorCodeViewController.swift; sourceTree = "<group>"; };
+		C06A756629685314006B69A2 /* TemporaryCommandFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemporaryCommandFile.swift; sourceTree = "<group>"; };
+		C06A7568296C3BE9006B69A2 /* VisitorCodeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitorCodeViewModel.swift; sourceTree = "<group>"; };
+		C06A756A296C3C48006B69A2 /* CallVisualizer+Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CallVisualizer+Environment.swift"; sourceTree = "<group>"; };
+		C06A756C296C3C77006B69A2 /* VisitorCodeViewModel+Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VisitorCodeViewModel+Environment.swift"; sourceTree = "<group>"; };
+		C06A756E296C3CA4006B69A2 /* VisitorCodeViewModel+Delegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VisitorCodeViewModel+Delegate.swift"; sourceTree = "<group>"; };
+		C06A7570296C3EFA006B69A2 /* CallVisualizer+Presentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CallVisualizer+Presentation.swift"; sourceTree = "<group>"; };
+		C06A7572296C4B49006B69A2 /* VisitorCodeView+NumberView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VisitorCodeView+NumberView.swift"; sourceTree = "<group>"; };
+		C06A7575296D7951006B69A2 /* VisitorCodeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitorCodeCoordinator.swift; sourceTree = "<group>"; };
+		C06A7577296D9BA1006B69A2 /* VisitorCodeCoordinator+Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VisitorCodeCoordinator+Environment.swift"; sourceTree = "<group>"; };
+		C06A7579296D9BD0006B69A2 /* VisitorCodeCoordinator+DelegateEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VisitorCodeCoordinator+DelegateEvent.swift"; sourceTree = "<group>"; };
+		C06A757E296EC76B006B69A2 /* VisitorCodeStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitorCodeStyle.swift; sourceTree = "<group>"; };
+		C06A7581296EC856006B69A2 /* NumberSlotStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberSlotStyle.swift; sourceTree = "<group>"; };
+		C06A7583296EC9DC006B69A2 /* NumberSlotStyle.Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberSlotStyle.Accessibility.swift; sourceTree = "<group>"; };
+		C06A7585296ECC57006B69A2 /* VisitorCodeStyle.Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitorCodeStyle.Accessibility.swift; sourceTree = "<group>"; };
+		C06A7587296ECD75006B69A2 /* Theme+VisitorCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Theme+VisitorCode.swift"; sourceTree = "<group>"; };
 		C0857DE428D470C1008D171D /* Theme+Shadow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Theme+Shadow.swift"; sourceTree = "<group>"; };
 		C0857DE628D470F2008D171D /* Theme+Layer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Theme+Layer.swift"; sourceTree = "<group>"; };
 		C0857DEA28D482D0008D171D /* Theme+Button.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Theme+Button.swift"; sourceTree = "<group>"; };
@@ -1107,6 +1146,7 @@
 		1A205D5A25655CB1003AA3CD /* GliaWidgets */ = {
 			isa = PBXGroup;
 			children = (
+				C05AB018295F176200AA381F /* CallVisualizer */,
 				84EFB05E28AB90610005E270 /* MessageRenderer */,
 				7562B2E728CBD7150040C784 /* RemoteConfiguration */,
 				75AF8CF227DBB3BE009EEE2C /* Layout */,
@@ -1442,6 +1482,7 @@
 		1A60AF6925656C0A00E53F53 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				C06A757D296EC743006B69A2 /* VisitorCode */,
 				1A60AFD12566990F00E53F53 /* Chat */,
 				1A0C143425B85C1E00B00695 /* Call */,
 				1A63B2F0257A3F0F00508478 /* Common */,
@@ -1454,6 +1495,7 @@
 		1A60AF6A25656C1E00E53F53 /* Component */ = {
 			isa = PBXGroup;
 			children = (
+				C06A7580296EC841006B69A2 /* NumberSlot */,
 				EB2CBB0E27D89F6B004F178E /* OnHoldOverlay */,
 				1A4674A525E905960078FA1C /* AttachmentList */,
 				C499A57C26382F80009962AC /* UnreadMessageIndicator */,
@@ -1512,6 +1554,7 @@
 				C0857DE628D470F2008D171D /* Theme+Layer.swift */,
 				C0857DEA28D482D0008D171D /* Theme+Button.swift */,
 				C0857DEC28D4831E008D171D /* Theme+Text.swift */,
+				C06A7587296ECD75006B69A2 /* Theme+VisitorCode.swift */,
 			);
 			path = Theme;
 			sourceTree = "<group>";
@@ -1694,6 +1737,7 @@
 				1A60B01C2567FCAD00E53F53 /* ButtonProperties.swift */,
 				1A60B0222567FD2D00E53F53 /* CloseButtonProperties.swift */,
 				1A63B2EC257A312700508478 /* AlertCloseButtonProperties.swift */,
+				C05AB01B295F416700AA381F /* VisitorCodeCloseButtonProperties.swift */,
 			);
 			path = Properties;
 			sourceTree = "<group>";
@@ -1776,6 +1820,7 @@
 				1ABD6C9525B6F46700D56EFA /* AlertViewController+SingleMediaUpgrade.swift */,
 				C47901B625ED2FB0007EE195 /* AlertViewController+ScreenShareOffer.swift */,
 				6E60DD5527146C9D001422EF /* AlertViewController+SingleAction.swift */,
+				C05AB016295DA9FC00AA381F /* AlertViewController+VisitorCode.swift */,
 			);
 			path = Alert;
 			sourceTree = "<group>";
@@ -2277,6 +2322,52 @@
 				AF9DB23028905A1D00A0C442 /* ViewFactory.Environment.Failing.swift */,
 			);
 			path = Factory;
+			sourceTree = "<group>";
+		};
+		C05AB018295F176200AA381F /* CallVisualizer */ = {
+			isa = PBXGroup;
+			children = (
+				C06A7574296C555D006B69A2 /* VisitorCode */,
+				C05AB019295F177700AA381F /* CallVisualizer.swift */,
+				C06A7570296C3EFA006B69A2 /* CallVisualizer+Presentation.swift */,
+				C06A756A296C3C48006B69A2 /* CallVisualizer+Environment.swift */,
+				C06A756629685314006B69A2 /* TemporaryCommandFile.swift */,
+			);
+			path = CallVisualizer;
+			sourceTree = "<group>";
+		};
+		C06A7574296C555D006B69A2 /* VisitorCode */ = {
+			isa = PBXGroup;
+			children = (
+				C06A7575296D7951006B69A2 /* VisitorCodeCoordinator.swift */,
+				C06A7579296D9BD0006B69A2 /* VisitorCodeCoordinator+DelegateEvent.swift */,
+				C06A7577296D9BA1006B69A2 /* VisitorCodeCoordinator+Environment.swift */,
+				C06A7568296C3BE9006B69A2 /* VisitorCodeViewModel.swift */,
+				C06A756E296C3CA4006B69A2 /* VisitorCodeViewModel+Delegate.swift */,
+				C06A756C296C3C77006B69A2 /* VisitorCodeViewModel+Environment.swift */,
+				C06A7564296852AF006B69A2 /* VisitorCodeViewController.swift */,
+				C06A756029685232006B69A2 /* VisitorCodeView.swift */,
+				C06A7572296C4B49006B69A2 /* VisitorCodeView+NumberView.swift */,
+			);
+			path = VisitorCode;
+			sourceTree = "<group>";
+		};
+		C06A757D296EC743006B69A2 /* VisitorCode */ = {
+			isa = PBXGroup;
+			children = (
+				C06A757E296EC76B006B69A2 /* VisitorCodeStyle.swift */,
+				C06A7585296ECC57006B69A2 /* VisitorCodeStyle.Accessibility.swift */,
+			);
+			path = VisitorCode;
+			sourceTree = "<group>";
+		};
+		C06A7580296EC841006B69A2 /* NumberSlot */ = {
+			isa = PBXGroup;
+			children = (
+				C06A7581296EC856006B69A2 /* NumberSlotStyle.swift */,
+				C06A7583296EC9DC006B69A2 /* NumberSlotStyle.Accessibility.swift */,
+			);
+			path = NumberSlot;
 			sourceTree = "<group>";
 		};
 		C42463722673ABCD0082C135 /* Screensharing */ = {
@@ -2803,16 +2894,20 @@
 				1AC7A77B25838AE800567FF8 /* ChatItem.swift in Sources */,
 				9A3E1D8C27B6B888005634EB /* FileDownload.Environment.Mock.swift in Sources */,
 				1A1E309F25F8E44300850E68 /* FileDownloader.swift in Sources */,
+				C06A756D296C3C77006B69A2 /* VisitorCodeViewModel+Environment.swift in Sources */,
 				C08D776028F583D7000461E5 /* Array+Extensions.swift in Sources */,
 				9AE9E4B727E1E30500BFE239 /* MockHelpers.swift in Sources */,
 				1A2DA72625EF892600032611 /* FilePickerController.swift in Sources */,
+				C06A7578296D9BA1006B69A2 /* VisitorCodeCoordinator+Environment.swift in Sources */,
 				1ABD6C9625B6F46700D56EFA /* AlertViewController+SingleMediaUpgrade.swift in Sources */,
 				9AB3401527F724BC006E0FE2 /* CallStyle.Accessibility.swift in Sources */,
 				1A277A1625FA60E1009FE131 /* ChatFileContentStyle.swift in Sources */,
+				C06A7576296D7951006B69A2 /* VisitorCodeCoordinator.swift in Sources */,
 				1A475BB325DE831F00296D55 /* BadgeView.swift in Sources */,
 				1A38A8A8258B652B0089DE7B /* OperatorChatMessageStyle.swift in Sources */,
 				1A7CA8212574D6760047CBBE /* ConnectOperatorView.swift in Sources */,
 				9AB196D427C3D7FD00FD60AB /* Interactor.Environment.Mock.swift in Sources */,
+				C06A756B296C3C48006B69A2 /* CallVisualizer+Environment.swift in Sources */,
 				1A0C9A7925C16F9700815406 /* Theme+AlertConfiguration.swift in Sources */,
 				1AC8AADD25D419CE00DAFE50 /* VideoStreamView.swift in Sources */,
 				1A4AD3C7256E863900468BFB /* ThemeColor.swift in Sources */,
@@ -2833,10 +2928,12 @@
 				845876AE282A95DE007AC3DF /* InputQuestionView.Props.Accessibility.swift in Sources */,
 				753A56B927CFEB730050D8E6 /* ChatViewModel.Mock.swift in Sources */,
 				1A0C9A7F25C1732F00815406 /* Theme+MinimizedBubble.swift in Sources */,
+				C06A756129685232006B69A2 /* VisitorCodeView.swift in Sources */,
 				1A60AF7E25656F0400E53F53 /* Glia.swift in Sources */,
 				C0857DE728D470F2008D171D /* Theme+Layer.swift in Sources */,
 				1A60AFB62566825400E53F53 /* ViewModel.swift in Sources */,
 				845E2F95283FC5D300C04D56 /* Theme.Survey.OptionButton.Accessibility.swift in Sources */,
+				C06A7569296C3BE9006B69A2 /* VisitorCodeViewModel.swift in Sources */,
 				845876B4282AA296007AC3DF /* ButtonView.Props.Accessibility.swift in Sources */,
 				1A0C9AE025C9624500815406 /* ObservableValue.swift in Sources */,
 				1A60AFB9256682AF00E53F53 /* FlowCoordinator.swift in Sources */,
@@ -2848,14 +2945,17 @@
 				75AF8D1027DFF4B3009EEE2C /* Survey.ValidationErrorView.swift in Sources */,
 				9A8130B927D757F900220BBD /* LocalFile.Mock.swift in Sources */,
 				1A60AFCE2566958900E53F53 /* ViewFactory.swift in Sources */,
+				C06A7586296ECC57006B69A2 /* VisitorCodeStyle.Accessibility.swift in Sources */,
 				9A186A3B27F5E6B50055886D /* ChatFileContentStyle.Accessibility.swift in Sources */,
 				9A3E1D9927B6D0DB005634EB /* FoundationBased.Live.swift in Sources */,
 				1A7CA82F25751B5A0047CBBE /* ConnectOperatorStyle.swift in Sources */,
+				C06A757F296EC76B006B69A2 /* VisitorCodeStyle.swift in Sources */,
 				9AB196D227C3D74300FD60AB /* Interactor.Environment.Interface.swift in Sources */,
 				9AE0A7622822AF3000725946 /* FontScaling.Environment.Live.swift in Sources */,
 				1A0452DD25DBD0A4000DA0C1 /* HeaderButton.swift in Sources */,
 				75AF8CEF27DAA819009EEE2C /* SurveyViewController.swift in Sources */,
 				1A60AF96256675C400E53F53 /* UIColor+Extensions.swift in Sources */,
+				C06A7588296ECD75006B69A2 /* Theme+VisitorCode.swift in Sources */,
 				C0857DED28D4831E008D171D /* Theme+Text.swift in Sources */,
 				845876A22823FF34007AC3DF /* Survey.ViewController.Props.Mock.swift in Sources */,
 				1A4674B625E907320078FA1C /* AttachmentSourceListStyle.swift in Sources */,
@@ -2876,6 +2976,7 @@
 				1A60AFE425669B0400E53F53 /* ChatCoordinator.swift in Sources */,
 				C0857DEB28D482D0008D171D /* Theme+Button.swift in Sources */,
 				EB2CBB1027D89F74004F178E /* OnHoldOverlayView.swift in Sources */,
+				C06A756F296C3CA4006B69A2 /* VisitorCodeViewModel+Delegate.swift in Sources */,
 				9AB3401727F74D66006E0FE2 /* ChoiceCardStyle.Accessibility.swift in Sources */,
 				9A8130B527D7563000220BBD /* LocalFile.Environment.Interface.swift in Sources */,
 				9AB3401B27FB4720006E0FE2 /* OperatorTypingIndicatorStyle.Accessibility.swift in Sources */,
@@ -2930,10 +3031,12 @@
 				1A0C9A6D25C16EED00815406 /* Theme+Call.swift in Sources */,
 				1A60AFAF256680EF00E53F53 /* L10n.swift in Sources */,
 				9A1992DD27D6254800161AAE /* ImageView.Cache.Live.swift in Sources */,
+				C06A756729685314006B69A2 /* TemporaryCommandFile.swift in Sources */,
 				845E2F9B283FCA9000C04D56 /* Theme.Survey.Checkbox.swift in Sources */,
 				1A60B0192567FC8A00E53F53 /* ButtonKind.swift in Sources */,
 				C42463742673ABE10082C135 /* ScreenShareHandler.swift in Sources */,
 				1A56D53D257E24A400141BC8 /* PoweredBy.swift in Sources */,
+				C06A7573296C4B49006B69A2 /* VisitorCodeView+NumberView.swift in Sources */,
 				6EEAD84E2701A8C10074C191 /* ChoiceCardOptionStateStyle.swift in Sources */,
 				845876B1282A9EAF007AC3DF /* CheckboxView.Props.Accessibility.swift in Sources */,
 				1A4AF5CD25AEF4A0002CD0F4 /* AlertViewController+Message.swift in Sources */,
@@ -2965,6 +3068,7 @@
 				845876A8282A94CF007AC3DF /* BooleanQuestionView.Props.Accessibility.swift in Sources */,
 				1A6EBB2525ADE36900EE325D /* MediaUpgradePresenter.swift in Sources */,
 				1AA738B925790DB400E1120F /* ActionButtonStyle.swift in Sources */,
+				C06A7582296EC856006B69A2 /* NumberSlotStyle.swift in Sources */,
 				1A2DA71F25EF720400032611 /* FilePickerViewModel.swift in Sources */,
 				750C0ADD2850D53F003E0415 /* Theme.Survey.ScaleQuestion.swift in Sources */,
 				1A60B0152567FC7000E53F53 /* Button.swift in Sources */,
@@ -3017,6 +3121,7 @@
 				9AB3402527FCBEB4006E0FE2 /* CallButtonStyle.Accessibility.swift in Sources */,
 				1A8B61D225C974A1000D780E /* ChatCallUpgradeView.swift in Sources */,
 				845E2F88283FB49F00C04D56 /* Theme.Survey.BooleanQuestion.Accessibility.swift in Sources */,
+				C06A7584296EC9DC006B69A2 /* NumberSlotStyle.Accessibility.swift in Sources */,
 				1ABD6C8125B6E97400D56EFA /* MultipleMediaUpgradeAlertConfiguration.swift in Sources */,
 				845E2F6C2837EF2E00C04D56 /* FilePreviewStyle.Accessibility.swift in Sources */,
 				EB750F53273BA9BB00BE5FBD /* GliaError.swift in Sources */,
@@ -3037,6 +3142,7 @@
 				1ABD6C9225B6F2D200D56EFA /* String+TemplateString.swift in Sources */,
 				84EFB06528AB97FA0005E270 /* MessageMetadata.swift in Sources */,
 				1A60B0042567F25600E53F53 /* Header.swift in Sources */,
+				C06A7571296C3EFA006B69A2 /* CallVisualizer+Presentation.swift in Sources */,
 				1A4674CD25ED08A30078FA1C /* MediaPickerController.swift in Sources */,
 				75AF8CF427DBB3C8009EEE2C /* Makeable.swift in Sources */,
 				1A63B2F6257A469A00508478 /* AlertPresenter.swift in Sources */,
@@ -3065,10 +3171,12 @@
 				9A8130BF27D7AEF700220BBD /* FileUpload.Mock.swift in Sources */,
 				9A8130BD27D7A53300220BBD /* FileUpload.Environment.Mock.swift in Sources */,
 				1A60AFB22566821B00E53F53 /* Asset.swift in Sources */,
+				C05AB01C295F416700AA381F /* VisitorCodeCloseButtonProperties.swift in Sources */,
 				AFA2FDEC28907D7C00428E6D /* RootCoordinator.Environment.swift in Sources */,
 				75FF151727F4E13900FE7BE2 /* Theme.Survey.BooleanQuestion.swift in Sources */,
 				1A1E309625F8CA4400850E68 /* FileDownload.swift in Sources */,
 				EB2CBB1527D8DB95004F178E /* OnHoldOverlayVisualEffectView.swift in Sources */,
+				C06A7565296852AF006B69A2 /* VisitorCodeViewController.swift in Sources */,
 				1A4AD3AF256D283700468BFB /* ChatMessageView.swift in Sources */,
 				1A0EDF6D25E7AC100076D1AD /* UIImage+Extensions.swift in Sources */,
 				6E60DD5827146DDB001422EF /* SingleActionAlertConfiguration.swift in Sources */,
@@ -3104,7 +3212,9 @@
 				C08D776228F58A18000461E5 /* ColorType.swift in Sources */,
 				84EFB05B28AA90220005E270 /* CustomCardContainerView.swift in Sources */,
 				9AB3401D27FB4F3C006E0FE2 /* ConnectOperatorStyle.Accessibility.swift in Sources */,
+				C06A757A296D9BD0006B69A2 /* VisitorCodeCoordinator+DelegateEvent.swift in Sources */,
 				AFA2FDF028907E3900428E6D /* RootCoordinator.Mock.swift in Sources */,
+				C05AB01A295F177700AA381F /* CallVisualizer.swift in Sources */,
 				9A1992E527D6679300161AAE /* UIKitBased.Live.swift in Sources */,
 				84EFB06028AB90820005E270 /* ChatMessageRenderer.Interface.swift in Sources */,
 				1A60B0232567FD2D00E53F53 /* CloseButtonProperties.swift in Sources */,

--- a/GliaWidgets/CallVisualizer/CallVisualizer+Environment.swift
+++ b/GliaWidgets/CallVisualizer/CallVisualizer+Environment.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+extension CallVisualizer {
+    struct Environment {
+        var timerProviding: FoundationBased.Timer.Providing
+        var requestVisitorCode: CoreSdkClient.RequestVisitorCode
+    }
+}

--- a/GliaWidgets/CallVisualizer/CallVisualizer+Presentation.swift
+++ b/GliaWidgets/CallVisualizer/CallVisualizer+Presentation.swift
@@ -1,0 +1,8 @@
+import UIKit
+
+extension CallVisualizer {
+    public enum Presentation {
+        case alert(UIViewController)
+        case embedded(UIView)
+    }
+}

--- a/GliaWidgets/CallVisualizer/CallVisualizer.swift
+++ b/GliaWidgets/CallVisualizer/CallVisualizer.swift
@@ -1,0 +1,65 @@
+import Foundation
+import UIKit
+import SalemoveSDK
+
+/// Call Visualizer is a feature for operators to transfer their visitors from conventional comunication methods,
+/// such as a phone call, to Glia solution. The visitor needs to provide to the operator a visitor code,
+/// which they will find in their app either via alert or embedded view. By telling the code to the operator, they can
+/// initiate engagement with the visitor directly through the app.
+///
+/// Call Visualizer class facilitates everything related to this feature:
+///  1. Requesting and displaying visitor code
+///  2. Starting an engagement once the visitor code has been submitted by the operator
+///  3. Handling engagement, featuring video calling, screen sharing, and much more in future.
+public final class CallVisualizer {
+    private var environment: Environment
+    private var visitorCodeCoordinator: VisitorCodeCoordinator?
+
+    init(environment: Environment) {
+        self.environment = environment
+    }
+
+    /// Show VisitorCode for current Visitor.
+    ///
+    /// Call Visualizer Operators use the Visitor's code to start an Call Visualizer Engagement with the Visitor.
+    ///
+    /// Each Visitor code is generated on demand and is unique for every Visitor on a particular site. Upon the first time
+    /// this function is called for a Visitor the code is generated and returned. For each successive call thereafter the
+    /// same code will be returned as long as the code has not expired. During that time the code can be used to initiate an engagement.
+    /// Once Operator uses the Visitor code to initiate an engagement, the code will expire immediately. When the Visitor Code
+    /// expires this function will return a new Visitor code.
+    ///
+    /// Visitor code can be displayed in 2 ways:
+    /// - `Popup alert`
+    /// - `Embedded view`
+    ///
+    ///  The way of displaying is determined by the 'presentation' parameter. If choosing alert, the current viewController
+    ///  needs to be passed in as an associated value. If, however, embedding is chosen, the view into which you want to
+    ///  embed it has to be passed in as an associated value.
+    public func showVisitorCodeViewController(
+        by presentation: Presentation,
+        uiConfig: RemoteConfiguration? = nil
+    ) {
+        let coordinator = VisitorCodeCoordinator(
+            environment: .init(
+                timerProviding: environment.timerProviding,
+                requestVisitorCode: environment.requestVisitorCode
+            ),
+            presentation: presentation,
+            uiConfig: uiConfig
+        )
+
+        coordinator.delegate = { [weak self] event in
+            switch event {
+            case .closeTap:
+                self?.visitorCodeCoordinator = nil
+            }
+        }
+
+        /// FlowCoordinator protocol requires start() to return a viewController, but it won't be used in Call Visualizer context.
+        /// Instead, it is handled seperately because of its unique nature.
+        _ = coordinator.start()
+
+        self.visitorCodeCoordinator = coordinator
+    }
+}

--- a/GliaWidgets/CallVisualizer/TemporaryCommandFile.swift
+++ b/GliaWidgets/CallVisualizer/TemporaryCommandFile.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Developer-friendly wrapper around a closure.
+/// It makes debugging easier by providing callee information.
+/// Note: since closure does not conform to `Equatable`, it will
+/// also be ignored in `Equatable` and `Hashable` implementations
+/// of `Command`.
+///
+/// Example of declaration and execution:
+/// ```
+/// let validateEmail = Command<String> { email in /* email validation goes here */ }
+/// validateEmail("email@example.test")
+/// ```
+struct Command<T>: Hashable {
+    let tag: String
+    let file: String
+    let function: String
+    let line: UInt
+    let closure: (T) -> Void
+
+    init(
+        tag: String = "",
+        file: StaticString = #file,
+        function: StaticString = #function,
+        line: UInt = #line,
+        closure: @escaping (T) -> Void
+    ) {
+        self.tag = tag
+        self.file = "\(file)"
+        self.function = "\(function)"
+        self.line = line
+        self.closure = closure
+    }
+
+    func execute(with value: T) {
+        closure(value)
+    }
+
+    func callAsFunction(_ value: T) {
+        execute(with: value)
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.tag == rhs.tag &&
+        lhs.file == rhs.file &&
+        lhs.function == rhs.function &&
+        lhs.line == rhs.line
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(tag)
+        hasher.combine(file)
+        hasher.combine(function)
+        hasher.combine(line)
+    }
+
+    /// Command with empty closure.
+    static var nop: Self { Self(tag: "nop", closure: { _ in }) }
+}
+
+/// A shorthand for Command for closure with zero parameters.
+typealias Cmd = Command<Void>
+
+extension Cmd {
+    func execute() where T == Void {
+        self.execute(with: ())
+    }
+
+    func callAsFunction() {
+        execute()
+    }
+}

--- a/GliaWidgets/CallVisualizer/VisitorCode/VisitorCodeCoordinator+DelegateEvent.swift
+++ b/GliaWidgets/CallVisualizer/VisitorCode/VisitorCodeCoordinator+DelegateEvent.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension CallVisualizer.VisitorCodeCoordinator {
+    enum DelegateEvent {
+        case closeTap
+    }
+}

--- a/GliaWidgets/CallVisualizer/VisitorCode/VisitorCodeCoordinator+Environment.swift
+++ b/GliaWidgets/CallVisualizer/VisitorCode/VisitorCodeCoordinator+Environment.swift
@@ -1,0 +1,6 @@
+extension CallVisualizer.VisitorCodeCoordinator {
+    struct Environment {
+        var timerProviding: FoundationBased.Timer.Providing
+        var requestVisitorCode: CoreSdkClient.RequestVisitorCode
+    }
+}

--- a/GliaWidgets/CallVisualizer/VisitorCode/VisitorCodeCoordinator.swift
+++ b/GliaWidgets/CallVisualizer/VisitorCode/VisitorCodeCoordinator.swift
@@ -1,0 +1,89 @@
+import UIKit
+
+extension CallVisualizer {
+    class VisitorCodeCoordinator: FlowCoordinator {
+        typealias ViewController = UIViewController
+        private let visitorCodeStyle: VisitorCodeStyle
+        private let theme: Theme
+
+        var delegate: ((DelegateEvent) -> Void)?
+        var environment: Environment
+        let presentation: CallVisualizer.Presentation
+        let uiConfig: RemoteConfiguration?
+        var viewModel: VisitorCodeViewModel?
+        var codeViewController: VisitorCodeViewController?
+
+        init(
+            theme: Theme = Theme(),
+            environment: Environment,
+            presentation: CallVisualizer.Presentation,
+            uiConfig: RemoteConfiguration?
+        ) {
+            self.visitorCodeStyle = theme.visitorCodeStyle
+            self.environment = environment
+            self.theme = theme
+            self.presentation = presentation
+            self.uiConfig = uiConfig
+        }
+
+        func start() -> UIViewController {
+            showVisitorCodeViewController(
+                by: presentation,
+                uiConfig: uiConfig
+            )
+        }
+
+        func showVisitorCodeViewController(
+            by presentation: CallVisualizer.Presentation,
+            uiConfig: RemoteConfiguration?
+        ) -> UIViewController {
+            if let uiConfig = uiConfig {
+                theme.applyRemoteConfiguration(uiConfig, assetsBuilder: .standard)
+            }
+            let viewModel = VisitorCodeViewModel(
+                presentation: presentation,
+                visitorCodeStyle: visitorCodeStyle,
+                environment: .init(
+                    timerProviding: environment.timerProviding,
+                    requestVisitorCode: environment.requestVisitorCode),
+                theme: theme,
+                delegate: { [weak self] action in
+                    switch action {
+                    case let .propsUpdated(props):
+                        self?.codeViewController?.props = props
+                    case .closeButtonTap:
+                        self?.codeViewController?.presentingViewController?.dismiss(animated: true)
+                        self?.delegate?(.closeTap)
+                    }
+                }
+            )
+            defer {
+                viewModel.requestVisitorCode()
+            }
+
+            self.viewModel = viewModel
+
+            let codeController = VisitorCodeViewController(props: viewModel.makeProps())
+            self.codeViewController = codeController
+
+            switch presentation {
+            case .alert(let parentController):
+                codeController.modalPresentationStyle = .overFullScreen
+                codeController.modalTransitionStyle = .crossDissolve
+                parentController.present(codeController, animated: true)
+            case .embedded(let parentView):
+                parentView.subviews.forEach { $0.removeFromSuperview() }
+                parentView.addSubview(codeController.view)
+                codeController.view.translatesAutoresizingMaskIntoConstraints = false
+                NSLayoutConstraint.activate([
+                    codeController.view.widthAnchor.constraint(equalTo: parentView.widthAnchor),
+                    codeController.view.heightAnchor.constraint(equalTo: parentView.heightAnchor),
+                    codeController.view.centerXAnchor.constraint(equalTo: parentView.centerXAnchor),
+                    codeController.view.centerYAnchor.constraint(equalTo: parentView.centerYAnchor)
+                ])
+            }
+
+            return codeController
+        }
+    }
+}

--- a/GliaWidgets/CallVisualizer/VisitorCode/VisitorCodeView+NumberView.swift
+++ b/GliaWidgets/CallVisualizer/VisitorCode/VisitorCodeView+NumberView.swift
@@ -1,0 +1,49 @@
+import UIKit
+
+extension CallVisualizer.VisitorCodeView {
+    class NumberView: UILabel {
+        struct Props: Equatable {
+            let character: Character
+            let style: VisitorCodeStyle
+        }
+
+        override init(frame: CGRect) {
+            super.init(frame: frame)
+            self.font = .boldSystemFont(ofSize: 40)
+            self.numberOfLines = 0
+            self.textColor = props.style.numberSlot.numberColor
+            self.textAlignment = .center
+            switch props.style.numberSlot.backgroundColor {
+            case .fill(let color):
+                self.backgroundColor = color
+            case .gradient(let colors):
+                makeGradientBackground(
+                    colors: colors,
+                    cornerRadius: props.style.numberSlot.cornerRadius
+                )
+            }
+            self.layer.cornerRadius = props.style.numberSlot.cornerRadius
+            self.layer.borderWidth = props.style.numberSlot.borderWidth
+            self.layer.borderColor = props.style.numberSlot.borderColor.cgColor
+            NSLayoutConstraint.activate([
+                self.heightAnchor.constraint(equalToConstant: 60),
+                self.widthAnchor.constraint(equalToConstant: 55).priority(.defaultHigh)
+            ])
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        var props: Props = Props(character: " ", style: Theme().visitorCode) {
+            didSet {
+                renderProps()
+            }
+        }
+
+        func renderProps() {
+            text = String(props.character)
+        }
+    }
+}

--- a/GliaWidgets/CallVisualizer/VisitorCode/VisitorCodeView.swift
+++ b/GliaWidgets/CallVisualizer/VisitorCode/VisitorCodeView.swift
@@ -1,0 +1,166 @@
+import UIKit
+
+extension CallVisualizer {
+    final class VisitorCodeView: BaseView {
+        struct Props: Equatable {
+            enum ViewType: Equatable {
+                case alert(closeButtonTap: Cmd)
+                case embedded
+            }
+
+            let viewType: ViewType
+            let style: VisitorCodeStyle
+            let visitorCode: String
+            let isPoweredByShown: Bool
+            var isShadowNeeded: Bool {
+                switch viewType {
+                case .alert:
+                    return true
+                case .embedded:
+                    return false
+                }
+            }
+
+            var closeButtonTap: Cmd? {
+                switch viewType {
+                case let .alert(closeButtonTap):
+                    return closeButtonTap
+                case .embedded:
+                    return nil
+                }
+            }
+
+            init(
+                viewType: ViewType = .alert(closeButtonTap: .nop),
+                style: VisitorCodeStyle = Theme().visitorCode,
+                visitorCode: String = "11111",
+                isPoweredByShown: Bool = true
+
+            ) {
+                self.viewType = viewType
+                self.style = style
+                self.visitorCode = visitorCode
+                self.isPoweredByShown = isPoweredByShown
+            }
+        }
+
+        var props: Props = Props() {
+            didSet {
+                renderProps()
+            }
+        }
+
+        private let titleLabel = UILabel().make { label in
+            label.numberOfLines = 0
+            label.textAlignment = .center
+        }
+
+        private lazy var stackView = UIStackView.make(.vertical, spacing: 24)(
+            titleLabel,
+            visitorCodeStack,
+            poweredBy
+        )
+
+        private lazy var closeButton = Button(
+            kind: .visitorCodeClose,
+            tap: { [weak self] in
+                self?.props.closeButtonTap?()
+            }
+        ).make { button in
+            button.accessibilityIdentifier = "visitorCode_alert_close_button"
+        }
+
+        private lazy var poweredBy: PoweredBy = PoweredBy(style: props.style.poweredBy)
+        private lazy var visitorCodeStack = UIStackView.make(.horizontal, spacing: 8)()
+        private let contentInsets = UIEdgeInsets(top: 24, left: 24, bottom: 21, right: 24)
+
+        override func setup() {
+            super.setup()
+            clipsToBounds = true
+            layer.masksToBounds = false
+            layer.cornerRadius = props.style.cornerRadius
+            renderProps()
+        }
+
+        override func defineLayout() {
+            super.defineLayout()
+            addSubview(stackView)
+            addSubview(closeButton)
+            visitorCodeStack.distribution = .fill
+            NSLayoutConstraint.activate([
+                stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: contentInsets.left),
+                stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -contentInsets.right),
+                stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -contentInsets.bottom),
+                stackView.topAnchor.constraint(equalTo: topAnchor, constant: contentInsets.top),
+                closeButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -30),
+                closeButton.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -26)
+            ])
+        }
+
+        override func layoutSubviews() {
+            super.layoutSubviews()
+
+            switch props.style.backgroundColor {
+            case .fill(let color):
+                backgroundColor = color
+            case .gradient(let colors):
+                makeGradientBackground(
+                    colors: colors,
+                    cornerRadius: props.style.cornerRadius
+                )
+            }
+            layer.shadowPath = UIBezierPath(
+                roundedRect: bounds,
+                byRoundingCorners: .allCorners,
+                cornerRadii: CGSize(
+                    width: props.style.cornerRadius,
+                    height: props.style.cornerRadius
+                )
+            ).cgPath
+        }
+
+        func renderProps() {
+            titleLabel.font = props.style.titleFont
+            titleLabel.textColor = props.style.titleColor
+            titleLabel.text = L10n.Alert.VisitorCode.title
+            setFontScalingEnabled(
+                props.style.accessibility.isFontScalingEnabled,
+                for: titleLabel
+            )
+            renderedVisitorCode = props.visitorCode
+            poweredBy.alpha = props.isPoweredByShown ? 1 : 0
+            renderShadow()
+
+            switch props.style.closeButtonColor {
+            case .fill(let color):
+                closeButton.tintColor = color
+            case .gradient(let colors):
+                closeButton.makeGradientBackground(colors: colors)
+            }
+
+            closeButton.isHidden = props.closeButtonTap == nil
+        }
+
+        var renderedVisitorCode: String = "" {
+            didSet {
+                guard renderedVisitorCode != oldValue else { return }
+                visitorCodeStack.removeArrangedSubviews()
+                renderedVisitorCode.forEach { char in
+                    let valueLabel = NumberView().make { numberView in
+                        numberView.props = .init(character: char, style: props.style)
+                    }
+                    visitorCodeStack.addArrangedSubview(valueLabel)
+                }
+            }
+        }
+
+        func renderShadow() {
+            layer.shadowColor = props.isShadowNeeded
+                            ? UIColor.black.withAlphaComponent(0.16).cgColor
+                            : UIColor.clear.cgColor
+            layer.shadowOffset = CGSize(width: 0.0, height: 8.0)
+            layer.shadowRadius = 24.0
+            layer.shadowOpacity = 1.0
+        }
+    }
+}

--- a/GliaWidgets/CallVisualizer/VisitorCode/VisitorCodeViewController.swift
+++ b/GliaWidgets/CallVisualizer/VisitorCode/VisitorCodeViewController.swift
@@ -1,0 +1,58 @@
+import UIKit
+
+extension CallVisualizer {
+    final class VisitorCodeViewController: UIViewController {
+        struct Props: Equatable {
+            let visitorCodeViewProps: VisitorCodeView.Props
+        }
+
+        private let codeView = VisitorCodeView()
+
+        init(props: Props) {
+            self.props = props
+            super.init(nibName: nil, bundle: nil)
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        var props: Props {
+            didSet {
+                renderProps()
+            }
+        }
+
+        override func viewDidLoad() {
+            super.viewDidLoad()
+            renderProps()
+        }
+
+        override func loadView() {
+            switch props.visitorCodeViewProps.viewType {
+            case .alert:
+                view = withContainer(codeView)
+            case .embedded:
+                view = codeView
+            }
+        }
+
+        func renderProps() {
+            codeView.props = props.visitorCodeViewProps
+        }
+
+        private func withContainer(_ view: VisitorCodeView) -> UIView {
+            let container = UIView()
+            view.translatesAutoresizingMaskIntoConstraints = false
+            container.addSubview(view)
+            NSLayoutConstraint.activate([
+                container.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+                container.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+                container.widthAnchor.constraint(greaterThanOrEqualTo: view.safeAreaLayoutGuide.widthAnchor, constant: 16)
+            ])
+
+            return container
+        }
+    }
+}

--- a/GliaWidgets/CallVisualizer/VisitorCode/VisitorCodeViewModel+Delegate.swift
+++ b/GliaWidgets/CallVisualizer/VisitorCode/VisitorCodeViewModel+Delegate.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+extension CallVisualizer.VisitorCodeViewModel {
+    enum Delegate {
+        case propsUpdated(CallVisualizer.VisitorCodeViewController.Props)
+        case closeButtonTap
+    }
+}

--- a/GliaWidgets/CallVisualizer/VisitorCode/VisitorCodeViewModel+Environment.swift
+++ b/GliaWidgets/CallVisualizer/VisitorCode/VisitorCodeViewModel+Environment.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+extension CallVisualizer.VisitorCodeViewModel {
+    struct Environment {
+        var timerProviding: FoundationBased.Timer.Providing
+        var requestVisitorCode: CoreSdkClient.RequestVisitorCode
+    }
+}

--- a/GliaWidgets/CallVisualizer/VisitorCode/VisitorCodeViewModel.swift
+++ b/GliaWidgets/CallVisualizer/VisitorCode/VisitorCodeViewModel.swift
@@ -1,0 +1,76 @@
+import UIKit
+import SalemoveSDK
+
+extension CallVisualizer {
+    class VisitorCodeViewModel {
+        let presentation: CallVisualizer.Presentation
+        var environment: Environment
+        var delegate: (Delegate) -> Void
+        var timer: FoundationBased.Timer?
+        var theme: Theme
+        var receivedVisitorCode: VisitorCode? {
+            didSet {
+                notifyPropsUpdated()
+                scheduleVisitorCodeRefresh()
+            }
+        }
+
+        init(
+            presentation: CallVisualizer.Presentation,
+            visitorCodeStyle: VisitorCodeStyle,
+            environment: Environment,
+            theme: Theme,
+            delegate: @escaping (Delegate) -> Void
+        ) {
+            self.presentation = presentation
+            self.environment = environment
+            self.delegate = delegate
+            self.theme = theme
+        }
+
+        func makeProps() -> VisitorCodeViewController.Props {
+            let viewType: VisitorCodeView.Props.ViewType
+
+            switch presentation {
+            case .alert:
+                viewType = .alert(closeButtonTap: Cmd { [weak self] in self?.delegate(.closeButtonTap) })
+            case .embedded:
+                viewType = .embedded
+            }
+
+            let codeViewProps = VisitorCodeView.Props(
+                viewType: viewType,
+                style: theme.visitorCodeStyle,
+                visitorCode: receivedVisitorCode?.code ?? "",
+                isPoweredByShown: theme.showsPoweredBy
+            )
+            return .init(visitorCodeViewProps: codeViewProps)
+        }
+
+        func notifyPropsUpdated() {
+            delegate(.propsUpdated(makeProps()))
+        }
+
+        func requestVisitorCode() {
+            _ = environment.requestVisitorCode { [weak self] result in
+                switch result {
+                case let .success(code):
+                    self?.receivedVisitorCode = code
+                case let .failure(error):
+                    debugPrint(error.localizedDescription)
+                }
+            }
+        }
+
+        func scheduleVisitorCodeRefresh() {
+            timer?.invalidate()
+            guard let expDate = receivedVisitorCode?.expiresAt else { return }
+            timer = environment.timerProviding.scheduledTimer(
+                withTimeInterval: expDate.timeIntervalSinceNow,
+                repeats: false
+            ) { [weak self] _ in
+                self?.requestVisitorCode()
+            }
+        }
+    }
+}

--- a/GliaWidgets/ColorType.swift
+++ b/GliaWidgets/ColorType.swift
@@ -1,10 +1,10 @@
 import UIKit
 
-public enum ColorType {
+public enum ColorType: Equatable {
     case fill(color: UIColor)
     case gradient(colors: [CGColor])
 
-    static func == (lhs: ColorType, rhs: ColorType) -> Bool {
+    public static func == (lhs: ColorType, rhs: ColorType) -> Bool {
         switch (lhs, rhs) {
         case (.fill, .gradient):
             return false

--- a/GliaWidgets/Component/Button/Action/ActionButtonStyle.swift
+++ b/GliaWidgets/Component/Button/Action/ActionButtonStyle.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 /// Style of an action button. This button contains a title placed on a rectangular background. Used for positive and negative actions in alerts and in the navigation bar (header) for the engagement ending button.
-public struct ActionButtonStyle {
+public struct ActionButtonStyle: Equatable {
     /// Title of the button.
     public var title: String
 

--- a/GliaWidgets/Component/Button/Style/ButtonKind.swift
+++ b/GliaWidgets/Component/Button/Style/ButtonKind.swift
@@ -1,6 +1,7 @@
 enum ButtonKind {
     case close
     case alertClose
+    case visitorCodeClose
 }
 
 extension ButtonKind {
@@ -10,6 +11,8 @@ extension ButtonKind {
             return CloseButtonProperties()
         case .alertClose:
             return AlertCloseButtonProperties()
+        case .visitorCodeClose:
+            return VisitorCodeCloseButtonProperties()
         }
     }
 }

--- a/GliaWidgets/Component/Button/Style/Properties/VisitorCodeCloseButtonProperties.swift
+++ b/GliaWidgets/Component/Button/Style/Properties/VisitorCodeCloseButtonProperties.swift
@@ -1,0 +1,8 @@
+import UIKit
+
+struct VisitorCodeCloseButtonProperties: ButtonProperties {
+    let image: UIImage? = Asset.close.image
+    let width: CGFloat? = 12
+    let height: CGFloat? = 12
+    let touchAreaInsets: TouchAreaInsets? = (dx: -10.0, dy: -10.0)
+}

--- a/GliaWidgets/Component/NumberSlot/NumberSlotStyle.Accessibility.swift
+++ b/GliaWidgets/Component/NumberSlot/NumberSlotStyle.Accessibility.swift
@@ -1,5 +1,5 @@
-extension PoweredByStyle {
-    /// Accessibility properties for PoweredByStyle.
+extension NumberSlotStyle {
+    /// Accessibility properties for AlertStyle.
     public struct Accessibility: Equatable {
         /// Flag that provides font dynamic type by setting `adjustsFontForContentSizeCategory` for component that supports it.
         public var isFontScalingEnabled: Bool
@@ -9,5 +9,8 @@ extension PoweredByStyle {
         public init(isFontScalingEnabled: Bool) {
             self.isFontScalingEnabled = isFontScalingEnabled
         }
+
+        /// Accessibility is not supported intentionally.
+        public static let unsupported = Self(isFontScalingEnabled: false)
     }
 }

--- a/GliaWidgets/Component/NumberSlot/NumberSlotStyle.swift
+++ b/GliaWidgets/Component/NumberSlot/NumberSlotStyle.swift
@@ -1,0 +1,96 @@
+import UIKit
+
+public struct NumberSlotStyle: Equatable {
+    /// Background color of the view.
+    public var backgroundColor: ColorType
+
+    /// Border color of the view.
+    public var borderColor: UIColor
+
+    /// Border width of the view.
+    public var borderWidth: CGFloat
+
+    /// Corner radius of the view.
+    public var cornerRadius: CGFloat
+
+    /// Font of the number.
+    public var numberFont: UIFont
+
+    /// Color of the number.
+    public var numberColor: UIColor
+
+    /// Style of the number.
+    public var numberStyle: UIFont.TextStyle
+
+    /// Accessibility related properties.
+    public var accessibility: Accessibility
+
+    ///
+    /// - Parameters:
+    ///   - backgroundColor: Color of the background.
+    ///   - borderColor: Border color of the view.
+    ///   - borderWidth: Border width of the view.
+    ///   - cornerRadius: Corner radius of the view.
+    ///   - numberColor: Color of the number.
+    ///   - numberFont: Font of the number.
+    ///   - accessibility: Accessibility related properties.
+    ///
+    public init(
+        backgroundColor: ColorType,
+        borderColor: UIColor,
+        borderWidth: CGFloat,
+        cornerRadius: CGFloat,
+        numberFont: UIFont,
+        numberColor: UIColor,
+        numberStyle: UIFont.TextStyle = .largeTitle,
+        accessibility: Accessibility
+    ) {
+        self.backgroundColor = backgroundColor
+        self.borderColor = borderColor
+        self.borderWidth = borderWidth
+        self.cornerRadius = cornerRadius
+        self.numberFont = numberFont
+        self.numberColor = numberColor
+        self.numberStyle = numberStyle
+        self.accessibility = accessibility
+    }
+
+    mutating func apply(
+        configuration: RemoteConfiguration.NumberSlot?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
+        UIFont.convertToFont(
+            uiFont: assetsBuilder.fontBuilder(configuration?.font),
+            textStyle: numberStyle
+        ).unwrap { numberFont = $0 }
+
+        configuration?.fontColor?.value
+            .map { UIColor(hex: $0) }
+            .first
+            .unwrap { numberColor = $0 }
+
+        configuration?.background?.color.unwrap {
+            switch $0.type {
+            case .fill:
+                $0.value
+                    .map { UIColor(hex: $0) }
+                    .first
+                    .unwrap { backgroundColor = .fill(color: $0) }
+            case .gradient:
+                let colors = $0.value.convertToCgColors()
+                backgroundColor = .gradient(colors: colors)
+            }
+        }
+
+        configuration?.background?.cornerRadius
+            .unwrap { cornerRadius = $0 }
+
+        configuration?.background?.borderWidth
+            .unwrap { borderWidth = $0 }
+
+        configuration?.background?.border?.value
+            .map { UIColor(hex: $0) }
+            .first
+            .unwrap { borderColor = $0 }
+    }
+}

--- a/GliaWidgets/Component/PoweredBy/PoweredByStyle.swift
+++ b/GliaWidgets/Component/PoweredBy/PoweredByStyle.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 /// Style of PoweredBy view (used in AlertView).
-public struct PoweredByStyle {
+public struct PoweredByStyle: Equatable {
     /// **Powered by** text.
     public var text: String
     /// Font used for `PoweredBy` view.

--- a/GliaWidgets/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -106,7 +106,7 @@ struct CoreSdkClient {
     typealias FetchChatHistory = (_ completion: @escaping (Result<[Self.Message], SalemoveSDK.GliaCoreError>) -> Void) -> Void
     var fetchChatHistory: FetchChatHistory
 
-    typealias RequestVisitorCode = (_ completion: @escaping VisitorCodeBlock) -> GliaCore.Cancellable
+    typealias RequestVisitorCode = (_ completion: @escaping (VisitorCodeBlock) -> Void) -> GliaCore.Cancellable
     var requestVisitorCode: RequestVisitorCode
 }
 
@@ -189,5 +189,5 @@ extension CoreSdkClient {
     typealias SurveyAnswerContainer = SalemoveSDK.Survey.Answer.ValueContainer
     typealias Authentication = SalemoveSDK.GliaCore.Authentication
     typealias AuthenticationBehavior = SalemoveSDK.GliaCore.Authentication.Behavior
-    typealias VisitorCodeBlock = (Result<VisitorCode, Swift.Error>) -> Void
+    typealias VisitorCodeBlock = (Result<VisitorCode, Swift.Error>)
 }

--- a/GliaWidgets/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -1,6 +1,6 @@
 #if DEBUG
 import Foundation
-@testable import SalemoveSDK
+import SalemoveSDK
 
 extension CoreSdkClient {
     static let mock = Self(
@@ -26,7 +26,7 @@ extension CoreSdkClient {
         submitSurveyAnswer: { _, _, _, _ in },
         authentication: { _ in .mock },
         fetchChatHistory: { _ in },
-        requestVisitorCode: { _ in .init() }
+        requestVisitorCode: { _ in fatalError() }
     )
 }
 

--- a/GliaWidgets/Glia.swift
+++ b/GliaWidgets/Glia.swift
@@ -48,9 +48,16 @@ public class Glia {
     var interactor: Interactor?
     var environment: Environment
     var messageRenderer: MessageRenderer?
+    public let callVisualizer: CallVisualizer
 
     init(environment: Environment) {
         self.environment = environment
+        self.callVisualizer = CallVisualizer(
+            environment: .init(
+                timerProviding: environment.timerProviding,
+                requestVisitorCode: environment.coreSdk.requestVisitorCode
+            )
+        )
     }
 
     /// Setup SDK using specific engagement configuration without starting the engagement.
@@ -367,9 +374,5 @@ public class Glia {
                 completion(.failure($0))
             }
         )
-    }
-
-    public func requestVisitorCode(completion: @escaping (Result<VisitorCode, Swift.Error>) -> Void) {
-        environment.coreSdk.requestVisitorCode(completion)
     }
 }

--- a/GliaWidgets/Glia.swift
+++ b/GliaWidgets/Glia.swift
@@ -375,4 +375,8 @@ public class Glia {
             }
         )
     }
+
+    public func requestVisitorCode(completion: @escaping (Result<VisitorCode, Swift.Error>) -> Void) {
+        environment.coreSdk.requestVisitorCode(completion)
+    }
 }

--- a/GliaWidgets/L10n.swift
+++ b/GliaWidgets/L10n.swift
@@ -48,6 +48,8 @@ public enum L10n {
       public static let settings = L10n.tr("Localizable", "alert.action.settings", fallback: "Settings")
       /// Yes
       public static let yes = L10n.tr("Localizable", "alert.action.yes", fallback: "Yes")
+      /// Refresh
+      public static let refresh = L10n.tr("Localizable", "alert.action.yes", fallback: "Refresh")
     }
     public enum ApiError {
       /// {message}
@@ -148,6 +150,9 @@ public enum L10n {
         /// {operatorName} has offered you to upgrade to video
         public static let title = L10n.tr("Localizable", "alert.videoUpgrade.twoWay.title", fallback: "{operatorName} has offered you to upgrade to video")
       }
+    }
+    public enum VisitorCode {
+        public static let title = L10n.tr("Localizable", "alert.visitorCode.title", fallback: "Your Visitor Code")
     }
   }
   public enum Call {

--- a/GliaWidgets/Lib/Extensions/UIViewController+Extensions.swift
+++ b/GliaWidgets/Lib/Extensions/UIViewController+Extensions.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 extension UIViewController {
-    func insertChild(_ viewController: UIViewController) {
+    public func insertChild(_ viewController: UIViewController) {
         viewController.willMove(toParent: self)
         addChild(viewController)
         view.addSubview(viewController.view)

--- a/GliaWidgets/Lib/Extensions/UIViewController+Extensions.swift
+++ b/GliaWidgets/Lib/Extensions/UIViewController+Extensions.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 extension UIViewController {
-    public func insertChild(_ viewController: UIViewController) {
+    func insertChild(_ viewController: UIViewController) {
         viewController.willMove(toParent: self)
         addChild(viewController)
         view.addSubview(viewController.view)

--- a/GliaWidgets/RemoteConfiguration/RemoteConfiguration.swift
+++ b/GliaWidgets/RemoteConfiguration/RemoteConfiguration.swift
@@ -6,6 +6,7 @@ public struct RemoteConfiguration: Codable {
     let surveyScreen: Survey?
     let alert: Alert?
     let bubble: Bubble?
+    let visitorCode: VisitorCode
 }
 
 extension RemoteConfiguration {
@@ -23,6 +24,19 @@ extension RemoteConfiguration {
             case callOperator = "operator"
             case topText
         }
+    }
+
+    struct VisitorCode: Codable {
+        let title: Text?
+        let actionButton: Button?
+        let numberSlot: NumberSlot?
+        let background: Layer?
+    }
+
+    struct NumberSlot: Codable {
+        let background: Layer?
+        let font: Font?
+        let fontColor: Color?
     }
 
     struct Alert: Codable {

--- a/GliaWidgets/Resources/en.lproj/Localizable.strings
+++ b/GliaWidgets/Resources/en.lproj/Localizable.strings
@@ -8,6 +8,7 @@
 "alert.action.ok" = "OK";
 "alert.action.settings" = "Settings";
 "alert.action.cancel" = "Cancel";
+"alert.action.refresh" = "Refresh";
 
 "alert.accessibility.action.yes" = "Yes";
 "alert.accessibility.action.no" = "No";
@@ -57,6 +58,8 @@
 "alert.screenSharing.start.message" = "{operatorName} would like to see the screen of your device";
 "alert.screenSharing.stop.title" = "Stop screen sharing?";
 "alert.screenSharing.stop.message" = "Are you sure you want to stop sharing your screen?";
+
+"alert.visitorCode.title" = "Your Visitor Code";
 
 "chat.title" = "Chat";
 "chat.endButton.title" = "End";

--- a/GliaWidgets/Theme/Theme+VisitorCode.swift
+++ b/GliaWidgets/Theme/Theme+VisitorCode.swift
@@ -1,0 +1,44 @@
+import UIKit
+
+extension Theme {
+    var visitorCodeStyle: VisitorCodeStyle {
+        let numberSlot = NumberSlotStyle(
+            backgroundColor: .fill(color: color.background),
+            borderColor: UIColor.ultraLightGray,
+            borderWidth: 1,
+            cornerRadius: 8,
+            numberFont: font.header1,
+            numberColor: color.baseDark,
+            accessibility: .init(isFontScalingEnabled: true)
+        )
+
+        let actionButton = ActionButtonStyle(
+            title: L10n.Alert.Action.refresh,
+            titleFont: font.buttonLabel,
+            titleColor: color.baseLight,
+            backgroundColor: .fill(color: color.primary)
+        )
+
+        let poweredBy = PoweredByStyle(
+            text: L10n.poweredBy,
+            font: font.caption,
+            accessibility: .init(isFontScalingEnabled: true)
+        )
+
+        return VisitorCodeStyle(
+            titleFont: font.header2,
+            titleColor: color.baseDark,
+            poweredBy: poweredBy,
+            numberSlot: numberSlot,
+            actionButton: actionButton,
+            accessibility: .init(isFontScalingEnabled: true),
+            backgroundColor: .fill(color: color.background),
+            cornerRadius: 30,
+            closeButtonColor: .fill(color: color.baseNormal)
+        )
+    }
+}
+
+private extension UIColor {
+    static let ultraLightGray = UIColor(red: 0.953, green: 0.953, blue: 0.953, alpha: 1)
+}

--- a/GliaWidgets/Theme/Theme.swift
+++ b/GliaWidgets/Theme/Theme.swift
@@ -44,6 +44,8 @@ public class Theme {
         alertStyle: alert
     )
 
+    public lazy var visitorCode: VisitorCodeStyle = { return visitorCodeStyle }()
+
     /// Controls the visibility of the "Powered by" text and image.
     public var showsPoweredBy: Bool
 
@@ -88,6 +90,10 @@ public class Theme {
         chat.apply(
             configuration: config.chatScreen,
             assetsBuilder: assetsBuilder
+        )
+        visitorCode.apply(
+            configuration: config.visitorCode,
+            assetBuilder: assetsBuilder
         )
     }
 }

--- a/GliaWidgets/View/Common/Alert/AlertStyle.swift
+++ b/GliaWidgets/View/Common/Alert/AlertStyle.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 /// Style of an alert view.
-public struct AlertStyle {
+public struct AlertStyle: Equatable {
     /// Font of the title text.
     public var titleFont: UIFont
 

--- a/GliaWidgets/View/VisitorCode/VisitorCodeStyle.Accessibility.swift
+++ b/GliaWidgets/View/VisitorCode/VisitorCodeStyle.Accessibility.swift
@@ -1,5 +1,5 @@
-extension PoweredByStyle {
-    /// Accessibility properties for PoweredByStyle.
+extension VisitorCodeStyle {
+    /// Accessibility properties for AlertStyle.
     public struct Accessibility: Equatable {
         /// Flag that provides font dynamic type by setting `adjustsFontForContentSizeCategory` for component that supports it.
         public var isFontScalingEnabled: Bool
@@ -9,5 +9,8 @@ extension PoweredByStyle {
         public init(isFontScalingEnabled: Bool) {
             self.isFontScalingEnabled = isFontScalingEnabled
         }
+
+        /// Accessibility is not supported intentionally.
+        public static let unsupported = Self(isFontScalingEnabled: false)
     }
 }

--- a/GliaWidgets/View/VisitorCode/VisitorCodeStyle.swift
+++ b/GliaWidgets/View/VisitorCode/VisitorCodeStyle.swift
@@ -1,0 +1,109 @@
+import UIKit
+
+public struct VisitorCodeStyle: Equatable {
+    // Color of the title text.
+    public var titleColor: UIColor
+
+    // Font of the title text.
+    public var titleFont: UIFont
+
+    /// Text style of the title text.
+    public var titleTextStyle: UIFont.TextStyle
+
+    /// Style of 'powered by' view.
+    public var poweredBy: PoweredByStyle
+
+    /// Style of the numberSlot
+    public var numberSlot: NumberSlotStyle
+
+    /// Style of an action button.
+    public var actionButton: ActionButtonStyle
+
+    /// Background color of the view.
+    public var backgroundColor: ColorType
+
+    /// Corner radius of the view.
+    public var cornerRadius: CGFloat
+
+    /// Color of the close button.
+    public var closeButtonColor: ColorType
+
+    /// Accessibility related properties.
+    public var accessibility: Accessibility
+
+    public init(
+        titleFont: UIFont,
+        titleColor: UIColor,
+        titleTextStyle: UIFont.TextStyle = .title2,
+        poweredBy: PoweredByStyle,
+        numberSlot: NumberSlotStyle,
+        actionButton: ActionButtonStyle,
+        accessibility: Accessibility = .unsupported,
+        backgroundColor: ColorType,
+        cornerRadius: CGFloat,
+        closeButtonColor: ColorType
+    ) {
+        self.titleColor = titleColor
+        self.titleFont = titleFont
+        self.titleTextStyle = titleTextStyle
+        self.poweredBy = poweredBy
+        self.numberSlot = numberSlot
+        self.actionButton = actionButton
+        self.accessibility = accessibility
+        self.cornerRadius = cornerRadius
+        self.backgroundColor = backgroundColor
+        self.closeButtonColor = closeButtonColor
+    }
+
+    mutating func apply(
+        configuration: RemoteConfiguration.VisitorCode?,
+        assetBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
+        applyTitleConfiguration(
+            configuration?.title,
+            assetsBuilder: assetBuilder
+        )
+        actionButton.apply(
+            configuration: configuration?.actionButton,
+            assetsBuilder: assetBuilder
+        )
+        numberSlot.apply(
+            configuration: configuration?.numberSlot,
+            assetsBuilder: assetBuilder
+        )
+
+        configuration?.background?.cornerRadius
+            .unwrap { cornerRadius = $0 }
+
+        configuration?.background?.color.unwrap {
+            switch $0.type {
+            case .fill:
+                $0.value
+                    .map { UIColor(hex: $0) }
+                    .first
+                    .unwrap { backgroundColor = .fill(color: $0) }
+            case .gradient:
+                let colors = $0.value.convertToCgColors()
+                backgroundColor = .gradient(colors: colors)
+            }
+        }
+    }
+}
+
+extension VisitorCodeStyle {
+
+    mutating func applyTitleConfiguration(
+        _ configuration: RemoteConfiguration.Text?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
+        UIFont.convertToFont(
+            uiFont: assetsBuilder.fontBuilder(configuration?.font),
+            textStyle: titleTextStyle
+        ).unwrap { titleFont = $0 }
+
+        configuration?.foreground?.value
+            .map { UIColor(hex: $0) }
+            .first
+            .unwrap { titleColor = $0 }
+    }
+}

--- a/GliaWidgetsTests/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/CoreSDKClient.Failing.swift
@@ -27,7 +27,10 @@ extension CoreSdkClient {
             return .mock
         },
         fetchChatHistory: { _ in },
-        requestVisitorCode: { _ in fail("\(Self.self).requestVisitorCode") }
+        requestVisitorCode: { _ in
+            fail("\(Self.self).requestVisitorCode")
+            return .init()
+        }
     )
 }
 

--- a/TestingApp/Main.storyboard
+++ b/TestingApp/Main.storyboard
@@ -17,8 +17,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="A3Y-Xf-Ufg">
-                                <rect key="frame" x="0.0" y="183" width="414" height="530"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="A3Y-Xf-Ufg">
+                                <rect key="frame" x="0.0" y="83" width="414" height="730.5"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FAP-5O-GCi">
                                         <rect key="frame" x="164.5" y="0.0" width="85" height="30"/>
@@ -32,7 +32,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zmv-pl-N2H">
-                                        <rect key="frame" x="173" y="50" width="68" height="30"/>
+                                        <rect key="frame" x="173" y="45" width="68" height="30"/>
                                         <accessibility key="accessibilityConfiguration" identifier="main_chat_button"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="9bb-ZJ-g4f"/>
@@ -43,7 +43,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="USF-zD-dZ5">
-                                        <rect key="frame" x="173.5" y="100" width="67" height="30"/>
+                                        <rect key="frame" x="173.5" y="90" width="67" height="30"/>
                                         <accessibility key="accessibilityConfiguration" identifier="main_audio_button"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="PFk-Yr-vcD"/>
@@ -54,7 +54,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tG2-uU-gYf">
-                                        <rect key="frame" x="173.5" y="150" width="67" height="30"/>
+                                        <rect key="frame" x="173.5" y="135" width="67" height="30"/>
                                         <accessibility key="accessibilityConfiguration" identifier="main_video_button"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="Hga-kH-fOK"/>
@@ -65,7 +65,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="P9U-ba-KVy">
-                                        <rect key="frame" x="179.5" y="200" width="55" height="30"/>
+                                        <rect key="frame" x="179.5" y="180" width="55" height="30"/>
                                         <accessibility key="accessibilityConfiguration" identifier="main_resume_button"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="mbg-qw-hCC"/>
@@ -76,7 +76,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0wb-9L-Csn">
-                                        <rect key="frame" x="161" y="250" width="92" height="30"/>
+                                        <rect key="frame" x="161" y="225" width="92" height="30"/>
                                         <accessibility key="accessibilityConfiguration" identifier="main_clearSession_button"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="wht-81-BI4"/>
@@ -87,7 +87,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pHy-59-v7T">
-                                        <rect key="frame" x="163" y="300" width="88" height="30"/>
+                                        <rect key="frame" x="163" y="270" width="88" height="30"/>
                                         <accessibility key="accessibilityConfiguration" identifier="main_authenticate_button"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="ezp-dJ-Nup"/>
@@ -98,7 +98,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3Ys-xS-zdq">
-                                        <rect key="frame" x="126" y="350" width="162" height="30"/>
+                                        <rect key="frame" x="126" y="315" width="162" height="30"/>
                                         <accessibility key="accessibilityConfiguration" identifier="main_endEngagement_button"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="QkV-yj-Sti"/>
@@ -109,7 +109,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ezc-iY-PbB">
-                                        <rect key="frame" x="141" y="400" width="132" height="30"/>
+                                        <rect key="frame" x="141" y="360" width="132" height="30"/>
                                         <accessibility key="accessibilityConfiguration" identifier="main_endEngagement_button"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="Nef-0j-qW7"/>
@@ -119,20 +119,8 @@
                                             <action selector="remoteConfigTapped" destination="Y6W-OH-hqX" eventType="touchUpInside" id="9aa-P2-FLo"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oR8-dm-fet">
-                                        <rect key="frame" x="164.5" y="450" width="85" height="30"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="30" id="NCp-mB-WjL"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                                        <state key="normal" title="Visitor Code"/>
-                                        <connections>
-                                            <action selector="visitorCodeTapped" destination="Y6W-OH-hqX" eventType="touchUpInside" id="zMe-CW-TCa"/>
-                                        </connections>
-                                    </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4yC-lN-tH2">
-                                        <rect key="frame" x="156.5" y="500" width="101" height="30"/>
+                                        <rect key="frame" x="156.5" y="405" width="101" height="30"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="qN6-sa-ywS"/>
                                         </constraints>
@@ -142,6 +130,46 @@
                                             <action selector="configureSDKTapped" destination="Y6W-OH-hqX" eventType="touchUpInside" id="3UC-r4-Dv0"/>
                                         </connections>
                                     </button>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VisitorCode" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tI8-TQ-jWA">
+                                        <rect key="frame" x="162.5" y="450" width="89" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="1gR-qB-lno">
+                                        <rect key="frame" x="90.5" y="485.5" width="233" height="30"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YnU-rR-gCc">
+                                                <rect key="frame" x="0.0" y="0.0" width="88" height="30"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="30" id="XhY-9v-cra"/>
+                                                </constraints>
+                                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                                <state key="normal" title="Present view"/>
+                                                <connections>
+                                                    <action selector="presentVisitorCodeAsAlertTapped" destination="Y6W-OH-hqX" eventType="touchUpInside" id="VYx-gg-Czl"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ohH-5E-lwb">
+                                                <rect key="frame" x="120" y="0.0" width="113" height="30"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="30" id="13m-sK-ejP"/>
+                                                </constraints>
+                                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                                <state key="normal" title="Embed into view"/>
+                                                <connections>
+                                                    <action selector="embedVisitorCodeViewTapped" destination="Y6W-OH-hqX" eventType="touchUpInside" id="8tm-3y-I3o"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                    </stackView>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7mi-et-ybT">
+                                        <rect key="frame" x="87" y="530.5" width="240" height="200"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="200" id="cj8-4r-PEu"/>
+                                        </constraints>
+                                    </view>
                                 </subviews>
                             </stackView>
                         </subviews>
@@ -155,6 +183,7 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="VisitorCodeView" destination="7mi-et-ybT" id="guR-OT-e1w"/>
                         <outlet property="toggleAuthenticateButton" destination="pHy-59-v7T" id="9rO-74-dfE"/>
                     </connections>
                 </viewController>

--- a/TestingApp/ViewController.swift
+++ b/TestingApp/ViewController.swift
@@ -5,7 +5,6 @@ import SalemoveSDK
 
 class ViewController: UIViewController {
     typealias Authentication = GliaWidgets.Glia.Authentication
-    var vc: UIViewController?
     private var glia: Glia!
 
     @UserDefaultsStored(key: "configuration", defaultValue: Configuration.empty(with: .beta), coder: .jsonCoding())

--- a/TestingApp/ViewController.swift
+++ b/TestingApp/ViewController.swift
@@ -5,7 +5,7 @@ import SalemoveSDK
 
 class ViewController: UIViewController {
     typealias Authentication = GliaWidgets.Glia.Authentication
-
+    var vc: UIViewController?
     private var glia: Glia!
 
     @UserDefaultsStored(key: "configuration", defaultValue: Configuration.empty(with: .beta), coder: .jsonCoding())
@@ -24,6 +24,7 @@ class ViewController: UIViewController {
         title = "Glia UI testing"
         view.backgroundColor = .white
     }
+    @IBOutlet weak var visitorCodeView: UIView!
 
     @IBOutlet var toggleAuthenticateButton: UIButton!
 
@@ -51,8 +52,12 @@ class ViewController: UIViewController {
         Glia.sharedInstance.clearVisitorSession()
     }
 
-    @IBAction private func visitorCodeTapped() {
-        requestVisitorCode()
+    @IBAction private func presentVisitorCodeAsAlertTapped() {
+        showVisitorCodeAlert()
+    }
+
+    @IBAction private func embedVisitorCodeViewTapped() {
+        showVisitorCodeEmbeddedView()
     }
 
     @IBAction private func configureSDKTapped() {
@@ -180,16 +185,12 @@ extension ViewController {
         }
     }
 
-    func requestVisitorCode() {
-        Glia.sharedInstance.requestVisitorCode { result in
-            switch result {
-            case .success(let visitorCode):
-                print("Visitor code is", visitorCode.code)
-                print("Visitor code expires at", visitorCode.expiresAt)
-            case .failure(let error):
-                print("Error getting visitor code.", error.localizedDescription)
-            }
-        }
+    func showVisitorCodeEmbeddedView() {
+        Glia.sharedInstance.callVisualizer.showVisitorCodeViewController(by: .embedded(visitorCodeView))
+    }
+
+    func showVisitorCodeAlert() {
+        Glia.sharedInstance.callVisualizer.showVisitorCodeViewController(by: .alert(self))
     }
 
     func configureSDK() {


### PR DESCRIPTION
Integrators need ways to display visitor code on their screen. In this
PR we provide 2 solutions for integrators:
1. Alert View
2. Embedded view

The visitor code refreshes itself every 3 hours. The view will be updated
when a new visitor code is available.

NB! Currently, the timer will go into an infinite loop if the visitor code
request fails. Error handling will be done in a separate PR.