### PR TITLE
Add Send a Slack message step to master-build workflow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -232,6 +232,12 @@ workflows:
     - deploy-to-bitrise-io@2:
         inputs:
         - notify_email_list: $NOTIFY_EMAILS
+    - slack@3:
+        is_always_run: false
+        inputs:
+        - channel: '#tm-mobile-builds'
+        - text: iOS Build Succeeded!
+        - webhook_url: $SLACK_IOS_WEBHOOK
     - cache-push@2: {}
     description: >-
       Workflow for creating builds of master branch. Triggered on each push to


### PR DESCRIPTION
In this PR `Send a Slack message` step was added to `master-build` workflow on Bitrise.
This step will be run only on successful deployment build from master branch to Bitrise.

MOB-1765

[MOB-1765]: https://glia.atlassian.net/browse/MOB-1765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ