### PR TITLE
Snapshot tests fixes

### DIFF
--- a/GliaWidgets/Component/Connect/ConnectView.swift
+++ b/GliaWidgets/Component/Connect/ConnectView.swift
@@ -4,7 +4,7 @@ final class ConnectView: BaseView {
     private enum Constants {
         static var contentInsets: UIEdgeInsets {
             .init(
-                top: State.none.chatTopPadding,
+                top: State.initial.chatTopPadding,
                 left: 0,
                 bottom: 10,
                 right: 0
@@ -17,7 +17,7 @@ final class ConnectView: BaseView {
     }
 
     enum State: Equatable {
-        case none
+        case initial
         case queue
         case connecting(name: String?, imageUrl: String?)
         case connected(name: String?, imageUrl: String?)
@@ -29,12 +29,19 @@ final class ConnectView: BaseView {
 
     private let layout: Layout
     private let style: ConnectStyle
-    private var state: State = .none
+    private var state: State = .initial
     private var connectTimer: FoundationBased.Timer?
     private var connectCounter: Int = 0
     private var isShowing = false
     private let environment: Environment
-    private let stackView = UIStackView()
+    private lazy var stackView = UIStackView.make(
+        .vertical,
+        spacing: State.initial.chatContentSpacing,
+        distribution: .fillProportionally
+    )(
+        operatorView,
+        statusView
+    )
     private var contentTopPadding: NSLayoutConstraint?
 
     init(
@@ -66,15 +73,8 @@ final class ConnectView: BaseView {
         accessibilityElements = [operatorView, statusView]
 
         addSubview(stackView)
-        stackView.axis = .vertical
-        stackView.spacing = State.none.chatContentSpacing
-        stackView.distribution = .fillProportionally
-        stackView.addArrangedSubviews([
-            operatorView,
-            statusView
-        ])
         stackView.translatesAutoresizingMaskIntoConstraints = false
-        setState(.none, animated: false)
+        setState(.initial, animated: false)
     }
 
     override func defineLayout() {
@@ -91,7 +91,7 @@ final class ConnectView: BaseView {
         updateConstraints()
 
         switch state {
-        case .none:
+        case .initial:
             stopConnectTimer()
             hide(animated: animated)
         case .queue:
@@ -207,7 +207,7 @@ extension ConnectView {
 extension ConnectView.State {
     var chatContentSpacing: CGFloat {
         switch self {
-        case .none, .queue, .connecting, .transferring:
+        case .initial, .queue, .connecting, .transferring:
             return 0
         case .connected:
             return 12
@@ -216,7 +216,7 @@ extension ConnectView.State {
 
     var callContentSpacing: CGFloat {
         switch self {
-        case .none, .queue, .connecting, .transferring:
+        case .initial, .queue, .connecting, .transferring:
             return 1
         case .connected:
             return 18
@@ -225,7 +225,7 @@ extension ConnectView.State {
 
     var chatTopPadding: CGFloat {
         switch self {
-        case .none, .queue, .connecting, .transferring:
+        case .initial, .queue, .connecting, .transferring:
             return 6
         case .connected:
             return 14
@@ -234,7 +234,7 @@ extension ConnectView.State {
 
     var callTopPadding: CGFloat {
         switch self {
-        case .none, .queue, .connecting, .transferring:
+        case .initial, .queue, .connecting, .transferring:
             return 32
         case .connected:
             return 14

--- a/GliaWidgets/Component/Connect/ConnectView.swift
+++ b/GliaWidgets/Component/Connect/ConnectView.swift
@@ -1,6 +1,21 @@
 import UIKit
 
 final class ConnectView: BaseView {
+    private enum Constants {
+        static var contentInsets: UIEdgeInsets {
+            .init(
+                top: State.none.chatTopPadding,
+                left: 0,
+                bottom: 10,
+                right: 0
+            )
+        }
+    }
+
+    enum Layout {
+        case chat, call
+    }
+
     enum State: Equatable {
         case none
         case queue
@@ -12,6 +27,7 @@ final class ConnectView: BaseView {
     let operatorView: ConnectOperatorView
     let statusView = ConnectStatusView()
 
+    private let layout: Layout
     private let style: ConnectStyle
     private var state: State = .none
     private var connectTimer: FoundationBased.Timer?
@@ -19,12 +35,15 @@ final class ConnectView: BaseView {
     private var isShowing = false
     private let environment: Environment
     private let stackView = UIStackView()
+    private var contentTopPadding: NSLayoutConstraint?
 
     init(
         with style: ConnectStyle,
+        layout: Layout,
         environment: Environment
     ) {
         self.style = style
+        self.layout = layout
         self.environment = environment
         self.operatorView = ConnectOperatorView(
             with: style.connectOperator,
@@ -37,35 +56,39 @@ final class ConnectView: BaseView {
         )
         super.init()
     }
-   
+
     required init() {
         fatalError("init() has not been implemented")
     }
 
     override func setup() {
         super.setup()
-        setState(.none, animated: false)
         accessibilityElements = [operatorView, statusView]
 
         addSubview(stackView)
         stackView.axis = .vertical
-        stackView.spacing = 32
+        stackView.spacing = State.none.chatContentSpacing
         stackView.distribution = .fillProportionally
         stackView.addArrangedSubviews([
             operatorView,
             statusView
         ])
         stackView.translatesAutoresizingMaskIntoConstraints = false
+        setState(.none, animated: false)
     }
 
     override func defineLayout() {
         super.defineLayout()
-        stackView.autoPinEdgesToSuperviewEdges(with: .init(top: 32, left: 0, bottom: 10, right: 0))
+        // `autoPinEdgesToSuperviewEdges` returns array of constraints where first one is for top padding.
+        contentTopPadding = stackView.autoPinEdgesToSuperviewEdges(with: Constants.contentInsets).first
     }
 
     // swiftlint:disable function_body_length
     func setState(_ state: State, animated: Bool) {
         self.state = state
+        stackView.spacing = layout.contentSpacing(for: state)
+        contentTopPadding?.constant = layout.topPadding(for: state)
+        updateConstraints()
 
         switch state {
         case .none:
@@ -178,5 +201,63 @@ extension ConnectView {
         var gcd: GCD
         var imageViewCache: ImageView.Cache
         var timerProviding: FoundationBased.Timer.Providing
+    }
+}
+
+extension ConnectView.State {
+    var chatContentSpacing: CGFloat {
+        switch self {
+        case .none, .queue, .connecting, .transferring:
+            return 0
+        case .connected:
+            return 12
+        }
+    }
+
+    var callContentSpacing: CGFloat {
+        switch self {
+        case .none, .queue, .connecting, .transferring:
+            return 1
+        case .connected:
+            return 18
+        }
+    }
+
+    var chatTopPadding: CGFloat {
+        switch self {
+        case .none, .queue, .connecting, .transferring:
+            return 6
+        case .connected:
+            return 14
+        }
+    }
+
+    var callTopPadding: CGFloat {
+        switch self {
+        case .none, .queue, .connecting, .transferring:
+            return 32
+        case .connected:
+            return 14
+        }
+    }
+}
+
+extension ConnectView.Layout {
+    func topPadding(for state: ConnectView.State) -> CGFloat {
+        switch self {
+        case .chat:
+            return state.chatTopPadding
+        case .call:
+            return state.callTopPadding
+        }
+    }
+
+    func contentSpacing(for state: ConnectView.State) -> CGFloat {
+        switch self {
+        case .chat:
+            return state.chatContentSpacing
+        case .call:
+            return state.callContentSpacing
+        }
     }
 }

--- a/GliaWidgets/Component/Connect/Operator/ConnectOperatorView.swift
+++ b/GliaWidgets/Component/Connect/Operator/ConnectOperatorView.swift
@@ -110,6 +110,10 @@ final class ConnectOperatorView: BaseView {
         self.animationView = animationView
 
         insertSubview(animationView, at: 0)
+        animationView.autoPinEdge(toSuperviewEdge: .left, withInset: 0, relation: .greaterThanOrEqual)
+        animationView.autoPinEdge(toSuperviewEdge: .top, withInset: 0)
+        animationView.autoPinEdge(toSuperviewEdge: .right, withInset: 0, relation: .greaterThanOrEqual)
+        animationView.autoPinEdge(toSuperviewEdge: .bottom, withInset: 0)
         animationView.autoCenterInSuperview()
         animationView.autoSetDimensions(to: .init(width: kAnimationViewSize, height: kAnimationViewSize))
         animationView.startAnimating()

--- a/GliaWidgets/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -103,7 +103,7 @@ struct CoreSdkClient {
     typealias CreateAuthentication = (_ behaviour: AuthenticationBehavior) throws -> Authentication
     var authentication: CreateAuthentication
 
-    typealias FetchChatHistory = (_ completion: @escaping (Result<[Self.Message], SalemoveSDK.GliaCoreError>) -> Void) -> Void
+    typealias FetchChatHistory = (_ completion: @escaping (Result<[ChatMessage], SalemoveSDK.GliaCoreError>) -> Void) -> Void
     var fetchChatHistory: FetchChatHistory
 }
 

--- a/GliaWidgets/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/CoreSDKClient/CoreSDKClient.Live.swift
@@ -25,7 +25,18 @@ extension CoreSdkClient {
             fetchSiteConfigurations: GliaCore.sharedInstance.fetchSiteConfiguration(_:),
             submitSurveyAnswer: GliaCore.sharedInstance.submitSurveyAnswer(_:surveyId:engagementId:completion:),
             authentication: GliaCore.sharedInstance.authentication,
-            fetchChatHistory: GliaCore.sharedInstance.fetchChatTranscript
+            fetchChatHistory: { completion in
+                GliaCore.sharedInstance.fetchChatTranscript { result in
+                    switch result {
+                    case let .success(messages):
+                        completion(
+                            .success(messages.map { ChatMessage(with: $0) })
+                        )
+                    case let .failure(error):
+                        completion(.failure(error))
+                    }
+                }
+            }
         )
     }()
 }

--- a/GliaWidgets/View/Call/CallView.swift
+++ b/GliaWidgets/View/Call/CallView.swift
@@ -49,17 +49,6 @@ class CallView: EngagementView {
             localVideoView.label.isHidden = !isVisitrOnHold
         }
     }
-    lazy var connectView: ConnectView = .init(
-        with: style.connect,
-        layout: .call,
-        environment: .init(
-            data: environment.data,
-            uuid: environment.uuid,
-            gcd: environment.gcd,
-            imageViewCache: environment.imageViewCache,
-            timerProviding: environment.timerProviding
-        )
-    )
 
     lazy var operatorNameLabel: UILabel = {
         let label = UILabel()
@@ -117,6 +106,7 @@ class CallView: EngagementView {
         self.buttonBar = CallButtonBar(with: style.buttonBar)
         super.init(
             with: style,
+            layout: .call,
             environment: .init(
                 data: environment.data,
                 uuid: environment.uuid,

--- a/GliaWidgets/View/Call/CallView.swift
+++ b/GliaWidgets/View/Call/CallView.swift
@@ -49,6 +49,17 @@ class CallView: EngagementView {
             localVideoView.label.isHidden = !isVisitrOnHold
         }
     }
+    lazy var connectView: ConnectView = .init(
+        with: style.connect,
+        layout: .call,
+        environment: .init(
+            data: environment.data,
+            uuid: environment.uuid,
+            gcd: environment.gcd,
+            imageViewCache: environment.imageViewCache,
+            timerProviding: environment.timerProviding
+        )
+    )
 
     lazy var operatorNameLabel: UILabel = {
         let label = UILabel()
@@ -129,7 +140,6 @@ class CallView: EngagementView {
         adjustLocalVideoFrameAfterLayout()
     }
 
-    // swiftlint:disable function_body_length
     override func setup() {
         accessibilityIdentifier = "call_root_view"
 
@@ -195,7 +205,6 @@ class CallView: EngagementView {
         header.backButton.accessibilityLabel = style.header.backButton.accessibility.label
         header.backButton.accessibilityHint = style.header.backButton.accessibility.hint
     }
-    // swiftlint:enable function_body_length
 
     func switchTo(_ mode: Mode) {
         self.mode = mode
@@ -259,7 +268,6 @@ class CallView: EngagementView {
         }
     }
 
-    // swiftlint:disable function_body_length
     private func layout() {
         let effect = UIBlurEffect(style: .dark)
         let effectView = UIVisualEffectView(effect: effect)
@@ -283,7 +291,7 @@ class CallView: EngagementView {
         topLabel.autoPinEdge(toSuperviewSafeArea: .right, withInset: 20)
 
         addSubview(connectView)
-        connectView.autoPinEdge(.top, to: .bottom, of: header)
+        connectView.autoPinEdge(.top, to: .bottom, of: header, withOffset: 10)
         connectView.autoPinEdge(toSuperviewMargin: .left, relation: .greaterThanOrEqual)
         connectView.autoPinEdge(toSuperviewMargin: .right, relation: .greaterThanOrEqual)
         connectView.autoAlignAxis(toSuperviewAxis: .vertical)
@@ -323,7 +331,6 @@ class CallView: EngagementView {
         adjustForCurrentOrientation()
         switchTo(mode)
     }
-    // swiftlint:enable function_body_length
 
     private func adjustForCurrentOrientation() {
         if currentOrientation.isLandscape {

--- a/GliaWidgets/View/Chat/Cells/ChatItemCell.swift
+++ b/GliaWidgets/View/Chat/Cells/ChatItemCell.swift
@@ -40,11 +40,6 @@ class ChatItemCell: UITableViewCell {
             case .none:
                 stackView.removeArrangedSubviews()
             default:
-//                let redView = UIView()
-//                redView.backgroundColor = .red
-//                redView.heightAnchor.constraint(equalToConstant: 44).isActive = true
-//                redView.widthAnchor.constraint(equalToConstant: 44).isActive = true
-//                stackView.replaceArrangedSubviews(with: [redView])
                 guard let view = content.view else { return }
                 stackView.replaceArrangedSubviews(with: [view])
             }

--- a/GliaWidgets/View/Chat/ChatView.swift
+++ b/GliaWidgets/View/Chat/ChatView.swift
@@ -121,7 +121,6 @@ class ChatView: EngagementView {
     }
 
     func setConnectState(_ state: ConnectView.State, animated: Bool) {
-        connectView.setState(state, animated: animated)
         updateTableView(animated: animated)
     }
 
@@ -278,6 +277,21 @@ extension ChatView {
     private func content(for item: ChatItem) -> ChatItemCell.Content {
         switch item.kind {
         case .queueOperator:
+            let connectView = ConnectView(
+                with: style.connect,
+                layout: .chat,
+                environment: .init(
+                    data: environment.data,
+                    uuid: environment.uuid,
+                    gcd: environment.gcd,
+                    imageViewCache: environment.imageViewCache,
+                    timerProviding: environment.timerProviding
+                )
+            )
+            connectView.setState(
+                .queue,
+                animated: false
+            )
             return .queueOperator(connectView)
         case .outgoingMessage(let message):
             let view = VisitorChatMessageView(
@@ -397,6 +411,7 @@ extension ChatView {
         case .operatorConnected(let name, let imageUrl):
             let connectView = ConnectView(
                 with: style.connect,
+                layout: .chat,
                 environment: .init(
                     data: environment.data,
                     uuid: environment.uuid,
@@ -412,6 +427,7 @@ extension ChatView {
         case .transferring:
             let connectView = ConnectView(
                 with: style.connect,
+                layout: .chat,
                 environment: .init(
                     data: environment.data,
                     uuid: environment.uuid,

--- a/GliaWidgets/View/Chat/ChatView.swift
+++ b/GliaWidgets/View/Chat/ChatView.swift
@@ -72,6 +72,7 @@ class ChatView: EngagementView {
         )
         super.init(
             with: style,
+            layout: .chat,
             environment: .init(
                 data: environment.data,
                 uuid: environment.uuid,
@@ -82,6 +83,7 @@ class ChatView: EngagementView {
             )
         )
         self.accessibilityIdentifier = "chat_root_view"
+        defineLayout()
     }
 
     required init() {
@@ -121,6 +123,7 @@ class ChatView: EngagementView {
     }
 
     func setConnectState(_ state: ConnectView.State, animated: Bool) {
+        connectView.setState(state, animated: animated)
         updateTableView(animated: animated)
     }
 
@@ -277,21 +280,6 @@ extension ChatView {
     private func content(for item: ChatItem) -> ChatItemCell.Content {
         switch item.kind {
         case .queueOperator:
-            let connectView = ConnectView(
-                with: style.connect,
-                layout: .chat,
-                environment: .init(
-                    data: environment.data,
-                    uuid: environment.uuid,
-                    gcd: environment.gcd,
-                    imageViewCache: environment.imageViewCache,
-                    timerProviding: environment.timerProviding
-                )
-            )
-            connectView.setState(
-                .queue,
-                animated: false
-            )
             return .queueOperator(connectView)
         case .outgoingMessage(let message):
             let view = VisitorChatMessageView(

--- a/GliaWidgets/View/Chat/Message/OperatorChatMessageView.swift
+++ b/GliaWidgets/View/Chat/Message/OperatorChatMessageView.swift
@@ -63,10 +63,10 @@ class OperatorChatMessageView: ChatMessageView {
         addSubview(contentViews)
         contentViews.autoPinEdge(.left, to: .right, of: operatorImageViewContainer, withOffset: 4)
         contentViews.autoPinEdge(toSuperviewEdge: .top, withInset: kInsets.top)
-        contentViews.autoPinEdge(toSuperviewEdge: .bottom, withInset: kInsets.bottom)
+        contentViews.autoPinEdge(toSuperviewEdge: .right, withInset: kInsets.right, relation: .greaterThanOrEqual)
 
         NSLayoutConstraint.autoSetPriority(.defaultHigh) {
-            contentViews.autoPinEdge(toSuperviewEdge: .right, withInset: kInsets.right, relation: .greaterThanOrEqual)
+            contentViews.autoPinEdge(toSuperviewEdge: .bottom, withInset: kInsets.bottom)
         }
     }
 }

--- a/GliaWidgets/View/EngagementView.swift
+++ b/GliaWidgets/View/EngagementView.swift
@@ -2,17 +2,30 @@ import UIKit
 
 class EngagementView: BaseView {
     let header: Header
+    let connectView: ConnectView
 
     private let style: EngagementStyle
     private let environment: Environment
 
     init(
         with style: EngagementStyle,
+        layout: ConnectView.Layout,
         environment: Environment
     ) {
         self.style = style
         self.header = Header(with: style.header)
         self.environment = environment
+        self.connectView = ConnectView(
+            with: style.connect,
+            layout: layout,
+            environment: .init(
+                data: environment.data,
+                uuid: environment.uuid,
+                gcd: environment.gcd,
+                imageViewCache: environment.imageViewCache,
+                timerProviding: environment.timerProviding
+            )
+        )
         super.init()
     }
 

--- a/GliaWidgets/View/EngagementView.swift
+++ b/GliaWidgets/View/EngagementView.swift
@@ -2,7 +2,6 @@ import UIKit
 
 class EngagementView: BaseView {
     let header: Header
-    let connectView: ConnectView
 
     private let style: EngagementStyle
     private let environment: Environment
@@ -14,16 +13,6 @@ class EngagementView: BaseView {
         self.style = style
         self.header = Header(with: style.header)
         self.environment = environment
-        self.connectView = ConnectView(
-            with: style.connect,
-            environment: .init(
-                data: environment.data,
-                uuid: environment.uuid,
-                gcd: environment.gcd,
-                imageViewCache: environment.imageViewCache,
-                timerProviding: environment.timerProviding
-            )
-        )
         super.init()
     }
 

--- a/GliaWidgets/ViewController/Chat/ChatViewController.Mock.swift
+++ b/GliaWidgets/ViewController/Chat/ChatViewController.Mock.swift
@@ -54,7 +54,136 @@ extension ChatViewController {
             return fileDownload
         }
 
-        chatViewModelEnv.fetchChatHistory = { $0(.success([])) }
+        let messageUuid = UUID.incrementing
+        let messageId = { messageUuid().uuidString }
+        let fileUuid = UUID.incrementing
+        let fileId = { fileUuid().uuidString }
+        let queueId = UUID.mock.uuidString
+        let operatorAttachmentURL = URL.mock.appendingPathComponent("image").appendingPathExtension("png")
+
+        let messages: [ChatMessage] = [
+            .mock(
+                id: messageId(),
+                queueID: queueId,
+                operator: nil,
+                sender: .visitor,
+                content: "Hi",
+                attachment: nil,
+                downloads: []
+            ),
+            .mock(
+                id: messageId(),
+                queueID: queueId,
+                operator: .mock(name: "John Smith", pictureUrl: URL.mock.absoluteString),
+                sender: .operator,
+                content: "hello",
+                attachment: nil,
+                downloads: []
+            ),
+            .mock(
+                id: messageId(),
+                queueID: queueId,
+                operator: nil,
+                sender: .visitor,
+                content: "",
+                attachment: .mock(
+                    type: .files,
+                    files: [
+                        .mock(
+                            id: fileId(),
+                            url: .mock,
+                            name: "File 1.pdf",
+                            size: 1024,
+                            contentType: "application/pdf",
+                            isDeleted: false
+                        )
+                    ],
+                    imageUrl: nil,
+                    options: nil,
+                    selectedOption: nil
+                ),
+                downloads: []
+            ),
+            .mock(
+                id: messageId(),
+                queueID: queueId,
+                operator: nil,
+                sender: .visitor,
+                content: "Message along with content",
+                attachment: .mock(
+                    type: .files,
+                    files: [
+                        .mock(
+                            id: fileId(),
+                            url: .mockFilePath,
+                            name: "File 2.mp3",
+                            size: 512,
+                            contentType: "audio/mpeg",
+                            isDeleted: false
+                        )
+                    ],
+                    imageUrl: nil,
+                    options: nil,
+                    selectedOption: nil
+                ),
+                downloads: []
+            ),
+            .mock(
+                id: messageId(),
+                queueID: queueId,
+                operator: .mock(
+                    name: "John Doe",
+                    pictureUrl: URL.mock.absoluteString
+                ),
+                sender: .operator,
+                content: "",
+                attachment: .mock(
+                    type: .files,
+                    files: [
+                        .mock(
+                            id: fileId(),
+                            url: operatorAttachmentURL,
+                            name: "Screen Shot.png",
+                            size: 11806,
+                            contentType: "image/png",
+                            isDeleted: false
+                        )
+                    ],
+                    imageUrl: nil,
+                    options: nil,
+                    selectedOption: nil
+                ),
+                downloads: []
+            ),
+            .mock(
+                id: messageId(),
+                queueID: queueId,
+                operator: .mock(
+                    name: "John Smith",
+                    pictureUrl: URL.mock.appendingPathComponent("opImage").appendingPathExtension("png").absoluteString
+                ),
+                sender: .operator,
+                content: "",
+                attachment: .mock(
+                    type: .files,
+                    files: [
+                        .mock(
+                            id: fileId(),
+                            url: .mock,
+                            name: "File 2.pdf",
+                            size: 1024,
+                            contentType: "application/pdf",
+                            isDeleted: false
+                        )
+                    ],
+                    imageUrl: nil,
+                    options: nil,
+                    selectedOption: nil
+                ),
+                downloads: []
+            )
+        ]
+        chatViewModelEnv.fetchChatHistory = { $0(.success(messages)) }
         let chatViewModel = ChatViewModel.mock(environment: chatViewModelEnv)
         var factoryEnv = ViewFactory.Environment.mock
         factoryEnv.data.dataWithContentsOfFileUrl = { _ in UIImage.mock.pngData() ?? Data() }
@@ -182,17 +311,43 @@ extension ChatViewController {
     // MARK: - Choice Card States
     static func mockChoiceCard() throws -> ChatViewController {
         var chatViewModelEnv = ChatViewModel.Environment.mock
-        chatViewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
-        chatViewModelEnv.loadChatMessagesFromHistory = {
-            true
-        }
-        chatViewModelEnv.fetchChatHistory = { $0(.success([])) }
+        chatViewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [URL.mock] }
+        chatViewModelEnv.loadChatMessagesFromHistory = { true }
+        let messageUuid = UUID.incrementing
+        let messageId = { messageUuid().uuidString }
+        let queueId = UUID.mock.uuidString
+
+        let options = [
+            ChatChoiceCardOption(with: try .mock(text: "Four", value: "ruof")),
+            ChatChoiceCardOption(with: try .mock(text: "Five", value: "evif")),
+            ChatChoiceCardOption(with: try .mock(text: "One", value: "eno"))
+        ]
+        let messages: [ChatMessage] = [
+            .mock(id: messageId(),
+                  queueID: queueId,
+                  operator: .mock(
+                    name: "Blob",
+                    pictureUrl: "https://mock.mock/operator/234/image.png"
+                  ),
+                  sender: .operator,
+                  content: "What is 2 + 2?",
+                  attachment: .init(
+                    type: .singleChoice,
+                    files: nil,
+                    imageUrl: "https://mock.mock/single_choice/567/image.png",
+                    options: options,
+                    selectedOption: .some("ruof")
+                  ),
+                  downloads: []
+                 )
+        ]
+        chatViewModelEnv.fetchChatHistory = { $0(.success(messages)) }
 
         var viewFactoryEnv = ViewFactory.Environment.mock
-        viewFactoryEnv.imageViewCache.getImageForKey = { _ in .mock }
+        viewFactoryEnv.imageViewCache.getImageForKey = { _ in UIImage.mock }
 
         let chatViewModel = ChatViewModel.mock(environment: chatViewModelEnv)
-        let controller: ChatViewController = .mock(
+        let controller = ChatViewController.mock(
             chatViewModel: chatViewModel,
             viewFactory: .init(
                 with: .mock(),
@@ -240,14 +395,14 @@ extension ChatViewController {
             )
 
         }
-
+        chatViewModelEnv.fetchChatHistory = { $0(.success(messages)) }
         var interEnv = Interactor.Environment.mock
         interEnv.coreSdk.configureWithConfiguration = { _, callback in
             callback?()
         }
         let interactor = Interactor.mock(environment: interEnv)
         let chatViewModel = ChatViewModel.mock(interactor: interactor, environment: chatViewModelEnv)
-        let controller: ChatViewController = .mock(chatViewModel: chatViewModel)
+        let controller = ChatViewController.mock(chatViewModel: chatViewModel)
         completion(messages)
         return controller
     }

--- a/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
@@ -40,7 +40,6 @@ class ChatViewModel: EngagementViewModel, ViewModel {
     private var pendingMessages: [OutgoingMessage] = []
     private var isViewLoaded: Bool = false
 
-    // swiftlint:disable function_body_length
     init(
         interactor: Interactor,
         alertConfiguration: AlertConfiguration,
@@ -109,7 +108,6 @@ class ChatViewModel: EngagementViewModel, ViewModel {
             self?.action?(.pickMediaButtonEnabled(!limitReached))
         }
     }
-    // swiftlint:enable function_body_length
 
     func event(_ event: Event) {
         switch event {
@@ -165,7 +163,6 @@ class ChatViewModel: EngagementViewModel, ViewModel {
         }
     }
 
-    // swiftlint:disable function_body_length
     override func update(for state: InteractorState) {
         super.update(for: state)
 
@@ -231,7 +228,6 @@ class ChatViewModel: EngagementViewModel, ViewModel {
             break
         }
     }
-    // swiftlint:enable function_body_length
 
     override func interactorEvent(_ event: InteractorEvent) {
         super.interactorEvent(event)

--- a/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/ViewModel/Chat/ChatViewModel.swift
@@ -317,9 +317,9 @@ extension ChatViewModel {
 // MARK: History
 
 extension ChatViewModel {
-    private func loadHistory(_ completion: @escaping ([CoreSdkClient.Message]) -> Void) {
+    private func loadHistory(_ completion: @escaping ([ChatMessage]) -> Void) {
         environment.fetchChatHistory { result in
-            let messages = ((try? result.get()) ?? []).compactMap { ChatMessage(with: $0) }
+            let messages = (try? result.get()) ?? []
             let items = messages.compactMap {
                 ChatItem(
                     with: $0,
@@ -330,7 +330,7 @@ extension ChatViewModel {
             self.historySection.set(items)
             self.action?(.refreshSection(self.historySection.index))
             self.action?(.scrollToBottom(animated: false))
-            completion((try? result.get()) ?? [])
+            completion(messages)
         }
     }
 }


### PR DESCRIPTION
- In this PR `ConnectView` was fixed according to design, added `Layout` enum to be able to differentiate the screens where `ConnectView` is shown
- Snapshot tests for Chat screen were fixed also by adding mocks.
- Also fixed `OperatorChatMessageView` trailing constraint

[MOB-1803](https://glia.atlassian.net/browse/MOB-1803)


[MOB-1803]: https://glia.atlassian.net/browse/MOB-1803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ