### PR TITLE
Extend QA-build workflow for running snapshot tests

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -340,24 +340,59 @@ workflows:
     - activate-ssh-key@4:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - git-clone@6: {}
+    - script@1:
+        inputs:
+        - content: >-
+            #!/usr/bin/env bash
+
+
+            # fail if any commands fails
+
+
+            set -e
+
+
+            # make pipelines' return status equal the last command to exit with
+            a non-zero status, or zero if all commands exit successfully
+
+
+            set -o pipefail
+
+
+            # debug log
+
+
+            set -x
+
+
+            make clone-snapshots
     - cache-pull@2: {}
     - certificate-and-profile-installer@1: {}
     - cocoapods-install@2: {}
     - recreate-user-schemes@1:
         inputs:
         - project_path: $BITRISE_PROJECT_PATH
-    - xcode-archive@3:
+    - xcode-test@4:
+        inputs:
+        - scheme: GliaWidgetsTests
+    - xcode-test@4:
+        inputs:
+        - scheme: SnapshotTests
+        - destination: 'platform=iOS Simulator,name=iPhone 13,OS=15.2'
+    - xcode-archive@4.5:
         inputs:
         - scheme: $APP_SCHEME
         - team_id: XR3G5NDPNH
         - export_method: $BITRISE_EXPORT_METHOD
     - deploy-to-bitrise-io@2:
         inputs:
-        - notify_email_list: $NOTIFY_EMAILS
+        - notify_email_list: ''
     - cache-push@2: {}
     description: >-
-      Workflow for creating builds of dev branch. Triggered on each push to dev
-      branch, notifies over email + Slack (internal)
+      Workflow for checking and building pull requests. Does not notify
+      anywhere, but shows on the pull request itself.
+    after_run:
+    - integration-spm
   update_dependencies:
     steps:
     - activate-ssh-key@4: {}


### PR DESCRIPTION
Since we don't use `QA-build` Bitrise workflow, it was temporarily updated for running snapshot tests. After testing it and being sure that is work well, `QA-build` will be rolled back and `pull-request` workflow will include this changes.

[MOB-1616](https://glia.atlassian.net/browse/MOB-1616)

[MOB-1616]: https://glia.atlassian.net/browse/MOB-1616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ