### PR TITLE
Commented after-run integration-spm for pull-request workflow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -268,8 +268,8 @@ workflows:
     description: >-
       Workflow for checking and building pull requests. Does not notify
       anywhere, but shows on the pull request itself.
-    after_run:
-    - integration-spm
+#    after_run:
+#    - integration-spm
   pull-request-snapshot:
     steps:
     - activate-ssh-key@4:


### PR DESCRIPTION
Running integration-spm workflow was commented because of it fails by time out. Example: [build](https://app.bitrise.io/build/fd2eaf0d-bee8-4903-a679-cd75f5191128). Yurii will investigate it later.


MOB-1813