### PR TITLE
Add loading and confirmation screen navigation after sending message

### DIFF
--- a/GliaWidgets/Coordinator/RootCoordinator.swift
+++ b/GliaWidgets/Coordinator/RootCoordinator.swift
@@ -387,6 +387,7 @@ extension RootCoordinator {
     private func startSecureConversations() -> UIViewController {
         let coordinator = SecureConversations.Coordinator(
             viewFactory: viewFactory,
+            navigationPresenter: navigationPresenter,
             environment: .init(
                 queueIds: [interactor.queueID],
                 sendSecureMessage: environment.sendSecureMessage

--- a/GliaWidgets/SecureConversations/Confirmation/SecureConversations.ConfirmationView.swift
+++ b/GliaWidgets/SecureConversations/Confirmation/SecureConversations.ConfirmationView.swift
@@ -161,7 +161,7 @@ extension SecureConversations {
         private func renderProps() {
             header.title = props.style.headerTitle
             header.backButton.tap = props.backButtonTap.execute
-            header.closeButton.tap = props.backButtonTap.execute
+            header.closeButton.tap = props.closeButtonTap.execute
             header.showCloseButton()
 
             titleLabel.text = props.style.titleStyle.text

--- a/GliaWidgets/SecureConversations/Confirmation/SecureConversations.ConfirmationViewController.swift
+++ b/GliaWidgets/SecureConversations/Confirmation/SecureConversations.ConfirmationViewController.swift
@@ -10,11 +10,14 @@ extension SecureConversations {
         }
 
         private let viewFactory: ViewFactory
+        private let viewModel: ConfirmationViewModel
 
         init(
+            viewModel: ConfirmationViewModel,
             viewFactory: ViewFactory,
             props: Props
         ) {
+            self.viewModel = viewModel
             self.viewFactory = viewFactory
             self.props = props
             super.init(nibName: nil, bundle: nil)

--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeView.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeView.swift
@@ -176,7 +176,7 @@ extension SecureConversations {
         func renderProps() {
             header.title = props.style.headerTitle
             header.backButton.tap = props.backButtonTap.execute
-            header.closeButton.tap = props.backButtonTap.execute
+            header.closeButton.tap = props.closeButtonTap.execute
             header.showCloseButton()
 
             titleIconView.tintColor = props.style.titleImageStyle.color


### PR DESCRIPTION
When sending a secure message, the button goes to a loading state, and then on success, it navigates to the confirmation view. The error handling is still on TODO, as I don't want to make the PR bigger.

MOB-1698