### PR TITLE
Introduce ability to change upload endpoint

### DIFF
--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -303,7 +303,8 @@ public class Glia {
                 fetchChatHistory: environment.coreSdk.fetchChatHistory,
                 sendSecureMessage: environment.coreSdk.sendSecureMessage,
                 createFileUploader: environment.createFileUploader,
-                createFileUploadListModel: environment.createFileUploadListModel
+                createFileUploadListModel: environment.createFileUploadListModel,
+                uploadSecureFile: environment.coreSdk.uploadSecureFile
             )
         )
         rootCoordinator?.delegate = { [weak self] event in

--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
@@ -35,7 +35,7 @@ extension SecureConversations {
                     fileUploader: environment.createFileUploader(
                         SecureConversations.WelcomeViewModel.maximumUploads,
                         .init(
-                            uploadFileToEngagement: environment.uploadFileToEngagement,
+                            uploadFile: .toConversation(environment.uploadSecureFile),
                             fileManager: environment.fileManager,
                             data: environment.data,
                             date: environment.date,
@@ -185,7 +185,7 @@ extension SecureConversations.Coordinator {
         var queueIds: [String]
         var sendSecureMessage: CoreSdkClient.SendSecureMessage
         var createFileUploader: FileUploader.Create
-        var uploadFileToEngagement: CoreSdkClient.UploadFileToEngagement
+        var uploadSecureFile: CoreSdkClient.SecureConversationsUploadFile
         var fileManager: FoundationBased.FileManager
         var data: FoundationBased.Data
         var date: () -> Date

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
@@ -22,7 +22,8 @@ extension EngagementCoordinator.Environment {
         fetchChatHistory: { _ in },
         sendSecureMessage: { _, _, _, _ in .init() },
         createFileUploader: FileUploader.mock,
-        createFileUploadListModel: SecureConversations.FileUploadListViewModel.mock(environment:)
+        createFileUploadListModel: SecureConversations.FileUploadListViewModel.mock(environment:),
+        uploadSecureFile: { _, _, _ in .mock }
     )
 }
 #endif

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
@@ -24,5 +24,7 @@ extension EngagementCoordinator {
         var sendSecureMessage: CoreSdkClient.SendSecureMessage
         var createFileUploader: FileUploader.Create
         var createFileUploadListModel: SecureConversations.FileUploadListViewModel.Create
+        var uploadSecureFile: CoreSdkClient.SecureConversationsUploadFile
+
     }
 }

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
@@ -394,7 +394,7 @@ extension EngagementCoordinator {
                 queueIds: [interactor.queueID],
                 sendSecureMessage: environment.sendSecureMessage,
                 createFileUploader: environment.createFileUploader,
-                uploadFileToEngagement: environment.uploadFileToEngagement,
+                uploadSecureFile: environment.uploadSecureFile,
                 fileManager: environment.fileManager,
                 data: environment.data,
                 date: environment.date,

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -114,8 +114,15 @@ struct CoreSdkClient {
         _ attachment: Self.Attachment?,
         _ queueIds: [String],
         _ completion: @escaping (Result<Self.Message, Error>) -> Void
-    ) -> Salemove.Cancellable
+    ) -> Self.Cancellable
     var sendSecureMessage: SendSecureMessage
+
+    typealias SecureConversationsUploadFile = (
+        _ file: EngagementFile,
+        _ progress: EngagementFileProgressBlock?,
+        _ completion: @escaping (Result<EngagementFileInformation, Swift.Error>) -> Void
+    ) -> Self.Cancellable
+    var uploadSecureFile: SecureConversationsUploadFile
 }
 
 extension CoreSdkClient {
@@ -199,4 +206,5 @@ extension CoreSdkClient {
     typealias AuthenticationBehavior = SalemoveSDK.GliaCore.Authentication.Behavior
     typealias VisitorCodeBlock = (Result<VisitorCode, Swift.Error>)
     typealias EngagementSource = SalemoveSDK.EngagementSource
+    typealias Cancellable = GliaCore.Cancellable
 }

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
@@ -38,7 +38,8 @@ extension CoreSdkClient {
                 }
             },
             requestVisitorCode: GliaCore.sharedInstance.callVisualizer.requestVisitorCode(completion:),
-            sendSecureMessage: GliaCore.sharedInstance.secureConversations.send(secureMessage:attachment:queueIds:completion:)
+            sendSecureMessage: GliaCore.sharedInstance.secureConversations.send(secureMessage:attachment:queueIds:completion:),
+            uploadSecureFile: GliaCore.sharedInstance.secureConversations.uploadFile(_:progress:completion:)
         )
     }()
 }

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -27,7 +27,8 @@ extension CoreSdkClient {
         authentication: { _ in .mock },
         fetchChatHistory: { _ in },
         requestVisitorCode: { _ in fatalError() },
-        sendSecureMessage: { _, _, _, _ in .init() }
+        sendSecureMessage: { _, _, _, _ in .mock },
+        uploadSecureFile: { _, _, _ in .mock }
     )
 }
 
@@ -350,5 +351,9 @@ extension CoreSdkClient.Message {
 
 extension MessageSender {
     static let mock = Self.init(type: .visitor)
+}
+
+extension CoreSdkClient.Cancellable {
+    static let mock = CoreSdkClient.Cancellable()
 }
 #endif

--- a/GliaWidgets/Sources/IdCollection/IdCollection.swift
+++ b/GliaWidgets/Sources/IdCollection/IdCollection.swift
@@ -26,8 +26,8 @@ struct IdCollection<Identifier: Hashable, Item: Equatable>: Equatable & Collecti
         list.index(after: i)
     }
 
-    subscript(by index: DictionaryType.Key) -> DictionaryType.Value? {
-        items[index]
+    subscript(by key: DictionaryType.Key) -> DictionaryType.Value? {
+        items[key]
     }
 
     mutating func insert(

--- a/GliaWidgets/Sources/Upload/FileUpload.Environment.Interface.swift
+++ b/GliaWidgets/Sources/Upload/FileUpload.Environment.Interface.swift
@@ -2,7 +2,42 @@ import Foundation
 
 extension FileUpload {
     struct Environment {
-        var uploadFileToEngagement: CoreSdkClient.UploadFileToEngagement
+        var uploadFile: UploadFile
         var uuid: () -> UUID
+    }
+}
+
+extension FileUpload.Environment {
+    enum UploadFile {
+        case toEngagement(CoreSdkClient.UploadFileToEngagement)
+        case toConversation(CoreSdkClient.SecureConversationsUploadFile)
+    }
+}
+
+extension FileUpload.Environment.UploadFile {
+    @discardableResult func uploadFile(
+        _ file: CoreSdkClient.EngagementFile,
+        progress: CoreSdkClient.EngagementFileProgressBlock?,
+        completion: @escaping (Result<CoreSdkClient.EngagementFileInformation, Swift.Error>) -> Void
+    ) -> CoreSdkClient.Cancellable? {
+        switch self {
+        case let .toEngagement(uploadFile):
+            uploadFile(file, progress) { fileInfo, error in
+                switch (fileInfo, error) {
+                case (.none, .none):
+                    break
+                case let (.none, .some(error)):
+                    completion(.failure(error))
+                case let (.some(fileInfo), .none):
+                    completion(.success(fileInfo))
+                case let (.some, .some(error)):
+                    completion(.failure(error))
+                }
+            }
+            return nil
+
+        case let .toConversation(uploadFile):
+            return uploadFile(file, progress, completion)
+        }
     }
 }

--- a/GliaWidgets/Sources/Upload/FileUpload.Environment.Mock.swift
+++ b/GliaWidgets/Sources/Upload/FileUpload.Environment.Mock.swift
@@ -1,8 +1,12 @@
 #if DEBUG
 extension FileUpload.Environment {
     static let mock = Self(
-        uploadFileToEngagement: { _, _, _ in },
+        uploadFile: .mock,
         uuid: { .mock }
     )
+}
+
+extension FileUpload.Environment.UploadFile {
+    static let mock = FileUploader.Environment.UploadFile.toConversation({ _, _, _ in .mock })
 }
 #endif

--- a/GliaWidgets/Sources/Upload/FileUploader.Environment.Interface.swift
+++ b/GliaWidgets/Sources/Upload/FileUploader.Environment.Interface.swift
@@ -1,6 +1,6 @@
 extension FileUploader {
     struct Environment {
-        var uploadFileToEngagement: CoreSdkClient.UploadFileToEngagement
+        var uploadFile: UploadFile
         var fileManager: FoundationBased.FileManager
         var data: FoundationBased.Data
         var date: () -> Date
@@ -9,4 +9,8 @@ extension FileUploader {
         var uiImage: UIKitBased.UIImage
         var uuid: () -> UUID
     }
+}
+
+extension FileUploader.Environment {
+    typealias UploadFile = FileUpload.Environment.UploadFile
 }

--- a/GliaWidgets/Sources/Upload/FileUploader.Environment.Mock.swift
+++ b/GliaWidgets/Sources/Upload/FileUploader.Environment.Mock.swift
@@ -2,7 +2,7 @@
 
 extension FileUploader.Environment {
     static let mock = FileUploader.Environment(
-        uploadFileToEngagement: { _, _, _ in },
+        uploadFile: .mock,
         fileManager: .mock,
         data: .mock,
         date: { .mock },

--- a/GliaWidgets/Sources/Upload/FileUploader.swift
+++ b/GliaWidgets/Sources/Upload/FileUploader.swift
@@ -87,7 +87,7 @@ class FileUploader {
             with: localFile,
             storage: storage,
             environment: .init(
-                uploadFileToEngagement: environment.uploadFileToEngagement,
+                uploadFile: environment.uploadFile,
                 uuid: environment.uuid
             )
         )

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -62,7 +62,7 @@ class ChatViewModel: EngagementViewModel, ViewModel {
         let uploader = FileUploader(
             maximumUploads: Self.maximumUploads,
             environment: .init(
-                uploadFileToEngagement: environment.uploadFileToEngagement,
+                uploadFile: .toEngagement(environment.uploadFileToEngagement),
                 fileManager: environment.fileManager,
                 data: environment.data,
                 date: environment.date,

--- a/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
+++ b/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
@@ -54,6 +54,10 @@ extension EngagementCoordinator.Environment {
             fail("\(Self.self).createFileUploadListModel")
             return .mock()
 
+        },
+        uploadSecureFile: { _, _, _ in
+            fail("\(Self.self).uploadSecureFile")
+            return .mock
         }
     )
 }

--- a/GliaWidgetsTests/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/CoreSDKClient.Failing.swift
@@ -34,6 +34,10 @@ extension CoreSdkClient {
         sendSecureMessage: { _, _, _, _ in
             fail("\(Self.self).sendSecureMessage")
             return .init()
+        },
+        uploadSecureFile: { _, _, _ in
+            fail("\(Self.self).uploadSecureFile")
+            return .mock
         }
     )
 }

--- a/GliaWidgetsTests/Lib/Upload/FileUploader.Environment.Failing.swift
+++ b/GliaWidgetsTests/Lib/Upload/FileUploader.Environment.Failing.swift
@@ -2,7 +2,7 @@
 
 extension FileUploader.Environment {
     static let failing = Self(
-        uploadFileToEngagement: CoreSdkClient.failing.uploadFileToEngagement,
+        uploadFile: .toEngagement(CoreSdkClient.failing.uploadFileToEngagement),
         fileManager: .failing,
         data: FoundationBased.Data.failing,
         date: {

--- a/GliaWidgetsTests/Sources/FileUploaderTests.swift
+++ b/GliaWidgetsTests/Sources/FileUploaderTests.swift
@@ -11,7 +11,7 @@ class FileUploaderTests: XCTestCase {
         fileManager.createDirectoryAtUrlWithIntermediateDirectories = { _, _, _ in }
 
         var env: FileUploader.Environment = .failing
-        env.uploadFileToEngagement = { _, _, _ in }
+        env.uploadFile = .mock
         env.uuid = { UUID() }
         env.fileManager = fileManager
 


### PR DESCRIPTION
Add ability to use same service for uploading files (Uploader) for engagement and secure messaging by specifying API endpoint from Core SDK.

MOB-1722