### PR TITLE
Call Visualizer. Remote configuration

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -272,6 +272,8 @@
 		84265E66298D7B2900D65842 /* ScreenSharingViewController+Props.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84265E5B298D7B2900D65842 /* ScreenSharingViewController+Props.swift */; };
 		84265E67298D7B2900D65842 /* ScreenSharingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84265E5C298D7B2900D65842 /* ScreenSharingViewController.swift */; };
 		84265E69298D7B9D00D65842 /* CallVisualizer+MediaUpgrade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84265E68298D7B9D00D65842 /* CallVisualizer+MediaUpgrade.swift */; };
+		84265E6B29912E2100D65842 /* RemoteConfiguration+CallVisualizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84265E6A29912E2100D65842 /* RemoteConfiguration+CallVisualizer.swift */; };
+		84265E6E29914DDA00D65842 /* ViewController+CallVisualizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84265E6D29914DDA00D65842 /* ViewController+CallVisualizer.swift */; };
 		844D3C6C29142C17002887A9 /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844D3C6B29142C17002887A9 /* Optional+Extensions.swift */; };
 		8458769F2823FD18007AC3DF /* SurveyViewControllerVoiceOverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8458769E2823FD18007AC3DF /* SurveyViewControllerVoiceOverTests.swift */; };
 		845876A22823FF34007AC3DF /* Survey.ViewController.Props.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845876A12823FF34007AC3DF /* Survey.ViewController.Props.Mock.swift */; };
@@ -795,6 +797,8 @@
 		84265E5B298D7B2900D65842 /* ScreenSharingViewController+Props.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ScreenSharingViewController+Props.swift"; sourceTree = "<group>"; };
 		84265E5C298D7B2900D65842 /* ScreenSharingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenSharingViewController.swift; sourceTree = "<group>"; };
 		84265E68298D7B9D00D65842 /* CallVisualizer+MediaUpgrade.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CallVisualizer+MediaUpgrade.swift"; sourceTree = "<group>"; };
+		84265E6A29912E2100D65842 /* RemoteConfiguration+CallVisualizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteConfiguration+CallVisualizer.swift"; sourceTree = "<group>"; };
+		84265E6D29914DDA00D65842 /* ViewController+CallVisualizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+CallVisualizer.swift"; sourceTree = "<group>"; };
 		844D3C6B29142C17002887A9 /* Optional+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+Extensions.swift"; sourceTree = "<group>"; };
 		8458769E2823FD18007AC3DF /* SurveyViewControllerVoiceOverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyViewControllerVoiceOverTests.swift; sourceTree = "<group>"; };
 		845876A12823FF34007AC3DF /* Survey.ViewController.Props.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Survey.ViewController.Props.Mock.swift; sourceTree = "<group>"; };
@@ -1270,11 +1274,11 @@
 		1A205D7925655CEC003AA3CD /* TestingApp */ = {
 			isa = PBXGroup;
 			children = (
+				84265E6C29914DAA00D65842 /* ViewController */,
 				C46B2463262F05BE001245A1 /* TestingApp.entitlements */,
 				1A60AFF32567CDFB00E53F53 /* Settings */,
 				1A4AD3D4256FE7DA00468BFB /* Extensions */,
 				1A205D7A25655CEC003AA3CD /* AppDelegate.swift */,
-				1A205D7E25655CEC003AA3CD /* ViewController.swift */,
 				1A205D8525655CEE003AA3CD /* LaunchScreen.storyboard */,
 				1A205D8825655CEE003AA3CD /* Info.plist */,
 				C4119E05268F41D1004DFEFB /* Main.storyboard */,
@@ -2217,6 +2221,7 @@
 				7594093A298D376A008B173A /* RemoteConfiguration+AssetsBuilder.swift */,
 				7594093B298D376A008B173A /* RemoteConfiguration.swift */,
 				7594093C298D376A008B173A /* RemoteConfiguration+Chat.swift */,
+				84265E6A29912E2100D65842 /* RemoteConfiguration+CallVisualizer.swift */,
 			);
 			path = RemoteConfiguration;
 			sourceTree = "<group>";
@@ -2458,6 +2463,15 @@
 			children = (
 				84265E5B298D7B2900D65842 /* ScreenSharingViewController+Props.swift */,
 				84265E5C298D7B2900D65842 /* ScreenSharingViewController.swift */,
+			);
+			path = ViewController;
+			sourceTree = "<group>";
+		};
+		84265E6C29914DAA00D65842 /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				1A205D7E25655CEC003AA3CD /* ViewController.swift */,
+				84265E6D29914DDA00D65842 /* ViewController+CallVisualizer.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -3525,6 +3539,7 @@
 				75940944298D378A008B173A /* CoreSDKClient.Interface.swift in Sources */,
 				754CC61227E2767A005676E9 /* Survey.BooleanQuestionView.swift in Sources */,
 				6EA3516926E139DA00BF5941 /* GliaViewTransitionController.swift in Sources */,
+				84265E6B29912E2100D65842 /* RemoteConfiguration+CallVisualizer.swift in Sources */,
 				1A1E30C725F9FDAB00850E68 /* ChatImageFileContentView.swift in Sources */,
 				AFA2FDEE28907DDB00428E6D /* EngagementCoordinator.Environment.Mock.swift in Sources */,
 				75940967298D38B6008B173A /* BundleManaging.swift in Sources */,
@@ -3633,6 +3648,7 @@
 				1A205D7B25655CEC003AA3CD /* AppDelegate.swift in Sources */,
 				754313CB2870A65400C9C1C6 /* SettingsViewController.Props.swift in Sources */,
 				7543141828806AEB00C9C1C6 /* EnvironmentSettingsTextCell.swift in Sources */,
+				84265E6E29914DDA00D65842 /* ViewController+CallVisualizer.swift in Sources */,
 				754313CF2870E64600C9C1C6 /* Configuration.Extensions.swift in Sources */,
 				1A4AD3D1256E92F300468BFB /* SettingsColorCell.swift in Sources */,
 				1A4AD3CE256E8F5500468BFB /* SettingsCell.swift in Sources */,

--- a/GliaWidgets/Sources/CallVisualizer/CallVisualizer+MediaUpgrade.swift
+++ b/GliaWidgets/Sources/CallVisualizer/CallVisualizer+MediaUpgrade.swift
@@ -7,7 +7,7 @@ extension CallVisualizer {
         accepted: @escaping () -> Void,
         declined: @escaping () -> Void
     ) {
-        coordinator.offerScreenShare(
+        coordinator?.offerScreenShare(
             from: operators,
             configuration: configuration,
             accepted: accepted,

--- a/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
+++ b/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
@@ -13,32 +13,10 @@ import SalemoveSDK
 ///  3. Handling engagement, featuring video calling, screen sharing, and much more in future.
 public final class CallVisualizer {
     private var environment: Environment
-    let coordinator: Coordinator
+    var coordinator: Coordinator?
 
     init(environment: Environment) {
         self.environment = environment
-        let viewFactory = ViewFactory(
-            with: Theme(),
-            messageRenderer: nil,
-            environment: .init(
-                data: environment.data,
-                uuid: environment.uuid,
-                gcd: environment.gcd,
-                imageViewCache: environment.imageViewCache,
-                timerProviding: environment.timerProviding,
-                uiApplication: environment.uiApplication
-            )
-        )
-        self.coordinator = Coordinator(
-            environment: .init(
-                viewFactory: viewFactory,
-                presenter: environment.callVisualizerPresenter,
-                bundleManaging: environment.bundleManaging,
-                screenShareHandler: environment.screenShareHandler,
-                timerProviding: environment.timerProviding,
-                requestVisitorCode: environment.requestVisitorCode
-            )
-        )
     }
 
     deinit {
@@ -67,10 +45,36 @@ public final class CallVisualizer {
         by presentation: Presentation,
         uiConfig: RemoteConfiguration? = nil
     ) {
-        coordinator.showVisitorCodeViewController(
-            by: presentation,
-            uiConfig: uiConfig
+
+        let theme = Theme()
+        if let uiConfig = uiConfig {
+            theme.applyRemoteConfiguration(uiConfig, assetsBuilder: .standard)
+        }
+
+        let viewFactory = ViewFactory(
+            with: theme,
+            messageRenderer: nil,
+            environment: .init(
+                data: environment.data,
+                uuid: environment.uuid,
+                gcd: environment.gcd,
+                imageViewCache: environment.imageViewCache,
+                timerProviding: environment.timerProviding,
+                uiApplication: environment.uiApplication
+            )
         )
+        coordinator = Coordinator(
+            environment: .init(
+                viewFactory: viewFactory,
+                presenter: environment.callVisualizerPresenter,
+                bundleManaging: environment.bundleManaging,
+                screenShareHandler: environment.screenShareHandler,
+                timerProviding: environment.timerProviding,
+                requestVisitorCode: environment.requestVisitorCode
+            )
+        )
+
+        coordinator?.showVisitorCodeViewController(by: presentation)
 
         startObservingInteractorEvents()
     }

--- a/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
@@ -153,11 +153,9 @@ extension CallVisualizer {
         }
 
         private func buildScreenSharingViewController(uiConfig: RemoteConfiguration? = nil) -> UIViewController {
-            let theme = Theme()
-            uiConfig.map { theme.applyRemoteConfiguration($0, assetsBuilder: .standard) }
             let coordinator = ScreenSharingCoordinator(
                 environment: .init(
-                    theme: theme,
+                    theme: environment.viewFactory.theme,
                     screenShareHandler: environment.screenShareHandler
                 )
             )

--- a/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
@@ -28,17 +28,14 @@ extension CallVisualizer {
             }
         }
 
-        func showVisitorCodeViewController(
-            by presentation: Presentation,
-            uiConfig: RemoteConfiguration? = nil
-        ) {
+        func showVisitorCodeViewController(by presentation: Presentation) {
             let coordinator = VisitorCodeCoordinator(
+                theme: environment.viewFactory.theme,
                 environment: .init(
                     timerProviding: environment.timerProviding,
                     requestVisitorCode: environment.requestVisitorCode
                 ),
-                presentation: presentation,
-                uiConfig: uiConfig
+                presentation: presentation
             )
 
             coordinator.delegate = { [weak self] event in

--- a/GliaWidgets/Sources/CallVisualizer/ScreenSharing/ScreenSharingViewStyle.swift
+++ b/GliaWidgets/Sources/CallVisualizer/ScreenSharing/ScreenSharingViewStyle.swift
@@ -16,11 +16,17 @@ public struct ScreenSharingViewStyle: Equatable {
     /// Color of the message text.
     public var messageTextColor: UIColor
 
+    /// Text style of the message text.
+    public var messageTextStyle: UIFont.TextStyle
+
     /// Style of end screen sharing button.
     public var buttonStyle: ActionButtonStyle
 
     /// End screen sharing button icon.
     public var buttonIcon: UIImage
+
+    /// Style for root view background color.
+    public var backgroundColor: ColorType
 
     /// Accessibility related properties.
     public var accessibility: Accessibility
@@ -32,8 +38,10 @@ public struct ScreenSharingViewStyle: Equatable {
     ///   - messageText: The text shown above the end screen sharing button.
     ///   - messageTextFont: Font of the message text.
     ///   - messageTextColor: Color of the message text.
+    ///   - messageTextStyle: Text style of the message text.
     ///   - buttonStyle: Style of end screen sharing button.
     ///   - buttonIcon: End screen sharing button icon.
+    ///   - backgroundColor: Style for root view background color.
     ///   - accessibility: Accessibility related properties.
     ///
     public init(
@@ -42,8 +50,10 @@ public struct ScreenSharingViewStyle: Equatable {
         messageText: String,
         messageTextFont: UIFont,
         messageTextColor: UIColor,
+        messageTextStyle: UIFont.TextStyle = .title2,
         buttonStyle: ActionButtonStyle,
         buttonIcon: UIImage,
+        backgroundColor: ColorType,
         accessibility: Accessibility
     ) {
         self.title = title
@@ -51,8 +61,48 @@ public struct ScreenSharingViewStyle: Equatable {
         self.messageText = messageText
         self.messageTextFont = messageTextFont
         self.messageTextColor = messageTextColor
+        self.messageTextStyle = messageTextStyle
         self.buttonStyle = buttonStyle
         self.buttonIcon = buttonIcon
+        self.backgroundColor = backgroundColor
         self.accessibility = accessibility
+    }
+
+    mutating func apply(
+        configuration: RemoteConfiguration.ScreenSharing?,
+        assetBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
+        header.apply(
+            configuration: configuration?.header,
+            assetsBuilder: assetBuilder
+        )
+
+        UIFont.convertToFont(
+            uiFont: assetBuilder.fontBuilder(configuration?.message?.font),
+            textStyle: messageTextStyle
+        ).unwrap { messageTextFont = $0 }
+
+        configuration?.message?.foreground?.value
+            .map { UIColor(hex: $0) }
+            .first
+            .unwrap { messageTextColor = $0 }
+
+        buttonStyle.apply(
+            configuration: configuration?.endButton,
+            assetsBuilder: assetBuilder
+        )
+
+        configuration?.background?.color.unwrap {
+            switch $0.type {
+            case .fill:
+                $0.value
+                    .map { UIColor(hex: $0) }
+                    .first
+                    .unwrap { backgroundColor = .fill(color: $0) }
+            case .gradient:
+                let colors = $0.value.convertToCgColors()
+                backgroundColor = .gradient(colors: colors)
+            }
+        }
     }
 }

--- a/GliaWidgets/Sources/CallVisualizer/ScreenSharing/View/ScreenSharingView.swift
+++ b/GliaWidgets/Sources/CallVisualizer/ScreenSharing/View/ScreenSharingView.swift
@@ -51,10 +51,21 @@ extension CallVisualizer {
             endScreenSharingButton
         )
 
-        var props: Props = Props() {
+        var props: Props {
             didSet {
                 renderProps()
             }
+        }
+
+        // MARK: - Initialization
+
+        init(props: Props) {
+            self.props = props
+            super.init()
+        }
+
+        required init() {
+            fatalError("init() has not been implemented")
         }
 
         // MARK: - Overrides
@@ -91,5 +102,12 @@ private extension CallVisualizer.ScreenSharingView {
         header.title = props.style.title
         header.backButton.tap = props.back.execute
         endScreenSharingButton.tap = props.endScreenSharing.execute
+
+        switch props.style.backgroundColor {
+        case .fill(let color):
+            backgroundColor = color
+        case .gradient(let colors):
+            makeGradientBackground(colors: colors)
+        }
     }
 }

--- a/GliaWidgets/Sources/CallVisualizer/ScreenSharing/ViewController/ScreenSharingViewController.swift
+++ b/GliaWidgets/Sources/CallVisualizer/ScreenSharing/ViewController/ScreenSharingViewController.swift
@@ -2,7 +2,7 @@ import UIKit
 
 public extension CallVisualizer {
     final class ScreenSharingViewController: UIViewController {
-        private let screenSharingView = ScreenSharingView()
+        private lazy var screenSharingView = ScreenSharingView(props: props.screenSharingViewProps)
 
         var props: Props = .initial {
             didSet {

--- a/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeCoordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeCoordinator.swift
@@ -9,37 +9,25 @@ extension CallVisualizer {
         var delegate: ((DelegateEvent) -> Void)?
         var environment: Environment
         let presentation: CallVisualizer.Presentation
-        let uiConfig: RemoteConfiguration?
         var viewModel: VisitorCodeViewModel?
         var codeViewController: VisitorCodeViewController?
 
         init(
-            theme: Theme = Theme(),
+            theme: Theme,
             environment: Environment,
-            presentation: CallVisualizer.Presentation,
-            uiConfig: RemoteConfiguration?
+            presentation: CallVisualizer.Presentation
         ) {
-            self.visitorCodeStyle = theme.visitorCodeStyle
+            self.visitorCodeStyle = theme.visitorCode
             self.environment = environment
             self.theme = theme
             self.presentation = presentation
-            self.uiConfig = uiConfig
         }
 
         func start() -> UIViewController {
-            showVisitorCodeViewController(
-                by: presentation,
-                uiConfig: uiConfig
-            )
+            showVisitorCodeViewController(by: presentation)
         }
 
-        func showVisitorCodeViewController(
-            by presentation: CallVisualizer.Presentation,
-            uiConfig: RemoteConfiguration?
-        ) -> UIViewController {
-            if let uiConfig = uiConfig {
-                theme.applyRemoteConfiguration(uiConfig, assetsBuilder: .standard)
-            }
+        func showVisitorCodeViewController(by presentation: CallVisualizer.Presentation) -> UIViewController {
             let viewModel = VisitorCodeViewModel(
                 presentation: presentation,
                 environment: .init(

--- a/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeView+NumberView.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeView+NumberView.swift
@@ -1,30 +1,17 @@
 import UIKit
 
 extension CallVisualizer.VisitorCodeView {
-    class NumberView: UILabel {
+    final class NumberView: UILabel {
         struct Props: Equatable {
             let character: Character
-            let style: VisitorCodeStyle
+            let style: NumberSlotStyle
         }
 
         override init(frame: CGRect) {
             super.init(frame: frame)
-            self.font = .boldSystemFont(ofSize: 40)
             self.numberOfLines = 0
-            self.textColor = props.style.numberSlot.numberColor
+            self.clipsToBounds = true
             self.textAlignment = .center
-            switch props.style.numberSlot.backgroundColor {
-            case .fill(let color):
-                self.backgroundColor = color
-            case .gradient(let colors):
-                makeGradientBackground(
-                    colors: colors,
-                    cornerRadius: props.style.numberSlot.cornerRadius
-                )
-            }
-            self.layer.cornerRadius = props.style.numberSlot.cornerRadius
-            self.layer.borderWidth = props.style.numberSlot.borderWidth
-            self.layer.borderColor = props.style.numberSlot.borderColor.cgColor
             NSLayoutConstraint.activate([
                 self.heightAnchor.constraint(equalToConstant: 60),
                 self.widthAnchor.constraint(equalToConstant: 55).priority(.defaultHigh)
@@ -36,14 +23,29 @@ extension CallVisualizer.VisitorCodeView {
             fatalError("init(coder:) has not been implemented")
         }
 
-        var props: Props = Props(character: " ", style: Theme().visitorCode) {
+        var props: Props = Props(character: " ", style: Theme().visitorCode.numberSlot) {
             didSet {
                 renderProps()
             }
         }
 
-        func renderProps() {
+        private func renderProps() {
             text = String(props.character)
+            font = props.style.numberFont
+            textColor = props.style.numberColor
+            layer.cornerRadius = props.style.cornerRadius
+            layer.borderWidth = props.style.borderWidth
+            layer.borderColor = props.style.borderColor.cgColor
+
+            switch props.style.backgroundColor {
+            case .fill(let color):
+                backgroundColor = color
+            case .gradient(let colors):
+                makeGradientBackground(
+                    colors: colors,
+                    cornerRadius: props.style.cornerRadius
+                )
+            }
         }
     }
 }

--- a/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeView.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeView.swift
@@ -67,7 +67,7 @@ extension CallVisualizer {
             button.accessibilityIdentifier = "visitor_code_refresh_button"
         }
         let spinnerView = UIImageView().make { imageView in
-            imageView.image = Asset.spinner.image
+            imageView.image = Asset.spinner.image.withRenderingMode(.alwaysTemplate)
             imageView.contentMode = .center
         }
 
@@ -99,11 +99,9 @@ extension CallVisualizer {
             super.setup()
             clipsToBounds = true
             layer.masksToBounds = false
-            layer.cornerRadius = props.style.cornerRadius
             renderProps()
             refreshButton.addTarget(self, action: #selector(refreshButtonTapped), for: .touchUpInside)
             accessibilityElements = [titleLabel, closeButton, visitorCodeStack, poweredBy, refreshButton]
-
         }
 
         override func defineLayout() {
@@ -142,6 +140,7 @@ extension CallVisualizer {
             refreshButton.layer.shadowRadius = props.style.actionButton.shadowRadius ?? 0.0
             refreshButton.layer.shadowOpacity = props.style.actionButton.shadowOpacity ?? 0
             refreshButton.setTitle(props.style.actionButton.title, for: .normal)
+            refreshButton.titleLabel?.font = props.style.actionButton.titleFont
             switch props.style.actionButton.backgroundColor {
             case .fill(let color):
                 refreshButton.backgroundColor = color
@@ -163,6 +162,10 @@ extension CallVisualizer {
         }
 
         func renderProps() {
+            layer.cornerRadius = props.style.cornerRadius
+            layer.borderColor = props.style.borderColor.cgColor
+            layer.borderWidth = props.style.borderWidth
+
             titleLabel.font = props.style.titleFont
             titleLabel.textColor = props.style.titleColor
             switch props.viewState {
@@ -196,15 +199,17 @@ extension CallVisualizer {
             }
 
             closeButton.isHidden = props.closeButtonTap == nil
+
+            layoutSubviews()
         }
 
         var renderedVisitorCode: String = "" {
             didSet {
                 guard renderedVisitorCode != oldValue else { return }
                 visitorCodeStack.removeArrangedSubviews()
-                renderedVisitorCode.enumerated().forEach { (index, char) in
+                renderedVisitorCode.enumerated().forEach { index, char in
                     let valueLabel = NumberView().make { numberView in
-                        numberView.props = .init(character: char, style: props.style)
+                        numberView.props = .init(character: char, style: props.style.numberSlot)
                         numberView.accessibilityIdentifier = "visitor_code_number_slot_at_index_\(index)"
                     }
                     visitorCodeStack.addArrangedSubview(valueLabel)
@@ -242,6 +247,7 @@ extension CallVisualizer {
             rotation.toValue = CGFloat.pi * 2
             rotation.duration = 1.0
             rotation.repeatCount = Float.infinity
+            spinnerView.tintColor = props.style.loadingProgressColor
             spinnerView.layer.add(rotation, forKey: "Spin")
         }
 

--- a/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeViewController.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeViewController.swift
@@ -50,6 +50,14 @@ extension CallVisualizer {
                 view.trailingAnchor.constraint(
                     equalTo: container.safeAreaLayoutGuide.trailingAnchor,
                     constant: -8
+                ),
+                view.topAnchor.constraint(
+                    greaterThanOrEqualTo: container.topAnchor,
+                    constant: 8
+                ),
+                view.bottomAnchor.constraint(
+                    lessThanOrEqualTo: container.bottomAnchor,
+                    constant: -8
                 )
             ])
 

--- a/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeViewModel.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeViewModel.swift
@@ -41,7 +41,7 @@ extension CallVisualizer {
             let codeViewProps = VisitorCodeView.Props(
                 viewType: viewType,
                 viewState: viewState,
-                style: theme.visitorCodeStyle,
+                style: theme.visitorCode,
                 isPoweredByShown: theme.showsPoweredBy
             )
             return .init(visitorCodeViewProps: codeViewProps)

--- a/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration+CallVisualizer.swift
+++ b/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration+CallVisualizer.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+extension RemoteConfiguration {
+    struct CallVisualizer: Codable {
+        let visitorCode: VisitorCode?
+        let screenSharing: ScreenSharing?
+    }
+
+    struct VisitorCode: Codable {
+        let title: Text?
+        let actionButton: Button?
+        let numberSlot: NumberSlot?
+        let background: Layer?
+        let loadingProgressColor: Color?
+    }
+
+    struct ScreenSharing: Codable {
+        let header: Header?
+        let message: Text?
+        let endButton: Button?
+        let background: Layer?
+    }
+
+    struct NumberSlot: Codable {
+        let background: Layer?
+        let font: Font?
+        let fontColor: Color?
+    }
+}

--- a/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration.swift
+++ b/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration.swift
@@ -6,7 +6,7 @@ public struct RemoteConfiguration: Codable {
     let surveyScreen: Survey?
     let alert: Alert?
     let bubble: Bubble?
-    let visitorCode: VisitorCode
+    let callVisualizer: CallVisualizer?
 }
 
 extension RemoteConfiguration {
@@ -24,19 +24,6 @@ extension RemoteConfiguration {
             case callOperator = "operator"
             case topText
         }
-    }
-
-    struct VisitorCode: Codable {
-        let title: Text?
-        let actionButton: Button?
-        let numberSlot: NumberSlot?
-        let background: Layer?
-    }
-
-    struct NumberSlot: Codable {
-        let background: Layer?
-        let font: Font?
-        let fontColor: Color?
     }
 
     struct Alert: Codable {

--- a/GliaWidgets/Sources/Theme/Theme+ScreenSharing.swift
+++ b/GliaWidgets/Sources/Theme/Theme+ScreenSharing.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 extension Theme {
-    var screenSharing: ScreenSharingViewStyle {
+    var screenSharingStyle: ScreenSharingViewStyle {
         return ScreenSharingViewStyle(
             title: L10n.ScreenSharing.title,
             header: chat.header,
@@ -20,6 +20,7 @@ extension Theme {
                 )
             ),
             buttonIcon: Asset.startScreenShare.image,
+            backgroundColor: .fill(color: .white),
             accessibility: .init(isFontScalingEnabled: true)
         )
     }

--- a/GliaWidgets/Sources/Theme/Theme+VisitorCode.swift
+++ b/GliaWidgets/Sources/Theme/Theme+VisitorCode.swift
@@ -31,10 +31,11 @@ extension Theme {
             poweredBy: poweredBy,
             numberSlot: numberSlot,
             actionButton: actionButton,
-            accessibility: .init(isFontScalingEnabled: true),
             backgroundColor: .fill(color: color.background),
             cornerRadius: 30,
-            closeButtonColor: .fill(color: color.baseNormal)
+            closeButtonColor: .fill(color: color.baseNormal),
+            loadingProgressColor: color.primary,
+            accessibility: .init(isFontScalingEnabled: true)
         )
     }
 }

--- a/GliaWidgets/Sources/Theme/Theme.swift
+++ b/GliaWidgets/Sources/Theme/Theme.swift
@@ -49,7 +49,11 @@ public class Theme {
         alertStyle: alert
     )
 
+    /// Call Visualizer Visitor Code view style.
     public lazy var visitorCode: VisitorCodeStyle = { return visitorCodeStyle }()
+
+    /// Call Visualizer Screen Sharing View style.
+    public lazy var screenSharing: ScreenSharingViewStyle = { return screenSharingStyle }()
 
     /// Controls the visibility of the "Powered by" text and image.
     public var showsPoweredBy: Bool
@@ -97,7 +101,11 @@ public class Theme {
             assetsBuilder: assetsBuilder
         )
         visitorCode.apply(
-            configuration: config.visitorCode,
+            configuration: config.callVisualizer?.visitorCode,
+            assetBuilder: assetsBuilder
+        )
+        screenSharing.apply(
+            configuration: config.callVisualizer?.screenSharing,
             assetBuilder: assetsBuilder
         )
     }

--- a/GliaWidgets/Sources/View/VisitorCode/VisitorCodeStyle.swift
+++ b/GliaWidgets/Sources/View/VisitorCode/VisitorCodeStyle.swift
@@ -25,8 +25,17 @@ public struct VisitorCodeStyle: Equatable {
     /// Corner radius of the view.
     public var cornerRadius: CGFloat
 
+    /// Border width of the view.
+    public var borderWidth: CGFloat
+
+    /// Border color of the view.
+    public var borderColor: UIColor
+
     /// Color of the close button.
     public var closeButtonColor: ColorType
+
+    /// Color of the loading progress.
+    public var loadingProgressColor: UIColor
 
     /// Accessibility related properties.
     public var accessibility: Accessibility
@@ -38,10 +47,13 @@ public struct VisitorCodeStyle: Equatable {
         poweredBy: PoweredByStyle,
         numberSlot: NumberSlotStyle,
         actionButton: ActionButtonStyle,
-        accessibility: Accessibility = .unsupported,
         backgroundColor: ColorType,
         cornerRadius: CGFloat,
-        closeButtonColor: ColorType
+        borderWidth: CGFloat = 0,
+        borderColor: UIColor = .clear,
+        closeButtonColor: ColorType,
+        loadingProgressColor: UIColor,
+        accessibility: Accessibility = .unsupported
     ) {
         self.titleColor = titleColor
         self.titleFont = titleFont
@@ -49,10 +61,13 @@ public struct VisitorCodeStyle: Equatable {
         self.poweredBy = poweredBy
         self.numberSlot = numberSlot
         self.actionButton = actionButton
-        self.accessibility = accessibility
-        self.cornerRadius = cornerRadius
         self.backgroundColor = backgroundColor
+        self.cornerRadius = cornerRadius
+        self.borderWidth = borderWidth
+        self.borderColor = borderColor
         self.closeButtonColor = closeButtonColor
+        self.loadingProgressColor = loadingProgressColor
+        self.accessibility = accessibility
     }
 
     mutating func apply(
@@ -72,8 +87,21 @@ public struct VisitorCodeStyle: Equatable {
             assetsBuilder: assetBuilder
         )
 
+        configuration?.loadingProgressColor?.value
+            .map { UIColor(hex: $0) }
+            .first
+            .unwrap { loadingProgressColor = $0 }
+
         configuration?.background?.cornerRadius
             .unwrap { cornerRadius = $0 }
+
+        configuration?.background?.borderWidth
+            .unwrap { borderWidth = $0 }
+
+        configuration?.background?.border?.value
+            .map { UIColor(hex: $0) }
+            .first
+            .unwrap { borderColor = $0 }
 
         configuration?.background?.color.unwrap {
             switch $0.type {

--- a/GliaWidgetsTests/CallVisualizer/ScreenSharing/Mocks/ScreenSharingViewStyle+Mock.swift
+++ b/GliaWidgetsTests/CallVisualizer/ScreenSharing/Mocks/ScreenSharingViewStyle+Mock.swift
@@ -11,6 +11,7 @@ extension ScreenSharingViewStyle {
             messageTextColor: .clear,
             buttonStyle: .mock(),
             buttonIcon: UIImage(),
+            backgroundColor: .fill(color: .white),
             accessibility: .unsupported
         )
     }

--- a/TestingApp/Main.storyboard
+++ b/TestingApp/Main.storyboard
@@ -21,7 +21,7 @@
                                 <rect key="frame" x="0.0" y="48" width="414" height="814"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="A3Y-Xf-Ufg">
-                                        <rect key="frame" x="0.0" y="16" width="414" height="737.5"/>
+                                        <rect key="frame" x="0.0" y="16" width="414" height="782.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Configuration" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4l1-DH-Wkd">
                                                 <rect key="frame" x="155.5" y="0.0" width="103.5" height="20.5"/>
@@ -140,20 +140,20 @@
                                                     <action selector="toggleAuthentication" destination="Y6W-OH-hqX" eventType="touchUpInside" id="ilH-Ar-YKu"/>
                                                 </connections>
                                             </button>
-							                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ojd-PF-wje">
-                            		            <rect key="frame" x="119" y="200" width="176" height="30"/>
-                                    		    <constraints>
-                                            		<constraint firstAttribute="height" constant="30" id="Nk7-ud-fyb"/>
-		                                        </constraints>
-        		                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                		                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                        		                <state key="normal" title="Start secure conversation"/>
-                                		        <connections>
-                                        		    <action selector="secureConversationTapped" destination="Y6W-OH-hqX" eventType="touchUpInside" id="pV9-8F-891"/>
-		                                        </connections>
-       			                             </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ojd-PF-wje">
+                                                <rect key="frame" x="119" y="331.5" width="176" height="30"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="30" id="Nk7-ud-fyb"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                                <state key="normal" title="Start secure conversation"/>
+                                                <connections>
+                                                    <action selector="secureConversationTapped" destination="Y6W-OH-hqX" eventType="touchUpInside" id="pV9-8F-891"/>
+                                                </connections>
+                                            </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3Ys-xS-zdq">
-                                                <rect key="frame" x="126" y="331.5" width="162" height="30"/>
+                                                <rect key="frame" x="126" y="376.5" width="162" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_endEngagement_button"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="QkV-yj-Sti"/>
@@ -164,13 +164,13 @@
                                                 </connections>
                                             </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="UI customization" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E1e-uA-HuC">
-                                                <rect key="frame" x="143.5" y="376.5" width="127.5" height="20.5"/>
+                                                <rect key="frame" x="143.5" y="421.5" width="127.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ezc-iY-PbB">
-                                                <rect key="frame" x="141" y="412" width="132" height="30"/>
+                                                <rect key="frame" x="141" y="457" width="132" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_endEngagement_button"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="Nef-0j-qW7"/>
@@ -181,13 +181,13 @@
                                                 </connections>
                                             </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VisitorCode" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tI8-TQ-jWA">
-                                                <rect key="frame" x="162.5" y="457" width="89" height="20.5"/>
+                                                <rect key="frame" x="162.5" y="502" width="89" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="1gR-qB-lno">
-                                                <rect key="frame" x="90.5" y="492.5" width="233" height="30"/>
+                                                <rect key="frame" x="90.5" y="537.5" width="233" height="30"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YnU-rR-gCc">
                                                         <rect key="frame" x="0.0" y="0.0" width="88" height="30"/>
@@ -214,10 +214,11 @@
                                                 </subviews>
                                             </stackView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7mi-et-ybT">
-                                                <rect key="frame" x="0.0" y="537.5" width="414" height="200"/>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <rect key="frame" x="0.0" y="582.5" width="414" height="200"/>
+                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="200" id="cj8-4r-PEu"/>
+                                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="200" id="GaG-7F-RUb"/>
+                                                    <constraint firstAttribute="height" priority="250" constant="200" id="cj8-4r-PEu"/>
                                                 </constraints>
                                             </view>
                                         </subviews>
@@ -247,9 +248,9 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="secureConversationsButton" destination="ojd-PF-wje" id="kN8-zY-QYl"/>
                         <outlet property="VisitorCodeView" destination="7mi-et-ybT" id="guR-OT-e1w"/>
                         <outlet property="configureButton" destination="4yC-lN-tH2" id="sAf-jg-YTC"/>
+                        <outlet property="secureConversationsButton" destination="ojd-PF-wje" id="kN8-zY-QYl"/>
                         <outlet property="toggleAuthenticateButton" destination="pHy-59-v7T" id="9rO-74-dfE"/>
                     </connections>
                 </viewController>

--- a/TestingApp/ViewController/ViewController+CallVisualizer.swift
+++ b/TestingApp/ViewController/ViewController+CallVisualizer.swift
@@ -1,0 +1,23 @@
+import UIKit
+import GliaWidgets
+
+extension ViewController {
+
+    @IBAction private func presentVisitorCodeAsAlertTapped() {
+        showVisitorCode(presentation: .alert(self))
+    }
+
+    @IBAction private func embedVisitorCodeViewTapped() {
+        showVisitorCode(presentation: .embedded(visitorCodeView))
+    }
+    
+    func showVisitorCode(presentation: CallVisualizer.Presentation) {
+        showRemoteConfigAlert { [weak self] fileName in
+            let config = self?.retrieveRemoteConfiguration(fileName)
+            Glia.sharedInstance.callVisualizer.showVisitorCodeViewController(
+                by: presentation,
+                uiConfig: config
+            )
+        }
+    }
+}


### PR DESCRIPTION
Added RemoteConfiguration elements for VisitorCode and ScreenSharing
Extended VisitorCodeStyle
Fixed UI of VisitorCodeView for customization
Fixed applying style for ScreenSharingView

[MOB-1826](https://glia.atlassian.net/browse/MOB-1826)

[MOB-1826]: https://glia.atlassian.net/browse/MOB-1826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ