### PR TITLE
Disable attachment button based on upload limit

### DIFF
--- a/GliaWidgets/SecureConversations/FileUploadListView/SecureConversations.FileUploadListViewModel.swift
+++ b/GliaWidgets/SecureConversations/FileUploadListView/SecureConversations.FileUploadListViewModel.swift
@@ -21,8 +21,8 @@ extension SecureConversations {
             environment.uploader.state.addObserver(self) { [weak self] state, _ in
                 self?.onUploaderStateChanged(state)
             }
-            environment.uploader.limitReached.addObserver(self) { [weak self] limitReached, _ in
-                // TODO: MOB-1838
+            environment.uploader.limitReached.addObserver(self) { [weak self] _, _ in
+                self?.reportChange()
             }
         }
 
@@ -132,6 +132,10 @@ extension SecureConversations.FileUploadListViewModel {
 
     var state: ObservableValue<FileUploader.State> {
         environment.uploader.state
+    }
+
+    var isLimitReached: Bool {
+        environment.uploader.limitReached.value
     }
 
     func removeSucceededUploads() {

--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeView.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeView.swift
@@ -226,6 +226,11 @@ extension SecureConversations {
             renderedWarning = props.warningMessage
 
             fileUploadListView.props = props.fileUploadListProps
+
+            rootStackView.setCustomSpacing(
+                props.fileUploadListProps.uploads.isEmpty ? 0 : 16,
+                after: fileUploadListView
+            )
         }
 
         var renderedWarning: Props.WarningMessage = "" {

--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.swift
@@ -100,8 +100,9 @@ extension SecureConversations.WelcomeViewModel {
     // some parts are refactored to pure static methods.
     func props() -> Props {
         let welcomeStyle = environment.welcomeStyle
-        let filePickerButton = SecureConversations.WelcomeView.Props.FilePickerButton(
-            isEnabled: true,
+        let isFilePickerEnabled = !fileUploadListModel.isLimitReached
+        let filePickerButton = WelcomeViewProps.FilePickerButton(
+            isEnabled: isFilePickerEnabled,
             tap: Command { [weak self, alertConfiguration = environment.alertConfiguration] originView in
                 self?.presentMediaPicker(
                     from: originView,


### PR DESCRIPTION
Take into account upload limit for toggling enabled state of attachment button on Message Center Welcome screen.

MOB-1838