### PR TITLE
Fix applying VisitorContext on configure SDK from Testing app

### DIFF
--- a/TestingApp/ViewController/ViewController.swift
+++ b/TestingApp/ViewController/ViewController.swift
@@ -176,7 +176,10 @@ extension ViewController {
         try? Glia.sharedInstance.configure(
             with: configuration,
             queueId: queueId,
-            visitorContext: nil
+            visitorContext: (configuration.visitorContext?.assetId)
+                .map(VisitorContext.AssetId.init(rawValue:))
+                .map(VisitorContext.ContextType.assetId)
+                .map(VisitorContext.init(_:))
         ) { [weak self] in
             self?.configureButton.setTitle(originalTitle, for: .normal)
             debugPrint("SDK has been configured")


### PR DESCRIPTION
Currently we don't pass VisitorContextAssetID entered into Settings to Live engagements.
This change fixes this.