### PR TITLE
Show alert for unavailable message center

### DIFF
--- a/GliaWidgets/L10n.swift
+++ b/GliaWidgets/L10n.swift
@@ -164,6 +164,12 @@ public enum L10n {
     public enum VisitorCode {
         public static let title = L10n.tr("Localizable", "alert.visitorCode.title", fallback: "Your Visitor Code")
     }
+    public enum UnavailableMessageCenter {
+      /// The Message Center is currently unavailable. Please try again later.
+      public static let message = L10n.tr("Localizable", "alert.unavailableMessageCenter.message", fallback: "The Message Center is currently unavailable. Please try again later.")
+      /// Message Center Unavailable
+      public static let title = L10n.tr("Localizable", "alert.unavailableMessageCenter.title", fallback: "Message Center Unavailable")
+      }
   }
   public enum Call {
     /// You can continue browsing and we’ll connect you automatically.

--- a/GliaWidgets/Resources/en.lproj/Localizable.strings
+++ b/GliaWidgets/Resources/en.lproj/Localizable.strings
@@ -32,6 +32,9 @@
 "alert.unexpected.title" = "We're sorry, there has been an unexpected error.";
 "alert.unexpected.message" = "Please try again later.";
 
+"alert.unavailableMessageCenter.title" = "Message Center Unavailable";
+"alert.unavailableMessageCenter.message" = "The Message Center is currently unavailable. Please try again later.";
+
 "alert.apiError.title" = "We're sorry, there has been an error.";
 "alert.apiError.message" = "{message}";
 

--- a/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.Mock.swift
+++ b/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.Mock.swift
@@ -17,7 +17,8 @@ extension AlertConfiguration {
             cameraSettings: .mock(),
             mediaSourceNotAvailable: .mock(),
             unexpectedError: .mock(),
-            apiError: .mock()
+            apiError: .mock(),
+            unavailableMessageCenter: .mock()
         )
     }
 }

--- a/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.swift
+++ b/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.swift
@@ -45,6 +45,9 @@ public struct AlertConfiguration {
     /// Configuration of the API error alert.
     public var apiError: MessageAlertConfiguration
 
+    /// Configuration of the unavailable message center error alert.
+    public var unavailableMessageCenter: MessageAlertConfiguration
+
     ///
     /// - Parameters:
     ///   - leaveQueue: Configuration of the queue leaving confirmation alert.
@@ -62,6 +65,7 @@ public struct AlertConfiguration {
     ///   - mediaSourceNotAvailable: Configuration of the unavailable media source (camera, etc) alert.
     ///   - unexpectedError: Configuration of the unexpected error alert.
     ///   - apiError: Configuration of the API error alert.
+    ///   - unavailableMessageCenter: Configuration of the unavailable message center error alert.
     ///
     public init(
         leaveQueue: ConfirmationAlertConfiguration,
@@ -78,7 +82,8 @@ public struct AlertConfiguration {
         cameraSettings: SettingsAlertConfiguration,
         mediaSourceNotAvailable: MessageAlertConfiguration,
         unexpectedError: MessageAlertConfiguration,
-        apiError: MessageAlertConfiguration
+        apiError: MessageAlertConfiguration,
+        unavailableMessageCenter: MessageAlertConfiguration
     ) {
         self.leaveQueue = leaveQueue
         self.endEngagement = endEngagement
@@ -95,5 +100,6 @@ public struct AlertConfiguration {
         self.mediaSourceNotAvailable = mediaSourceNotAvailable
         self.unexpectedError = unexpectedError
         self.apiError = apiError
+        self.unavailableMessageCenter = unavailableMessageCenter
     }
 }

--- a/GliaWidgets/Sources/Theme/Alert/MessageAlertConfiguration.swift
+++ b/GliaWidgets/Sources/Theme/Alert/MessageAlertConfiguration.swift
@@ -6,21 +6,39 @@ public struct MessageAlertConfiguration {
     /// Message of the alert. Include `{message}` template parameter in the string to display Glia's error message.
     public var message: String?
 
+    /// Controls the appearance of the X button in the alert. Defaults to true. If this value is true, an X button
+    /// shows up on the alert so that the visitor can dismiss it, and the background gets dimmed. If the value is false,
+    /// no X button shows up, and the background doesn't get dimmed.
+    public var shouldShowCloseButton = true
     private let kMessagePlaceholder = "{message}"
 
     ///
     /// - Parameters:
     ///   - title: Title of the alert.
     ///   - message: Message of the alert. Include `{message}` template parameter in the string to display Glia's error message.
+    ///   - shouldShowCloseButton: Controls the appearance of the X button in the alert. Defaults to true. If this value is true, an
+    ///   X button shows up on the alert so that the visitor can dismiss it, and the background gets dimmed. If the value is false,
+    ///   no X button shows up, and the background doesn't get dimmed.
     ///
-    public init(title: String?, message: String?) {
+    public init(
+        title: String?,
+        message: String?,
+        shouldShowCloseButton: Bool = true
+    ) {
         self.title = title
         self.message = message
+        self.shouldShowCloseButton = shouldShowCloseButton
     }
 
-    init(with error: CoreSdkClient.SalemoveError, templateConf: MessageAlertConfiguration) {
+    init(
+        with error: CoreSdkClient.SalemoveError,
+        templateConf: MessageAlertConfiguration
+    ) {
         self.title = templateConf.title
-        self.message = templateConf.message?.replacingOccurrences(of: kMessagePlaceholder,
-                                                                  with: error.reason)
+        self.message = templateConf.message?.replacingOccurrences(
+            of: kMessagePlaceholder,
+            with: error.reason
+        )
+        self.shouldShowCloseButton = templateConf.shouldShowCloseButton
     }
 }

--- a/GliaWidgets/Sources/Theme/Theme+AlertConfiguration.swift
+++ b/GliaWidgets/Sources/Theme/Theme+AlertConfiguration.swift
@@ -118,6 +118,11 @@ extension Theme {
             title: Alert.ApiError.title,
             message: Alert.ApiError.message
         )
+        let unavailableMessageCenter = MessageAlertConfiguration(
+            title: Alert.UnavailableMessageCenter.title,
+            message: Alert.UnavailableMessageCenter.message,
+            shouldShowCloseButton: false
+        )
 
         return AlertConfiguration(
             leaveQueue: leaveQueue,
@@ -134,7 +139,8 @@ extension Theme {
             cameraSettings: cameraSettings,
             mediaSourceNotAvailable: mediaSourceNotAvailable,
             unexpectedError: unexpected,
-            apiError: api
+            apiError: api,
+            unavailableMessageCenter: unavailableMessageCenter
         )
     }
 }

--- a/GliaWidgets/Sources/ViewController/Common/Alert/AlertPresenter.swift
+++ b/GliaWidgets/Sources/ViewController/Common/Alert/AlertPresenter.swift
@@ -8,6 +8,11 @@ protocol AlertPresenter where Self: UIViewController {
         accessibilityIdentifier: String?,
         dismissed: (() -> Void)?
     )
+    func presentAlertAsView(
+        with conf: MessageAlertConfiguration,
+        accessibilityIdentifier: String?,
+        dismissed: (() -> Void)?
+    )
     func presentConfirmation(
         with conf: ConfirmationAlertConfiguration,
         accessibilityIdentifier: String,
@@ -39,6 +44,30 @@ extension AlertPresenter {
             viewFactory: viewFactory
         )
         present(alert, animated: true, completion: nil)
+    }
+
+    func presentAlertAsView(
+        with conf: MessageAlertConfiguration,
+        accessibilityIdentifier: String? = nil,
+        dismissed: (() -> Void)? = nil
+    ) {
+        let alert = AlertViewController(
+            kind: .message(
+                conf,
+                accessibilityIdentifier: accessibilityIdentifier,
+                dismissed: dismissed
+            ),
+            viewFactory: viewFactory
+        )
+
+        insertChild(alert)
+        alert.view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            view.topAnchor.constraint(equalTo: alert.view.topAnchor),
+            view.bottomAnchor.constraint(equalTo: alert.view.bottomAnchor),
+            view.leadingAnchor.constraint(equalTo: alert.view.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: alert.view.trailingAnchor)
+        ])
     }
 
     func presentConfirmation(

--- a/GliaWidgets/Sources/ViewController/Common/Alert/AlertViewController+Message.swift
+++ b/GliaWidgets/Sources/ViewController/Common/Alert/AlertViewController+Message.swift
@@ -9,7 +9,7 @@ extension AlertViewController {
         let alertView = viewFactory.makeAlertView()
         alertView.title = conf.title
         alertView.message = conf.message
-        alertView.showsCloseButton = true
+        alertView.showsCloseButton = conf.shouldShowCloseButton
         alertView.closeTapped = { [weak self] in
             self?.dismiss(animated: true) {
                 dismissed?()

--- a/GliaWidgets/Sources/ViewController/Common/Alert/AlertViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Common/Alert/AlertViewController.swift
@@ -54,7 +54,15 @@ class AlertViewController: UIViewController {
     override public func loadView() {
         super.loadView()
         let view = UIView()
-        view.backgroundColor = UIColor.black.withAlphaComponent(0.2)
+
+        if case let Kind.message(conf, _, _) = kind, !conf.shouldShowCloseButton {
+            view.backgroundColor = UIColor.clear
+            view.isUserInteractionEnabled = false
+        } else {
+            view.backgroundColor = UIColor.black.withAlphaComponent(0.2)
+            view.isUserInteractionEnabled = true
+        }
+
         self.view = view
     }
 
@@ -68,6 +76,7 @@ class AlertViewController: UIViewController {
 
         let alertView = makeAlertView()
         self.alertView = alertView
+        alertView.isUserInteractionEnabled = false
 
         view.addSubview(alertView)
         alertView.autoPinEdgesToSuperviewSafeArea(with: kAlertInsets,


### PR DESCRIPTION
When the message center is unavailable, an alert is shown which is different from what is currently in place. The alert needs to have transparent background and you need to be able to interact with the view behind. All our alerts are currently presented modally, which doesn’t allow a straightforward way to pass touches to the view behind. Thus, this alert is added as a subview instead of modally. Instead of trying to use the current method, I created a new one so that there’s a clear distinction between both. This can be discussed.

MOB-1724