### PR TITLE
Fix issue with alerts not being enabled for interactions

### DIFF
--- a/GliaWidgets/Sources/ViewController/Common/Alert/AlertViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Common/Alert/AlertViewController.swift
@@ -76,7 +76,6 @@ class AlertViewController: UIViewController {
 
         let alertView = makeAlertView()
         self.alertView = alertView
-        alertView.isUserInteractionEnabled = false
 
         view.addSubview(alertView)
         alertView.autoPinEdgesToSuperviewSafeArea(with: kAlertInsets,


### PR DESCRIPTION
I don't really know why this line slipped through, I guess it was while I was doing some tests. This line made it so that all alerts were disabled, so acceptance tests would fail because you couldn't click on buttons.