### PR TITLE
Add accessibility to welcome screen

### DIFF
--- a/GliaWidgets/L10n.swift
+++ b/GliaWidgets/L10n.swift
@@ -685,8 +685,45 @@ public enum L10n {
   }
   public enum MessageCenter {
     public enum Welcome {
+      // Messaging
+      public static let header = L10n.tr("Localizable", "messageCenter.welcome.header", fallback: "Messaging")
+      // Welcome to Message Center
+      public static let title = L10n.tr("Localizable", "messageCenter.welcome.title", fallback: "Welcome to Message Center")
+      // Send a message and we’ll get back to you within 48 hours
+      public static let subtitle = L10n.tr("Localizable", "messageCenter.welcome.subtitle", fallback: "Send a message and we’ll get back to you within 48 hours")
+      // Check messages
+      public static let checkMessages = L10n.tr("Localizable", "messageCenter.welcome.checkMessages", fallback: "Check messages")
+      // Your messages
+      public static let messageTitle = L10n.tr("Localizable", "messageCenter.welcome.messageTitle", fallback: "Your message")
+      // Enter your message
+      public static let messageTextViewNormal = L10n.tr("Localizable", "messageCenter.welcome.messageTextViewNormal", fallback: "Enter your message")
+      // Enter your message
+      public static let messageTextViewActive = L10n.tr("Localizable", "messageCenter.welcome.messageTextViewActive", fallback: "Enter your message")
+      // Enter your message
+      public static let messageTextViewDisabled = L10n.tr("Localizable", "messageCenter.welcome.messageTextViewDisabled", fallback: "Enter your message")
+      // Send
+      public static let sendEnabled = L10n.tr("Localizable", "messageCenter.welcome.sendEnabled", fallback: "Send")
+      // Send
+      public static let sendDisabled = L10n.tr("Localizable", "messageCenter.welcome.sendDisabled", fallback: "Send")
+      // Send
+      public static let sendLoading = L10n.tr("Localizable", "messageCenter.welcome.sendLoading", fallback: "Send")
       /// The message cannot exceed {textLength} characters.
       public static let messageLengthWarning = L10n.tr("Localizable", "messageCenter.welcome.messageLengthWarning", fallback: "The message cannot exceed {textLength} characters.")
+
+      public enum Accessibility {
+        // Check messages
+        public static let checkMessagesLabel = L10n.tr("Localizable", "messageCenter.welcome.accessibility.checkMessagesLabel", fallback: "Check messages")
+        // Navigates you to the chat transcript.
+        public static let checkMessagesHint = L10n.tr("Localizable", "messageCenter.welcome.accessibility.checkMessagesHint", fallback: "Navigates you to the chat transcript.")
+        // File picker
+        public static let filePickerLabel = L10n.tr("Localizable", "messageCenter.welcome.accessibility.filePickerLabel", fallback: "File picker")
+        // Opens the file picker to attach media.
+        public static let filePickerHint = L10n.tr("Localizable", "messageCenter.welcome.accessibility.filePickerHint", fallback: "Opens the file picker to attach media.")
+        // Send
+        public static let sendLabel = L10n.tr("Localizable", "messageCenter.welcome.accessibility.sendLabel", fallback: "Send")
+        // Sends a secure message.
+        public static let sendHint = L10n.tr("Localizable", "messageCenter.welcome.accessibility.sendHint", fallback: "Sends a secure message.")
+      }
     }
   }
 

--- a/GliaWidgets/Resources/en.lproj/Localizable.strings
+++ b/GliaWidgets/Resources/en.lproj/Localizable.strings
@@ -221,6 +221,24 @@
 "survey.accessibility.validation.title.label" = "Please provide an answer for question above";
 
 "messageCenter.welcome.messageLengthWarning" = "The message cannot exceed {textLength} characters.";
+"messageCenter.welcome.header" = "Messaging";
+"messageCenter.welcome.title" = "Welcome to Message Center";
+"messageCenter.welcome.subtitle" = "Send a message and we’ll get back to you within 48 hours";
+"messageCenter.welcome.checkMessages" = "Check messages";
+"messageCenter.welcome.messageTitle" = "Your message";
+"messageCenter.welcome.messageTextViewNormal" = "Enter your message";
+"messageCenter.welcome.messageTextViewActive" = "Enter your message";
+"messageCenter.welcome.messageTextViewDisabled" = "Enter your message";
+"messageCenter.welcome.sendEnabled" = "Send";
+"messageCenter.welcome.sendDisabled" = "Send";
+"messageCenter.welcome.sendLoading" = "Send";
+"messageCenter.welcome.accessibility.checkMessagesLabel" = "Check messages";
+"messageCenter.welcome.accessibility.checkMessagesHint" = "Navigates you to the chat transcript.";
+"messageCenter.welcome.accessibility.filePickerLabel" = "File picker";
+"messageCenter.welcome.accessibility.filePickerHint" = "Opens the file picker to attach media.";
+"messageCenter.welcome.accessibility.sendLabel" = "Send";
+"messageCenter.welcome.accessibility.sendHint" = "Sends a secure message.";
+
 "visitorCode.title.standard" = "Your Visitor Code";
 "visitorCode.title.error" = "Could not show visitor code. Please try refreshing.";
 "visitorCode.action.refresh" = "Refresh";

--- a/GliaWidgets/SecureConversations/SecureConversations.SendMessageButton.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.SendMessageButton.swift
@@ -12,7 +12,10 @@ extension SecureConversations {
                 borderWidth: 3,
                 cornerRadius: 8,
                 activityIndicatorColor: .green,
-                isActivityIndicatorShown: false
+                isActivityIndicatorShown: false,
+                isFontScalingEnabled: false,
+                accessibilityLabel: "",
+                accessibilityHint: ""
             )
         ) {
             didSet {
@@ -65,6 +68,10 @@ extension SecureConversations {
             layer.cornerRadius = props.cornerRadius
             activityIndicator.color = props.activityIndicatorColor
             renderedIsIndicatorShown = props.isActivityIndicatorShown
+            accessibilityTraits = .button
+            accessibilityLabel = props.accessibilityLabel
+            accessibilityHint = props.accessibilityHint
+            isAccessibilityElement = true
         }
 
         var renderedIsIndicatorShown: Bool = false {
@@ -100,6 +107,9 @@ extension SecureConversations.SendMessageButton.Props {
         let cornerRadius: Double
         let activityIndicatorColor: UIColor
         let isActivityIndicatorShown: Bool
+        let isFontScalingEnabled: Bool
+        let accessibilityLabel: String
+        let accessibilityHint: String
     }
 
     struct DisabledState: Equatable {
@@ -112,6 +122,9 @@ extension SecureConversations.SendMessageButton.Props {
         let cornerRadius: Double
         let activityIndicatorColor: UIColor
         let isActivityIndicatorShown: Bool
+        let isFontScalingEnabled: Bool
+        let accessibilityLabel: String
+        let accessibilityHint: String
     }
 }
 
@@ -127,6 +140,9 @@ extension SecureConversations.SendMessageButton {
         let activityIndicatorColor: UIColor
         let isActivityIndicatorShown: Bool
         let isEnabled: Bool
+        let isFontScalingEnabled: Bool
+        let accessibilityLabel: String
+        let accessibilityHint: String
 
         init(_ props: Props) {
             switch props {
@@ -141,6 +157,9 @@ extension SecureConversations.SendMessageButton {
                 self.activityIndicatorColor = state.activityIndicatorColor
                 self.isActivityIndicatorShown = state.isActivityIndicatorShown
                 self.isEnabled = true
+                self.isFontScalingEnabled = state.isFontScalingEnabled
+                self.accessibilityLabel = state.accessibilityLabel
+                self.accessibilityHint = state.accessibilityHint
             case let .disabled(state):
                 self.title = state.title
                 self.titleFont = state.titleFont
@@ -152,6 +171,9 @@ extension SecureConversations.SendMessageButton {
                 self.activityIndicatorColor = state.activityIndicatorColor
                 self.isActivityIndicatorShown = state.isActivityIndicatorShown
                 self.isEnabled = false
+                self.isFontScalingEnabled = state.isFontScalingEnabled
+                self.accessibilityLabel = state.accessibilityLabel
+                self.accessibilityHint = state.accessibilityHint
             }
         }
     }
@@ -169,7 +191,10 @@ extension SecureConversations.SendMessageButton.Props {
                 borderWidth: enabledStyle.borderWidth,
                 cornerRadius: enabledStyle.cornerRadius,
                 activityIndicatorColor: .clear,
-                isActivityIndicatorShown: false
+                isActivityIndicatorShown: false,
+                isFontScalingEnabled: enabledStyle.accessibility.isFontScalingEnabled,
+                accessibilityLabel: enabledStyle.accessibility.label,
+                accessibilityHint: enabledStyle.accessibility.hint
             )
         )
     }
@@ -185,7 +210,10 @@ extension SecureConversations.SendMessageButton.Props {
                 borderWidth: disabledStyle.borderWidth,
                 cornerRadius: disabledStyle.cornerRadius,
                 activityIndicatorColor: .clear,
-                isActivityIndicatorShown: false
+                isActivityIndicatorShown: false,
+                isFontScalingEnabled: disabledStyle.accessibility.isFontScalingEnabled,
+                accessibilityLabel: disabledStyle.accessibility.label,
+                accessibilityHint: disabledStyle.accessibility.hint
             )
         )
     }
@@ -201,7 +229,10 @@ extension SecureConversations.SendMessageButton.Props {
                 borderWidth: loadingStyle.borderWidth,
                 cornerRadius: loadingStyle.cornerRadius,
                 activityIndicatorColor: loadingStyle.activityIndicatorColor,
-                isActivityIndicatorShown: true
+                isActivityIndicatorShown: true,
+                isFontScalingEnabled: loadingStyle.accessibility.isFontScalingEnabled,
+                accessibilityLabel: loadingStyle.accessibility.label,
+                accessibilityHint: loadingStyle.accessibility.hint
             )
         )
     }

--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeStyle.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeStyle.swift
@@ -102,23 +102,28 @@ extension SecureConversations.WelcomeStyle {
         public var font: UIFont
         /// Title color.
         public var color: UIColor
+        /// Accessibility related properties.
+        public var accessibility: Accessibility
 
         /// - Parameters:
         ///   - text: Title text value.
         ///   - font: Title font.
         ///   - color: Title color.
+        ///   - accessibility: Accessibility related properties.
         public init(
             text: String,
             font: UIFont,
-            color: UIColor
+            color: UIColor,
+            accessibility: Accessibility
         ) {
             self.text = text
             self.font = font
             self.color = color
+            self.accessibility = accessibility
         }
 
         /// Accessibility properties for TitleStyle.
-        public struct Accessibility {
+        public struct Accessibility: Equatable {
             /// Flag that provides font dynamic type by setting `adjustsFontForContentSizeCategory` for component that supports it.
             public var isFontScalingEnabled: Bool
 
@@ -140,23 +145,28 @@ extension SecureConversations.WelcomeStyle {
         public var font: UIFont
         /// Subtitle color.
         public var color: UIColor
+        /// Accessibility related properties.
+        public var accessibility: Accessibility
 
         /// - Parameters:
         ///   - text: Subtitle text value.
         ///   - font: Subtitle font.
         ///   - color: Subtitle color.
+        ///   - accessibility: Accessibility related properties.
         public init(
             text: String,
             font: UIFont,
-            color: UIColor
+            color: UIColor,
+            accessibility: Accessibility
         ) {
             self.text = text
             self.font = font
             self.color = color
+            self.accessibility = accessibility
         }
 
         /// Accessibility properties for SubtitleStyle.
-        public struct Accessibility {
+        public struct Accessibility: Equatable {
             /// Flag that provides font dynamic type by setting `adjustsFontForContentSizeCategory` for component that supports it.
             public var isFontScalingEnabled: Bool
 
@@ -178,6 +188,8 @@ extension SecureConversations.WelcomeStyle {
         public var font: UIFont
         /// Color of the button title.
         public var color: UIColor
+        /// Accessibility related properties.
+        public var accessibility: Accessibility
 
         /// - Parameters:
         ///   - title: Button title.
@@ -186,25 +198,45 @@ extension SecureConversations.WelcomeStyle {
         public init(
             title: String,
             font: UIFont,
-            color: UIColor
+            color: UIColor,
+            accessibility: Accessibility
         ) {
             self.title = title
             self.font = font
             self.color = color
+            self.accessibility = accessibility
         }
 
         /// Accessibility properties for CheckMessagesButtonStyle.
         public struct Accessibility: Equatable {
             /// Flag that provides font dynamic type by setting `adjustsFontForContentSizeCategory` for component that supports it.
             public var isFontScalingEnabled: Bool
+            /// Accessibility label.
+            public var label: String
+            /// Accessibility hint.
+            public var hint: String
 
-            /// - Parameter isFontScalingEnabled: Flag that provides font dynamic type by setting `adjustsFontForContentSizeCategory` for component that supports it.
-            public init(isFontScalingEnabled: Bool) {
+            /// - Parameters:
+            ///   - isFontScalingEnabled: Flag that provides font dynamic type by setting
+            ///    `adjustsFontForContentSizeCategory` for component that supports it.
+            ///   - label: Accessibility label.
+            ///   - hint: Accessibility hint.
+            public init(
+                isFontScalingEnabled: Bool,
+                label: String,
+                hint: String
+            ) {
                 self.isFontScalingEnabled = isFontScalingEnabled
+                self.label = label
+                self.hint = hint
             }
 
             /// Accessibility is not supported intentionally.
-            public static let unsupported = Self(isFontScalingEnabled: false)
+            public static let unsupported = Self(
+                isFontScalingEnabled: false,
+                label: "",
+                hint: ""
+            )
         }
     }
 
@@ -216,6 +248,8 @@ extension SecureConversations.WelcomeStyle {
         public var font: UIFont
         /// Color of the message title.
         public var color: UIColor
+        /// Accessibility related properties.
+        public var accessibility: Accessibility
 
         /// - Parameters:
         ///   - title: Message title text.
@@ -224,11 +258,13 @@ extension SecureConversations.WelcomeStyle {
         public init(
             title: String,
             font: UIFont,
-            color: UIColor
+            color: UIColor,
+            accessibility: Accessibility
         ) {
             self.title = title
             self.font = font
             self.color = color
+            self.accessibility = accessibility
         }
 
         /// Accessibility properties for MessageTitleStyle.
@@ -288,6 +324,8 @@ extension SecureConversations.WelcomeStyle {
         public var cornerRadius: Double
         /// Color of the background of the text view.
         public var backgroundColor: UIColor
+        /// Accessibility related properties.
+        public var accessibility: Accessibility
 
         /// - Parameters:
         ///   - placeholderText: Placeholder text for text view.
@@ -308,7 +346,8 @@ extension SecureConversations.WelcomeStyle {
             borderColor: UIColor,
             borderWidth: Double,
             cornerRadius: Double,
-            backgroundColor: UIColor
+            backgroundColor: UIColor,
+            accessibility: Accessibility
         ) {
             self.placeholderText = placeholderText
             self.placeholderFont = placeholderFont
@@ -319,6 +358,7 @@ extension SecureConversations.WelcomeStyle {
             self.borderWidth = borderWidth
             self.cornerRadius = cornerRadius
             self.backgroundColor = backgroundColor
+            self.accessibility = accessibility
         }
 
         /// Accessibility properties for MessageTextViewDisabledStyle.
@@ -356,6 +396,8 @@ extension SecureConversations.WelcomeStyle {
         public var cornerRadius: Double
         /// Color of the background of the text view.
         public var backgroundColor: UIColor
+        /// Accessibility related properties.
+        public var accessibility: Accessibility
 
         /// - Parameters:
         ///   - placeholderText: Placeholder text for text view.
@@ -376,7 +418,8 @@ extension SecureConversations.WelcomeStyle {
             borderColor: UIColor,
             borderWidth: Double,
             cornerRadius: Double,
-            backgroundColor: UIColor
+            backgroundColor: UIColor,
+            accessibility: Accessibility
         ) {
             self.placeholderText = placeholderText
             self.placeholderFont = placeholderFont
@@ -387,6 +430,7 @@ extension SecureConversations.WelcomeStyle {
             self.borderWidth = borderWidth
             self.cornerRadius = cornerRadius
             self.backgroundColor = backgroundColor
+            self.accessibility = accessibility
         }
 
         /// Accessibility properties for MessageTextViewNormalStyle.
@@ -424,6 +468,8 @@ extension SecureConversations.WelcomeStyle {
         public var cornerRadius: Double
         /// Color of the background of the text view.
         public var backgroundColor: UIColor
+        /// Accessibility related properties.
+        public var accessibility: Accessibility
 
         /// - Parameters:
         ///   - placeholderText: Placeholder text for text view.
@@ -444,7 +490,8 @@ extension SecureConversations.WelcomeStyle {
             borderColor: UIColor,
             borderWidth: Double,
             cornerRadius: Double,
-            backgroundColor: UIColor
+            backgroundColor: UIColor,
+            accessibility: Accessibility
         ) {
             self.placeholderText = placeholderText
             self.placeholderFont = placeholderFont
@@ -455,6 +502,7 @@ extension SecureConversations.WelcomeStyle {
             self.borderWidth = borderWidth
             self.cornerRadius = cornerRadius
             self.backgroundColor = backgroundColor
+            self.accessibility = accessibility
         }
 
         /// Accessibility properties for MessageTextViewActiveStyle.
@@ -512,6 +560,8 @@ extension SecureConversations.WelcomeStyle {
         public var borderWidth: Double
         /// Corner radius of the button.
         public var cornerRadius: Double
+        /// Accessibility related properties.
+        public var accessibility: Accessibility
 
         /// - Parameters:
         ///   - title: Title text of the button.
@@ -528,7 +578,8 @@ extension SecureConversations.WelcomeStyle {
             backgroundColor: UIColor,
             borderColor: UIColor,
             borderWidth: Double,
-            cornerRadius: Double
+            cornerRadius: Double,
+            accessibility: Accessibility
         ) {
             self.title = title
             self.font = font
@@ -537,20 +588,39 @@ extension SecureConversations.WelcomeStyle {
             self.cornerRadius = cornerRadius
             self.borderColor = borderColor
             self.borderWidth = borderWidth
+            self.accessibility = accessibility
         }
 
         /// Accessibility properties for SendButtonEnabledStyle.
         public struct Accessibility: Equatable {
             /// Flag that provides font dynamic type by setting `adjustsFontForContentSizeCategory` for component that supports it.
             public var isFontScalingEnabled: Bool
+            /// Accessibility label.
+            public var label: String
+            /// Accessibility hint.
+            public var hint: String
 
-            /// - Parameter isFontScalingEnabled: Flag that provides font dynamic type by setting `adjustsFontForContentSizeCategory` for component that supports it.
-            public init(isFontScalingEnabled: Bool) {
+            /// - Parameters:
+            ///   - isFontScalingEnabled: Flag that provides font dynamic type by setting
+            ///    `adjustsFontForContentSizeCategory` for component that supports it.
+            ///   - label: Accessibility label.
+            ///   - hint: Accessibility hint.
+            public init(
+                isFontScalingEnabled: Bool,
+                label: String,
+                hint: String
+            ) {
                 self.isFontScalingEnabled = isFontScalingEnabled
+                self.label = label
+                self.hint = hint
             }
 
             /// Accessibility is not supported intentionally.
-            public static let unsupported = Self(isFontScalingEnabled: false)
+            public static let unsupported = Self(
+                isFontScalingEnabled: false,
+                label: "",
+                hint: ""
+            )
         }
     }
 
@@ -570,6 +640,8 @@ extension SecureConversations.WelcomeStyle {
         public var borderWidth: Double
         /// Corner radius of the button.
         public var cornerRadius: Double
+        /// Accessibility related properties.
+        public var accessibility: Accessibility
 
         /// - Parameters:
         ///   - title: Title text of the button.
@@ -586,7 +658,8 @@ extension SecureConversations.WelcomeStyle {
             backgroundColor: UIColor,
             borderColor: UIColor,
             borderWidth: Double,
-            cornerRadius: Double
+            cornerRadius: Double,
+            accessibility: Accessibility
         ) {
             self.title = title
             self.font = font
@@ -595,20 +668,39 @@ extension SecureConversations.WelcomeStyle {
             self.cornerRadius = cornerRadius
             self.borderColor = borderColor
             self.borderWidth = borderWidth
+            self.accessibility = accessibility
         }
 
         /// Accessibility properties for SendButtonDisabledStyle.
         public struct Accessibility: Equatable {
             /// Flag that provides font dynamic type by setting `adjustsFontForContentSizeCategory` for component that supports it.
             public var isFontScalingEnabled: Bool
+            /// Accessibility label.
+            public var label: String
+            /// Accessibility hint.
+            public var hint: String
 
-            /// - Parameter isFontScalingEnabled: Flag that provides font dynamic type by setting `adjustsFontForContentSizeCategory` for component that supports it.
-            public init(isFontScalingEnabled: Bool) {
+            /// - Parameters:
+            ///   - isFontScalingEnabled: Flag that provides font dynamic type by setting
+            ///    `adjustsFontForContentSizeCategory` for component that supports it.
+            ///   - label: Accessibility label.
+            ///   - hint: Accessibility hint.
+            public init(
+                isFontScalingEnabled: Bool,
+                label: String,
+                hint: String
+            ) {
                 self.isFontScalingEnabled = isFontScalingEnabled
+                self.label = label
+                self.hint = hint
             }
 
             /// Accessibility is not supported intentionally.
-            public static let unsupported = Self(isFontScalingEnabled: false)
+            public static let unsupported = Self(
+                isFontScalingEnabled: false,
+                label: "",
+                hint: ""
+            )
         }
     }
 
@@ -630,6 +722,8 @@ extension SecureConversations.WelcomeStyle {
         public var activityIndicatorColor: UIColor
         /// Corner radius of the button.
         public var cornerRadius: Double
+        /// Accessibility related properties.
+        public var accessibility: Accessibility
 
         /// - Parameters:
         ///   - title: Title text of the button.
@@ -648,7 +742,8 @@ extension SecureConversations.WelcomeStyle {
             borderColor: UIColor,
             borderWidth: Double,
             activityIndicatorColor: UIColor,
-            cornerRadius: Double
+            cornerRadius: Double,
+            accessibility: Accessibility
         ) {
             self.title = title
             self.font = font
@@ -658,20 +753,39 @@ extension SecureConversations.WelcomeStyle {
             self.borderColor = borderColor
             self.borderWidth = borderWidth
             self.activityIndicatorColor = activityIndicatorColor
+            self.accessibility = accessibility
         }
 
         /// Accessibility properties for SendButtonEnabledStyle.
         public struct Accessibility: Equatable {
             /// Flag that provides font dynamic type by setting `adjustsFontForContentSizeCategory` for component that supports it.
             public var isFontScalingEnabled: Bool
+            /// Accessibility label.
+            public var label: String
+            /// Accessibility hint.
+            public var hint: String
 
-            /// - Parameter isFontScalingEnabled: Flag that provides font dynamic type by setting `adjustsFontForContentSizeCategory` for component that supports it.
-            public init(isFontScalingEnabled: Bool) {
+            /// - Parameters:
+            ///   - isFontScalingEnabled: Flag that provides font dynamic type by setting
+            ///    `adjustsFontForContentSizeCategory` for component that supports it.
+            ///   - label: Accessibility label.
+            ///   - hint: Accessibility hint.
+            public init(
+                isFontScalingEnabled: Bool,
+                label: String,
+                hint: String
+            ) {
                 self.isFontScalingEnabled = isFontScalingEnabled
+                self.label = label
+                self.hint = hint
             }
 
             /// Accessibility is not supported intentionally.
-            public static let unsupported = Self(isFontScalingEnabled: false)
+            public static let unsupported = Self(
+                isFontScalingEnabled: false,
+                label: "",
+                hint: ""
+            )
         }
     }
 
@@ -685,6 +799,8 @@ extension SecureConversations.WelcomeStyle {
         public var iconColor: UIColor
         /// Text for the message limit warning.
         public var messageLengthLimitText: String
+        /// Accessibility related properties.
+        public var accessibility: Accessibility
 
         /// - Parameters:
         ///   - textColor: Color of the warning text.
@@ -695,12 +811,14 @@ extension SecureConversations.WelcomeStyle {
             textColor: UIColor,
             textFont: UIFont,
             iconColor: UIColor,
-            messageLengthLimitText: String
+            messageLengthLimitText: String,
+            accessibility: Accessibility
         ) {
             self.textColor = textColor
             self.textFont = textFont
             self.iconColor = iconColor
             self.messageLengthLimitText = messageLengthLimitText
+            self.accessibility = accessibility
         }
 
         /// Accessibility properties for MessageWarningStyle.
@@ -724,30 +842,52 @@ extension SecureConversations.WelcomeStyle {
         public var color: UIColor
         /// Button image color for disabled state.
         public var disabledColor: UIColor
+        /// Accessibility related properties.
+        public var accessibility: Accessibility
 
         /// - Parameters:
         ///   - color: Button image color.
         ///   - disabledColor: Button image color for disabled state.
         public init(
             color: UIColor,
-            disabledColor: UIColor
+            disabledColor: UIColor,
+            accessibility: Accessibility
         ) {
             self.color = color
             self.disabledColor = disabledColor
+            self.accessibility = accessibility
         }
 
         /// Accessibility properties for FilePickerButtonStyle.
         public struct Accessibility: Equatable {
             /// Flag that provides font dynamic type by setting `adjustsFontForContentSizeCategory` for component that supports it.
             public var isFontScalingEnabled: Bool
+            /// Accessibility label.
+            public var label: String
+            /// Accessibility hint.
+            public var hint: String
 
-            /// - Parameter isFontScalingEnabled: Flag that provides font dynamic type by setting `adjustsFontForContentSizeCategory` for component that supports it.
-            public init(isFontScalingEnabled: Bool) {
+            /// - Parameters:
+            ///   - isFontScalingEnabled: Flag that provides font dynamic type by setting
+            ///    `adjustsFontForContentSizeCategory` for component that supports it.
+            ///   - label: Accessibility label.
+            ///   - hint: Accessibility hint.
+            public init(
+                isFontScalingEnabled: Bool,
+                accessibilityLabel: String,
+                accessibilityHint: String
+            ) {
                 self.isFontScalingEnabled = isFontScalingEnabled
+                self.label = accessibilityLabel
+                self.hint = accessibilityHint
             }
 
             /// Accessibility is not supported intentionally.
-            public static let unsupported = Self(isFontScalingEnabled: false)
+            public static let unsupported = Self(
+                isFontScalingEnabled: false,
+                accessibilityLabel: "",
+                accessibilityHint: ""
+            )
         }
     }
 
@@ -755,10 +895,16 @@ extension SecureConversations.WelcomeStyle {
     public struct TitleImageStyle: Equatable {
         /// Color of the image.
         public var color: UIColor
+        /// Accessibility related properties.
+        public var accessibility: Accessibility
 
         /// - Parameter color: Color of the image.
-        public init(color: UIColor) {
+        public init(
+            color: UIColor,
+            accessibility: Accessibility
+        ) {
             self.color = color
+            self.accessibility = accessibility
         }
 
         /// Accessibility properties for TitleImageStyle.

--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeView.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeView.swift
@@ -181,67 +181,6 @@ extension SecureConversations {
             endEditing(false)
         }
 
-        func renderProps() {
-            header.props = props.headerProps
-            header.showCloseButton()
-
-            titleIconView.tintColor = props.style.titleImageStyle.color
-
-            titleLabel.text = props.style.welcomeTitleStyle.text
-            titleLabel.font = props.style.welcomeTitleStyle.font
-            titleLabel.textColor = props.style.welcomeTitleStyle.color
-
-            subtitleLabel.text = props.style.welcomeSubtitleStyle.text
-            subtitleLabel.font = props.style.welcomeSubtitleStyle.font
-            subtitleLabel.textColor = props.style.welcomeSubtitleStyle.color
-
-            messageTextView.isHidden = props.messageTextViewProps == nil
-            if let messageTextViewProps = props.messageTextViewProps {
-                messageTextView.props = messageTextViewProps
-            }
-
-            checkMessagesButton.setTitle(props.style.checkMessagesButtonStyle.title, for: .normal)
-            checkMessagesButton.titleLabel?.font = props.style.checkMessagesButtonStyle.font
-            checkMessagesButton.setTitleColor(props.style.checkMessagesButtonStyle.color, for: .normal)
-            checkMessagesButton.accessibilityLabel = "some acc. label"
-
-            messageTitleLabel.isHidden = props.style.messageTitleStyle == nil
-            if let messageTitleStyle = props.style.messageTitleStyle {
-                messageTitleLabel.text = messageTitleStyle.title
-                messageTitleLabel.font = messageTitleStyle.font
-                messageTitleLabel.textColor = messageTitleStyle.color
-            }
-
-            sendMessageButton.isHidden = props.sendMessageButton == nil
-            if let sendMessageButtonProps = props.sendMessageButton {
-                switch sendMessageButtonProps {
-                case .active:
-                    sendMessageButton.props = .init(enabledStyle: props.style.sendButtonStyle.enabledStyle)
-                case .disabled:
-                    sendMessageButton.props = .init(disabledStyle: props.style.sendButtonStyle.disabledStyle)
-                case .loading:
-                    sendMessageButton.props = .init(loadingStyle: props.style.sendButtonStyle.loadingStyle)
-                }
-            }
-
-            backgroundColor = props.style.backgroundColor
-
-            filePickerButton.isHidden = props.filePickerButton == nil
-            filePickerButton.isEnabled = props.filePickerButton?.isEnabled == true
-            filePickerButton.tintColor = filePickerButton.isEnabled
-                ? props.style.filePickerButtonStyle.color
-                : props.style.filePickerButtonStyle.disabledColor
-
-            renderedWarning = props.warningMessage
-
-            fileUploadListView.props = props.fileUploadListProps
-
-            rootStackView.setCustomSpacing(
-                props.fileUploadListProps.uploads.isEmpty ? 0 : 16,
-                after: fileUploadListView
-            )
-        }
-
         var renderedWarning: Props.WarningMessage = "" {
             didSet {
                 guard renderedWarning != oldValue else { return }
@@ -273,6 +212,105 @@ extension SecureConversations {
                 messageWarningStackView.isHidden = false
                 rootStackView.setCustomSpacing(4, after: messageTextView)
                 rootStackView.setCustomSpacing(14, after: messageWarningStackView)
+            }
+        }
+    }
+}
+
+// MARK: - Render props
+extension SecureConversations.WelcomeView {
+    func renderProps() {
+        header.props = props.headerProps
+        header.showCloseButton()
+
+        titleIconView.tintColor = props.style.titleImageStyle.color
+
+        titleLabel.text = props.style.welcomeTitleStyle.text
+        titleLabel.font = props.style.welcomeTitleStyle.font
+        titleLabel.textColor = props.style.welcomeTitleStyle.color
+        setFontScalingEnabled(
+            props.style.welcomeTitleStyle.accessibility.isFontScalingEnabled,
+            for: titleLabel
+        )
+
+        subtitleLabel.text = props.style.welcomeSubtitleStyle.text
+        subtitleLabel.font = props.style.welcomeSubtitleStyle.font
+        subtitleLabel.textColor = props.style.welcomeSubtitleStyle.color
+        setFontScalingEnabled(
+            props.style.welcomeSubtitleStyle.accessibility.isFontScalingEnabled,
+            for: subtitleLabel
+        )
+
+        messageTextView.isHidden = props.messageTextViewProps == nil
+        if let messageTextViewProps = props.messageTextViewProps {
+            messageTextView.props = messageTextViewProps
+        }
+
+        renderCheckMessagesButtonProps()
+
+        messageTitleLabel.isHidden = props.style.messageTitleStyle == nil
+        if let messageTitleStyle = props.style.messageTitleStyle {
+            messageTitleLabel.text = messageTitleStyle.title
+            messageTitleLabel.font = messageTitleStyle.font
+            messageTitleLabel.textColor = messageTitleStyle.color
+
+            setFontScalingEnabled(
+                messageTitleStyle.accessibility.isFontScalingEnabled,
+                for: messageTitleLabel
+            )
+        }
+
+        renderSendMessageButtonProps()
+
+        backgroundColor = props.style.backgroundColor
+
+        filePickerButton.isHidden = props.filePickerButton == nil
+        filePickerButton.isEnabled = props.filePickerButton?.isEnabled == true
+        filePickerButton.tintColor = filePickerButton.isEnabled
+            ? props.style.filePickerButtonStyle.color
+            : props.style.filePickerButtonStyle.disabledColor
+        filePickerButton.accessibilityTraits = .button
+        filePickerButton.accessibilityLabel = props.style.filePickerButtonStyle.accessibility.label
+        filePickerButton.accessibilityHint = props.style.filePickerButtonStyle.accessibility.hint
+        setFontScalingEnabled(
+            props.style.filePickerButtonStyle.accessibility.isFontScalingEnabled,
+            for: filePickerButton
+        )
+
+        renderedWarning = props.warningMessage
+
+        fileUploadListView.props = props.fileUploadListProps
+
+        rootStackView.setCustomSpacing(
+            props.fileUploadListProps.uploads.isEmpty ? 0 : 16,
+            after: fileUploadListView
+        )
+    }
+
+    private func renderCheckMessagesButtonProps() {
+        checkMessagesButton.setTitle(props.style.checkMessagesButtonStyle.title, for: .normal)
+        checkMessagesButton.titleLabel?.font = props.style.checkMessagesButtonStyle.font
+        checkMessagesButton.setTitleColor(props.style.checkMessagesButtonStyle.color, for: .normal)
+        checkMessagesButton.accessibilityLabel = props.style.checkMessagesButtonStyle.accessibility.label
+        checkMessagesButton.accessibilityHint = props.style.checkMessagesButtonStyle.accessibility.hint
+        checkMessagesButton.accessibilityTraits = .button
+
+        setFontScalingEnabled(
+            props.style.checkMessagesButtonStyle.accessibility.isFontScalingEnabled,
+            for: checkMessagesButton
+        )
+    }
+
+    private func renderSendMessageButtonProps() {
+        sendMessageButton.isHidden = props.sendMessageButton == nil
+        if let sendMessageButtonProps = props.sendMessageButton {
+            switch sendMessageButtonProps {
+            case .active:
+                sendMessageButton.props = .init(enabledStyle: props.style.sendButtonStyle.enabledStyle)
+            case .disabled:
+                sendMessageButton.props = .init(disabledStyle: props.style.sendButtonStyle.disabledStyle)
+            case .loading:
+                sendMessageButton.props = .init(loadingStyle: props.style.sendButtonStyle.loadingStyle)
             }
         }
     }
@@ -766,7 +804,8 @@ private extension SecureConversations.WelcomeStyle.MessageTextViewStyle {
             borderColor: .black,
             borderWidth: 1,
             cornerRadius: 4,
-            backgroundColor: .black
+            backgroundColor: .black,
+            accessibility: .init(isFontScalingEnabled: true)
         ),
         disabledStyle: .init(
             placeholderText: "",
@@ -777,7 +816,8 @@ private extension SecureConversations.WelcomeStyle.MessageTextViewStyle {
             borderColor: .black,
             borderWidth: 1,
             cornerRadius: 4,
-            backgroundColor: .lightGray
+            backgroundColor: .lightGray,
+            accessibility: .init(isFontScalingEnabled: true)
         ),
         activeStyle: .init(
             placeholderText: "",
@@ -788,7 +828,8 @@ private extension SecureConversations.WelcomeStyle.MessageTextViewStyle {
             borderColor: .black,
             borderWidth: 1,
             cornerRadius: 4,
-            backgroundColor: .blue
+            backgroundColor: .blue,
+            accessibility: .init(isFontScalingEnabled: true)
         )
     )
 }

--- a/GliaWidgets/SecureConversations/Welcome/Theme+SecureConversationsWelcome.swift
+++ b/GliaWidgets/SecureConversations/Welcome/Theme+SecureConversationsWelcome.swift
@@ -2,34 +2,43 @@ import UIKit
 
 extension Theme {
     var secureConversationsWelcomeStyle: SecureConversations.WelcomeStyle {
+        typealias Welcome = L10n.MessageCenter.Welcome
         let chat = chatStyle
 
         let welcomeTitleStyle = SecureConversations.WelcomeStyle.TitleStyle(
-            text: "Welcome to Message Center",
+            text: Welcome.title,
             font: font.header3,
-            color: .black
+            color: .black,
+            accessibility: .init(isFontScalingEnabled: true)
         )
 
         let welcomeSubtitleStyle = SecureConversations.WelcomeStyle.SubtitleStyle(
-            text: "Send a message and we’ll get back to you within 48 hours",
+            text: Welcome.subtitle,
             font: font.subtitle,
-            color: .black
+            color: .black,
+            accessibility: .init(isFontScalingEnabled: true)
         )
 
         let checkMessagesButtonStyle = SecureConversations.WelcomeStyle.CheckMessagesButtonStyle(
-            title: "Check messages",
+            title: Welcome.checkMessages,
             font: font.header2,
-            color: color.primary
+            color: color.primary,
+            accessibility: .init(
+                isFontScalingEnabled: true,
+                label: Welcome.Accessibility.checkMessagesLabel,
+                hint: Welcome.Accessibility.checkMessagesHint
+            )
         )
 
         let messageTitleStyle = SecureConversations.WelcomeStyle.MessageTitleStyle(
-            title: "Your message",
+            title: Welcome.messageTitle,
             font: font.mediumSubtitle1,
-            color: .black
+            color: .black,
+            accessibility: .init(isFontScalingEnabled: true)
         )
 
         let messageTextViewNormalStyle = SecureConversations.WelcomeStyle.MessageTextViewNormalStyle(
-            placeholderText: "Enter your message",
+            placeholderText: Welcome.messageTextViewNormal,
             placeholderFont: font.bodyText,
             placeholderColor: color.baseNormal,
             textFont: font.bodyText,
@@ -37,11 +46,12 @@ extension Theme {
             borderColor: color.baseNormal,
             borderWidth: 1,
             cornerRadius: 4,
-            backgroundColor: color.background
+            backgroundColor: color.background,
+            accessibility: .init(isFontScalingEnabled: true)
         )
 
         let messageTextViewActiveStyle = SecureConversations.WelcomeStyle.MessageTextViewActiveStyle(
-            placeholderText: "Enter your message",
+            placeholderText: Welcome.messageTextViewActive,
             placeholderFont: font.bodyText,
             placeholderColor: color.baseNormal,
             textFont: font.bodyText,
@@ -49,11 +59,12 @@ extension Theme {
             borderColor: color.primary,
             borderWidth: 1,
             cornerRadius: 4,
-            backgroundColor: color.background
+            backgroundColor: color.background,
+            accessibility: .init(isFontScalingEnabled: true)
         )
 
         let messageTextViewDisabledStyle = SecureConversations.WelcomeStyle.MessageTextViewDisabledStyle(
-            placeholderText: "Enter your message",
+            placeholderText: Welcome.messageTextViewDisabled,
             placeholderFont: font.bodyText,
             placeholderColor: color.baseNormal,
             textFont: font.bodyText,
@@ -61,7 +72,8 @@ extension Theme {
             borderColor: .disabledBorder,
             borderWidth: 1,
             cornerRadius: 4,
-            backgroundColor: .disabledBackground
+            backgroundColor: .disabledBackground,
+            accessibility: .init(isFontScalingEnabled: true)
         )
 
         let messageTextViewStyle = SecureConversations.WelcomeStyle.MessageTextViewStyle(
@@ -71,34 +83,49 @@ extension Theme {
         )
 
         let sendButtonEnabledStyle = SecureConversations.WelcomeStyle.SendButtonEnabledStyle(
-            title: "Send",
+            title: Welcome.sendEnabled,
             font: font.bodyText,
             textColor: color.baseLight,
             backgroundColor: color.primary,
             borderColor: .clear,
             borderWidth: 1,
-            cornerRadius: 4
+            cornerRadius: 4,
+            accessibility: .init(
+                isFontScalingEnabled: true,
+                label: Welcome.Accessibility.sendLabel,
+                hint: Welcome.Accessibility.sendHint
+            )
         )
 
         let sendButtonDisabledStyle = SecureConversations.WelcomeStyle.SendButtonDisabledStyle(
-            title: "Send",
+            title: Welcome.sendDisabled,
             font: font.bodyText,
             textColor: .disabledTitle,
             backgroundColor: .disabledBackground,
             borderColor: .disabledBorder,
             borderWidth: 1,
-            cornerRadius: 4
+            cornerRadius: 4,
+            accessibility: .init(
+                isFontScalingEnabled: true,
+                label: Welcome.Accessibility.sendLabel,
+                hint: Welcome.Accessibility.sendHint
+            )
         )
 
         let sendButtonLoadingStyle = SecureConversations.WelcomeStyle.SendButtonLoadingStyle(
-            title: "Send",
+            title: Welcome.sendLoading,
             font: font.bodyText,
             textColor: .disabledTitle,
             backgroundColor: .disabledBackground,
             borderColor: .disabledBorder,
             borderWidth: 1,
             activityIndicatorColor: .disabledActivityIndicator,
-            cornerRadius: 4
+            cornerRadius: 4,
+            accessibility: .init(
+                isFontScalingEnabled: true,
+                label: Welcome.Accessibility.sendLabel,
+                hint: Welcome.Accessibility.sendHint
+            )
         )
 
         let sendButtonStyle = SecureConversations.WelcomeStyle.SendButtonStyle(
@@ -111,15 +138,24 @@ extension Theme {
             textColor: color.systemNegative,
             textFont: .systemFont(ofSize: 12.0),
             iconColor: color.systemNegative,
-            messageLengthLimitText: L10n.MessageCenter.Welcome.messageLengthWarning
+            messageLengthLimitText: L10n.MessageCenter.Welcome.messageLengthWarning,
+            accessibility: .init(isFontScalingEnabled: true)
         )
 
         let filePickerButtonStyle = SecureConversations.WelcomeStyle.FilePickerButtonStyle(
             color: .gray,
-            disabledColor: .lightGray
+            disabledColor: .lightGray,
+            accessibility: .init(
+                isFontScalingEnabled: true,
+                accessibilityLabel: Welcome.Accessibility.filePickerLabel,
+                accessibilityHint: Welcome.Accessibility.filePickerHint
+            )
         )
 
-        let titleImageStyle = SecureConversations.WelcomeStyle.TitleImageStyle(color: color.primary)
+        let titleImageStyle = SecureConversations.WelcomeStyle.TitleImageStyle(
+            color: color.primary,
+            accessibility: .unsupported
+        )
 
         var uploadListStyle: MessageCenterFileUploadListStyle {
             // TODO: Introduce dedicated localization for Secure conversations upload list instaed of using Chat's one.
@@ -230,7 +266,7 @@ extension Theme {
 
         return .init(
             header: chat.header,
-            headerTitle: "Messaging",
+            headerTitle: Welcome.header,
             welcomeTitleStyle: welcomeTitleStyle,
             titleImageStyle: titleImageStyle,
             welcomeSubtitleStyle: welcomeSubtitleStyle,


### PR DESCRIPTION
Because the accessibility labels and hints need to be localized, all strings from the welcome screen have been also localized. Labels and hints have been added where needed. The commit seems big but the `renderProps()` method in the welcome view had to be moved somewhere else to avoid a SwiftLint issue.

MOB-1710