### PR TITLE
Add unit tests for video call

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -465,6 +465,21 @@
 		C0D2F04C2992789000803B47 /* VideoCallView.UserImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F04B2992789000803B47 /* VideoCallView.UserImageView.swift */; };
 		C0D2F0542993CCD100803B47 /* VideoCallView.CallButtonBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F0532993CCD100803B47 /* VideoCallView.CallButtonBar.swift */; };
 		C0D2F060299F93EC00803B47 /* PlaybookViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F05F299F93EC00803B47 /* PlaybookViewController.swift */; };
+		C0D2F06429A4B1E900803B47 /* VideoCallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F06329A4B1E900803B47 /* VideoCallTests.swift */; };
+		C0D2F06829A4B71C00803B47 /* VideoCallViewModel.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F06629A4B68F00803B47 /* VideoCallViewModel.Mock.swift */; };
+		C0D2F06B29A4DAA000803B47 /* VideoCallViewMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F06929A4DA8300803B47 /* VideoCallViewMock.swift */; };
+		C0D2F06E29A4DADE00803B47 /* VideoCallVIewModel.Environment.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F06C29A4DAD500803B47 /* VideoCallVIewModel.Environment.Mock.swift */; };
+		C0D2F07329A4DC2000803B47 /* CallStyle.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F07129A4DBC400803B47 /* CallStyle.Mock.swift */; };
+		C0D2F07629A4E2CE00803B47 /* ConnectOperatorStyle.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F07429A4E29000803B47 /* ConnectOperatorStyle.Mock.swift */; };
+		C0D2F07929A4E3DF00803B47 /* UserImageView.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F07729A4E3B200803B47 /* UserImageView.Mock.swift */; };
+		C0D2F07C29A4E47200803B47 /* ConnectOperatorView.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F07A29A4E44C00803B47 /* ConnectOperatorView.Mock.swift */; };
+		C0D2F07F29A4E59200803B47 /* CallButtonBarStyle.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F07D29A4E57900803B47 /* CallButtonBarStyle.Mock.swift */; };
+		C0D2F08229A4E75200803B47 /* Header.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F08029A4E72700803B47 /* Header.Mock.swift */; };
+		C0D2F08529A4E7CB00803B47 /* HeaderStyle.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F08329A4E7A600803B47 /* HeaderStyle.Mock.swift */; };
+		C0D2F08829A4E8E100803B47 /* CallButtonBar.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F08629A4E8AE00803B47 /* CallButtonBar.Mock.swift */; };
+		C0D2F08B29A4E95700803B47 /* ConnectView.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F08929A4E92D00803B47 /* ConnectView.Mock.swift */; };
+		C0D2F08C29A4EBA900803B47 /* VIdeoCallView.Environment.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F06F29A4DB5C00803B47 /* VIdeoCallView.Environment.Mock.swift */; };
+		C0D2F08F29A61A8D00803B47 /* VideoCallViewController.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F08D29A61A7800803B47 /* VideoCallViewController.Mock.swift */; };
 		C2B201AEDBE3A53369DF524F /* Pods_GliaWidgetsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CCF7E6C5499635E67EF6A604 /* Pods_GliaWidgetsTests.framework */; };
 		C4119E06268F41D1004DFEFB /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C4119E05268F41D1004DFEFB /* Main.storyboard */; };
 		C42463742673ABE10082C135 /* ScreenShareHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42463732673ABE10082C135 /* ScreenShareHandler.swift */; };
@@ -1018,6 +1033,21 @@
 		C0D2F0532993CCD100803B47 /* VideoCallView.CallButtonBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCallView.CallButtonBar.swift; sourceTree = "<group>"; };
 		C0D2F058299B8DB300803B47 /* LibertyMutual.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = LibertyMutual.json; sourceTree = "<group>"; };
 		C0D2F05F299F93EC00803B47 /* PlaybookViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaybookViewController.swift; sourceTree = "<group>"; };
+		C0D2F06329A4B1E900803B47 /* VideoCallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCallTests.swift; sourceTree = "<group>"; };
+		C0D2F06629A4B68F00803B47 /* VideoCallViewModel.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCallViewModel.Mock.swift; sourceTree = "<group>"; };
+		C0D2F06929A4DA8300803B47 /* VideoCallViewMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCallViewMock.swift; sourceTree = "<group>"; };
+		C0D2F06C29A4DAD500803B47 /* VideoCallVIewModel.Environment.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCallVIewModel.Environment.Mock.swift; sourceTree = "<group>"; };
+		C0D2F06F29A4DB5C00803B47 /* VIdeoCallView.Environment.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VIdeoCallView.Environment.Mock.swift; sourceTree = "<group>"; };
+		C0D2F07129A4DBC400803B47 /* CallStyle.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallStyle.Mock.swift; sourceTree = "<group>"; };
+		C0D2F07429A4E29000803B47 /* ConnectOperatorStyle.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectOperatorStyle.Mock.swift; sourceTree = "<group>"; };
+		C0D2F07729A4E3B200803B47 /* UserImageView.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserImageView.Mock.swift; sourceTree = "<group>"; };
+		C0D2F07A29A4E44C00803B47 /* ConnectOperatorView.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectOperatorView.Mock.swift; sourceTree = "<group>"; };
+		C0D2F07D29A4E57900803B47 /* CallButtonBarStyle.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallButtonBarStyle.Mock.swift; sourceTree = "<group>"; };
+		C0D2F08029A4E72700803B47 /* Header.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Header.Mock.swift; sourceTree = "<group>"; };
+		C0D2F08329A4E7A600803B47 /* HeaderStyle.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderStyle.Mock.swift; sourceTree = "<group>"; };
+		C0D2F08629A4E8AE00803B47 /* CallButtonBar.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallButtonBar.Mock.swift; sourceTree = "<group>"; };
+		C0D2F08929A4E92D00803B47 /* ConnectView.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectView.Mock.swift; sourceTree = "<group>"; };
+		C0D2F08D29A61A7800803B47 /* VideoCallViewController.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCallViewController.Mock.swift; sourceTree = "<group>"; };
 		C4119E05268F41D1004DFEFB /* Main.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		C42463732673ABE10082C135 /* ScreenShareHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenShareHandler.swift; sourceTree = "<group>"; };
 		C43C12F82694B14900C37E1B /* GliaPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GliaPresenter.swift; sourceTree = "<group>"; };
@@ -2762,6 +2792,7 @@
 		C096B408297EBCEB00F0C552 /* CallVisualizer */ = {
 			isa = PBXGroup;
 			children = (
+				C0D2F06229A4B18000803B47 /* VideoCall */,
 				84265E05298AE93700D65842 /* ScreenSharing */,
 				C096B40A297EBDE400F0C552 /* VisitorCodeTests.swift */,
 			);
@@ -2850,6 +2881,36 @@
 				C0D2F05F299F93EC00803B47 /* PlaybookViewController.swift */,
 			);
 			path = Playbook;
+			sourceTree = "<group>";
+		};
+		C0D2F06229A4B18000803B47 /* VideoCall */ = {
+			isa = PBXGroup;
+			children = (
+				C0D2F06529A4B66F00803B47 /* Mocks */,
+				C0D2F06329A4B1E900803B47 /* VideoCallTests.swift */,
+			);
+			path = VideoCall;
+			sourceTree = "<group>";
+		};
+		C0D2F06529A4B66F00803B47 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				C0D2F06629A4B68F00803B47 /* VideoCallViewModel.Mock.swift */,
+				C0D2F06C29A4DAD500803B47 /* VideoCallVIewModel.Environment.Mock.swift */,
+				C0D2F06929A4DA8300803B47 /* VideoCallViewMock.swift */,
+				C0D2F06F29A4DB5C00803B47 /* VIdeoCallView.Environment.Mock.swift */,
+				C0D2F07729A4E3B200803B47 /* UserImageView.Mock.swift */,
+				C0D2F07129A4DBC400803B47 /* CallStyle.Mock.swift */,
+				C0D2F07429A4E29000803B47 /* ConnectOperatorStyle.Mock.swift */,
+				C0D2F07A29A4E44C00803B47 /* ConnectOperatorView.Mock.swift */,
+				C0D2F08929A4E92D00803B47 /* ConnectView.Mock.swift */,
+				C0D2F07D29A4E57900803B47 /* CallButtonBarStyle.Mock.swift */,
+				C0D2F08629A4E8AE00803B47 /* CallButtonBar.Mock.swift */,
+				C0D2F08329A4E7A600803B47 /* HeaderStyle.Mock.swift */,
+				C0D2F08029A4E72700803B47 /* Header.Mock.swift */,
+				C0D2F08D29A61A7800803B47 /* VideoCallViewController.Mock.swift */,
+			);
+			path = Mocks;
 			sourceTree = "<group>";
 		};
 		C42463722673ABCD0082C135 /* Screensharing */ = {
@@ -3369,6 +3430,7 @@
 				9A19926A27D3BA8700161AAE /* ViewFactory.Environment.Interface.swift in Sources */,
 				1A0EDF8225E8E0150076D1AD /* PopoverViewController.swift in Sources */,
 				84265E4B298D7B1900D65842 /* CallVisualizer.Coordinator.swift in Sources */,
+				C0D2F07629A4E2CE00803B47 /* ConnectOperatorStyle.Mock.swift in Sources */,
 				75940987298D38C2008B173A /* VisitorCodeViewModel+Environment.swift in Sources */,
 				1A60AFBC256682C800E53F53 /* SubFlowCoordinator.swift in Sources */,
 				1A0C9A8C25C4092400815406 /* CallButtonStyle.swift in Sources */,
@@ -3384,6 +3446,8 @@
 				1AC7A77B25838AE800567FF8 /* ChatItem.swift in Sources */,
 				9A3E1D8C27B6B888005634EB /* FileDownload.Environment.Mock.swift in Sources */,
 				1A1E309F25F8E44300850E68 /* FileDownloader.swift in Sources */,
+				C0D2F06E29A4DADE00803B47 /* VideoCallVIewModel.Environment.Mock.swift in Sources */,
+				C0D2F07C29A4E47200803B47 /* ConnectOperatorView.Mock.swift in Sources */,
 				C08D776028F583D7000461E5 /* Array+Extensions.swift in Sources */,
 				9AE9E4B727E1E30500BFE239 /* MockHelpers.swift in Sources */,
 				1A2DA72625EF892600032611 /* FilePickerController.swift in Sources */,
@@ -3468,6 +3532,7 @@
 				9A3E1D9427B6C29C005634EB /* ChatEngagementFile.Mock.swift in Sources */,
 				1A2DA73B25EFC00500032611 /* FileUploadListStyle.swift in Sources */,
 				7594095A298D386F008B173A /* NSLayoutConstraint.Extensions.swift in Sources */,
+				C0D2F06829A4B71C00803B47 /* VideoCallViewModel.Mock.swift in Sources */,
 				AFEF5C6F29928DB0005C3D8D /* SecureConversations.FileUploadView.swift in Sources */,
 				75940953298D3832008B173A /* Command.swift in Sources */,
 				C4F176CE261D1543009D9F07 /* ChatFileDownloadContentStyle.swift in Sources */,
@@ -3500,6 +3565,7 @@
 				EB2CBB1227D89F7D004F178E /* OnHoldOverlayStyle.swift in Sources */,
 				75940983298D38C2008B173A /* VisitorCodeViewModel+Delegate.swift in Sources */,
 				84265E66298D7B2900D65842 /* ScreenSharingViewController+Props.swift in Sources */,
+				C0D2F08C29A4EBA900803B47 /* VIdeoCallView.Environment.Mock.swift in Sources */,
 				313EBD552943116E008E9597 /* SecureConversations.swift in Sources */,
 				7529F2B627E1EB9A004D3581 /* Survey.ButtonView.swift in Sources */,
 				C49A29E42614A29700819269 /* FilePreviewView.swift in Sources */,
@@ -3544,6 +3610,7 @@
 				1A60AFAF256680EF00E53F53 /* L10n.swift in Sources */,
 				9A1992DD27D6254800161AAE /* ImageView.Cache.Live.swift in Sources */,
 				845E2F9B283FCA9000C04D56 /* Theme.Survey.Checkbox.swift in Sources */,
+				C0D2F07F29A4E59200803B47 /* CallButtonBarStyle.Mock.swift in Sources */,
 				1A60B0192567FC8A00E53F53 /* ButtonKind.swift in Sources */,
 				C42463742673ABE10082C135 /* ScreenShareHandler.swift in Sources */,
 				3100EEFD293F757E00D57F71 /* SecureConversations.WelcomeStyle.swift in Sources */,
@@ -3552,6 +3619,7 @@
 				6EEAD84E2701A8C10074C191 /* ChoiceCardOptionStateStyle.swift in Sources */,
 				845876B1282A9EAF007AC3DF /* CheckboxView.Props.Accessibility.swift in Sources */,
 				1A4AF5CD25AEF4A0002CD0F4 /* AlertViewController+Message.swift in Sources */,
+				C0D2F08F29A61A8D00803B47 /* VideoCallViewController.Mock.swift in Sources */,
 				1A7CA8242574D68E0047CBBE /* ConnectStatusView.swift in Sources */,
 				845E2F78283E2D4200C04D56 /* PoweredByStyle.swift in Sources */,
 				845E2F7F283F99F200C04D56 /* Theme.Survey.ValidationError.swift in Sources */,
@@ -3568,6 +3636,7 @@
 				1A60AF7A25656E0500E53F53 /* Theme.swift in Sources */,
 				84CFB7732822700000167258 /* Theme.Button.Accessibility.swift in Sources */,
 				1A475BB725DE833200296D55 /* BadgeStyle.swift in Sources */,
+				C0D2F08229A4E75200803B47 /* Header.Mock.swift in Sources */,
 				1A4AD3B3256D2A7600468BFB /* VisitorChatMessageStyle.swift in Sources */,
 				845E2F98283FC9A900C04D56 /* Theme.Survey.OptionButton.swift in Sources */,
 				84265E60298D7B2900D65842 /* ScreenSharingCoordinator+Environment.swift in Sources */,
@@ -3597,6 +3666,7 @@
 				9A1992E927D6BCD700161AAE /* FileDownload.Mock.swift in Sources */,
 				AF3D520D2983B3DD00AD8E69 /* FileUploader.Environment.Interface.swift in Sources */,
 				1ABD6C5925B5758000D56EFA /* BubbleStyle.swift in Sources */,
+				C0D2F08B29A4E95700803B47 /* ConnectView.Mock.swift in Sources */,
 				75AF8CF127DBB1F9009EEE2C /* SurveyViewController.View.swift in Sources */,
 				9AA64E142811B91C00FA56FF /* FontScaling.swift in Sources */,
 				C0D2F04629925C5A00803B47 /* VideoCallView.ConnectStatusView.swift in Sources */,
@@ -3636,6 +3706,7 @@
 				75940985298D38C2008B173A /* VisitorCodeCoordinator+DelegateEvent.swift in Sources */,
 				1A0C9AC225C9400000815406 /* CallDurationCounter.swift in Sources */,
 				9A19926527D3BA3A00161AAE /* UIKitBased.Mock.swift in Sources */,
+				C0D2F06B29A4DAA000803B47 /* VideoCallViewMock.swift in Sources */,
 				1AFB1E6225F7AE1300CA460D /* ChatEngagementFile.swift in Sources */,
 				3100EEF2293E214B00D57F71 /* SecureConversations.Coordinator.swift in Sources */,
 				1AA738AE2578E0D500E1120F /* ConnectAnimationView.swift in Sources */,
@@ -3723,8 +3794,10 @@
 				84D2292B28C61C8D00F64FE7 /* WKNavigationPolicyProvider.CustomResponseCard.swift in Sources */,
 				1A1E30A325F8E4A400850E68 /* FileSystemStorage.swift in Sources */,
 				75940944298D378A008B173A /* CoreSDKClient.Interface.swift in Sources */,
+				C0D2F08529A4E7CB00803B47 /* HeaderStyle.Mock.swift in Sources */,
 				754CC61227E2767A005676E9 /* Survey.BooleanQuestionView.swift in Sources */,
 				6EA3516926E139DA00BF5941 /* GliaViewTransitionController.swift in Sources */,
+				C0D2F07929A4E3DF00803B47 /* UserImageView.Mock.swift in Sources */,
 				AFC40C1A299650CD001B4C53 /* TranscriptCoordinator.swift in Sources */,
 				84265E6B29912E2100D65842 /* RemoteConfiguration+CallVisualizer.swift in Sources */,
 				1A1E30C725F9FDAB00850E68 /* ChatImageFileContentView.swift in Sources */,
@@ -3749,6 +3822,7 @@
 				1A60AFEC2566A0E700E53F53 /* NavigationController.swift in Sources */,
 				1A63B2ED257A312700508478 /* AlertCloseButtonProperties.swift in Sources */,
 				3100EEF5293E24C700D57F71 /* SecureConversations.WelcomeViewController.swift in Sources */,
+				C0D2F07329A4DC2000803B47 /* CallStyle.Mock.swift in Sources */,
 				C0D2F03B299149D600803B47 /* VideoCallViewModel.swift in Sources */,
 				C0D2F02E2991221900803B47 /* VideoCallCoordinator.DelegateEvent.swift in Sources */,
 				1A2DA73125EFA77E00032611 /* FileUploader.swift in Sources */,
@@ -3774,6 +3848,7 @@
 				845E2F7A283E2D4E00C04D56 /* PoweredByStyle.Accessibility.swift in Sources */,
 				1A4674C825ED084A0078FA1C /* MediaPickerViewModel.swift in Sources */,
 				9A186A3927F5E3010055886D /* MessageButtonStyle.Accessibility.swift in Sources */,
+				C0D2F08829A4E8E100803B47 /* CallButtonBar.Mock.swift in Sources */,
 				9AB196D627C3E1E400FD60AB /* ChatViewModel.Environment.Interface.swift in Sources */,
 				AF0D26D82971912A00816CCB /* SecureConversations.SendMessageButton.swift in Sources */,
 				1A0C9A8625C4090D00815406 /* CallButton.swift in Sources */,
@@ -3801,6 +3876,7 @@
 				9A3E1DA227BA7D00005634EB /* FileSystemStorage.Environment.Failing.swift in Sources */,
 				9A1992E127D6313500161AAE /* ImageView.Cache.Failing.swift in Sources */,
 				84265E0C298AECBA00D65842 /* ScreenSharingViewStyle+Mock.swift in Sources */,
+				C0D2F06429A4B1E900803B47 /* VideoCallTests.swift in Sources */,
 				C03A8047292BA76D00DDECA6 /* ChatViewControllerTests.swift in Sources */,
 				EB9ADB552828E66B00FAE8A4 /* CallTests.swift in Sources */,
 				AF9DB22E2890571A00A0C442 /* RootCoordinator.Environment.Failing.swift in Sources */,

--- a/GliaWidgets/Sources/CallVisualizer/VideoCall/ViewModel/VideoCallViewModel.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VideoCall/ViewModel/VideoCallViewModel.swift
@@ -6,12 +6,12 @@ extension CallVisualizer {
         // MARK: - Properties
 
         var delegate: ((DelegateEvent) -> Void)?
-        private let environment: Environment
+        let environment: Environment
         private let style: CallStyle
         private var state: State = .initial
         private let durationCounter: CallDurationCounter
         private var imageDownloadID: String = ""
-        private let call: Call
+        let call: Call
         private var connectTimer: FoundationBased.Timer?
         private var connectCounter: Int = 0
 
@@ -59,7 +59,7 @@ extension CallVisualizer {
 
         private var remoteVideoStream: CoreSdkClient.StreamView? { didSet { reportChange() } }
 
-        private var localVideoStream: CoreSdkClient.StreamView? { didSet { reportChange() } }
+        var localVideoStream: CoreSdkClient.StreamView? { didSet { reportChange() } }
 
         private var topLabelHidden: Bool { didSet { reportChange() } }
 

--- a/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/CallButtonBar.Mock.swift
+++ b/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/CallButtonBar.Mock.swift
@@ -1,0 +1,17 @@
+#if DEBUG
+
+extension CallVisualizer.VideoCallView.CallButtonBar.Props {
+    static func mock(
+        style: CallButtonBarStyle = .mock,
+        videoButtonTap: Cmd = .nop,
+        minimizeTap: Cmd = .nop
+    ) -> CallVisualizer.VideoCallView.CallButtonBar.Props {
+        .init(
+            style: style,
+            videoButtonTap: videoButtonTap,
+            minimizeTap: minimizeTap
+        )
+    }
+}
+
+#endif

--- a/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/CallButtonBarStyle.Mock.swift
+++ b/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/CallButtonBarStyle.Mock.swift
@@ -1,0 +1,38 @@
+#if DEBUG
+
+import UIKit
+
+extension CallButtonBarStyle {
+    static let mock = Self(
+        chatButton: .mock,
+        videoButton: .mock,
+        muteButton: .mock,
+        speakerButton: .mock,
+        minimizeButton: .mock,
+        badge: .mock()
+    )
+}
+
+extension CallButtonStyle {
+    static let mock = Self(
+        active: .mock,
+        inactive: .mock,
+        selected: .mock,
+        accessibility: .unsupported
+    )
+}
+
+extension CallButtonStyle.StateStyle {
+    static let mock = Self(
+        backgroundColor: .fill(color: .white),
+        image: .mock,
+        imageColor: .fill(color: .white),
+        title: "",
+        titleFont: .font(weight: .regular, size: 12),
+        titleColor: .white,
+        textStyle: .body,
+        accessibility: .unsupported
+    )
+}
+
+#endif

--- a/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/CallStyle.Mock.swift
+++ b/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/CallStyle.Mock.swift
@@ -1,0 +1,11 @@
+#if DEBUG
+
+import UIKit
+
+extension CallStyle {
+    static func mock() -> CallStyle {
+        return Theme().callStyle
+    }
+}
+
+#endif

--- a/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/ConnectOperatorStyle.Mock.swift
+++ b/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/ConnectOperatorStyle.Mock.swift
@@ -1,0 +1,11 @@
+#if DEBUG
+
+import Foundation
+
+extension ConnectOperatorStyle {
+    static let mock = Self(
+        operatorImage: .mock(),
+        animationColor: .white)
+}
+
+#endif

--- a/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/ConnectOperatorView.Mock.swift
+++ b/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/ConnectOperatorView.Mock.swift
@@ -1,0 +1,11 @@
+#if DEBUG
+
+extension CallVisualizer.VideoCallView.ConnectOperatorView.Props {
+    static let mock = Self(
+        style: .mock,
+        size: .init(size: .normal, animated: false),
+        operatorAnimate: false,
+        userImageViewProps: .mock)
+}
+
+#endif

--- a/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/ConnectView.Mock.swift
+++ b/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/ConnectView.Mock.swift
@@ -1,0 +1,14 @@
+#if DEBUG
+
+import Foundation
+
+extension CallVisualizer.VideoCallView.ConnectView.Props {
+    static let mock = Self(
+        operatorViewProps: .mock,
+        statusViewProps: .init(),
+        state: .connected(name: "", imageUrl: ""),
+        transition: .show(animation: true)
+    )
+}
+
+#endif

--- a/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/Header.Mock.swift
+++ b/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/Header.Mock.swift
@@ -1,0 +1,25 @@
+#if DEBUG
+
+extension Header.Props {
+    static func mock(
+        title: String = "",
+        effect: Header.Effect = .none,
+        endButton: ActionButton.Props = .init(),
+        backButton: HeaderButton.Props = .init(style: .mock),
+        closeButton: HeaderButton.Props = .init(style: .mock),
+        endScreenShareButton: HeaderButton.Props = .init(style: .mock),
+        style: HeaderStyle = .mock
+    ) -> Header.Props {
+        .init(
+            title: title,
+            effect: effect,
+            endButton: endButton,
+            backButton: backButton,
+            closeButton: closeButton,
+            endScreenshareButton: endScreenShareButton,
+            style: style
+        )
+    }
+}
+
+#endif

--- a/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/HeaderStyle.Mock.swift
+++ b/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/HeaderStyle.Mock.swift
@@ -1,0 +1,28 @@
+#if DEBUG
+
+extension HeaderStyle {
+    static let mock = Self(
+        titleFont: .font(weight: .regular, size: 12),
+        titleColor: .white,
+        backgroundColor: .fill(color: .white),
+        backButton: .mock,
+        closeButton: .mock,
+        endButton: .mock,
+        endScreenShareButton: .mock
+    )
+}
+
+extension HeaderButtonStyle {
+    static let mock = Self(image: .mock, color: .white)
+}
+
+extension ActionButtonStyle {
+    static let mock = Self(
+        title: "",
+        titleFont: .font(weight: .regular, size: 12),
+        titleColor: .white,
+        backgroundColor: .fill(color: .white)
+    )
+}
+
+#endif

--- a/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/UserImageView.Mock.swift
+++ b/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/UserImageView.Mock.swift
@@ -1,0 +1,13 @@
+#if DEBUG
+
+import UIKit
+
+extension CallVisualizer.VideoCallView.UserImageView.Props {
+    static let mock = Self(
+        style: .mock(),
+        operatorImageVisible: false,
+        placeHolderImage: .mock,
+        operatorImageViewProps: .init())
+}
+
+#endif

--- a/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/VIdeoCallView.Environment.Mock.swift
+++ b/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/VIdeoCallView.Environment.Mock.swift
@@ -1,0 +1,9 @@
+#if DEBUG
+
+import Foundation
+
+extension CallVisualizer.VideoCallView.Environment {
+    static let mock = Self(gcd: .mock)
+}
+
+#endif

--- a/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/VideoCallVIewModel.Environment.Mock.swift
+++ b/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/VideoCallVIewModel.Environment.Mock.swift
@@ -1,0 +1,18 @@
+
+#if DEBUG
+
+extension CallVisualizer.VideoCallViewModel.Environment {
+    static let mock = Self(
+        data: .mock,
+        uuid: { .mock },
+        gcd: .mock,
+        imageViewCache: .mock,
+        timerProviding: .mock,
+        uiApplication: .mock,
+        date: { .mock },
+        engagedOperator: { .mock() },
+        screenShareHandler: .mock()
+    )
+}
+
+#endif

--- a/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/VideoCallViewController.Mock.swift
+++ b/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/VideoCallViewController.Mock.swift
@@ -1,0 +1,15 @@
+#if DEBUG
+
+extension CallVisualizer.VideoCallViewController {
+    static func mock(
+        props: Props = .init(videoCallViewProps: .mock),
+        environment: CallVisualizer.VideoCallView.Environment = .mock
+    ) -> CallVisualizer.VideoCallViewController {
+        .init(
+            props: props,
+            environment: environment
+        )
+    }
+}
+
+#endif

--- a/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/VideoCallViewMock.swift
+++ b/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/VideoCallViewMock.swift
@@ -1,0 +1,23 @@
+#if DEBUG
+
+import UIKit
+
+extension CallVisualizer.VideoCallView.Props {
+    static let mock = Self(
+        style: .mock(),
+        callDuration: "",
+        connectViewProps: .mock,
+        buttonBarProps: .mock(),
+        headerTitle: "",
+        operatorName: "",
+        remoteVideoStream: .none,
+        localVideoStream: .none,
+        topLabelHidden: false,
+        endScreenShareButtonHidden: false,
+        connectViewHidden: false,
+        topStackAlpha: 1.0,
+        headerProps: .mock()
+    )
+}
+
+#endif

--- a/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/VideoCallViewModel.Mock.swift
+++ b/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/VideoCallViewModel.Mock.swift
@@ -1,0 +1,15 @@
+#if DEBUG
+
+import Foundation
+
+extension CallVisualizer.VideoCallViewModel {
+    static func mock(
+        style: CallStyle = Theme().callStyle,
+        environment: CallVisualizer.VideoCallViewModel.Environment = .mock,
+        call: Call = .mock()
+    ) -> CallVisualizer.VideoCallViewModel {
+        return .init(style: style, environment: environment, call: call)
+    }
+}
+
+#endif

--- a/GliaWidgetsTests/CallVisualizer/VideoCall/VideoCallTests.swift
+++ b/GliaWidgetsTests/CallVisualizer/VideoCall/VideoCallTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+@testable import GliaWidgets
+
+final class VideoCallTests: XCTestCase {
+    func test_vc_deinit() {
+        weak var weakViewController: CallVisualizer.VideoCallViewController?
+        autoreleasepool {
+            let viewController: CallVisualizer.VideoCallViewController = .mock()
+            weakViewController = viewController
+        }
+        XCTAssertNil(weakViewController, "VisitorCodeViewController not deinitilized")
+    }
+
+    func test_end_screen_sharing() {
+        let viewModel: CallVisualizer.VideoCallViewModel = .mock()
+        viewModel.environment.screenShareHandler.status.value = .started
+
+        let headerProps: Header.Props = .mock(
+            endScreenShareButton: .init(
+                tap: .init { _ in
+                    viewModel.environment.screenShareHandler.stop()
+                },
+                style: .mock()
+            )
+        )
+
+        XCTAssertEqual(viewModel.environment.screenShareHandler.status.value, .started)
+        headerProps.endScreenshareButton.tap()
+        XCTAssertEqual(viewModel.environment.screenShareHandler.status.value, .stopped)
+    }
+
+    func test_video_button_action() {
+        var wasExecuted: Bool = false
+        let buttonBarProps: CallVisualizer.VideoCallView.CallButtonBar.Props = .mock(
+            videoButtonTap: .init { _ in
+                wasExecuted = true
+            }
+        )
+
+        buttonBarProps.videoButtonTap()
+        XCTAssertEqual(wasExecuted, true)
+    }
+
+    func test_minimize_button_action() {
+        var wasExecuted: Bool = false
+        let buttonBarProps: CallVisualizer.VideoCallView.CallButtonBar.Props = .mock(
+            minimizeTap: .init { _ in
+                wasExecuted = true
+            }
+        )
+
+        buttonBarProps.minimizeTap()
+        XCTAssertEqual(wasExecuted, true)
+    }
+
+    func test_back_button_action() {
+        var wasExecuted: Bool = false
+        let headerProps: Header.Props = .mock(
+            backButton: .init(
+                tap: .init { _ in
+                    wasExecuted = true
+                },
+                style: .mock()
+            )
+        )
+
+        headerProps.backButton.tap()
+        XCTAssertEqual(wasExecuted, true)
+    }
+}


### PR DESCRIPTION
This PR covers Call Visualizer with Unit tests and adds extensive mocking
for Styles and Props. This is aimed for simplifying further testing in
future if necessary.

MOB-1875