### PR TITLE
Enable toggling of attachment button visibility via several parameters

### DIFF
--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
@@ -304,7 +304,7 @@ extension ChatViewController {
         chatViewModel.action?(.updateUnreadMessageIndicator(itemCount: 5))
         chatViewModel.action?(.setChoiceCardInputModeEnabled(false))
         chatViewModel.action?(.connected(name: "Mocked Operator Name", imageUrl: localFileURL.absoluteString))
-        chatViewModel.action?(.setIsAttachmentButtonHidden(false))
+        chatViewModel.action?(.setAttachmentButtonVisibility(.enabled(.enagagementConnection(isConnected: true))))
         chatViewModel.action?(.pickMediaButtonEnabled(true))
         chatViewModel.action?(.setOperatorTypingIndicatorIsHiddenTo(false, false))
 

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
@@ -143,8 +143,8 @@ class ChatViewController: EngagementViewController, MediaUpgradePresenter,
                     view.scrollToBottom(animated: true)
                 }
                 view.setOperatorTypingIndicatorIsHidden(to: isHidden)
-            case .setIsAttachmentButtonHidden(let isHidden):
-                view.messageEntryView.isAttachmentButtonHidden = isHidden
+            case let .setAttachmentButtonVisibility(visibility):
+                view.messageEntryView.setPickMediaButtonVisibility(visibility)
             case .transferring:
                 view.setConnectState(.transferring, animated: true)
             case .setCallBubbleImage(let imageUrl):


### PR DESCRIPTION
Toggle attachment button visibility via context parameters for chat and secure transcript screens. These changes needed because button visibility can no longer be dependent on engagement connected state in case of Transcript screen.
This PR is for enabling visibility control in Chat screen first.

MOB-1876