### PR TITLE
Hide back button on welcome and confirmation screens

### DIFF
--- a/GliaWidgets/SecureConversations/Confirmation/SecureConversations.ConfirmationViewModel.swift
+++ b/GliaWidgets/SecureConversations/Confirmation/SecureConversations.ConfirmationViewModel.swift
@@ -53,11 +53,13 @@ extension SecureConversations.ConfirmationViewModel {
         backButtonCmd: Cmd,
         closeButtonCmd: Cmd
     ) -> Header.Props {
-        Header.Props(
+        let backButton = style.header.backButton.map { HeaderButton.Props(tap: backButtonCmd, style: $0) }
+
+        return Header.Props(
             title: style.headerTitle,
             effect: .none,
             endButton: .init(style: style.header.endButton),
-            backButton: .init(tap: backButtonCmd, style: style.header.backButton),
+            backButton: backButton,
             closeButton: .init(tap: closeButtonCmd, style: style.header.closeButton),
             endScreenshareButton: .init(style: style.header.endScreenShareButton),
             style: style.header

--- a/GliaWidgets/SecureConversations/Confirmation/Theme+SecureConversationsConfirmation.swift
+++ b/GliaWidgets/SecureConversations/Confirmation/Theme+SecureConversationsConfirmation.swift
@@ -3,6 +3,8 @@ import Foundation
 extension Theme {
     var secureConversationsConfirmationStyle: SecureConversations.ConfirmationStyle {
         let chatStyle = chatStyle
+        var header = chatStyle.header
+        header.backButton = nil
 
         let titleStyle = SecureConversations.ConfirmationStyle.TitleStyle(
             text: "Thank you!",
@@ -24,7 +26,7 @@ extension Theme {
         )
 
         return .init(
-            header: chatStyle.header,
+            header: header,
             headerTitle: "Messaging",
             confirmationImage: Asset.mcEnvelope.image,
             titleStyle: titleStyle,

--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.swift
@@ -306,14 +306,18 @@ extension SecureConversations.WelcomeViewModel {
         for instance: SecureConversations.WelcomeViewModel,
         with style: SecureConversations.WelcomeStyle
     ) -> Header.Props {
-        .init(
+        let backButton = style.header.backButton.map {
+            HeaderButton.Props(
+                tap: Cmd { [weak instance] in instance?.delegate?(.backTapped) },
+                style: $0
+            )
+        }
+
+        return .init(
             title: style.headerTitle,
             effect: .none,
             endButton: .init(),
-            backButton: .init(
-                tap: Cmd { [weak instance] in instance?.delegate?(.backTapped) },
-                style: style.header.backButton
-            ),
+            backButton: backButton,
             closeButton: .init(
                 tap: Cmd { [weak instance] in instance?.delegate?(.closeTapped) },
                 style: style.header.closeButton

--- a/GliaWidgets/SecureConversations/Welcome/Theme+SecureConversationsWelcome.swift
+++ b/GliaWidgets/SecureConversations/Welcome/Theme+SecureConversationsWelcome.swift
@@ -5,6 +5,9 @@ extension Theme {
         typealias Welcome = L10n.MessageCenter.Welcome
         let chat = chatStyle
 
+        var header = chat.header
+        header.backButton = nil
+
         let welcomeTitleStyle = SecureConversations.WelcomeStyle.TitleStyle(
             text: Welcome.title,
             font: font.header3,
@@ -265,7 +268,7 @@ extension Theme {
        }
 
         return .init(
-            header: chat.header,
+            header: header,
             headerTitle: Welcome.header,
             welcomeTitleStyle: welcomeTitleStyle,
             titleImageStyle: titleImageStyle,

--- a/GliaWidgets/Sources/CallVisualizer/ScreenSharing/Coordinator/ScreenSharingCoordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/ScreenSharing/Coordinator/ScreenSharingCoordinator.swift
@@ -50,11 +50,13 @@ extension CallVisualizer {
         }
 
         private static func createHeaderProps(with header: HeaderStyle) -> Header.Props {
-            .init(
+            let backButton = header.backButton.map { HeaderButton.Props(style: $0) }
+
+            return .init(
                 title: "",
                 effect: .none,
                 endButton: .init(),
-                backButton: .init(style: header.backButton),
+                backButton: backButton,
                 closeButton: .init(style: header.closeButton),
                 endScreenshareButton: .init(style: header.endScreenShareButton),
                 style: header

--- a/GliaWidgets/Sources/CallVisualizer/ScreenSharing/ViewModel/ScreenSharingViewModel.swift
+++ b/GliaWidgets/Sources/CallVisualizer/ScreenSharing/ViewModel/ScreenSharingViewModel.swift
@@ -26,14 +26,18 @@ extension CallVisualizer {
 
 extension CallVisualizer.ScreenSharingViewModel {
     func props() -> Props {
+        let backButton = style.header.backButton.map {
+            HeaderButton.Props(
+                tap: Cmd { [delegate] in delegate(.close) },
+                style: $0
+            )
+        }
+
         let headerProps = Header.Props(
             title: style.title,
             effect: .none,
             endButton: .init(style: style.header.endButton),
-            backButton: .init(
-                tap: Cmd { [delegate] in delegate(.close) },
-                style: style.header.backButton
-            ),
+            backButton: backButton,
             closeButton: .init(
                 style: style.header.closeButton
             ),

--- a/GliaWidgets/Sources/CallVisualizer/VideoCall/View/VideoCallView.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VideoCall/View/VideoCallView.swift
@@ -75,8 +75,11 @@ extension CallVisualizer {
             header.endButton.isHidden = true
             header.closeButton.isHidden = true
             header.endScreenShareButton.isHidden = true
-            header.backButton.accessibilityLabel = props.style.header.backButton.accessibility.label
-            header.backButton.accessibilityHint = props.style.header.backButton.accessibility.hint
+
+            if let backButton = props.style.header.backButton {
+                header.backButton?.accessibilityLabel = backButton.accessibility.label
+                header.backButton?.accessibilityHint = backButton.accessibility.hint
+            }
         }
 
         private lazy var topStackView = UIStackView().make {

--- a/GliaWidgets/Sources/CallVisualizer/VideoCall/ViewModel/VideoCallViewModel.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VideoCall/ViewModel/VideoCallViewModel.swift
@@ -143,6 +143,14 @@ extension CallVisualizer.VideoCallViewModel {
     func makeProps() -> Props {
         let connectViewProps = makeConnectViewProps()
         let buttonBarProps = makeButtonBarProps()
+        let backButton = style.header.backButton.map {
+            HeaderButton.Props(
+                tap: .init { [weak self] in
+                    self?.delegate?(.minimized)
+                },
+                style: $0
+            )
+        }
 
         return Props(
             videoCallViewProps: .init(
@@ -162,12 +170,7 @@ extension CallVisualizer.VideoCallViewModel {
                     title: title,
                     effect: interfaceOrientation.isLandscape ? .blur : .none,
                     endButton: .init(),
-                    backButton: .init(
-                        tap: .init { [weak self] in
-                            self?.delegate?(.minimized)
-                        },
-                        style: style.header.backButton
-                    ),
+                    backButton: backButton,
                     closeButton: .init(style: style.header.closeButton),
                     endScreenshareButton: .init(
                         tap: .init { [weak self] in

--- a/GliaWidgets/Sources/Component/Header/Header+Playbook.swift
+++ b/GliaWidgets/Sources/Component/Header/Header+Playbook.swift
@@ -30,15 +30,18 @@ extension ViewPlaybook {
     static var chat: Header {
         var headerStyle = standardTheme.chat.header
         headerStyle.endButton.title = "#endButton#"
+
+        let backButton = headerStyle.backButton.map { HeaderButton.Props(style: $0) }
+
         let header = Header(
             props: .init(
                 title: "Chat",
                 effect: .none,
                 endButton: .init(style: headerStyle.endButton),
-                backButton: .init(style: headerStyle.backButton),
-                closeButton: .init(style: headerStyle.closeButton),
-                endScreenshareButton: .init(style: headerStyle.endScreenShareButton),
-                style: headerStyle
+                backButton: backButton,
+                closeButton: .init(style: standardTheme.chat.header.closeButton),
+                endScreenshareButton: .init(style: standardTheme.chat.header.endScreenShareButton),
+                style: standardTheme.chat.header
             )
         )
         DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(3)) {
@@ -51,17 +54,21 @@ extension ViewPlaybook {
     static var call: Header {
         var headerStyle = standardTheme.call.header
         headerStyle.endButton.title = "#endButton#"
+
+        let backButton = headerStyle.backButton.map { HeaderButton.Props(style: $0) }
+
         let header = Header(
             props: .init(
                 title: "Audio Call",
                 effect: .blur,
                 endButton: .init(style: headerStyle.endButton),
-                backButton: .init(style: headerStyle.backButton),
+                backButton: backButton,
                 closeButton: .init(style: headerStyle.closeButton),
                 endScreenshareButton: .init(style: headerStyle.endScreenShareButton),
                 style: headerStyle
             )
         )
+
         DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(3)) {
             header.props = .createNewProps(with: "Video Call", props: header.props)
         }

--- a/GliaWidgets/Sources/Component/Header/Header.Props.swift
+++ b/GliaWidgets/Sources/Component/Header/Header.Props.swift
@@ -5,7 +5,7 @@ extension Header {
         let title: String
         let effect: Effect
         let endButton: ActionButton.Props
-        let backButton: HeaderButton.Props
+        let backButton: HeaderButton.Props?
         let closeButton: HeaderButton.Props
         let endScreenshareButton: HeaderButton.Props
         let style: HeaderStyle

--- a/GliaWidgets/Sources/Component/Header/Header.swift
+++ b/GliaWidgets/Sources/Component/Header/Header.swift
@@ -10,7 +10,7 @@ final class Header: BaseView {
         case blur
     }
 
-    var backButton: HeaderButton
+    var backButton: HeaderButton?
     var closeButton: HeaderButton
     var endButton: ActionButton
     var endScreenShareButton: HeaderButton
@@ -31,8 +31,11 @@ final class Header: BaseView {
     private let height: CGFloat = 58
 
     init(props: Props) {
+        if let backButtonProps = props.backButton {
+            self.backButton = HeaderButton(with: backButtonProps)
+        }
+
         self.props = props
-        self.backButton = HeaderButton(with: props.backButton)
         self.closeButton = HeaderButton(with: props.closeButton)
         self.endButton = ActionButton(props: props.endButton)
 
@@ -57,7 +60,11 @@ final class Header: BaseView {
     }
 
     func renderProps() {
-        backButton.props = props.backButton
+        backButton?.isEnabled = props.backButton != nil
+        if let backButtonProps = props.backButton {
+            backButton?.props = backButtonProps
+        }
+
         closeButton.props = props.closeButton
         endButton.props = props.endButton
 
@@ -77,7 +84,7 @@ final class Header: BaseView {
     }
 
     func showBackButton() {
-        backButton.isHidden = false
+        backButton?.isHidden = false
     }
 
     func showCloseButton() {
@@ -104,7 +111,7 @@ final class Header: BaseView {
         rightItemContainer.axis = .horizontal
         rightItemContainer.spacing = 16
         rightItemContainer.alignment = .center
-        backButton.accessibilityIdentifier = "header_back_button"
+        backButton?.accessibilityIdentifier = "header_back_button"
         closeButton.accessibilityIdentifier = "header_close_button"
     }
 
@@ -124,9 +131,11 @@ final class Header: BaseView {
         titleLabel.autoPinEdge(toSuperviewEdge: .right)
         titleLabel.autoAlignAxis(toSuperviewAxis: .horizontal)
 
-        contentView.addSubview(backButton)
-        backButton.autoPinEdge(toSuperviewEdge: .left)
-        backButton.autoAlignAxis(toSuperviewAxis: .horizontal)
+        if let backButton = backButton {
+            contentView.addSubview(backButton)
+            backButton.autoPinEdge(toSuperviewEdge: .left)
+            backButton.autoAlignAxis(toSuperviewAxis: .horizontal)
+        }
 
         rightItemContainer.addArrangedSubviews([endScreenShareButton, endButton, closeButton])
         contentView.addSubview(rightItemContainer)

--- a/GliaWidgets/Sources/Component/Header/HeaderStyle.swift
+++ b/GliaWidgets/Sources/Component/Header/HeaderStyle.swift
@@ -15,7 +15,7 @@ public struct HeaderStyle: Equatable {
     public var backgroundColor: ColorType
 
     /// Style of the back button.
-    public var backButton: HeaderButtonStyle
+    public var backButton: HeaderButtonStyle?
 
     /// Style of the queue closing button.
     public var closeButton: HeaderButtonStyle
@@ -109,7 +109,7 @@ public struct HeaderStyle: Equatable {
             // The logic for title background has not been implemented
         }
 
-        backButton.apply(configuration: configuration?.backButton)
+        backButton?.apply(configuration: configuration?.backButton)
         closeButton.apply(configuration: configuration?.closeButton)
         endButton.apply(
             configuration: configuration?.endButton,

--- a/GliaWidgets/Sources/View/Call/CallView.swift
+++ b/GliaWidgets/Sources/View/Call/CallView.swift
@@ -203,8 +203,10 @@ class CallView: EngagementView {
             self?.adjustLocalVideoFrameAfterPanGesture(translation: $0)
         }
 
-        header.backButton.accessibilityLabel = style.header.backButton.accessibility.label
-        header.backButton.accessibilityHint = style.header.backButton.accessibility.hint
+        if let backButton = style.header.backButton {
+            header.backButton?.accessibilityLabel = backButton.accessibility.label
+            header.backButton?.accessibilityHint = backButton.accessibility.hint
+        }
     }
 
     func switchTo(_ mode: Mode) {

--- a/GliaWidgets/Sources/ViewFactory/ViewFactory.swift
+++ b/GliaWidgets/Sources/ViewFactory/ViewFactory.swift
@@ -49,12 +49,14 @@ class ViewFactory {
         endScreenshareCmd: Cmd,
         backCmd: Cmd
     ) -> ChatView.Props {
-        .init(
+        let backButton = theme.chat.header.backButton.map { HeaderButton.Props(tap: backCmd,style: $0) }
+
+        return .init(
             header: .init(
                 title: theme.chat.title,
                 effect: .none,
                 endButton: .init(style: theme.chat.header.endButton, tap: endCmd),
-                backButton: .init(tap: backCmd, style: theme.chat.header.backButton),
+                backButton: backButton,
                 closeButton: .init(tap: closeCmd, style: theme.chat.header.closeButton),
                 endScreenshareButton: .init(tap: endScreenshareCmd, style: theme.chat.header.endScreenShareButton),
                 style: theme.chat.header
@@ -95,12 +97,14 @@ class ViewFactory {
         endScreenshareCmd: Cmd,
         backCmd: Cmd
     ) -> CallView.Props {
-        .init(
+        let backButton = theme.call.header.backButton.map { HeaderButton.Props( tap: backCmd, style: $0) }
+
+        return .init(
             header: .init(
                 title: "",
                 effect: .none,
                 endButton: .init(style: theme.call.header.endButton, tap: endCmd),
-                backButton: .init(tap: backCmd, style: theme.call.header.backButton),
+                backButton: backButton,
                 closeButton: .init(tap: closeCmd, style: theme.call.header.closeButton),
                 endScreenshareButton: .init(style: theme.call.header.endScreenShareButton),
                 style: theme.call.header

--- a/GliaWidgetsTests/CallVisualizer/ScreenSharing/ScreenSharingViewModelTests.swift
+++ b/GliaWidgetsTests/CallVisualizer/ScreenSharing/ScreenSharingViewModelTests.swift
@@ -56,7 +56,7 @@ final class ScreenSharingViewModelTests: XCTestCase {
         props?.screenSharingViewProps.endScreenSharing.tap.execute()
         XCTAssertEqual(calls, [.close])
 
-        props?.screenSharingViewProps.header.backButton.tap.execute()
+        props?.screenSharingViewProps.header.backButton?.tap.execute()
         XCTAssertEqual(calls, [.close, .close])
     }
 }

--- a/GliaWidgetsTests/CallVisualizer/VideoCall/VideoCallTests.swift
+++ b/GliaWidgetsTests/CallVisualizer/VideoCall/VideoCallTests.swift
@@ -64,7 +64,7 @@ final class VideoCallTests: XCTestCase {
             )
         )
 
-        headerProps.backButton.tap()
+        headerProps.backButton?.tap()
         XCTAssertEqual(wasExecuted, true)
     }
 }


### PR DESCRIPTION
This requires some changes in the header that affect all other views. Chat transcript wasn’t done because it uses ChatView, which is not data driven. Another PR will be created to deal with that one in isolation.

Let me know if you think of a better approach for it. It feels a little bit cumbersome.

MOB-1866