### PR TITLE
Fix call visualizer double video call issue

### DIFF
--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -134,7 +134,7 @@ public class Glia {
                         answer: answer,
                         accepted: {
                             answer(true, nil)
-                            self?.callVisualizer.showVideoCallViewController()
+                            self?.callVisualizer.handleAcceptedUpgrade()
                         },
                         declined: { answer(false, nil) }
                     )

--- a/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
+++ b/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
@@ -87,8 +87,8 @@ public final class CallVisualizer {
         startObservingInteractorEvents()
     }
 
-    public func showVideoCallViewController() {
-        coordinator?.showVideoCallViewController()
+    func handleAcceptedUpgrade() {
+        coordinator?.handleAcceptedUpgrade()
     }
 
     func addVideoStream(stream: CoreSdkClient.VideoStreamable) {

--- a/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
@@ -96,6 +96,11 @@ extension CallVisualizer {
                 .present(alert, animated: true)
         }
 
+        func handleAcceptedUpgrade() {
+            guard videoCallCoordinator == nil else { return }
+            showVideoCallViewController()
+        }
+
         func showEndScreenSharingViewController() {
             let viewController = buildScreenSharingViewController()
             environment


### PR DESCRIPTION
Fix an issue when during the one-way video, visitors can accept two-way video which is displayed on top of the one-way video screen. 