### PR TITLE
Allow specifying the initial screen in secure conversations

### DIFF
--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -12,7 +12,20 @@ public enum EngagementKind: Equatable {
     /// Video call
     case videoCall
     /// Secure conversations
-    case messaging
+    case messaging(SecureConversations.InitialScreen = .welcome)
+}
+
+extension SecureConversations {
+    /// The initial screen seen by a visitor when starting a secure conversation.
+    public enum InitialScreen: Equatable {
+        /// Shows a screen that has welcome text, and allows to send messages and
+        /// attachments. It also allows navigation to the chat transcript screen.
+        case welcome
+        /// Shows a screen with the chat transcript, which consists of the message
+        /// history of the currently authenticated visitor. Also allows sending
+        /// messages and attachments.
+        case chatTranscript
+    }
 }
 
 /// An event providing engagement state information.

--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
@@ -9,19 +9,29 @@ extension SecureConversations {
         private let environment: Environment
         private var viewModel: SecureConversations.WelcomeViewModel?
         private var selectedPickerController: SelectedPickerController?
+        private var messagingInitialScreen: SecureConversations.InitialScreen
 
         init(
+            messagingInitialScreen: SecureConversations.InitialScreen,
             viewFactory: ViewFactory,
             navigationPresenter: NavigationPresenter,
             environment: Environment
         ) {
+            self.messagingInitialScreen = messagingInitialScreen
             self.viewFactory = viewFactory
             self.navigationPresenter = navigationPresenter
             self.environment = environment
         }
 
         func start() -> UIViewController {
-            let viewController = makeSecureConversationsWelcomeViewController()
+            var viewController: UIViewController
+
+            switch messagingInitialScreen {
+            case .chatTranscript:
+                viewController = navigateToTranscript()
+            default:
+                viewController = makeSecureConversationsWelcomeViewController()
+            }
 
             return viewController
         }
@@ -226,7 +236,8 @@ extension SecureConversations {
             navigationPresenter.present(controller.viewController)
         }
 
-        private func navigateToTranscript() {
+        @discardableResult
+        private func navigateToTranscript() -> UIViewController {
             let transcriptCoordinator = TranscriptCoordinator(
                 navigationPresenter: navigationPresenter,
                 environment: .init(
@@ -254,10 +265,14 @@ extension SecureConversations {
                 )
             )
             pushCoordinator(transcriptCoordinator)
+
+            let viewController = transcriptCoordinator.start()
             navigationPresenter.push(
-                transcriptCoordinator.start(),
+                viewController,
                 replacingLast: true
             )
+
+            return viewController
         }
     }
 }

--- a/GliaWidgets/SecureConversations/Transcript/TranscriptCoordinator.swift
+++ b/GliaWidgets/SecureConversations/Transcript/TranscriptCoordinator.swift
@@ -19,38 +19,7 @@ extension SecureConversations {
         }
 
         func start() -> ChatViewController {
-            let model = TranscriptModel(
-                isCustomCardSupported: environment.viewFactory.messageRenderer != nil,
-                environment: .init(
-                    fetchFile: environment.fetchFile,
-                    fileManager: environment.fileManager,
-                    data: environment.data,
-                    date: environment.date,
-                    gcd: environment.gcd,
-                    localFileThumbnailQueue: environment.localFileThumbnailQueue,
-                    uiImage: environment.uiImage,
-                    createFileDownload: environment.createFileDownload,
-                    loadChatMessagesFromHistory: environment.loadChatMessagesFromHistory,
-                    fetchChatHistory: environment.fetchChatHistory,
-                    uiApplication: environment.uiApplication,
-                    sendSecureMessage: environment.sendSecureMessage,
-                    queueIds: environment.queueIds,
-                    listQueues: environment.listQueues,
-                    alertConfiguration: environment.alertConfiguration,
-					createFileUploadListModel: environment.createFileUploadListModel,
-                    uuid: environment.uuid,
-                    secureUploadFile: environment.secureUploadFile,
-                    fileUploadListStyle: environment.fileUploadListStyle,
-                    fetchSiteConfigurations: environment.fetchSiteConfigurations
-                ),
-                availability: .init(
-                    environment: .init(
-                        listQueues: environment.listQueues,
-                        queueIds: environment.queueIds
-                    )
-                ),
-                deliveredStatusText: environment.viewFactory.theme.chat.visitorMessage.delivered
-            )
+            let model = transcriptModel()
             let controller = ChatViewController(viewModel: .transcript(model), viewFactory: environment.viewFactory)
 
             model.delegate = { [weak self, weak controller] event in
@@ -83,6 +52,41 @@ extension SecureConversations {
             }
 
             return controller
+        }
+
+        private func transcriptModel() -> TranscriptModel {
+            .init(
+                isCustomCardSupported: environment.viewFactory.messageRenderer != nil,
+                environment: .init(
+                    fetchFile: environment.fetchFile,
+                    fileManager: environment.fileManager,
+                    data: environment.data,
+                    date: environment.date,
+                    gcd: environment.gcd,
+                    localFileThumbnailQueue: environment.localFileThumbnailQueue,
+                    uiImage: environment.uiImage,
+                    createFileDownload: environment.createFileDownload,
+                    loadChatMessagesFromHistory: environment.loadChatMessagesFromHistory,
+                    fetchChatHistory: environment.fetchChatHistory,
+                    uiApplication: environment.uiApplication,
+                    sendSecureMessage: environment.sendSecureMessage,
+                    queueIds: environment.queueIds,
+                    listQueues: environment.listQueues,
+                    alertConfiguration: environment.alertConfiguration,
+                    createFileUploadListModel: environment.createFileUploadListModel,
+                    uuid: environment.uuid,
+                    secureUploadFile: environment.secureUploadFile,
+                    fileUploadListStyle: environment.fileUploadListStyle,
+                    fetchSiteConfigurations: environment.fetchSiteConfigurations
+                ),
+                availability: .init(
+                    environment: .init(
+                        listQueues: environment.listQueues,
+                        queueIds: environment.queueIds
+                    )
+                ),
+                deliveredStatusText: environment.viewFactory.theme.chat.visitorMessage.delivered
+            )
         }
 
         private func presentQuickLookController(with file: LocalFile) {

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
@@ -102,8 +102,8 @@ class EngagementCoordinator: SubFlowCoordinator, FlowCoordinator {
                 [callViewController],
                 animated: false
             )
-        case .messaging:
-            let secureConversationsWelcomeViewController: UIViewController = startSecureConversations()
+        case .messaging(let messagingInitialScreen):
+            let secureConversationsWelcomeViewController = startSecureConversations(using: messagingInitialScreen)
             engagement = .secureConversations(secureConversationsWelcomeViewController)
             navigationPresenter.setViewControllers(
                 [secureConversationsWelcomeViewController],
@@ -387,8 +387,11 @@ extension EngagementCoordinator {
         }
     }
 
-    private func startSecureConversations() -> UIViewController {
+    private func startSecureConversations(
+        using messagingInitialScreen: SecureConversations.InitialScreen
+    ) -> UIViewController {
         let coordinator = SecureConversations.Coordinator(
+            messagingInitialScreen: messagingInitialScreen,
             viewFactory: viewFactory,
             navigationPresenter: navigationPresenter,
             environment: .init(

--- a/TestingApp/ViewController/ViewController.swift
+++ b/TestingApp/ViewController/ViewController.swift
@@ -76,7 +76,7 @@ class ViewController: UIViewController {
 
     @IBAction private func secureConversationTapped() {
         if features.contains(.secureConversations) {
-            presentGlia(.messaging)
+            presentGlia(.messaging())
         }
     }
 
@@ -225,7 +225,7 @@ extension ViewController {
             (.chat, "Chat"),
             (.audioCall, "Audio"),
             (.videoCall, "Video"),
-            (.messaging, "Messaging")
+            (.messaging(), "Messaging")
         ]
         let alert = UIAlertController(
             title: "Choose engagement type",


### PR DESCRIPTION
It is important that by default, welcome screen should be started. Integrator should do nothing special to start welcome screen, and has to manually opt for the chat transcript in order to go there. Please note the public enum and suggest better names if needed.

MOB-1883