### PR TITLE
Navigate to chat transcript from confirmation screen

### DIFF
--- a/GliaWidgets/SecureConversations/Confirmation/SecureConversations.ConfirmationViewModel.swift
+++ b/GliaWidgets/SecureConversations/Confirmation/SecureConversations.ConfirmationViewModel.swift
@@ -38,7 +38,7 @@ extension SecureConversations.ConfirmationViewModel {
                 backButtonCmd: Cmd(closure: { [weak self] in self?.delegate?(.backTapped) }),
                 closeButtonCmd: Cmd(closure: { [weak self] in self?.delegate?(.closeTapped) })
             ),
-            checkMessageButtonTap: Cmd { print("check messages") }
+            checkMessageButtonTap: Cmd { [weak self] in self?.delegate?(.chatTranscriptScreenRequested) }
         )
 
         let viewControllerProps = SecureConversations.ConfirmationViewController.Props(
@@ -81,6 +81,7 @@ extension SecureConversations.ConfirmationViewModel {
         case backTapped
         case closeTapped
         case renderProps(SecureConversations.ConfirmationViewController.Props)
+        case chatTranscriptScreenRequested
     }
 
     enum StartAction {

--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
@@ -165,6 +165,8 @@ extension SecureConversations {
                 // Bind changes in view model to view controller.
                 case let .renderProps(props):
                     controller?.props = props
+                case .chatTranscriptScreenRequested:
+                    self?.navigateToTranscript()
                 }
             }
 


### PR DESCRIPTION
When pressing the "Check messages" button in the confirmation screen, the widgets now navigate to the chat transcript screen.

MOB-1889