### PR TITLE
Allow welcome screen send button press regardless of touch coordinates

### DIFF
--- a/GliaWidgets/SecureConversations/SecureConversations.SendMessageButton.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.SendMessageButton.swift
@@ -36,6 +36,7 @@ extension SecureConversations {
             stackView.axis = .horizontal
             stackView.alignment = .center
             stackView.spacing = 11
+            stackView.isUserInteractionEnabled = false
         }
 
         override init(frame: CGRect) {


### PR DESCRIPTION
If you press the button dead center, where the "Send" text is, the button doesn't react. You need to press it on the sides where there is no text for it to work. This is because the stack view is absorbing the touch event and not relaying it to the UIControl. It doesn't happen to the sides because the stack view doesn't extend to the whole width of the button.

MOB-1891