### PR TITLE
Rename fontColor field of NumberSlot element

### DIFF
--- a/GliaWidgets/Sources/Component/NumberSlot/NumberSlotStyle.swift
+++ b/GliaWidgets/Sources/Component/NumberSlot/NumberSlotStyle.swift
@@ -56,20 +56,21 @@ public struct NumberSlotStyle: Equatable {
     }
 
     mutating func apply(
-        configuration: RemoteConfiguration.NumberSlot?,
+        text: RemoteConfiguration.Text?,
+        background: RemoteConfiguration.Layer?,
         assetsBuilder: RemoteConfiguration.AssetsBuilder
     ) {
         UIFont.convertToFont(
-            uiFont: assetsBuilder.fontBuilder(configuration?.font),
+            uiFont: assetsBuilder.fontBuilder(text?.font),
             textStyle: numberStyle
         ).unwrap { numberFont = $0 }
 
-        configuration?.fontColor?.value
+        text?.foreground?.value
             .map { UIColor(hex: $0) }
             .first
             .unwrap { numberColor = $0 }
 
-        configuration?.background?.color.unwrap {
+        background?.color.unwrap {
             switch $0.type {
             case .fill:
                 $0.value
@@ -82,13 +83,9 @@ public struct NumberSlotStyle: Equatable {
             }
         }
 
-        configuration?.background?.cornerRadius
-            .unwrap { cornerRadius = $0 }
-
-        configuration?.background?.borderWidth
-            .unwrap { borderWidth = $0 }
-
-        configuration?.background?.border?.value
+        background?.cornerRadius.unwrap { cornerRadius = $0 }
+        background?.borderWidth.unwrap { borderWidth = $0 }
+        background?.border?.value
             .map { UIColor(hex: $0) }
             .first
             .unwrap { borderColor = $0 }

--- a/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration+CallVisualizer.swift
+++ b/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration+CallVisualizer.swift
@@ -9,9 +9,11 @@ extension RemoteConfiguration {
     struct VisitorCode: Codable {
         let title: Text?
         let actionButton: Button?
-        let numberSlot: NumberSlot?
+        let numberSlotText: Text?
+        let numberSlotBackground: Layer?
         let background: Layer?
         let loadingProgressColor: Color?
+        let closeButtonColor: Color?
     }
 
     struct ScreenSharing: Codable {
@@ -19,11 +21,5 @@ extension RemoteConfiguration {
         let message: Text?
         let endButton: Button?
         let background: Layer?
-    }
-
-    struct NumberSlot: Codable {
-        let background: Layer?
-        let font: Font?
-        let fontColor: Color?
     }
 }

--- a/GliaWidgets/Sources/View/VisitorCode/VisitorCodeStyle.swift
+++ b/GliaWidgets/Sources/View/VisitorCode/VisitorCodeStyle.swift
@@ -83,7 +83,8 @@ public struct VisitorCodeStyle: Equatable {
             assetsBuilder: assetBuilder
         )
         numberSlot.apply(
-            configuration: configuration?.numberSlot,
+            text: configuration?.numberSlotText,
+            background: configuration?.numberSlotBackground,
             assetsBuilder: assetBuilder
         )
 
@@ -115,6 +116,11 @@ public struct VisitorCodeStyle: Equatable {
                 backgroundColor = .gradient(colors: colors)
             }
         }
+
+        configuration?.closeButtonColor?.value
+            .map { UIColor(hex: $0) }
+            .first
+            .unwrap { closeButtonColor = .fill(color: $0) }
     }
 }
 


### PR DESCRIPTION
For consistency we agreed to rename numberSlot.fontColor property to foreground.