### PR TITLE
Add accessibility identifiers for acceptance tests

### DIFF
--- a/GliaWidgets/SecureConversations/Confirmation/SecureConversations.ConfirmationView.swift
+++ b/GliaWidgets/SecureConversations/Confirmation/SecureConversations.ConfirmationView.swift
@@ -177,6 +177,7 @@ extension SecureConversations {
             checkMessagesButton.setTitleColor(props.style.checkMessagesButtonStyle.textColor, for: .normal)
             checkMessagesButton.backgroundColor = props.style.checkMessagesButtonStyle.backgroundColor
             checkMessagesButton.accessibilityTraits = .button
+            checkMessagesButton.accessibilityIdentifier = "secureConversations_confirmationCheckMessages_button"
             checkMessagesButton.accessibilityLabel = props.style.checkMessagesButtonStyle.accessibility.label
             checkMessagesButton.accessibilityHint = props.style.checkMessagesButtonStyle.accessibility.hint
             setFontScalingEnabled(

--- a/GliaWidgets/SecureConversations/SecureConversations.SendMessageButton.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.SendMessageButton.swift
@@ -73,6 +73,7 @@ extension SecureConversations {
             accessibilityLabel = props.accessibilityLabel
             accessibilityHint = props.accessibilityHint
             isAccessibilityElement = true
+            accessibilityIdentifier = "secureConversations_welcomeSend_button"
         }
 
         var renderedIsIndicatorShown: Bool = false {

--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeView.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeView.swift
@@ -232,6 +232,7 @@ extension SecureConversations.WelcomeView {
             props.style.welcomeTitleStyle.accessibility.isFontScalingEnabled,
             for: titleLabel
         )
+        titleLabel.accessibilityIdentifier = "secureConversations_welcomeTitle_label"
 
         subtitleLabel.text = props.style.welcomeSubtitleStyle.text
         subtitleLabel.font = props.style.welcomeSubtitleStyle.font
@@ -270,6 +271,7 @@ extension SecureConversations.WelcomeView {
             ? props.style.filePickerButtonStyle.color
             : props.style.filePickerButtonStyle.disabledColor
         filePickerButton.accessibilityTraits = .button
+        filePickerButton.accessibilityIdentifier = "secureConversations_welcomeFilePicker_button"
         filePickerButton.accessibilityLabel = props.style.filePickerButtonStyle.accessibility.label
         filePickerButton.accessibilityHint = props.style.filePickerButtonStyle.accessibility.hint
         setFontScalingEnabled(
@@ -294,6 +296,7 @@ extension SecureConversations.WelcomeView {
         checkMessagesButton.accessibilityLabel = props.style.checkMessagesButtonStyle.accessibility.label
         checkMessagesButton.accessibilityHint = props.style.checkMessagesButtonStyle.accessibility.hint
         checkMessagesButton.accessibilityTraits = .button
+        checkMessagesButton.accessibilityIdentifier = "secureConversations_welcomeCheckMessages_button"
 
         setFontScalingEnabled(
             props.style.checkMessagesButtonStyle.accessibility.isFontScalingEnabled,
@@ -601,6 +604,8 @@ extension SecureConversations.WelcomeView {
             // Hide placeholder if textfield is active or has non-empty text.
             placeholderLabel.isHidden = !textView.text.isEmpty || textView.isFirstResponder
             renderedActive = props.isActive
+
+            textView.accessibilityIdentifier = "secureConversations_welcome_textView"
         }
 
         var renderedActive: Bool = false {

--- a/TestingApp/Main.storyboard
+++ b/TestingApp/Main.storyboard
@@ -142,6 +142,7 @@
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ojd-PF-wje">
                                                 <rect key="frame" x="119" y="331.5" width="176" height="30"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="main_secureConversations_button"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="Nk7-ud-fyb"/>
                                                 </constraints>


### PR DESCRIPTION
For acceptance tests, there's several accessibility identifiers needed to trigger different observations and clicks.

MOB-1750