### PR TITLE
Add additional accessibility to call visualizer

### DIFF
--- a/GliaWidgets/L10n.swift
+++ b/GliaWidgets/L10n.swift
@@ -14,18 +14,6 @@ public enum L10n {
   public static let `operator` = L10n.tr("Localizable", "operator", fallback: "Operator")
   /// Powered by
   public static let poweredBy = L10n.tr("Localizable", "poweredBy", fallback: "Powered by")
-  public enum VisitorCode {
-    public enum Title {
-      /// Standard
-      public static let standard = L10n.tr("Localizable", "visitorCode.title.standard", fallback: "Your Visitor Code")
-      /// Error
-      public static let error = L10n.tr("Localizable", "visitorCode.title.error", fallback: "Could not show visitor code. Please try refreshing.")
-    }
-    public enum Action {
-      /// Refresh
-      public static let refresh = L10n.tr("Localizable", "visitorCode.action.refresh", fallback: "Refresh")
-    }
-  }
   public enum Alert {
     public enum Accessibility {
       public enum Action {
@@ -145,6 +133,12 @@ public enum L10n {
         public static let title = L10n.tr("Localizable", "alert.screenSharing.stop.title", fallback: "Stop screen sharing?")
       }
     }
+    public enum UnavailableMessageCenter {
+      /// The Message Center is currently unavailable. Please try again later.
+      public static let message = L10n.tr("Localizable", "alert.unavailableMessageCenter.message", fallback: "The Message Center is currently unavailable. Please try again later.")
+      /// Message Center Unavailable
+      public static let title = L10n.tr("Localizable", "alert.unavailableMessageCenter.title", fallback: "Message Center Unavailable")
+    }
     public enum Unexpected {
       /// Please try again later.
       public static let message = L10n.tr("Localizable", "alert.unexpected.message", fallback: "Please try again later.")
@@ -162,14 +156,9 @@ public enum L10n {
       }
     }
     public enum VisitorCode {
-        public static let title = L10n.tr("Localizable", "alert.visitorCode.title", fallback: "Your Visitor Code")
+      /// Your Visitor Code
+      public static let title = L10n.tr("Localizable", "alert.visitorCode.title", fallback: "Your Visitor Code")
     }
-    public enum UnavailableMessageCenter {
-      /// The Message Center is currently unavailable. Please try again later.
-      public static let message = L10n.tr("Localizable", "alert.unavailableMessageCenter.message", fallback: "The Message Center is currently unavailable. Please try again later.")
-      /// Message Center Unavailable
-      public static let title = L10n.tr("Localizable", "alert.unavailableMessageCenter.title", fallback: "Message Center Unavailable")
-      }
   }
   public enum Call {
     /// You can continue browsing and we’ll connect you automatically.
@@ -435,6 +424,53 @@ public enum L10n {
       public static let title = L10n.tr("Localizable", "call.video.title", fallback: "Video")
     }
   }
+  public enum CallVisualizer {
+    public enum ScreenSharing {
+      /// Your Screen
+      /// is Being Shared
+      public static let message = L10n.tr("Localizable", "callVisualizer.screenSharing.message", fallback: "Your Screen\nis Being Shared")
+      /// Screen Sharing
+      public static let title = L10n.tr("Localizable", "callVisualizer.screenSharing.title", fallback: "Screen Sharing")
+      public enum Accessibility {
+        /// Ends screen sharing
+        public static let buttonHint = L10n.tr("Localizable", "callVisualizer.screenSharing.accessibility.buttonHint", fallback: "Ends screen sharing")
+        /// End Screen Sharing
+        public static let buttonLabel = L10n.tr("Localizable", "callVisualizer.screenSharing.accessibility.buttonLabel", fallback: "End Screen Sharing")
+        /// Message label
+        public static let messageHint = L10n.tr("Localizable", "callVisualizer.screenSharing.accessibility.messageHint", fallback: "Message label")
+      }
+      public enum Button {
+        /// End Screen Sharing
+        public static let title = L10n.tr("Localizable", "callVisualizer.screenSharing.button.title", fallback: "End Screen Sharing")
+      }
+    }
+    public enum VisitorCode {
+      public enum Accessibility {
+        /// Closes visitor code
+        public static let closeHint = L10n.tr("Localizable", "callVisualizer.visitorCode.accessibility.closeHint", fallback: "Closes visitor code")
+        /// Close Button
+        public static let closeLabel = L10n.tr("Localizable", "callVisualizer.visitorCode.accessibility.closeLabel", fallback: "Close Button")
+        /// Generates new visitor code
+        public static let refreshHint = L10n.tr("Localizable", "callVisualizer.visitorCode.accessibility.refreshHint", fallback: "Generates new visitor code")
+        /// Refresh Button
+        public static let refreshLabel = L10n.tr("Localizable", "callVisualizer.visitorCode.accessibility.refreshLabel", fallback: "Refresh Button")
+        /// Your five-digit visitor code is
+        public static let titleHint = L10n.tr("Localizable", "callVisualizer.visitorCode.accessibility.titleHint", fallback: "Your five-digit visitor code is")
+      }
+      public enum Action {
+        /// Close
+        public static let close = L10n.tr("Localizable", "callVisualizer.visitorCode.action.close", fallback: "Close")
+        /// Refresh
+        public static let refresh = L10n.tr("Localizable", "callVisualizer.visitorCode.action.refresh", fallback: "Refresh")
+      }
+      public enum Title {
+        /// Could not show visitor code. Please try refreshing.
+        public static let error = L10n.tr("Localizable", "callVisualizer.visitorCode.title.error", fallback: "Could not show visitor code. Please try refreshing.")
+        /// Your Visitor Code
+        public static let standard = L10n.tr("Localizable", "callVisualizer.visitorCode.title.standard", fallback: "Your Visitor Code")
+      }
+    }
+  }
   public enum Chat {
     /// Chat
     public static let title = L10n.tr("Localizable", "chat.title", fallback: "Chat")
@@ -684,78 +720,64 @@ public enum L10n {
     }
   }
   public enum MessageCenter {
+    public enum Confirmation {
+      /// Check messages
+      public static let checkMessages = L10n.tr("Localizable", "messageCenter.confirmation.checkMessages", fallback: "Check messages")
+      /// Messaging
+      public static let header = L10n.tr("Localizable", "messageCenter.confirmation.header", fallback: "Messaging")
+      /// Your message has been sent.
+      /// We will get back to you within 48 hours.
+      public static let subtitle = L10n.tr("Localizable", "messageCenter.confirmation.subtitle", fallback: "Your message has been sent.\nWe will get back to you within 48 hours.")
+      /// Thank you!
+      public static let title = L10n.tr("Localizable", "messageCenter.confirmation.title", fallback: "Thank you!")
+      public enum Accessibility {
+        /// Navigates you to the chat transcript.
+        public static let checkMessagesHint = L10n.tr("Localizable", "messageCenter.confirmation.accessibility.checkMessagesHint", fallback: "Navigates you to the chat transcript.")
+        /// Check messages
+        public static let checkMessagesLabel = L10n.tr("Localizable", "messageCenter.confirmation.accessibility.checkMessagesLabel", fallback: "Check messages")
+      }
+    }
     public enum Welcome {
-      // Messaging
-      public static let header = L10n.tr("Localizable", "messageCenter.welcome.header", fallback: "Messaging")
-      // Welcome to Message Center
-      public static let title = L10n.tr("Localizable", "messageCenter.welcome.title", fallback: "Welcome to Message Center")
-      // Send a message and we’ll get back to you within 48 hours
-      public static let subtitle = L10n.tr("Localizable", "messageCenter.welcome.subtitle", fallback: "Send a message and we’ll get back to you within 48 hours")
-      // Check messages
+      /// Check messages
       public static let checkMessages = L10n.tr("Localizable", "messageCenter.welcome.checkMessages", fallback: "Check messages")
-      // Your messages
-      public static let messageTitle = L10n.tr("Localizable", "messageCenter.welcome.messageTitle", fallback: "Your message")
-      // Enter your message
-      public static let messageTextViewNormal = L10n.tr("Localizable", "messageCenter.welcome.messageTextViewNormal", fallback: "Enter your message")
-      // Enter your message
-      public static let messageTextViewActive = L10n.tr("Localizable", "messageCenter.welcome.messageTextViewActive", fallback: "Enter your message")
-      // Enter your message
-      public static let messageTextViewDisabled = L10n.tr("Localizable", "messageCenter.welcome.messageTextViewDisabled", fallback: "Enter your message")
-      // Send
-      public static let sendEnabled = L10n.tr("Localizable", "messageCenter.welcome.sendEnabled", fallback: "Send")
-      // Send
-      public static let sendDisabled = L10n.tr("Localizable", "messageCenter.welcome.sendDisabled", fallback: "Send")
-      // Send
-      public static let sendLoading = L10n.tr("Localizable", "messageCenter.welcome.sendLoading", fallback: "Send")
+      /// Messaging
+      public static let header = L10n.tr("Localizable", "messageCenter.welcome.header", fallback: "Messaging")
       /// The message cannot exceed {textLength} characters.
       public static let messageLengthWarning = L10n.tr("Localizable", "messageCenter.welcome.messageLengthWarning", fallback: "The message cannot exceed {textLength} characters.")
-
+      /// Enter your message
+      public static let messageTextViewActive = L10n.tr("Localizable", "messageCenter.welcome.messageTextViewActive", fallback: "Enter your message")
+      /// Enter your message
+      public static let messageTextViewDisabled = L10n.tr("Localizable", "messageCenter.welcome.messageTextViewDisabled", fallback: "Enter your message")
+      /// Enter your message
+      public static let messageTextViewNormal = L10n.tr("Localizable", "messageCenter.welcome.messageTextViewNormal", fallback: "Enter your message")
+      /// Your message
+      public static let messageTitle = L10n.tr("Localizable", "messageCenter.welcome.messageTitle", fallback: "Your message")
+      /// Send
+      public static let sendDisabled = L10n.tr("Localizable", "messageCenter.welcome.sendDisabled", fallback: "Send")
+      /// Send
+      public static let sendEnabled = L10n.tr("Localizable", "messageCenter.welcome.sendEnabled", fallback: "Send")
+      /// Send
+      public static let sendLoading = L10n.tr("Localizable", "messageCenter.welcome.sendLoading", fallback: "Send")
+      /// Send a message and we’ll get back to you within 48 hours
+      public static let subtitle = L10n.tr("Localizable", "messageCenter.welcome.subtitle", fallback: "Send a message and we’ll get back to you within 48 hours")
+      /// Welcome to Message Center
+      public static let title = L10n.tr("Localizable", "messageCenter.welcome.title", fallback: "Welcome to Message Center")
       public enum Accessibility {
-        // Check messages
-        public static let checkMessagesLabel = L10n.tr("Localizable", "messageCenter.welcome.accessibility.checkMessagesLabel", fallback: "Check messages")
-        // Navigates you to the chat transcript.
+        /// Navigates you to the chat transcript.
         public static let checkMessagesHint = L10n.tr("Localizable", "messageCenter.welcome.accessibility.checkMessagesHint", fallback: "Navigates you to the chat transcript.")
-        // File picker
-        public static let filePickerLabel = L10n.tr("Localizable", "messageCenter.welcome.accessibility.filePickerLabel", fallback: "File picker")
-        // Opens the file picker to attach media.
+        /// Check messages
+        public static let checkMessagesLabel = L10n.tr("Localizable", "messageCenter.welcome.accessibility.checkMessagesLabel", fallback: "Check messages")
+        /// Opens the file picker to attach media.
         public static let filePickerHint = L10n.tr("Localizable", "messageCenter.welcome.accessibility.filePickerHint", fallback: "Opens the file picker to attach media.")
-        // Send
-        public static let sendLabel = L10n.tr("Localizable", "messageCenter.welcome.accessibility.sendLabel", fallback: "Send")
-        // Sends a secure message.
+        /// File picker
+        public static let filePickerLabel = L10n.tr("Localizable", "messageCenter.welcome.accessibility.filePickerLabel", fallback: "File picker")
+        /// Sends a secure message.
         public static let sendHint = L10n.tr("Localizable", "messageCenter.welcome.accessibility.sendHint", fallback: "Sends a secure message.")
-      }
-    }
-    public enum Confirmation {
-      // Messaging
-      public static let header = L10n.tr("Localizable", "messageCenter.confirmation.header", fallback: "Messaging")
-      // Thank you!
-      public static let title = L10n.tr("Localizable", "messageCenter.confirmation.title", fallback: "Thank you!")
-      // Your message has been sent.\nWe will get back to you within 48 hours.
-      public static let subtitle = L10n.tr("Localizable", "messageCenter.confirmation.subtitle", fallback: "Your message has been sent.\nWe will get back to you within 48 hours.")
-      // Check messages
-      public static let checkMessages = L10n.tr("Localizable", "messageCenter.confirmation.checkMessages", fallback: "Check messages")
-
-      public enum Accessibility {
-          // Check messages
-          public static let checkMessagesLabel = L10n.tr("Localizable", "messageCenter.confirmation.accessibility.checkMessagesLabel", fallback: "Check messages")
-          // Navigates you to the chat transcript.
-          public static let checkMessagesHint = L10n.tr("Localizable", "messageCenter.confirmation.accessibility.checkMessagesHint", fallback: "Navigates you to the chat transcript.")
+        /// Send
+        public static let sendLabel = L10n.tr("Localizable", "messageCenter.welcome.accessibility.sendLabel", fallback: "Send")
       }
     }
   }
-
-  public enum ScreenSharing {
-    /// Your Screen
-    /// is Being Shared
-    public static let message = L10n.tr("Localizable", "screenSharing.message", fallback: "Screen Sharing")
-    /// Screen Sharing
-    public static let title = L10n.tr("Localizable", "screenSharing.title", fallback: "Your Screen\nis Being Shared")
-    public enum Button {
-      /// End Screen Sharing
-      public static let title = L10n.tr("Localizable", "screenSharing.button.title", fallback: "End Screen Sharing")
-    }
-  }
-
   public enum Survey {
     public enum Accessibility {
       public enum Footer {

--- a/GliaWidgets/Resources/en.lproj/Localizable.strings
+++ b/GliaWidgets/Resources/en.lproj/Localizable.strings
@@ -245,10 +245,18 @@
 "messageCenter.confirmation.accessibility.checkMessagesLabel" = "Check messages";
 "messageCenter.confirmation.accessibility.checkMessagesHint" = "Navigates you to the chat transcript.";
 
-"visitorCode.title.standard" = "Your Visitor Code";
-"visitorCode.title.error" = "Could not show visitor code. Please try refreshing.";
-"visitorCode.action.refresh" = "Refresh";
-
-"screenSharing.title" = "Screen Sharing";
-"screenSharing.message" = "Your Screen\nis Being Shared";
-"screenSharing.button.title" = "End Screen Sharing";
+"callVisualizer.visitorCode.title.standard" = "Your Visitor Code";
+"callVisualizer.visitorCode.title.error" = "Could not show visitor code. Please try refreshing.";
+"callVisualizer.visitorCode.action.refresh" = "Refresh";
+"callVisualizer.visitorCode.action.close" = "Close";
+"callVisualizer.visitorCode.accessibility.titleHint" = "Your five-digit visitor code is";
+"callVisualizer.visitorCode.accessibility.refreshLabel" = "Refresh Button";
+"callVisualizer.visitorCode.accessibility.refreshHint" = "Generates new visitor code";
+"callVisualizer.visitorCode.accessibility.closeLabel" = "Close Button";
+"callVisualizer.visitorCode.accessibility.closeHint" = "Closes visitor code";
+"callVisualizer.screenSharing.title" = "Screen Sharing";
+"callVisualizer.screenSharing.message" = "Your Screen\nis Being Shared";
+"callVisualizer.screenSharing.button.title" = "End Screen Sharing";
+"callVisualizer.screenSharing.accessibility.messageHint" = "Message label";
+"callVisualizer.screenSharing.accessibility.buttonLabel" = "End screen sharing";
+"callVisualizer.screenSharing.accessibility.buttonHint" = "Ends screen sharing";

--- a/GliaWidgets/Sources/CallVisualizer/ScreenSharing/View/ScreenSharingView.swift
+++ b/GliaWidgets/Sources/CallVisualizer/ScreenSharing/View/ScreenSharingView.swift
@@ -38,12 +38,15 @@ extension CallVisualizer {
             $0.numberOfLines = 2
             $0.textAlignment = .center
             $0.accessibilityIdentifier = "end_screen_sharing_message"
+            $0.accessibilityHint = L10n.CallVisualizer.ScreenSharing.Accessibility.messageHint
         }
         private lazy var endScreenSharingButton = ActionButton(props: props.endScreenSharing).make {
             $0.setImage(props.style.buttonIcon, for: .normal)
             $0.tintColor = props.style.buttonStyle.titleColor
             $0.titleEdgeInsets = .init(top: 0, left: 8, bottom: 0, right: 0)
             $0.accessibilityIdentifier = "end_screen_sharing_button"
+            $0.accessibilityLabel = L10n.CallVisualizer.ScreenSharing.Accessibility.buttonLabel
+            $0.accessibilityHint = L10n.CallVisualizer.ScreenSharing.Accessibility.buttonHint
         }
         private lazy var contentStackView = UIStackView.make(
             .vertical,

--- a/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeView.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeView.swift
@@ -65,6 +65,9 @@ extension CallVisualizer {
 
         let refreshButton = UIButton().make { button in
             button.accessibilityIdentifier = "visitor_code_refresh_button"
+            button.accessibilityTraits = .button
+            button.accessibilityLabel = L10n.CallVisualizer.VisitorCode.Accessibility.refreshLabel
+            button.accessibilityHint = L10n.CallVisualizer.VisitorCode.Accessibility.refreshHint
         }
         let spinnerView = UIImageView().make { imageView in
             imageView.image = Asset.spinner.image.withRenderingMode(.alwaysTemplate)
@@ -75,6 +78,7 @@ extension CallVisualizer {
             label.numberOfLines = 2
             label.textAlignment = .center
             label.accessibilityIdentifier = "visitor_code_title_label"
+            label.accessibilityHint = L10n.CallVisualizer.VisitorCode.Accessibility.titleHint
         }
 
         lazy var stackView = UIStackView.make(.vertical, spacing: 24)(
@@ -89,6 +93,9 @@ extension CallVisualizer {
             }
         ).make { button in
             button.accessibilityIdentifier = "visitor_code_alert_close_button"
+            button.accessibilityTraits = .button
+            button.accessibilityLabel = L10n.CallVisualizer.VisitorCode.Accessibility.closeLabel
+            button.accessibilityHint = L10n.CallVisualizer.VisitorCode.Accessibility.closeHint
         }
 
         lazy var poweredBy: PoweredBy = PoweredBy(style: props.style.poweredBy)
@@ -171,13 +178,13 @@ extension CallVisualizer {
             switch props.viewState {
             case .success(visitorCode: let code):
                 renderedVisitorCode = code
-                titleLabel.text = L10n.VisitorCode.Title.standard
+                titleLabel.text = L10n.CallVisualizer.VisitorCode.Title.standard
                 renderVisitorCode()
             case .error:
-                titleLabel.text = L10n.VisitorCode.Title.error
+                titleLabel.text = L10n.CallVisualizer.VisitorCode.Title.error
                 renderError()
             case .loading:
-                titleLabel.text = L10n.VisitorCode.Title.standard
+                titleLabel.text = L10n.CallVisualizer.VisitorCode.Title.standard
                 renderSpinner()
             }
             setFontScalingEnabled(
@@ -211,6 +218,7 @@ extension CallVisualizer {
                     let valueLabel = NumberView().make { numberView in
                         numberView.props = .init(character: char, style: props.style.numberSlot)
                         numberView.accessibilityIdentifier = "visitor_code_number_slot_at_index_\(index)"
+                        numberView.accessibilityLabel = "\(char)"
                     }
                     visitorCodeStack.addArrangedSubview(valueLabel)
                 }

--- a/GliaWidgets/Sources/Theme/Theme+ScreenSharing.swift
+++ b/GliaWidgets/Sources/Theme/Theme+ScreenSharing.swift
@@ -3,19 +3,19 @@ import UIKit
 extension Theme {
     var screenSharingStyle: ScreenSharingViewStyle {
         return ScreenSharingViewStyle(
-            title: L10n.ScreenSharing.title,
+            title: L10n.CallVisualizer.ScreenSharing.title,
             header: chat.header,
-            messageText: L10n.ScreenSharing.message,
+            messageText: L10n.CallVisualizer.ScreenSharing.message,
             messageTextFont: font.header2,
             messageTextColor: color.baseDark,
             buttonStyle: .init(
-                title: L10n.ScreenSharing.Button.title,
+                title: L10n.CallVisualizer.ScreenSharing.Button.title,
                 titleFont: font.buttonLabel,
                 titleColor: .white,
                 backgroundColor: .fill(color: color.systemNegative),
                 cornerRaidus: 4,
                 accessibility: .init(
-                    label: L10n.ScreenSharing.Button.title,
+                    label: L10n.CallVisualizer.ScreenSharing.Button.title,
                     isFontScalingEnabled: true
                 )
             ),

--- a/GliaWidgets/Sources/Theme/Theme+VisitorCode.swift
+++ b/GliaWidgets/Sources/Theme/Theme+VisitorCode.swift
@@ -13,7 +13,7 @@ extension Theme {
         )
 
         let actionButton = ActionButtonStyle(
-            title: L10n.VisitorCode.Action.refresh,
+            title: L10n.CallVisualizer.VisitorCode.Action.refresh,
             titleFont: font.buttonLabel,
             titleColor: color.baseLight,
             backgroundColor: .fill(color: color.primary)

--- a/GliaWidgetsTests/CallVisualizer/VisitorCodeTests.swift
+++ b/GliaWidgetsTests/CallVisualizer/VisitorCodeTests.swift
@@ -19,21 +19,21 @@ class VisitorCodeTests: XCTestCase {
         let view = CallVisualizer.VisitorCodeView()
         view.props = .init(viewState: .success(visitorCode: visitorCode))
         XCTAssertEqual(visitorCode, view.renderedVisitorCode, "Visitor Code not displayed properly")
-        XCTAssertEqual(view.titleLabel.text, L10n.VisitorCode.Title.standard)
+        XCTAssertEqual(view.titleLabel.text, L10n.CallVisualizer.VisitorCode.Title.standard)
     }
 
     func test_error_displayed() {
         let view = CallVisualizer.VisitorCodeView()
         view.props = .init(viewState: .error(refreshTap: .nop))
         XCTAssertTrue(view.stackView.arrangedSubviews.contains(view.refreshButton))
-        XCTAssertEqual(view.titleLabel.text, L10n.VisitorCode.Title.error)
+        XCTAssertEqual(view.titleLabel.text, L10n.CallVisualizer.VisitorCode.Title.error)
     }
 
     func test_spinner_displayed() {
         let view = CallVisualizer.VisitorCodeView()
         view.props = .init(viewState: .loading)
         XCTAssertTrue(view.stackView.arrangedSubviews.contains(view.spinnerView))
-        XCTAssertEqual(view.titleLabel.text, L10n.VisitorCode.Title.standard)
+        XCTAssertEqual(view.titleLabel.text, L10n.CallVisualizer.VisitorCode.Title.standard)
     }
 
     func test_closeButton_visibility() {


### PR DESCRIPTION
Call Visualizer was missing some key accessibility for snapshots tests to run as effectively as possible. This PR also changes the order of properties in L10n.swift file to alphabetical order. Please ignore, changes unrelated to call visualizer.

MOB-1908