### PR TITLE
Add Snapshot Tests for Call Visualizer

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -281,7 +281,6 @@
 		75FF151D27F4F8E000FE7BE2 /* Theme.Survey.InputQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FF151C27F4F8E000FE7BE2 /* Theme.Survey.InputQuestion.swift */; };
 		84265DF02983E62100D65842 /* Theme+ScreenSharing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84265DEF2983E62100D65842 /* Theme+ScreenSharing.swift */; };
 		84265E07298AE96B00D65842 /* ScreenSharingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84265E06298AE96B00D65842 /* ScreenSharingViewModelTests.swift */; };
-		84265E0C298AECBA00D65842 /* ScreenSharingViewStyle+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84265E0B298AECBA00D65842 /* ScreenSharingViewStyle+Mock.swift */; };
 		84265E4B298D7B1900D65842 /* CallVisualizer.Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84265E49298D7B1900D65842 /* CallVisualizer.Coordinator.swift */; };
 		84265E4C298D7B1900D65842 /* CallVisualizer.Coordinator.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84265E4A298D7B1900D65842 /* CallVisualizer.Coordinator.Environment.swift */; };
 		84265E5D298D7B2900D65842 /* ScreenSharingViewModel+Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84265E4F298D7B2900D65842 /* ScreenSharingViewModel+Environment.swift */; };
@@ -461,6 +460,13 @@
 		C06A7584296EC9DC006B69A2 /* NumberSlotStyle.Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06A7583296EC9DC006B69A2 /* NumberSlotStyle.Accessibility.swift */; };
 		C06A7586296ECC57006B69A2 /* VisitorCodeStyle.Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06A7585296ECC57006B69A2 /* VisitorCodeStyle.Accessibility.swift */; };
 		C06A7588296ECD75006B69A2 /* Theme+VisitorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06A7587296ECD75006B69A2 /* Theme+VisitorCode.swift */; };
+		C07FA04029AF542A00E9FB7F /* ScreenSharingViewStyle+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84265E0B298AECBA00D65842 /* ScreenSharingViewStyle+Mock.swift */; };
+		C07FA04329AF551D00E9FB7F /* ScreenSharingView.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07FA04129AF550500E9FB7F /* ScreenSharingView.Mock.swift */; };
+		C07FA04629AF560A00E9FB7F /* ScreenSharingViewController.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07FA04429AF55F600E9FB7F /* ScreenSharingViewController.Mock.swift */; };
+		C07FA04B29AF83B900E9FB7F /* ActionButton.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07FA04929AF83A400E9FB7F /* ActionButton.Mock.swift */; };
+		C07FA04F29B0E41A00E9FB7F /* ScreenShareViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07FA04C29B0E41A00E9FB7F /* ScreenShareViewControllerTests.swift */; };
+		C07FA05029B0E41A00E9FB7F /* VideoCallViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07FA04D29B0E41A00E9FB7F /* VideoCallViewControllerTests.swift */; };
+		C07FA05129B0E41A00E9FB7F /* VisitorCodeViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07FA04E29B0E41A00E9FB7F /* VisitorCodeViewControllerTests.swift */; };
 		C0857DE528D470C1008D171D /* Theme+Shadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0857DE428D470C1008D171D /* Theme+Shadow.swift */; };
 		C0857DE728D470F2008D171D /* Theme+Layer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0857DE628D470F2008D171D /* Theme+Layer.swift */; };
 		C0857DEB28D482D0008D171D /* Theme+Button.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0857DEA28D482D0008D171D /* Theme+Button.swift */; };
@@ -1048,6 +1054,12 @@
 		C06A7583296EC9DC006B69A2 /* NumberSlotStyle.Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberSlotStyle.Accessibility.swift; sourceTree = "<group>"; };
 		C06A7585296ECC57006B69A2 /* VisitorCodeStyle.Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitorCodeStyle.Accessibility.swift; sourceTree = "<group>"; };
 		C06A7587296ECD75006B69A2 /* Theme+VisitorCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Theme+VisitorCode.swift"; sourceTree = "<group>"; };
+		C07FA04129AF550500E9FB7F /* ScreenSharingView.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenSharingView.Mock.swift; sourceTree = "<group>"; };
+		C07FA04429AF55F600E9FB7F /* ScreenSharingViewController.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenSharingViewController.Mock.swift; sourceTree = "<group>"; };
+		C07FA04929AF83A400E9FB7F /* ActionButton.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionButton.Mock.swift; sourceTree = "<group>"; };
+		C07FA04C29B0E41A00E9FB7F /* ScreenShareViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenShareViewControllerTests.swift; sourceTree = "<group>"; };
+		C07FA04D29B0E41A00E9FB7F /* VideoCallViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoCallViewControllerTests.swift; sourceTree = "<group>"; };
+		C07FA04E29B0E41A00E9FB7F /* VisitorCodeViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VisitorCodeViewControllerTests.swift; sourceTree = "<group>"; };
 		C0857DE428D470C1008D171D /* Theme+Shadow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Theme+Shadow.swift"; sourceTree = "<group>"; };
 		C0857DE628D470F2008D171D /* Theme+Layer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Theme+Layer.swift"; sourceTree = "<group>"; };
 		C0857DEA28D482D0008D171D /* Theme+Button.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Theme+Button.swift"; sourceTree = "<group>"; };
@@ -2563,6 +2575,9 @@
 			isa = PBXGroup;
 			children = (
 				84265E0B298AECBA00D65842 /* ScreenSharingViewStyle+Mock.swift */,
+				C07FA04929AF83A400E9FB7F /* ActionButton.Mock.swift */,
+				C07FA04129AF550500E9FB7F /* ScreenSharingView.Mock.swift */,
+				C07FA04429AF55F600E9FB7F /* ScreenSharingViewController.Mock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -2736,12 +2751,15 @@
 			isa = PBXGroup;
 			children = (
 				846E822728996A5C008EFBF0 /* AlertViewControllerTests.swift */,
-				9A1992D627D61F8100161AAE /* ChatViewControllerVoiceOverTests.swift */,
-				9A1992D727D61F8100161AAE /* SnapshotTestCase.swift */,
-				9AE9E4B427E0EE2E00BFE239 /* CallViewControllerVoiceOverTests.swift */,
 				9AB3401227F71D5D006E0FE2 /* BubbleViewVoiceOverTests.swift */,
+				9AE9E4B427E0EE2E00BFE239 /* CallViewControllerVoiceOverTests.swift */,
 				9AB3402828002422006E0FE2 /* ChatCallUpgradeViewVoiceOverTests.swift */,
+				9A1992D627D61F8100161AAE /* ChatViewControllerVoiceOverTests.swift */,
+				C07FA04C29B0E41A00E9FB7F /* ScreenShareViewControllerTests.swift */,
+				9A1992D727D61F8100161AAE /* SnapshotTestCase.swift */,
 				8458769E2823FD18007AC3DF /* SurveyViewControllerVoiceOverTests.swift */,
+				C07FA04D29B0E41A00E9FB7F /* VideoCallViewControllerTests.swift */,
+				C07FA04E29B0E41A00E9FB7F /* VisitorCodeViewControllerTests.swift */,
 			);
 			path = SnapshotTests;
 			sourceTree = "<group>";
@@ -3637,8 +3655,10 @@
 				EB2CBB1227D89F7D004F178E /* OnHoldOverlayStyle.swift in Sources */,
 				75940983298D38C2008B173A /* VisitorCodeViewModel+Delegate.swift in Sources */,
 				84265E66298D7B2900D65842 /* ScreenSharingViewController+Props.swift in Sources */,
+				C07FA04B29AF83B900E9FB7F /* ActionButton.Mock.swift in Sources */,
 				C0D2F08C29A4EBA900803B47 /* VIdeoCallView.Environment.Mock.swift in Sources */,
 				313EBD552943116E008E9597 /* SecureConversations.swift in Sources */,
+				C07FA04329AF551D00E9FB7F /* ScreenSharingView.Mock.swift in Sources */,
 				7529F2B627E1EB9A004D3581 /* Survey.ButtonView.swift in Sources */,
 				C49A29E42614A29700819269 /* FilePreviewView.swift in Sources */,
 				1A5F815F258A43E600A605DA /* Section.swift in Sources */,
@@ -3666,6 +3686,7 @@
 				1A4AD3C4256E7A0C00468BFB /* ThemeFontStyle.swift in Sources */,
 				1A0C9AC825C9493D00815406 /* Int+Extensions.swift in Sources */,
 				C4C2A1702670E848003AC039 /* UIViewController+Extensions.swift in Sources */,
+				C07FA04029AF542A00E9FB7F /* ScreenSharingViewStyle+Mock.swift in Sources */,
 				755D186D29A6A5E30009F5E8 /* WelcomeStyle+MessageTextViewStyle.swift in Sources */,
 				9A19926B27D3BA8700161AAE /* ViewFactory.Environment.Mock.swift in Sources */,
 				1A6EB05725A717CB0007081A /* ChatMessage.swift in Sources */,
@@ -3912,6 +3933,7 @@
 				C0D2F07329A4DC2000803B47 /* CallStyle.Mock.swift in Sources */,
 				C0D2F03B299149D600803B47 /* VideoCallViewModel.swift in Sources */,
 				C0D2F02E2991221900803B47 /* VideoCallCoordinator.DelegateEvent.swift in Sources */,
+				C07FA04629AF560A00E9FB7F /* ScreenSharingViewController.Mock.swift in Sources */,
 				1A2DA73125EFA77E00032611 /* FileUploader.swift in Sources */,
 				1A60B0272568070800E53F53 /* UIStackView+Extensions.swift in Sources */,
 				75940945298D378A008B173A /* CoreSDKClient.Mock.swift in Sources */,
@@ -3962,7 +3984,6 @@
 				7512A5A727C3926500319DF1 /* GliaTests.swift in Sources */,
 				9A3E1DA227BA7D00005634EB /* FileSystemStorage.Environment.Failing.swift in Sources */,
 				9A1992E127D6313500161AAE /* ImageView.Cache.Failing.swift in Sources */,
-				84265E0C298AECBA00D65842 /* ScreenSharingViewStyle+Mock.swift in Sources */,
 				C0D2F06429A4B1E900803B47 /* VideoCallTests.swift in Sources */,
 				C03A8047292BA76D00DDECA6 /* ChatViewControllerTests.swift in Sources */,
 				EB9ADB552828E66B00FAE8A4 /* CallTests.swift in Sources */,
@@ -4018,10 +4039,13 @@
 			files = (
 				846E822828996A5C008EFBF0 /* AlertViewControllerTests.swift in Sources */,
 				9AE9E4B527E0EE2E00BFE239 /* CallViewControllerVoiceOverTests.swift in Sources */,
+				C07FA05029B0E41A00E9FB7F /* VideoCallViewControllerTests.swift in Sources */,
 				9AB3401327F71D5D006E0FE2 /* BubbleViewVoiceOverTests.swift in Sources */,
 				9A1992D827D61F8100161AAE /* ChatViewControllerVoiceOverTests.swift in Sources */,
 				8458769F2823FD18007AC3DF /* SurveyViewControllerVoiceOverTests.swift in Sources */,
+				C07FA05129B0E41A00E9FB7F /* VisitorCodeViewControllerTests.swift in Sources */,
 				9AB3402928002422006E0FE2 /* ChatCallUpgradeViewVoiceOverTests.swift in Sources */,
+				C07FA04F29B0E41A00E9FB7F /* ScreenShareViewControllerTests.swift in Sources */,
 				9A1992D927D61F8100161AAE /* SnapshotTestCase.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeView.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeView.swift
@@ -78,7 +78,6 @@ extension CallVisualizer {
             label.numberOfLines = 2
             label.textAlignment = .center
             label.accessibilityIdentifier = "visitor_code_title_label"
-            label.accessibilityHint = L10n.CallVisualizer.VisitorCode.Accessibility.titleHint
         }
 
         lazy var stackView = UIStackView.make(.vertical, spacing: 24)(
@@ -180,9 +179,11 @@ extension CallVisualizer {
                 renderedVisitorCode = code
                 titleLabel.text = L10n.CallVisualizer.VisitorCode.Title.standard
                 renderVisitorCode()
+                titleLabel.accessibilityHint = L10n.CallVisualizer.VisitorCode.Accessibility.titleHint
             case .error:
                 titleLabel.text = L10n.CallVisualizer.VisitorCode.Title.error
                 renderError()
+                titleLabel.accessibilityHint = nil
             case .loading:
                 titleLabel.text = L10n.CallVisualizer.VisitorCode.Title.standard
                 renderSpinner()

--- a/GliaWidgets/Sources/Component/PoweredBy/PoweredBy.swift
+++ b/GliaWidgets/Sources/Component/PoweredBy/PoweredBy.swift
@@ -25,6 +25,7 @@ class PoweredBy: UIView {
     private func setup() {
         label.text = style.text
         label.font = style.font
+        label.accessibilityLabel = "Powered By Glia"
         setFontScalingEnabled(
             style.accessibility.isFontScalingEnabled,
             for: label

--- a/GliaWidgetsTests/CallVisualizer/ScreenSharing/Mocks/ActionButton.Mock.swift
+++ b/GliaWidgetsTests/CallVisualizer/ScreenSharing/Mocks/ActionButton.Mock.swift
@@ -1,0 +1,21 @@
+#if DEBUG
+
+import UIKit
+
+extension ActionButton.Props {
+    static func mock(
+        style: ActionButtonStyle = .mock(),
+        height: CGFloat = 40,
+        tap: Cmd = .nop,
+        accessibilityIdentifier: String = ""
+    ) -> ActionButton.Props {
+        return .init(
+            style: style,
+            height: height,
+            tap: tap,
+            accessibilityIdentifier: accessibilityIdentifier
+        )
+    }
+}
+
+#endif

--- a/GliaWidgetsTests/CallVisualizer/ScreenSharing/Mocks/ScreenSharingView.Mock.swift
+++ b/GliaWidgetsTests/CallVisualizer/ScreenSharing/Mocks/ScreenSharingView.Mock.swift
@@ -1,0 +1,15 @@
+#if DEBUG
+
+import UIKit
+
+extension CallVisualizer.ScreenSharingView.Props {
+    static func mock(
+        style: ScreenSharingViewStyle = .mock(),
+        header: Header.Props = .mock(),
+        endScreenSharing: ActionButton.Props = .mock()
+    ) -> CallVisualizer.ScreenSharingView.Props {
+        return .init(style: style, header: header, endScreenSharing: endScreenSharing)
+    }
+}
+
+#endif

--- a/GliaWidgetsTests/CallVisualizer/ScreenSharing/Mocks/ScreenSharingViewController.Mock.swift
+++ b/GliaWidgetsTests/CallVisualizer/ScreenSharing/Mocks/ScreenSharingViewController.Mock.swift
@@ -1,0 +1,13 @@
+#if DEBUG
+
+import UIKit
+
+extension CallVisualizer.ScreenSharingViewController.Props {
+    static func mock(
+        screenShareViewProps: CallVisualizer.ScreenSharingView.Props = .mock()
+    ) -> CallVisualizer.ScreenSharingViewController.Props {
+        return .init(screenSharingViewProps: screenShareViewProps)
+    }
+}
+
+#endif

--- a/GliaWidgetsTests/CallVisualizer/ScreenSharing/Mocks/ScreenSharingViewStyle+Mock.swift
+++ b/GliaWidgetsTests/CallVisualizer/ScreenSharing/Mocks/ScreenSharingViewStyle+Mock.swift
@@ -1,54 +1,23 @@
+#if DEBUG
+
 import UIKit
-@testable import GliaWidgets
 
 extension ScreenSharingViewStyle {
-    static func mock() -> ScreenSharingViewStyle {
+    static func mock(
+        title: String = ""
+    ) -> ScreenSharingViewStyle {
         ScreenSharingViewStyle(
-            title: "",
+            title: title,
             header: .mock(),
-            messageText: "",
-            messageTextFont: .systemFont(ofSize: 16),
-            messageTextColor: .clear,
+            messageText: L10n.CallVisualizer.ScreenSharing.message,
+            messageTextFont: .systemFont(ofSize: 20, weight: .regular),
+            messageTextColor: Color.baseDark,
             buttonStyle: .mock(),
-            buttonIcon: UIImage(),
+            buttonIcon: Asset.startScreenShare.image,
             backgroundColor: .fill(color: .white),
             accessibility: .unsupported
         )
     }
 }
 
-extension HeaderStyle {
-    static func mock() -> HeaderStyle {
-        HeaderStyle(
-            titleFont: .systemFont(ofSize: 16),
-            titleColor: .cyan,
-            backgroundColor: .fill(color: .clear),
-            backButton: .mock(),
-            closeButton: .mock(),
-            endButton: .mock(),
-            endScreenShareButton: .mock()
-        )
-    }
-}
-
-extension HeaderButtonStyle {
-    static func mock() -> HeaderButtonStyle {
-        HeaderButtonStyle(
-            image: UIImage(),
-            color: .clear
-        )
-    }
-}
-
-extension ActionButtonStyle {
-    static func mock() -> ActionButtonStyle {
-        ActionButtonStyle(
-            title: "",
-            titleFont: .systemFont(ofSize: 16),
-            titleColor: .clear,
-            backgroundColor: .fill(color: .clear)
-        )
-    }
-}
-
-
+#endif

--- a/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/CallButtonBar.Mock.swift
+++ b/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/CallButtonBar.Mock.swift
@@ -2,14 +2,20 @@
 
 extension CallVisualizer.VideoCallView.CallButtonBar.Props {
     static func mock(
-        style: CallButtonBarStyle = .mock,
+        style: CallButtonBarStyle = .mock(),
         videoButtonTap: Cmd = .nop,
-        minimizeTap: Cmd = .nop
+        minimizeTap: Cmd = .nop,
+        videoButtonState: CallButton.State = .active,
+        videoButtonEnabled: Bool = true,
+        minimizeButtonEnabled: Bool = true
     ) -> CallVisualizer.VideoCallView.CallButtonBar.Props {
         .init(
             style: style,
             videoButtonTap: videoButtonTap,
-            minimizeTap: minimizeTap
+            minimizeTap: minimizeTap,
+            videoButtonState: videoButtonState,
+            videoButtonEnabled: videoButtonEnabled,
+            minimizeButtonEnabled: minimizeButtonEnabled
         )
     }
 }

--- a/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/CallButtonBarStyle.Mock.swift
+++ b/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/CallButtonBarStyle.Mock.swift
@@ -3,36 +3,113 @@
 import UIKit
 
 extension CallButtonBarStyle {
-    static let mock = Self(
-        chatButton: .mock,
-        videoButton: .mock,
-        muteButton: .mock,
-        speakerButton: .mock,
-        minimizeButton: .mock,
-        badge: .mock()
-    )
+    static func mock(
+        chatButton: CallButtonStyle = .mock(),
+        videButton: CallButtonStyle = .mock(),
+        muteButton: CallButtonStyle = .mock(),
+        speakerButton: CallButtonStyle = .mock(),
+        minimizeButton: CallButtonStyle = .mock(),
+        badge: BadgeStyle = .mock()
+    ) -> CallButtonBarStyle {
+        return .init(
+            chatButton: chatButton,
+            videoButton: videButton,
+            muteButton: muteButton,
+            speakerButton: speakerButton,
+            minimizeButton: minimizeButton,
+            badge: badge
+        )
+    }
 }
 
 extension CallButtonStyle {
-    static let mock = Self(
-        active: .mock,
-        inactive: .mock,
-        selected: .mock,
-        accessibility: .unsupported
-    )
+    static func mock(
+        active: StateStyle = .activeMock(),
+        inactive: StateStyle = .inactiveMock(),
+        selected: StateStyle = .selectedMock(),
+        accessibility: Accessibility = .unsupported
+    ) -> CallButtonStyle {
+        return .init(
+            active: active,
+            inactive: inactive,
+            selected: selected,
+            accessibility: accessibility
+        )
+    }
 }
 
 extension CallButtonStyle.StateStyle {
-    static let mock = Self(
-        backgroundColor: .fill(color: .white),
-        image: .mock,
-        imageColor: .fill(color: .white),
-        title: "",
-        titleFont: .font(weight: .regular, size: 12),
-        titleColor: .white,
-        textStyle: .body,
-        accessibility: .unsupported
-    )
+    static func activeMock(
+        backgroundColor: ColorType = .fill(color: UIColor.white.withAlphaComponent(0.9)),
+        image: UIImage = Asset.callChat.image,
+        imageColor: ColorType = .fill(color: Color.baseDark),
+        title: String = L10n.Call.Buttons.Chat.title,
+        titleFont: UIFont = .systemFont(ofSize: 12, weight: .regular),
+        titleColor: UIColor = Color.baseLight,
+        textStyle: UIFont.TextStyle = .caption1,
+        accessibility: Accessibility = .init(
+            label: L10n.Call.Accessibility.Buttons.Chat.Active.label
+        )
+    ) -> CallButtonStyle.StateStyle {
+        return .init(
+            backgroundColor: backgroundColor,
+            image: image,
+            imageColor: imageColor,
+            title: title,
+            titleFont: titleFont,
+            titleColor: titleColor,
+            textStyle: textStyle,
+            accessibility: accessibility
+        )
+    }
+
+    static func inactiveMock(
+        backgroundColor: ColorType = .fill(color: UIColor.black.withAlphaComponent(0.4)),
+        image: UIImage = Asset.callChat.image,
+        imageColor: ColorType = .fill(color: Color.baseLight),
+        title: String = L10n.Call.Buttons.Chat.title,
+        titleFont: UIFont = .systemFont(ofSize: 12, weight: .regular),
+        titleColor: UIColor = Color.baseLight,
+        textStyle: UIFont.TextStyle = .caption1,
+        accessibility: Accessibility = .init(
+            label: L10n.Call.Accessibility.Buttons.Chat.Inactive.label
+        )
+    ) -> CallButtonStyle.StateStyle {
+        return .init(
+            backgroundColor: backgroundColor,
+            image: image,
+            imageColor: imageColor,
+            title: title,
+            titleFont: titleFont,
+            titleColor: titleColor,
+            textStyle: textStyle,
+            accessibility: accessibility
+        )
+    }
+
+    static func selectedMock(
+        backgroundColor: ColorType = .fill(color: UIColor.black.withAlphaComponent(0.4)),
+        image: UIImage = Asset.callChat.image,
+        imageColor: ColorType = .fill(color: Color.baseLight),
+        title: String = L10n.Call.Buttons.Chat.title,
+        titleFont: UIFont = .systemFont(ofSize: 12, weight: .regular),
+        titleColor: UIColor = Color.baseLight,
+        textStyle: UIFont.TextStyle = .caption1,
+        accessibility: Accessibility = .init(
+            label: L10n.Call.Accessibility.Buttons.Chat.Inactive.label
+        )
+    ) -> CallButtonStyle.StateStyle {
+        return .init(
+            backgroundColor: backgroundColor,
+            image: image,
+            imageColor: imageColor,
+            title: title,
+            titleFont: titleFont,
+            titleColor: titleColor,
+            textStyle: textStyle,
+            accessibility: accessibility
+        )
+    }
 }
 
 #endif

--- a/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/Header.Mock.swift
+++ b/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/Header.Mock.swift
@@ -5,10 +5,10 @@ extension Header.Props {
         title: String = "",
         effect: Header.Effect = .none,
         endButton: ActionButton.Props = .init(),
-        backButton: HeaderButton.Props = .init(style: .mock),
-        closeButton: HeaderButton.Props = .init(style: .mock),
-        endScreenShareButton: HeaderButton.Props = .init(style: .mock),
-        style: HeaderStyle = .mock
+        backButton: HeaderButton.Props = .init(style: .mock()),
+        closeButton: HeaderButton.Props = .init(style: .mock()),
+        endScreenShareButton: HeaderButton.Props = .init(style: .mock()),
+        style: HeaderStyle = .mock()
     ) -> Header.Props {
         .init(
             title: title,

--- a/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/HeaderStyle.Mock.swift
+++ b/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/HeaderStyle.Mock.swift
@@ -1,28 +1,52 @@
 #if DEBUG
 
+import UIKit
+
 extension HeaderStyle {
-    static let mock = Self(
-        titleFont: .font(weight: .regular, size: 12),
-        titleColor: .white,
-        backgroundColor: .fill(color: .white),
-        backButton: .mock,
-        closeButton: .mock,
-        endButton: .mock,
-        endScreenShareButton: .mock
-    )
+    static func mock(
+        titleFont: UIFont = .systemFont(ofSize: 20, weight: .regular),
+        titleColor: UIColor = .white,
+        backgroundColor: ColorType = .fill(color: .blue),
+        backButton: HeaderButtonStyle = .mock(),
+        closeButton: HeaderButtonStyle = .mock(),
+        endButton: ActionButtonStyle = .mock(),
+        endScreenShareButton: HeaderButtonStyle = .mock()
+    ) -> HeaderStyle {
+        return .init(
+            titleFont: titleFont,
+            titleColor: titleColor,
+            backgroundColor: backgroundColor,
+            backButton: backButton,
+            closeButton: closeButton,
+            endButton: endButton,
+            endScreenShareButton: endScreenShareButton
+        )
+    }
 }
 
 extension HeaderButtonStyle {
-    static let mock = Self(image: .mock, color: .white)
+    static func mock(
+        image: UIImage = .mock,
+        color: UIColor = .white
+    ) -> HeaderButtonStyle {
+        return .init(image: image, color: color)
+    }
 }
 
 extension ActionButtonStyle {
-    static let mock = Self(
-        title: "",
-        titleFont: .font(weight: .regular, size: 12),
-        titleColor: .white,
-        backgroundColor: .fill(color: .white)
-    )
+    static func mock(
+        title: String = L10n.CallVisualizer.ScreenSharing.Button.title,
+        titleFont: UIFont = .systemFont(ofSize: 16, weight: .regular),
+        titleColor: UIColor = .white,
+        backgroundColor: ColorType = .fill(color: Color.systemNegative)
+    ) -> ActionButtonStyle {
+        return .init(
+            title: title,
+            titleFont: titleFont,
+            titleColor: titleColor,
+            backgroundColor: backgroundColor
+        )
+    }
 }
 
 #endif

--- a/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/VideoCallViewController.Mock.swift
+++ b/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/VideoCallViewController.Mock.swift
@@ -2,7 +2,7 @@
 
 extension CallVisualizer.VideoCallViewController {
     static func mock(
-        props: Props = .init(videoCallViewProps: .mock),
+        props: Props = .init(videoCallViewProps: .mock()),
         environment: CallVisualizer.VideoCallView.Environment = .mock
     ) -> CallVisualizer.VideoCallViewController {
         .init(

--- a/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/VideoCallViewMock.swift
+++ b/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/VideoCallViewMock.swift
@@ -3,21 +3,37 @@
 import UIKit
 
 extension CallVisualizer.VideoCallView.Props {
-    static let mock = Self(
-        style: .mock(),
-        callDuration: "",
-        connectViewProps: .mock,
-        buttonBarProps: .mock(),
-        headerTitle: "",
-        operatorName: "",
-        remoteVideoStream: .none,
-        localVideoStream: .none,
-        topLabelHidden: false,
-        endScreenShareButtonHidden: false,
-        connectViewHidden: false,
-        topStackAlpha: 1.0,
-        headerProps: .mock()
-    )
+    static func mock(
+        style: CallStyle = .mock(),
+        callDuration: String? = "",
+        connectViewProps: CallVisualizer.VideoCallView.ConnectView.Props = .mock,
+        buttonBarProps: CallVisualizer.VideoCallView.CallButtonBar.Props = .mock(),
+        headerTitle: String = "",
+        operatorName: String? = "",
+        remoteVideoStream: CoreSdkClient.StreamView? = .none,
+        localVideoStream: CoreSdkClient.StreamView? = .none,
+        topLabelHidden: Bool = false,
+        endScreenShareButtonHidden: Bool = false,
+        connectViewHidden: Bool = false,
+        topStackAlpha: CGFloat = 1.0,
+        headerProps: Header.Props = .mock()
+    ) -> CallVisualizer.VideoCallView.Props {
+        return .init(
+            style: style,
+            callDuration: callDuration,
+            connectViewProps: connectViewProps,
+            buttonBarProps: buttonBarProps,
+            headerTitle: headerTitle,
+            operatorName: operatorName,
+            remoteVideoStream: remoteVideoStream,
+            localVideoStream: localVideoStream,
+            topLabelHidden: topLabelHidden,
+            endScreenShareButtonHidden: endScreenShareButtonHidden,
+            connectViewHidden: connectViewHidden,
+            topStackAlpha: topStackAlpha,
+            headerProps: headerProps
+        )
+    }
 }
 
 #endif

--- a/SnapshotTests/ScreenShareViewControllerTests.swift
+++ b/SnapshotTests/ScreenShareViewControllerTests.swift
@@ -1,0 +1,28 @@
+import AccessibilitySnapshot
+@testable import GliaWidgets
+import SnapshotTesting
+import XCTest
+
+class ScreenShareViewControllerTests: SnapshotTestCase {
+    func testScreenShareViewController() {
+        let props: CallVisualizer.ScreenSharingViewController.Props = .init(
+            screenSharingViewProps: .init(
+                style: .mock(),
+                header: .mock(
+                    title: L10n.CallVisualizer.ScreenSharing.title,
+                    backButton: .init(style: .mock(image: Asset.back.image))
+                ),
+                endScreenSharing: .mock()
+            )
+        )
+        let screenShareViewController = CallVisualizer.ScreenSharingViewController(props: props)
+        screenShareViewController.view.frame = UIScreen.main.bounds
+
+        assertSnapshot(
+            matching: screenShareViewController,
+            as: .accessibilityImage(precision: Self.possiblePrecision),
+            named: nameForDevice()
+        )
+
+    }
+}

--- a/SnapshotTests/VideoCallViewControllerTests.swift
+++ b/SnapshotTests/VideoCallViewControllerTests.swift
@@ -1,0 +1,60 @@
+import AccessibilitySnapshot
+@testable import GliaWidgets
+import SnapshotTesting
+import XCTest
+
+class VideoCallViewControllerTests: SnapshotTestCase {
+    func testVideoCallViewController() {
+        let videoCallViewProps: CallVisualizer.VideoCallView.Props = .mock(
+            buttonBarProps: .mock(
+                style: .mock(
+                    chatButton: .mock(),
+                    videButton: .mock(
+                        inactive: .activeMock(
+                            image: Asset.callVideoActive.image,
+                            title: L10n.Call.Buttons.Video.title,
+                            accessibility: .init(label: L10n.Call.Accessibility.Buttons.Video.Active.label)
+                        )
+                    ),
+                    muteButton: .mock(
+                        inactive: .inactiveMock(
+                            image: Asset.callMuteInactive.image,
+                            title: L10n.Call.Buttons.Mute.Inactive.title,
+                            accessibility: .init(label: L10n.Call.Accessibility.Buttons.Mute.Inactive.label)
+                        )
+                    ),
+                    speakerButton: .mock(
+                        inactive: .inactiveMock(
+                            image: Asset.callSpeakerInactive.image,
+                            title: L10n.Call.Buttons.Speaker.title,
+                            accessibility: .init(label: L10n.Call.Accessibility.Buttons.Speaker.Inactive.label)
+                        )
+                    ),
+                    minimizeButton: .mock(
+                        inactive: .inactiveMock(
+                            image: Asset.callMiminize.image,
+                            title: L10n.Call.Buttons.Minimize.title,
+                            accessibility: .init(label: L10n.Call.Accessibility.Buttons.Minimize.Inactive.label)
+                        )
+                    ),
+                    badge: .mock()
+                )
+            ),
+            headerProps: .mock(
+                title: "Video",
+                effect: .blur,
+                backButton: .init(style: .mock(image: Asset.back.image))
+            )
+        )
+        let props: CallVisualizer.VideoCallViewController.Props = .init(videoCallViewProps: videoCallViewProps)
+
+        let videoCallViewController: CallVisualizer.VideoCallViewController = .mock(props: props)
+        videoCallViewController.view.frame = UIScreen.main.bounds
+
+        assertSnapshot(
+            matching: videoCallViewController,
+            as: .accessibilityImage(precision: Self.possiblePrecision),
+            named: nameForDevice()
+        )
+    }
+}

--- a/SnapshotTests/VisitorCodeViewControllerTests.swift
+++ b/SnapshotTests/VisitorCodeViewControllerTests.swift
@@ -1,0 +1,107 @@
+import AccessibilitySnapshot
+@testable import GliaWidgets
+import SnapshotTesting
+import XCTest
+
+class VisitorCodeViewControllerTests: SnapshotTestCase {
+    func testVisitorCodeAlertWhenLoading() {
+        let props: CallVisualizer.VisitorCodeViewController.Props = .init(
+            visitorCodeViewProps: .init(
+                viewType: .alert(closeButtonTap: .nop),
+                viewState: .loading
+            )
+        )
+        let visitorCodeViewController = CallVisualizer.VisitorCodeViewController(props: props)
+        visitorCodeViewController.view.frame = UIScreen.main.bounds
+
+        assertSnapshot(
+            matching: visitorCodeViewController,
+            as: .accessibilityImage(precision: Self.possiblePrecision),
+            named: nameForDevice()
+        )
+    }
+
+    func testVisitorCodeAlertWhenError() {
+        let props: CallVisualizer.VisitorCodeViewController.Props = .init(
+            visitorCodeViewProps: .init(
+                viewType: .alert(closeButtonTap: .nop),
+                viewState: .error(refreshTap: .nop)
+            )
+        )
+        let visitorCodeViewController = CallVisualizer.VisitorCodeViewController(props: props)
+        visitorCodeViewController.view.frame = UIScreen.main.bounds
+
+        assertSnapshot(
+            matching: visitorCodeViewController,
+            as: .accessibilityImage(precision: Self.possiblePrecision),
+            named: nameForDevice()
+        )
+    }
+
+    func testVisitorCodeAlertWhenSuccess() {
+        let props: CallVisualizer.VisitorCodeViewController.Props = .init(
+            visitorCodeViewProps: .init(
+                viewType: .alert(closeButtonTap: .nop),
+                viewState: .success(visitorCode: "12345")
+            )
+        )
+        let visitorCodeViewController = CallVisualizer.VisitorCodeViewController(props: props)
+        visitorCodeViewController.view.frame = UIScreen.main.bounds
+
+        assertSnapshot(
+            matching: visitorCodeViewController,
+            as: .accessibilityImage(precision: Self.possiblePrecision),
+            named: nameForDevice()
+        )
+    }
+
+    func testVisitorCodeEmbeddedWhenLoading() {
+        let props: CallVisualizer.VisitorCodeViewController.Props = .init(
+            visitorCodeViewProps: .init(
+                viewType: .embedded,
+                viewState: .loading
+            )
+        )
+        let visitorCodeViewController = CallVisualizer.VisitorCodeViewController(props: props)
+        visitorCodeViewController.view.frame = UIScreen.main.bounds
+
+        assertSnapshot(
+            matching: visitorCodeViewController,
+            as: .accessibilityImage(precision: Self.possiblePrecision),
+            named: nameForDevice()
+        )
+    }
+
+    func testVisitorCodeEmbeddedWhenError() {
+        let props: CallVisualizer.VisitorCodeViewController.Props = .init(
+            visitorCodeViewProps: .init(
+                viewType: .embedded,
+                viewState: .error(refreshTap: .nop)
+            )
+        )
+        let visitorCodeViewController = CallVisualizer.VisitorCodeViewController(props: props)
+        visitorCodeViewController.view.frame = UIScreen.main.bounds
+
+        assertSnapshot(
+            matching: visitorCodeViewController,
+            as: .accessibilityImage(precision: Self.possiblePrecision),
+            named: nameForDevice()
+        )
+    }
+    func testVisitorCodeEmbeddedWhenSuccess() {
+        let props: CallVisualizer.VisitorCodeViewController.Props = .init(
+            visitorCodeViewProps: .init(
+                viewType: .embedded,
+                viewState: .success(visitorCode: "12345")
+            )
+        )
+        let visitorCodeViewController = CallVisualizer.VisitorCodeViewController(props: props)
+        visitorCodeViewController.view.frame = UIScreen.main.bounds
+
+        assertSnapshot(
+            matching: visitorCodeViewController,
+            as: .accessibilityImage(precision: Self.possiblePrecision),
+            named: nameForDevice()
+        )
+    }
+}


### PR DESCRIPTION
This PR covers snapshot tests for the call visualizer, including screen sharing, visitor code, and video call views. For better testability, mock objects were created or refactored

MOB-1777