### PR TITLE
Change header title and skip enqueueing state for secure flow

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -426,6 +426,7 @@
 		AD57658B6D7BB11749113284 /* Pods_SnapshotTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9131A19E516E338E979C0C43 /* Pods_SnapshotTests.framework */; };
 		AF0D26D629705FDF00816CCB /* SecureConversations.ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0D26D529705FDE00816CCB /* SecureConversations.ActivityIndicator.swift */; };
 		AF0D26D82971912A00816CCB /* SecureConversations.SendMessageButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0D26D72971912A00816CCB /* SecureConversations.SendMessageButton.swift */; };
+		AF10ED8B29B7A4C000E85309 /* ChatViewModel+ChoiceCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF10ED8A29B7A4C000E85309 /* ChatViewModel+ChoiceCards.swift */; };
 		AF11F30728BE6F0C002ACEB4 /* UIAlertController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF11F30628BE6F0C002ACEB4 /* UIAlertController+Extensions.swift */; };
 		AF39330B29B2A6A00008B60D /* ChatViewModel.SecureConverstaions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF39330A29B2A6A00008B60D /* ChatViewModel.SecureConverstaions.swift */; };
 		AF3D520B2983235C00AD8E69 /* FileUploader.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D520A2983235C00AD8E69 /* FileUploader.Mock.swift */; };
@@ -1012,6 +1013,7 @@
 		AB58EB188E5FABE4A07F2ACD /* Pods-GliaWidgets.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GliaWidgets.release.xcconfig"; path = "Target Support Files/Pods-GliaWidgets/Pods-GliaWidgets.release.xcconfig"; sourceTree = "<group>"; };
 		AF0D26D529705FDE00816CCB /* SecureConversations.ActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.ActivityIndicator.swift; sourceTree = "<group>"; };
 		AF0D26D72971912A00816CCB /* SecureConversations.SendMessageButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.SendMessageButton.swift; sourceTree = "<group>"; };
+		AF10ED8A29B7A4C000E85309 /* ChatViewModel+ChoiceCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatViewModel+ChoiceCards.swift"; sourceTree = "<group>"; };
 		AF11F30628BE6F0C002ACEB4 /* UIAlertController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+Extensions.swift"; sourceTree = "<group>"; };
 		AF39330A29B2A6A00008B60D /* ChatViewModel.SecureConverstaions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.SecureConverstaions.swift; sourceTree = "<group>"; };
 		AF3D520A2983235C00AD8E69 /* FileUploader.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploader.Mock.swift; sourceTree = "<group>"; };
@@ -1836,6 +1838,7 @@
 				1A60AFD42566992A00E53F53 /* ChatViewModel.swift */,
 				AF39330A29B2A6A00008B60D /* ChatViewModel.SecureConverstaions.swift */,
 				84D2293B28D1FC4B00F64FE7 /* ChatViewModel+CustomCard.swift */,
+				AF10ED8A29B7A4C000E85309 /* ChatViewModel+ChoiceCards.swift */,
 				9AB196DF27C401F600FD60AB /* ChatViewModel.Mock.swift */,
 				9AB196D527C3E1E400FD60AB /* ChatViewModel.Environment.Interface.swift */,
 				9AB196D727C3E27300FD60AB /* ChatViewModel.Environment.Mock.swift */,
@@ -3841,6 +3844,7 @@
 				84D2293C28D1FC4B00F64FE7 /* ChatViewModel+CustomCard.swift in Sources */,
 				84265DF02983E62100D65842 /* Theme+ScreenSharing.swift in Sources */,
 				6E9C01AD26D3B8B500EBE1D4 /* OperatorTypingIndicatorView.swift in Sources */,
+				AF10ED8B29B7A4C000E85309 /* ChatViewModel+ChoiceCards.swift in Sources */,
 				7594097E298D38C2008B173A /* CallVisualizer.BubbleIcon.swift in Sources */,
 				AFA2FDF628907FC800428E6D /* BubbleStyle.Mock.swift in Sources */,
 				755D186B29A6A5830009F5E8 /* WelcomeStyle+MessageTitleStyle.swift in Sources */,

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
@@ -150,6 +150,8 @@ extension ChatCoordinator {
             isWindowVisible: isWindowVisible,
             startAction: startAction,
             deliveredStatusText: viewFactory.theme.chat.visitorMessage.delivered,
+            // We should not show enqueueing state in case of secure transcript flow.
+            shouldSkipEnqueueingState: startWithSecureTranscriptFlow,
             environment: Self.enviromentForChatModel(environment: environment, viewFactory: viewFactory)
         )
         viewModel.isInteractableCard = viewFactory.messageRenderer?.isInteractable

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
@@ -159,6 +159,7 @@ class ChatViewController: EngagementViewController, MediaUpgradePresenter,
             case let .fileUploadListPropsUpdated(fileUploadListProps):
                 view.messageEntryView.uploadListView.props = fileUploadListProps
             }
+            self?.renderTitle()
         }
     }
 
@@ -182,8 +183,11 @@ class ChatViewController: EngagementViewController, MediaUpgradePresenter,
         let headerProps = chatView.props.header
         let headerTitle: String
         switch viewModel {
-        case .chat:
-            headerTitle = viewFactory.theme.chat.title
+        case let .chat(chatViewModel):
+            headerTitle = Self.headerTitleForChatModel(
+                chatViewModel,
+                chatStyle: viewFactory.theme.chat
+            )
         case .transcript:
             headerTitle = viewFactory.theme.chat.secureTranscriptTitle
         }
@@ -218,5 +222,17 @@ extension ChatViewController {
             viewModel: viewModel,
             to: chatView
         )
+    }
+
+    static func headerTitleForChatModel(_ chatViewModel: ChatViewModel, chatStyle: ChatStyle) -> String {
+        let headerTitle: String
+        if chatViewModel.shouldSkipEnqueueingState {
+            headerTitle = chatViewModel.activeEngagement != nil
+            ? chatStyle.title
+            : chatStyle.secureTranscriptTitle
+        } else {
+            headerTitle = chatStyle.title
+        }
+        return headerTitle
     }
 }

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+ChoiceCards.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+ChoiceCards.swift
@@ -1,0 +1,62 @@
+import Foundation
+import SalemoveSDK
+
+extension ChatViewModel {
+    func sendChoiceCardResponse(_ option: ChatChoiceCardOption, to messageId: String) {
+        guard let option = option.asSingleChoiceOption() else { return }
+        environment.sendSelectedOptionValue(option) { [weak self] result in
+            guard let self = self else { return }
+
+            switch result {
+            case .success(let message):
+                guard
+                    let selection = message.attachment?.selectedOption
+                else { return }
+
+                self.respond(to: messageId, with: selection)
+
+            case .failure:
+                self.showAlert(
+                    with: self.alertConfiguration.unexpectedError,
+                    dismissed: nil
+                )
+            }
+        }
+    }
+
+    private func respond(to choiceCardId: String, with selection: String?) {
+        guard let index = messagesSection.items
+            .enumerated()
+            .first(where: {
+                guard case .choiceCard(let message, _, _, _) = $0.element.kind
+                else { return false }
+                return message.id == choiceCardId
+            })?.offset
+        else { return }
+
+        let choiceCard = messagesSection[index]
+
+        guard case .choiceCard(
+            let message,
+            let showsImage,
+            let imageUrl,
+            _
+        ) = choiceCard.kind else { return }
+
+        message.attachment?.selectedOption = selection
+        message.queueID = interactor.queueID
+        let item = ChatItem(kind: .choiceCard(
+            message,
+            showsImage: showsImage,
+            imageUrl: imageUrl,
+            isActive: false
+        ))
+
+        messagesSection.replaceItem(at: index, with: item)
+        action?(.refreshRow(index, in: messagesSection.index, animated: true))
+        action?(.setChoiceCardInputModeEnabled(false))
+        // Update stored choice card mode to be in
+        // sync after response.
+        isChoiceCardInputModeEnabled = false
+    }
+}

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Mock.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Mock.swift
@@ -24,6 +24,7 @@ extension ChatViewModel {
             isWindowVisible: isWindowVisible,
             startAction: startAction,
             deliveredStatusText: deliveredStatusText,
+            shouldSkipEnqueueingState: false,
             environment: environment
         )
     }

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -44,7 +44,7 @@ class ChatViewModel: EngagementViewModel, ViewModel {
 
     private var pendingMessages: [OutgoingMessage] = []
     var isViewLoaded: Bool = false
-    private (set) var isChoiceCardInputModeEnabled: Bool = false
+    var isChoiceCardInputModeEnabled: Bool = false
     private (set) var siteConfiguration: CoreSdkClient.Site?
 
     var mediaPickerButtonVisibility: MediaPickerButtonVisibility {
@@ -56,6 +56,8 @@ class ChatViewModel: EngagementViewModel, ViewModel {
         guard !isChoiceCardInputModeEnabled else { return .enabled(.choiceCard) }
         return .enabled(.enagagementConnection(isConnected: environment.getCurrentEngagement() != nil))
     }
+
+    let shouldSkipEnqueueingState: Bool
 
     // swiftlint:disable function_body_length
     init(
@@ -69,12 +71,15 @@ class ChatViewModel: EngagementViewModel, ViewModel {
         isWindowVisible: ObservableValue<Bool>,
         startAction: StartAction,
         deliveredStatusText: String,
+        shouldSkipEnqueueingState: Bool,
         environment: Environment
+
     ) {
         self.call = call
         self.showsCallBubble = showsCallBubble
         self.isCustomCardSupported = isCustomCardSupported
         self.startAction = startAction
+        self.shouldSkipEnqueueingState = shouldSkipEnqueueingState
         let uploader = FileUploader(
             maximumUploads: Self.maximumUploads,
             environment: .init(
@@ -207,6 +212,7 @@ class ChatViewModel: EngagementViewModel, ViewModel {
 
         switch state {
         case .enqueueing:
+            guard !shouldSkipEnqueueingState else { return }
             let item = ChatItem(kind: .queueOperator)
 
             appendItem(
@@ -831,69 +837,6 @@ extension ChatViewModel {
     private func showCallBubble() {
         let imageUrl = interactor.engagedOperator?.picture?.url
         action?(.showCallBubble(imageUrl: imageUrl))
-    }
-}
-
-// MARK: Choice Card
-
-extension ChatViewModel {
-    func sendChoiceCardResponse(_ option: ChatChoiceCardOption, to messageId: String) {
-
-        guard let option = option.asSingleChoiceOption() else { return }
-        environment.sendSelectedOptionValue(option) { [weak self] result in
-            guard let self = self else { return }
-
-            switch result {
-            case .success(let message):
-                guard
-                    let selection = message.attachment?.selectedOption
-                else { return }
-
-                self.respond(to: messageId, with: selection)
-
-            case .failure:
-                self.showAlert(
-                    with: self.alertConfiguration.unexpectedError,
-                    dismissed: nil
-                )
-            }
-        }
-    }
-
-    private func respond(to choiceCardId: String, with selection: String?) {
-        guard let index = messagesSection.items
-            .enumerated()
-            .first(where: {
-                guard case .choiceCard(let message, _, _, _) = $0.element.kind
-                else { return false }
-                return message.id == choiceCardId
-            })?.offset
-        else { return }
-
-        let choiceCard = messagesSection[index]
-
-        guard case .choiceCard(
-            let message,
-            let showsImage,
-            let imageUrl,
-            _
-        ) = choiceCard.kind else { return }
-
-        message.attachment?.selectedOption = selection
-        message.queueID = interactor.queueID
-        let item = ChatItem(kind: .choiceCard(
-            message,
-            showsImage: showsImage,
-            imageUrl: imageUrl,
-            isActive: false
-        ))
-
-        messagesSection.replaceItem(at: index, with: item)
-        action?(.refreshRow(index, in: messagesSection.index, animated: true))
-        action?(.setChoiceCardInputModeEnabled(false))
-        // Update stored choice card mode to be in
-        // sync after response.
-        isChoiceCardInputModeEnabled = false
     }
 }
 

--- a/GliaWidgetsTests/Sources/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModelTests.swift
@@ -25,6 +25,7 @@ class ChatViewModelTests: XCTestCase {
             isWindowVisible: .init(with: true),
             startAction: .none,
             deliveredStatusText: "Delivered",
+            shouldSkipEnqueueingState: false,
             environment: .init(
                 fetchFile: { _, _, _ in },
                 sendSelectedOptionValue: { _, _ in


### PR DESCRIPTION
Make start of engagement implicit by skipping enqueueing state and changing title only when engagement is created for secure messaging flow.
Also move choice cards extension to separate file to address linter warning about class body length of `ChatViewModel`.

MOB-1920