### PR TITLE
Support sending secure files with empty message

### DIFF
--- a/GliaWidgets/SecureConversations/SecureConversations.ChatWithTranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.ChatWithTranscriptModel.swift
@@ -429,12 +429,17 @@ extension SecureConversations {
 
         @discardableResult
         private func validateMessage() -> Bool {
-            let canSendText = !messageText.trimmingCharacters(in: .whitespacesAndNewlines)
-                .isEmpty && messageText.count <= Self.messageTextLimit
             let canSendAttachments =
             fileUploadListModel.failedUploads.isEmpty &&
             fileUploadListModel.activeUploads.isEmpty && !fileUploadListModel.isLimitReached
-            let isValid = canSendText && canSendAttachments
+
+            guard canSendAttachments else { return false }
+
+            let canSendText = !messageText.trimmingCharacters(in: .whitespacesAndNewlines)
+                .isEmpty && messageText.count <= Self.messageTextLimit
+            let hasAttachments = !fileUploadListModel.succeededUploads.isEmpty
+
+            let isValid = canSendText || hasAttachments
             action?(.sendButtonHidden(!isValid))
             return isValid
         }

--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.swift
@@ -276,8 +276,16 @@ extension SecureConversations.WelcomeViewModel {
             return .disabled
         }
 
-        // Is message text valid?
-        guard isInputTextValid(instance.messageText) else {
+        // Is file upload limit not yet reached?
+        guard !instance.fileUploadListModel.isLimitReached else {
+            return .disabled
+        }
+
+        // Is message text valid or have attachments been successfully uploaded?
+        guard
+            isInputTextValid(instance.messageText) ||
+            !instance.fileUploadListModel.succeededUploads.isEmpty
+        else {
             return .disabled
         }
 
@@ -295,7 +303,7 @@ extension SecureConversations.WelcomeViewModel {
     }
 
     static func isInputTextValid(_ text: String) -> Bool {
-        guard !text.isEmpty else {
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return false
         }
 


### PR DESCRIPTION
Allow sending a secure file with an empty message from both the welcome screen and the chat transcript screen. Also added a check for file upload limit, just as the secure conversations chat transcript is doing.

MOB-1904