### PR TITLE
Close Visitor Code When Engagement Starts

### DIFF
--- a/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
+++ b/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
@@ -146,6 +146,8 @@ private extension CallVisualizer {
             switch event {
             case let .screenSharingStateChanged(state):
                 self?.environment.screenShareHandler.updateState(to: state)
+            case .engagementRequestAccepted:
+                self?.coordinator?.handleEngagementRequestAccepted()
             default:
                 break
             }

--- a/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
@@ -127,6 +127,11 @@ extension CallVisualizer {
             }
         }
 
+        func handleEngagementRequestAccepted() {
+            visitorCodeCoordinator?.codeViewController?.dismiss(animated: true)
+            visitorCodeCoordinator = nil
+        }
+
         func end() {
             removeBubbleView()
             videoCallCoordinator?.viewController?.dismiss(animated: true)

--- a/GliaWidgets/Sources/Interactor/Interactor.swift
+++ b/GliaWidgets/Sources/Interactor/Interactor.swift
@@ -31,6 +31,7 @@ enum InteractorEvent {
     case error(CoreSdkClient.SalemoveError)
     case engagementTransferred(CoreSdkClient.Operator?)
     case engagementTransferring
+    case engagementRequestAccepted
 }
 
 class Interactor {
@@ -289,6 +290,7 @@ extension Interactor: CoreSdkClient.Interactable {
                 .map(CoreSdkClient.VisitorContext.ContextType.assetId)
                 .map(CoreSdkClient.VisitorContext.init(_:))
             answer(coreSdkVisitorContext, true, completion)
+            self?.notify(.engagementRequestAccepted)
         }
     }
 


### PR DESCRIPTION
When SDK accepts an operator engagement request, the visitor code will automatically close. This is only for the alert presentation mode, as the embedded one will not be affected.

MOB-1932 and MOB-1934