### PR TITLE
Close screen sharing view silently when video call is present

### DIFF
--- a/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
@@ -272,6 +272,10 @@ extension CallVisualizer {
             coordinator.delegate = { event in
                 switch event {
                 case .close:
+                    self.screenSharingCoordinator.unwrap {
+                        $0.viewController?.dismiss(animated: false)
+                        self.screenSharingCoordinator = nil
+                    }
                     viewController.dismiss(animated: true)
                 }
             }

--- a/GliaWidgets/Sources/CallVisualizer/ScreenSharing/Coordinator/ScreenSharingCoordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/ScreenSharing/Coordinator/ScreenSharingCoordinator.swift
@@ -7,6 +7,7 @@ extension CallVisualizer {
 
         private let environment: Environment
         private var viewModel: ScreenSharingViewModel?
+        var viewController: ScreenSharingViewController?
 
         // MARK: - Initialization
 
@@ -23,17 +24,18 @@ extension CallVisualizer {
         // MARK: - Private
 
         private func showEndScreenSharingViewController() -> ViewController {
-            let model = ScreenSharingViewModel(
+            let viewModel = ScreenSharingViewModel(
                 style: environment.theme.screenSharing,
                 environment: .init(screenShareHandler: environment.screenShareHandler)
             )
 
-            defer { viewModel = model }
+            self.viewModel = viewModel
 
-            let viewController = ScreenSharingViewController(props: model.props())
+            let viewController = ScreenSharingViewController(props: viewModel.props())
             viewController.modalPresentationStyle = .overFullScreen
+            self.viewController = viewController
 
-            model.delegate = .init { [weak self, weak viewController] event in
+            viewModel.delegate = .init { [weak self, weak viewController] event in
                 switch event {
                 case .close:
                     viewController?.dismiss(animated: true)


### PR DESCRIPTION
When visitor was on screen sharing view, and they accepted video call view, if they clicked back button from video view they should have landed in main view. However they were back in screen sharing view. This PR fixes it

MOB-1925