### PR TITLE
Fix handling screen sharing events in CallVisualizer during Live Engagement

### DIFF
--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -76,7 +76,8 @@ public class Glia {
                 self?.environment.coreSdk.getCurrentEngagement()?.engagedOperator
             },
             uiConfig: { [weak self] in self?.uiConfig },
-            assetsBuilder: { [weak self] in self?.assetsBuilder ?? .standard }
+            assetsBuilder: { [weak self] in self?.assetsBuilder ?? .standard },
+            getCurrentEngagement: environment.coreSdk.getCurrentEngagement
         )
     )
     var rootCoordinator: EngagementCoordinator?

--- a/GliaWidgets/Sources/CallVisualizer/CallVisualizer+Environment.swift
+++ b/GliaWidgets/Sources/CallVisualizer/CallVisualizer+Environment.swift
@@ -18,5 +18,6 @@ extension CallVisualizer {
         var engagedOperator: () -> CoreSdkClient.Operator?
         var uiConfig: () -> RemoteConfiguration?
         var assetsBuilder: () -> RemoteConfiguration.AssetsBuilder
+        var getCurrentEngagement: CoreSdkClient.GetCurrentEngagement
     }
 }

--- a/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
+++ b/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
@@ -57,11 +57,6 @@ public final class CallVisualizer {
         self.environment = environment
     }
 
-    deinit {
-        environment.screenShareHandler.status.removeObserver(self)
-        environment.screenShareHandler.cleanUp()
-    }
-
     /// Show VisitorCode for current Visitor.
     ///
     /// Call Visualizer Operators use the Visitor's code to start an Call Visualizer Engagement with the Visitor.
@@ -99,6 +94,7 @@ extension CallVisualizer {
 
     func endSession() {
         coordinator.end()
+        stopObservingInteractorEvents()
     }
 
     func offerScreenShare(
@@ -142,9 +138,16 @@ extension CallVisualizer {
             break
         }
     }
+}
 
+// MARK: - Private
+
+private extension CallVisualizer {
     func startObservingInteractorEvents() {
         environment.interactorProviding()?.addObserver(self) { [weak self] event in
+            guard let engagement = self?.environment.getCurrentEngagement(), engagement.source == .callVisualizer else {
+                return
+            }
             switch event {
             case let .screenSharingStateChanged(state):
                 self?.environment.screenShareHandler.updateState(to: state)
@@ -152,5 +155,9 @@ extension CallVisualizer {
                 break
             }
         }
+    }
+
+    func stopObservingInteractorEvents() {
+        environment.interactorProviding()?.removeObserver(self)
     }
 }

--- a/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
@@ -7,19 +7,6 @@ extension CallVisualizer {
             self.environment = environment
             self.bubbleView = environment.viewFactory.makeBubbleView()
 
-            environment
-                .screenShareHandler
-                .status
-                .addObserver(self) { [weak self] newStatus, _ in
-                    guard self?.videoCallCoordinator == nil else { return }
-                    switch newStatus {
-                    case .started:
-                        self?.createScreenShareBubbleView()
-                    case .stopped:
-                        self?.removeBubbleView()
-                    }
-                }
-
             bubbleView.tap = { [weak self] in
                 guard let self = self else { return }
                 if self.videoCallCoordinator == nil {
@@ -50,9 +37,7 @@ extension CallVisualizer {
                 }
             }
 
-            /// FlowCoordinator protocol requires start() to return a viewController, but it won't be used in Call Visualizer context.
-            /// Instead, it is handled seperately because of its unique nature.
-            _ = coordinator.start()
+            coordinator.start()
 
             self.visitorCodeCoordinator = coordinator
         }
@@ -63,10 +48,14 @@ extension CallVisualizer {
             accepted: @escaping () -> Void,
             declined: @escaping () -> Void
         ) {
+            let acceptedHandler = { [weak self] in
+                self?.observeScreenSharingHandlerState()
+                accepted()
+            }
             let alert = AlertViewController(
                 kind: .screenShareOffer(
                     configuration.withOperatorName(operators.compactMap { $0.name }.joined()),
-                    accepted: accepted,
+                    accepted: acceptedHandler,
                     declined: declined
                 ),
                 viewFactory: environment.viewFactory
@@ -131,7 +120,7 @@ extension CallVisualizer {
             removeBubbleView()
             videoCallCoordinator?.viewController?.dismiss(animated: true)
             videoCallCoordinator = nil
-            environment.screenShareHandler.stop()
+            stopObservingScreenSharingHandlerState()
             screenSharingCoordinator = nil
         }
 
@@ -278,6 +267,30 @@ extension CallVisualizer {
 
             return viewController
         }
+    }
+}
+
+// MARK: - Private
+
+private extension CallVisualizer.Coordinator {
+    func observeScreenSharingHandlerState() {
+        self.environment
+            .screenShareHandler
+            .status
+            .addObserver(self) { [weak self] newStatus, _ in
+                guard self?.videoCallCoordinator == nil else { return }
+                switch newStatus {
+                case .started:
+                    self?.createScreenShareBubbleView()
+                case .stopped:
+                    self?.removeBubbleView()
+                }
+            }
+    }
+
+    func stopObservingScreenSharingHandlerState() {
+        environment.screenShareHandler.status.removeObserver(self)
+        environment.screenShareHandler.stop()
     }
 }
 

--- a/GliaWidgets/Sources/CallVisualizer/Mock/CallVisualizer.Environment.Mock.swift
+++ b/GliaWidgets/Sources/CallVisualizer/Mock/CallVisualizer.Environment.Mock.swift
@@ -17,7 +17,8 @@ extension CallVisualizer.Environment {
         date: { .mock },
         engagedOperator: { .mock() },
         uiConfig: { nil },
-        assetsBuilder: { .standard }
+        assetsBuilder: { .standard },
+        getCurrentEngagement: CoreSdkClient.mock.getCurrentEngagement
     )
 }
 

--- a/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeCoordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeCoordinator.swift
@@ -21,6 +21,7 @@ extension CallVisualizer {
             self.presentation = presentation
         }
 
+        @discardableResult
         func start() -> UIViewController {
             showVisitorCodeViewController(by: presentation)
         }

--- a/GliaWidgets/Sources/Interactor/Interactor.swift
+++ b/GliaWidgets/Sources/Interactor/Interactor.swift
@@ -368,7 +368,7 @@ extension Interactor: CoreSdkClient.Interactable {
             start()
 
         case .callVisualizer:
-            break
+            start()
 
         case .unknown(let type):
             debugPrint("Unknown engagement started (type='\(type)').")


### PR DESCRIPTION
There were several issues related to screen sharing events. In case when after CallVisualizer session visitor starts Live engagement, we didn't stop observing screen sharing events, so it causes displaying bubble over Live Engagement screen.  
[MOB-1922](https://glia.atlassian.net/browse/MOB-1922) [MOB-1923](https://glia.atlassian.net/browse/MOB-1922)

Also was added back calling `start()` method in Interactor when CallVisualizer engagement is started. 
[MOB-1924](https://glia.atlassian.net/browse/MOB-1924)



[MOB-1922]: https://glia.atlassian.net/browse/MOB-1922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOB-1923]: https://glia.atlassian.net/browse/MOB-1923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOB-1924]: https://glia.atlassian.net/browse/MOB-1924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ