### PR TITLE
Remove the back button on secure conversations chat transcript

### DIFF
--- a/GliaWidgets/Sources/Component/Header/Header.swift
+++ b/GliaWidgets/Sources/Component/Header/Header.swift
@@ -60,7 +60,7 @@ final class Header: BaseView {
     }
 
     func renderProps() {
-        backButton?.isEnabled = props.backButton != nil
+        backButton?.isHidden = props.backButton == nil
         if let backButtonProps = props.backButton {
             backButton?.props = backButtonProps
         }

--- a/GliaWidgets/Sources/Component/Header/HeaderStyle.swift
+++ b/GliaWidgets/Sources/Component/Header/HeaderStyle.swift
@@ -45,7 +45,7 @@ public struct HeaderStyle: Equatable {
         titleColor: UIColor,
         textStyle: UIFont.TextStyle = .title2,
         backgroundColor: ColorType,
-        backButton: HeaderButtonStyle,
+        backButton: HeaderButtonStyle?,
         closeButton: HeaderButtonStyle,
         endButton: ActionButtonStyle,
         endScreenShareButton: HeaderButtonStyle,

--- a/GliaWidgets/Sources/Theme/Theme+Chat.swift
+++ b/GliaWidgets/Sources/Theme/Theme+Chat.swift
@@ -52,6 +52,10 @@ extension Theme {
             endScreenShareButton: endScreenShareButton,
             accessibility: .init(isFontScalingEnabled: true)
         )
+
+        var secureTranscriptHeader = header
+        secureTranscriptHeader.backButton = nil
+
         let operatorImage = UserImageStyle(
             placeholderImage: Asset.operatorPlaceholder.image,
             placeholderColor: color.baseLight,
@@ -355,7 +359,8 @@ extension Theme {
                 visitor: Accessibility.visitorName,
                 isFontScalingEnabled: true
             ),
-            secureTranscriptTitle: Chat.secureTranscriptTitle
+            secureTranscriptTitle: Chat.secureTranscriptTitle,
+            secureTranscriptHeader: secureTranscriptHeader
         )
     }
 

--- a/GliaWidgets/Sources/View/Chat/ChatStyle.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatStyle.swift
@@ -41,9 +41,12 @@ public class ChatStyle: EngagementStyle {
     /// Header title for secure messaging transcript.
     public var secureTranscriptTitle: String
 
+    /// Header style for secure messaging transcript.
+    public var secureTranscriptHeader: HeaderStyle
+
     ///
     /// - Parameters:
-    ///   - header: Style of the view's header (navigation bar area).
+    ///   - header: Style of the view's header (navigation bar area) when the screen is displaying live chat.
     ///   - connect: Styles for different engagement connection states.
     ///   - backgroundColor: View's background color.
     ///   - preferredStatusBarStyle: Preferred style of the status bar.
@@ -60,6 +63,7 @@ public class ChatStyle: EngagementStyle {
     ///   - operatorTypingIndicator: Style of the view that indicates that the operator is currently typing.
     ///   - accessibility: Accessibility related properties.
     ///   - secureTranscriptTitle: Header title for secure messaging transcript.
+    ///   - secureTranscriptHeader: Style of the view's header (navigation bar area) when the screen is displaying secure conversations.
     ///
     public init(
         header: HeaderStyle,
@@ -78,7 +82,8 @@ public class ChatStyle: EngagementStyle {
         unreadMessageIndicator: UnreadMessageIndicatorStyle,
         operatorTypingIndicator: OperatorTypingIndicatorStyle,
         accessibility: Accessibility = .unsupported,
-        secureTranscriptTitle: String
+        secureTranscriptTitle: String,
+        secureTranscriptHeader: HeaderStyle
     ) {
         self.title = title
         self.visitorMessage = visitorMessage
@@ -93,6 +98,8 @@ public class ChatStyle: EngagementStyle {
         self.operatorTypingIndicator = operatorTypingIndicator
         self.accessibility = accessibility
         self.secureTranscriptTitle = secureTranscriptTitle
+        self.secureTranscriptHeader = secureTranscriptHeader
+
         super.init(
             header: header,
             connect: connect,


### PR DESCRIPTION
SORRY THAT THIS TOOK SO LONG :(

The current logic correctly identifies when to show the secure conversations title or the chat title. This logic is encapsulated into its own function so that it can be used to determine back button behavior. The secure chat transcript header style is the same as the regular chat style but with the back button set as `nil`.

MOB-1888