### PR TITLE
Introduce GliaWidgets framework as xcframework

### DIFF
--- a/GliaWidgets/Info.plist
+++ b/GliaWidgets/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.8</string>
+	<string>0.10.9</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/GliaWidgets/StaticValues.swift
+++ b/GliaWidgets/StaticValues.swift
@@ -6,5 +6,5 @@ final class StaticValues {
     /// version cannot be changed by integrators, so this ensures that our code will
     /// always have the correct version regardless of what our integrators do with
     /// our plist files.
-    static let sdkVersion = "0.10.8"
+    static let sdkVersion = "0.10.9"
 }

--- a/GliaWidgetsTests/Info.plist
+++ b/GliaWidgetsTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.8</string>
+	<string>0.10.9</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,10 @@ let package = Package(
         .library(
             name: "GliaWidgets",
             targets: ["GliaWidgetsSDK"]
+        ),
+        .library(
+            name: "GliaWidgets-xcframework",
+            targets: ["GliaWidgetsSDK-xcframework"]
         )
     ],
     dependencies: [
@@ -38,6 +42,21 @@ let package = Package(
             url: "https://github.com/salemove/ios-bundle/releases/download/0.35.6/SalemoveSDK.xcframework.zip",
             checksum: "0a371206cd0e67fd21ca098f5af3f6da9c4438d679f98e75dd64102a0f853c8f"
         ),
+        .binaryTarget(
+            name: "PureLayoutXcf",
+            url: "https://github.com/salemove/ios-sdk-widgets/releases/download/0.10.8/PureLayoutXcf.xcframework.zip",
+            checksum: "93f00268ba710a0ee513be7cef94a385637bfb76c292942cc5f062a7b2f0037b"
+        ),
+        .binaryTarget(
+            name: "LottieXcf",
+            url: "https://github.com/salemove/ios-sdk-widgets/releases/download/0.10.8/LottieXcf.xcframework.zip",
+            checksum: "9f2340bfb15f734ebd3a4e79d67ce3581822aa5ceec3a37a38ebaa505bf1a8a3"
+        ),
+        .binaryTarget(
+            name: "GliaWidgetsXcf",
+            url: "https://github.com/salemove/ios-sdk-widgets/releases/download/0.10.8/GliaWidgetsXcf.xcframework.zip",
+            checksum: "3deacedffc912751d8a597d56d17b33b20191679c10d7c909222a0baefb6a137"
+        ),
         .target(
             name: "GliaWidgets",
             dependencies: [
@@ -62,6 +81,18 @@ let package = Package(
                 "TwilioVoice",
                 "WebRTC",
                 "GliaWidgets"
+            ]
+        ),
+        .target(
+            name: "GliaWidgetsSDK-xcframework",
+            dependencies: [
+                "SalemoveSDK",
+                "GliaWidgetsXcf",
+                "GliaCoreDependency",
+                "TwilioVoice",
+                "WebRTC",
+                "PureLayoutXcf",
+                "LottieXcf"
             ]
         )
     ]

--- a/Sources/GliaWidgetsSDK-xcframework/GliaWidgetsSDK.swift
+++ b/Sources/GliaWidgetsSDK-xcframework/GliaWidgetsSDK.swift
@@ -1,0 +1,1 @@
+struct GliaWidgetsSDK { }

--- a/TestingApp/Info.plist
+++ b/TestingApp/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.8</string>
+	<string>0.10.9</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -401,4 +401,5 @@ trigger_map:
   workflow: pull-request
 meta:
   bitrise.io:
-    stack: osx-xcode-13.3.x
+    stack: osx-xcode-14.2.x-ventura
+    machine_type_id: g2-m1.4core


### PR DESCRIPTION
GliaWidgets-xcframework target has been introduced to provide choice for integrator use GliaWidgets as a Swift Package or xcframework.