### PR TITLE
Add loading of transcript and unread count in parallel

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -427,6 +427,7 @@
 		AF0D26D629705FDF00816CCB /* SecureConversations.ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0D26D529705FDE00816CCB /* SecureConversations.ActivityIndicator.swift */; };
 		AF0D26D82971912A00816CCB /* SecureConversations.SendMessageButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0D26D72971912A00816CCB /* SecureConversations.SendMessageButton.swift */; };
 		AF10ED8B29B7A4C000E85309 /* ChatViewModel+ChoiceCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF10ED8A29B7A4C000E85309 /* ChatViewModel+ChoiceCards.swift */; };
+		AF10ED8D29BA210500E85309 /* SecureConversations.MessagesWithUnreadCountLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF10ED8C29BA210500E85309 /* SecureConversations.MessagesWithUnreadCountLoader.swift */; };
 		AF11F30728BE6F0C002ACEB4 /* UIAlertController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF11F30628BE6F0C002ACEB4 /* UIAlertController+Extensions.swift */; };
 		AF39330B29B2A6A00008B60D /* ChatViewModel.SecureConverstaions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF39330A29B2A6A00008B60D /* ChatViewModel.SecureConverstaions.swift */; };
 		AF3D520B2983235C00AD8E69 /* FileUploader.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D520A2983235C00AD8E69 /* FileUploader.Mock.swift */; };
@@ -1022,6 +1023,7 @@
 		AF0D26D529705FDE00816CCB /* SecureConversations.ActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.ActivityIndicator.swift; sourceTree = "<group>"; };
 		AF0D26D72971912A00816CCB /* SecureConversations.SendMessageButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.SendMessageButton.swift; sourceTree = "<group>"; };
 		AF10ED8A29B7A4C000E85309 /* ChatViewModel+ChoiceCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatViewModel+ChoiceCards.swift"; sourceTree = "<group>"; };
+		AF10ED8C29BA210500E85309 /* SecureConversations.MessagesWithUnreadCountLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.MessagesWithUnreadCountLoader.swift; sourceTree = "<group>"; };
 		AF11F30628BE6F0C002ACEB4 /* UIAlertController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+Extensions.swift"; sourceTree = "<group>"; };
 		AF39330A29B2A6A00008B60D /* ChatViewModel.SecureConverstaions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.SecureConverstaions.swift; sourceTree = "<group>"; };
 		AF3D520A2983235C00AD8E69 /* FileUploader.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploader.Mock.swift; sourceTree = "<group>"; };
@@ -2238,6 +2240,7 @@
 				AFEF5C6D29928376005C3D8D /* FileUploadListView */,
 				AF0D26D72971912A00816CCB /* SecureConversations.SendMessageButton.swift */,
 				AFC40C1B29965F0F001B4C53 /* SecureConversations.ChatWithTranscriptModel.swift */,
+				AF10ED8C29BA210500E85309 /* SecureConversations.MessagesWithUnreadCountLoader.swift */,
 				3115D45B29A4FD3F00D99561 /* SecureConversations.Availability.swift */,
 			);
 			path = SecureConversations;
@@ -3832,6 +3835,7 @@
 				1A8B61D225C974A1000D780E /* ChatCallUpgradeView.swift in Sources */,
 				845E2F88283FB49F00C04D56 /* Theme.Survey.BooleanQuestion.Accessibility.swift in Sources */,
 				C06A7584296EC9DC006B69A2 /* NumberSlotStyle.Accessibility.swift in Sources */,
+				AF10ED8D29BA210500E85309 /* SecureConversations.MessagesWithUnreadCountLoader.swift in Sources */,
 				C0D2F04A2992765F00803B47 /* VideoCallView.OperatorImageView.swift in Sources */,
 				755D186F29A6A6160009F5E8 /* WelcomeStyle+MessageTextViewDisabledStyle.swift in Sources */,
 				1ABD6C8125B6E97400D56EFA /* MultipleMediaUpgradeAlertConfiguration.swift in Sources */,

--- a/GliaWidgets/SecureConversations/SecureConversations.MessagesWithUnreadCountLoader.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.MessagesWithUnreadCountLoader.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+extension SecureConversations {
+    struct MessagesWithUnreadCount {
+        var messages: [ChatMessage]
+        var unreadCount: Int
+    }
+
+    /// Due to async nature of requests, we need to make sure
+    /// that `unread message count` and `transcript messages`
+    /// are delivered at once. This entity makes it possible.
+    struct MessagesWithUnreadCountLoader {
+        static let unreadCountFallbackTimeoutSeconds: TimeInterval = 3.0
+
+        struct TimeoutError: Error {}
+
+        var environment: Environment
+
+        func loadMessagesWithUnreadCount(callback: @escaping (Result<MessagesWithUnreadCount, Error>) -> Void) {
+            typealias ReactiveSwift = CoreSdkClient.ReactiveSwift
+            let unreadCountTimeoutProducer = ReactiveSwift.SignalProducer<Void, Never>(value: ())
+            let unreadCountRequestSource = ReactiveSwift.Signal<Result<Int, Error>, Never>.pipe()
+            let unreadCountTimeoutSource = ReactiveSwift.Signal<Result<Int, Error>, Never>.pipe()
+            // In case if `unreadCount` will never be delivered,
+            // (for example if sockets are disconnected, because
+            // `unreadCount` is based on sockets)
+            // we will still receive callback by timeout.
+            let unreadCountRequestWithTimeoutSource = ReactiveSwift.Signal.merge(
+                unreadCountRequestSource.output,
+                unreadCountTimeoutSource.output
+            ).take(first: 1)
+
+            let messagesSource = ReactiveSwift.Signal<Result<[ChatMessage], CoreSdkClient.SalemoveError>, Never>.pipe()
+
+            let combined = ReactiveSwift.Signal.zip(
+                messagesSource.output,
+                unreadCountRequestWithTimeoutSource
+            )
+
+            unreadCountTimeoutProducer
+                .delay(Self.unreadCountFallbackTimeoutSeconds, on: environment.scheduler)
+                .startWithCompleted {
+                    unreadCountTimeoutSource.input.send(value: .failure(TimeoutError()))
+                }
+
+            combined
+                .observe(on: environment.scheduler)
+                .observeValues { messageResult, unreadCountResult in
+                    callback(
+                        Self.messageWithUnreadCountResult(
+                            messageResult: messageResult.mapError { $0 as Error },
+                            unreadCountResult: unreadCountResult
+                        )
+                    )
+                }
+
+            environment.getSecureUnreadMessageCount(unreadCountRequestSource.input.send(value:))
+            environment.fetchChatHistory(messagesSource.input.send(value:))
+        }
+
+        static func messageWithUnreadCountResult(
+            messageResult: Result<[ChatMessage], Error>,
+            unreadCountResult: Result<Int, Error>) -> Result<MessagesWithUnreadCount, Error> {
+                // Without messages unread count does not make much sense,
+                // that is why we prefer to report error for messages in case
+                // of failure for both requests. Same for success - ignore
+                // unreadCount failure in case of successful loading of messages.
+                switch (messageResult, unreadCountResult) {
+                case let (.success(messages), .success(unreadCount)):
+                    return .success(MessagesWithUnreadCount(messages: messages, unreadCount: unreadCount))
+                case let (.success(messages), .failure):
+                    return .success(MessagesWithUnreadCount(messages: messages, unreadCount: .zero))
+                case let (.failure(error), .failure), let (.failure(error), .success):
+                    return .failure(error)
+                }
+            }
+    }
+}
+
+extension SecureConversations.MessagesWithUnreadCount {
+    static let empty = SecureConversations.MessagesWithUnreadCount(
+        messages: [],
+        unreadCount: 0
+    )
+}
+
+extension SecureConversations.MessagesWithUnreadCountLoader {
+    struct Environment {
+        var getSecureUnreadMessageCount: CoreSdkClient.GetSecureUnreadMessageCount
+        var fetchChatHistory: CoreSdkClient.FetchChatHistory
+        var scheduler: CoreSdkClient.ReactiveSwift.DateScheduler
+    }
+}

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -1,5 +1,6 @@
 import SalemoveSDK
 import UIKit
+import GliaCoreDependency
 
 struct CoreSdkClient {
     var pushNotifications: PushNotifications
@@ -128,6 +129,9 @@ struct CoreSdkClient {
         _ completion: @escaping (Result<EngagementFileInformation, Swift.Error>) -> Void
     ) -> Self.Cancellable
     var uploadSecureFile: SecureConversationsUploadFile
+
+    typealias GetSecureUnreadMessageCount = (_ callback: @escaping (Result<Int, Error>) -> Void) -> Void
+    var getSecureUnreadMessageCount: GetSecureUnreadMessageCount
 }
 
 extension CoreSdkClient {
@@ -168,6 +172,7 @@ extension CoreSdkClient {
     typealias EngagementTransferringBlock = SalemoveSDK.EngagementTransferringBlock
     typealias FileError = SalemoveSDK.FileError
     typealias GeneralError = SalemoveSDK.GeneralError
+    typealias GliaCoreError = SalemoveSDK.GliaCoreError
     typealias Interactable = SalemoveSDK.Interactable
     typealias MediaDirection = SalemoveSDK.MediaDirection
     typealias MediaError = SalemoveSDK.MediaError
@@ -214,4 +219,5 @@ extension CoreSdkClient {
     typealias VisitorCodeBlock = (Result<VisitorCode, Swift.Error>)
     typealias EngagementSource = SalemoveSDK.EngagementSource
     typealias Cancellable = GliaCore.Cancellable
+    typealias ReactiveSwift = GliaCoreDependency.ReactiveSwift
 }

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
@@ -40,7 +40,8 @@ extension CoreSdkClient {
             },
             requestVisitorCode: GliaCore.sharedInstance.callVisualizer.requestVisitorCode(completion:),
             sendSecureMessage: GliaCore.sharedInstance.secureConversations.send(secureMessage:attachment:queueIds:completion:),
-            uploadSecureFile: GliaCore.sharedInstance.secureConversations.uploadFile(_:progress:completion:)
+            uploadSecureFile: GliaCore.sharedInstance.secureConversations.uploadFile(_:progress:completion:),
+            getSecureUnreadMessageCount: GliaCore.sharedInstance.secureConversations.getUnreadMessageCount(completion:)
         )
     }()
 }

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -29,7 +29,8 @@ extension CoreSdkClient {
         fetchChatHistory: { _ in },
         requestVisitorCode: { _ in fatalError() },
         sendSecureMessage: { _, _, _, _ in .mock },
-        uploadSecureFile: { _, _, _ in .mock }
+        uploadSecureFile: { _, _, _ in .mock },
+        getSecureUnreadMessageCount: { _ in }
     )
 }
 

--- a/GliaWidgetsTests/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/CoreSDKClient.Failing.swift
@@ -39,6 +39,9 @@ extension CoreSdkClient {
         uploadSecureFile: { _, _, _ in
             fail("\(Self.self).uploadSecureFile")
             return .mock
+        },
+        getSecureUnreadMessageCount: { _ in
+            fail("\(Self.self).getSecureUnreadMessageCount")
         }
     )
 }


### PR DESCRIPTION
Add ability to combine unread count and transcript request required for message divider implementation.
With this change both requests will start separately but always finish together, so then they can already be displayed with the new message divider if needed.

MOB-1949