### PR TITLE
Fix long messages being displayed out of bounds

### DIFF
--- a/GliaWidgets/Sources/View/Chat/Message/OperatorChatMessageView.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/OperatorChatMessageView.swift
@@ -65,7 +65,7 @@ class OperatorChatMessageView: ChatMessageView {
         contentViews.autoPinEdge(toSuperviewEdge: .top, withInset: kInsets.top)
         contentViews.autoPinEdge(toSuperviewEdge: .right, withInset: kInsets.right, relation: .greaterThanOrEqual)
 
-        NSLayoutConstraint.autoSetPriority(.defaultHigh) {
+        NSLayoutConstraint.autoSetPriority(.required) {
             contentViews.autoPinEdge(toSuperviewEdge: .bottom, withInset: kInsets.bottom)
         }
     }

--- a/GliaWidgets/Sources/View/Chat/Message/VisitorChatMessageView.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/VisitorChatMessageView.swift
@@ -44,7 +44,7 @@ class VisitorChatMessageView: ChatMessageView {
         statusLabel.autoPinEdge(toSuperviewEdge: .right, withInset: kInsets.right)
         statusLabel.autoPinEdge(toSuperviewEdge: .bottom, withInset: kInsets.bottom)
 
-        NSLayoutConstraint.autoSetPriority(.defaultHigh) {
+        NSLayoutConstraint.autoSetPriority(.required) {
             contentViews.autoPinEdge(toSuperviewEdge: .left, withInset: kInsets.left, relation: .greaterThanOrEqual)
         }
     }


### PR DESCRIPTION
These constraints are important, so they should be required. When set to `.defaultHigh`, under some circumstances, they would not be respected and the message would appear out of bounds.

MOB-1941