### PR TITLE
Add Listener for engagement start in Call Visualizer

### DIFF
--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -254,6 +254,12 @@ public class Glia {
 private extension Glia {
     func startObservingInteractorEvents() {
         interactor?.addObserver(self) { [weak self] event in
+            // Since engagement is accepted before current engagement is established,
+            // this case needs to be checked before any other so that visitor code alert
+            // can be dismissed properly and visitor code embedded view can trigger callback.
+            if case .engagementRequestAccepted = event {
+                self?.callVisualizer.handleEngagementRequestAccepted()
+            }
             guard let engagement = self?.environment.coreSdk.getCurrentEngagement(), engagement.source == .callVisualizer else {
                 return
             }

--- a/GliaWidgets/Sources/CallVisualizer/CallVisualizer+Presentation.swift
+++ b/GliaWidgets/Sources/CallVisualizer/CallVisualizer+Presentation.swift
@@ -3,6 +3,9 @@ import UIKit
 extension CallVisualizer {
     public enum Presentation {
         case alert(UIViewController)
-        case embedded(UIView)
+        case embedded(
+            UIView,
+            onEngagementAccepted: (() -> Void)
+        )
     }
 }

--- a/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
+++ b/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
@@ -88,6 +88,10 @@ extension CallVisualizer {
         coordinator.handleAcceptedUpgrade()
     }
 
+    func handleEngagementRequestAccepted() {
+        coordinator.handleEngagementRequestAccepted()
+    }
+
     func addVideoStream(stream: CoreSdkClient.VideoStreamable) {
         coordinator.addVideoStream(stream: stream)
     }
@@ -151,8 +155,6 @@ private extension CallVisualizer {
             switch event {
             case let .screenSharingStateChanged(state):
                 self?.environment.screenShareHandler.updateState(to: state)
-            case .engagementRequestAccepted:
-                self?.coordinator.handleEngagementRequestAccepted()
             default:
                 break
             }

--- a/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
@@ -34,6 +34,13 @@ extension CallVisualizer {
                 switch event {
                 case .closeTap:
                     self?.visitorCodeCoordinator = nil
+                case .engagementAccepted:
+                    switch coordinator.presentation {
+                    case let .embedded(_, onEngagementAccepted: callback):
+                        callback()
+                    case .alert:
+                        break
+                    }
                 }
             }
 
@@ -117,6 +124,7 @@ extension CallVisualizer {
         }
 
         func handleEngagementRequestAccepted() {
+            visitorCodeCoordinator?.delegate?(.engagementAccepted)
             visitorCodeCoordinator?.codeViewController?.dismiss(animated: true)
             visitorCodeCoordinator = nil
         }

--- a/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeCoordinator+DelegateEvent.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeCoordinator+DelegateEvent.swift
@@ -3,5 +3,6 @@ import Foundation
 extension CallVisualizer.VisitorCodeCoordinator {
     enum DelegateEvent {
         case closeTap
+        case engagementAccepted
     }
 }

--- a/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeCoordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeCoordinator.swift
@@ -55,7 +55,7 @@ extension CallVisualizer {
                 codeController.modalPresentationStyle = .overFullScreen
                 codeController.modalTransitionStyle = .crossDissolve
                 parentController.present(codeController, animated: true)
-            case .embedded(let parentView):
+            case .embedded(let parentView, _):
                 parentView.subviews.forEach { $0.removeFromSuperview() }
                 parentView.addSubview(codeController.view)
                 codeController.view.translatesAutoresizingMaskIntoConstraints = false

--- a/TestingApp/ViewController/ViewController+CallVisualizer.swift
+++ b/TestingApp/ViewController/ViewController+CallVisualizer.swift
@@ -11,7 +11,12 @@ extension ViewController {
 
     @IBAction private func embedVisitorCodeViewTapped() {
         Glia.sharedInstance.callVisualizer.showVisitorCodeViewController(
-            by: .embedded(visitorCodeView)
+            by: .embedded(
+                visitorCodeView,
+                onEngagementAccepted: {
+                    self.visitorCodeView.subviews.forEach { $0.removeFromSuperview() }
+                }
+            )
         )
     }
 }


### PR DESCRIPTION
In order to trigger callback for embedded visitor code view, a listener for engagement start needed to be refactored.

MOB-1934