### PR TITLE
Remove the back button on secure conversations chat transcript

### DIFF
--- a/GliaWidgets/SecureConversations/SecureConversations.ChatWithTranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.ChatWithTranscriptModel.swift
@@ -385,7 +385,11 @@ extension SecureConversations {
         }
 
         func event(_ event: EngagementViewModel.Event) {
-            // Not used for transcript.
+            switch event {
+            case .closeTapped:
+                engagementDelegate?(.finished)
+            default: break
+            }
         }
 
         func event(_ event: Event) {

--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
@@ -235,60 +235,70 @@ extension SecureConversations {
 
             navigationPresenter.present(controller.viewController)
         }
+    }
+}
 
-        @discardableResult
-        private func navigateToTranscript() -> UIViewController {
-            let coordinator = ChatCoordinator(
-                interactor: environment.interactor,
-                viewFactory: environment.viewFactory,
-                navigationPresenter: navigationPresenter,
-                call: environment.chatCall,
-                unreadMessages: environment.unreadMessages,
-                showsCallBubble: environment.showsCallBubble,
-                screenShareHandler: environment.screenShareHandler,
-                isWindowVisible: environment.isWindowVisible,
-                startAction: .startEngagement,
-                environment: .init(
-                    fetchFile: environment.fetchFile,
-                    sendSelectedOptionValue: environment.sendSelectedOptionValue,
-                    uploadFileToEngagement: environment.uploadFileToEngagement,
-                    fileManager: environment.fileManager,
-                    data: environment.data,
-                    date: environment.date,
-                    gcd: environment.gcd,
-                    localFileThumbnailQueue: environment.localFileThumbnailQueue,
-                    uiImage: environment.uiImage,
-                    createFileDownload: environment.createFileDownload,
-                    fromHistory: environment.loadChatMessagesFromHistory,
-                    fetchSiteConfigurations: environment.fetchSiteConfigurations,
-                    getCurrentEngagement: environment.getCurrentEngagement,
-                    submitSurveyAnswer: environment.submitSurveyAnswer,
-                    uuid: environment.uuid,
-                    uiApplication: environment.uiApplication,
-                    fetchChatHistory: environment.fetchChatHistory,
-                    createFileUploadListModel: environment.createFileUploadListModel,
-                    sendSecureMessage: environment.sendSecureMessage,
-                    queueIds: environment.queueIds,
-                    listQueues: environment.listQueues,
-                    secureUploadFile: environment.uploadSecureFile
-                ),
-                startWithSecureTranscriptFlow: true
-            )
+// Chat transcript
+extension SecureConversations.Coordinator {
+    @discardableResult
+    private func navigateToTranscript() -> UIViewController {
+        let coordinator = ChatCoordinator(
+            interactor: environment.interactor,
+            viewFactory: environment.viewFactory,
+            navigationPresenter: navigationPresenter,
+            call: environment.chatCall,
+            unreadMessages: environment.unreadMessages,
+            showsCallBubble: environment.showsCallBubble,
+            screenShareHandler: environment.screenShareHandler,
+            isWindowVisible: environment.isWindowVisible,
+            startAction: .startEngagement,
+            environment: .init(
+                fetchFile: environment.fetchFile,
+                sendSelectedOptionValue: environment.sendSelectedOptionValue,
+                uploadFileToEngagement: environment.uploadFileToEngagement,
+                fileManager: environment.fileManager,
+                data: environment.data,
+                date: environment.date,
+                gcd: environment.gcd,
+                localFileThumbnailQueue: environment.localFileThumbnailQueue,
+                uiImage: environment.uiImage,
+                createFileDownload: environment.createFileDownload,
+                fromHistory: environment.loadChatMessagesFromHistory,
+                fetchSiteConfigurations: environment.fetchSiteConfigurations,
+                getCurrentEngagement: environment.getCurrentEngagement,
+                submitSurveyAnswer: environment.submitSurveyAnswer,
+                uuid: environment.uuid,
+                uiApplication: environment.uiApplication,
+                fetchChatHistory: environment.fetchChatHistory,
+                createFileUploadListModel: environment.createFileUploadListModel,
+                sendSecureMessage: environment.sendSecureMessage,
+                queueIds: environment.queueIds,
+                listQueues: environment.listQueues,
+                secureUploadFile: environment.uploadSecureFile
+            ),
+            startWithSecureTranscriptFlow: true
+        )
 
-            coordinator.delegate = { [weak self] event in
+        coordinator.delegate = { [weak self] event in
+            switch event {
+            case .back:
+                self?.delegate?(.backTapped)
+            case .finished:
+                self?.delegate?(.closeTapped)
+            default:
                 self?.delegate?(.chat(event))
             }
-
-            pushCoordinator(coordinator)
-
-            let viewController = coordinator.start()
-            navigationPresenter.push(
-                viewController,
-                replacingLast: true
-            )
-
-            return viewController
         }
+
+        pushCoordinator(coordinator)
+
+        let viewController = coordinator.start()
+        navigationPresenter.push(
+            viewController,
+            replacingLast: true
+        )
+
+        return viewController
     }
 }
 

--- a/GliaWidgets/Sources/Component/Header/Header.swift
+++ b/GliaWidgets/Sources/Component/Header/Header.swift
@@ -60,7 +60,7 @@ final class Header: BaseView {
     }
 
     func renderProps() {
-        backButton?.isEnabled = props.backButton != nil
+        backButton?.isHidden = props.backButton == nil
         if let backButtonProps = props.backButton {
             backButton?.props = backButtonProps
         }

--- a/GliaWidgets/Sources/Component/Header/HeaderStyle.swift
+++ b/GliaWidgets/Sources/Component/Header/HeaderStyle.swift
@@ -45,7 +45,7 @@ public struct HeaderStyle: Equatable {
         titleColor: UIColor,
         textStyle: UIFont.TextStyle = .title2,
         backgroundColor: ColorType,
-        backButton: HeaderButtonStyle,
+        backButton: HeaderButtonStyle?,
         closeButton: HeaderButtonStyle,
         endButton: ActionButtonStyle,
         endScreenShareButton: HeaderButtonStyle,

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
@@ -70,7 +70,11 @@ class ChatCoordinator: SubFlowCoordinator, FlowCoordinator {
         let model: SecureConversations.ChatWithTranscriptModel = startWithSecureTranscriptFlow
         ? .transcript(transcriptModel(with: { [weak self] in self?.controller }))
             : .chat(chatModel())
-        let chatController = ChatViewController(viewModel: model, viewFactory: viewFactory)
+
+        let chatController = ChatViewController(
+            viewModel: model,
+            viewFactory: viewFactory
+        )
         self.controller = chatController
         return chatController
 
@@ -241,6 +245,14 @@ extension ChatCoordinator {
             ),
             deliveredStatusText: viewFactory.theme.chat.visitorMessage.delivered
         )
+
+        viewModel.engagementDelegate = { [weak self] event in
+            switch event {
+            case .finished:
+                self?.delegate?(.finished)
+            default: break
+            }
+        }
 
         viewModel.delegate = { [weak self] event in
             switch event {

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
@@ -422,7 +422,7 @@ extension EngagementCoordinator {
                 fetchSiteConfigurations: environment.fetchSiteConfigurations,
                 chatCall: chatCall,
                 unreadMessages: unreadMessages,
-                showsCallBubble: true, // TODO: pass show bubble as parameter for this method
+                showsCallBubble: false,
                 screenShareHandler: screenShareHandler,
                 isWindowVisible: isWindowVisible,
                 sendSelectedOptionValue: environment.sendSelectedOptionValue,

--- a/GliaWidgets/Sources/Theme/Theme+Chat.swift
+++ b/GliaWidgets/Sources/Theme/Theme+Chat.swift
@@ -52,6 +52,10 @@ extension Theme {
             endScreenShareButton: endScreenShareButton,
             accessibility: .init(isFontScalingEnabled: true)
         )
+
+        var secureTranscriptHeader = header
+        secureTranscriptHeader.backButton = nil
+
         let operatorImage = UserImageStyle(
             placeholderImage: Asset.operatorPlaceholder.image,
             placeholderColor: color.baseLight,
@@ -355,7 +359,8 @@ extension Theme {
                 visitor: Accessibility.visitorName,
                 isFontScalingEnabled: true
             ),
-            secureTranscriptTitle: Chat.secureTranscriptTitle
+            secureTranscriptTitle: Chat.secureTranscriptTitle,
+            secureTranscriptHeader: secureTranscriptHeader
         )
     }
 

--- a/GliaWidgets/Sources/View/Chat/ChatStyle.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatStyle.swift
@@ -41,9 +41,12 @@ public class ChatStyle: EngagementStyle {
     /// Header title for secure messaging transcript.
     public var secureTranscriptTitle: String
 
+    /// Header style for secure messaging transcript.
+    public var secureTranscriptHeader: HeaderStyle
+
     ///
     /// - Parameters:
-    ///   - header: Style of the view's header (navigation bar area).
+    ///   - header: Style of the view's header (navigation bar area) when the screen is displaying live chat.
     ///   - connect: Styles for different engagement connection states.
     ///   - backgroundColor: View's background color.
     ///   - preferredStatusBarStyle: Preferred style of the status bar.
@@ -60,6 +63,7 @@ public class ChatStyle: EngagementStyle {
     ///   - operatorTypingIndicator: Style of the view that indicates that the operator is currently typing.
     ///   - accessibility: Accessibility related properties.
     ///   - secureTranscriptTitle: Header title for secure messaging transcript.
+    ///   - secureTranscriptHeader: Style of the view's header (navigation bar area) when the screen is displaying secure conversations.
     ///
     public init(
         header: HeaderStyle,
@@ -78,7 +82,8 @@ public class ChatStyle: EngagementStyle {
         unreadMessageIndicator: UnreadMessageIndicatorStyle,
         operatorTypingIndicator: OperatorTypingIndicatorStyle,
         accessibility: Accessibility = .unsupported,
-        secureTranscriptTitle: String
+        secureTranscriptTitle: String,
+        secureTranscriptHeader: HeaderStyle
     ) {
         self.title = title
         self.visitorMessage = visitorMessage
@@ -93,6 +98,8 @@ public class ChatStyle: EngagementStyle {
         self.operatorTypingIndicator = operatorTypingIndicator
         self.accessibility = accessibility
         self.secureTranscriptTitle = secureTranscriptTitle
+        self.secureTranscriptHeader = secureTranscriptHeader
+
         super.init(
             header: header,
             connect: connect,

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -153,36 +153,6 @@ class ChatViewModel: EngagementViewModel, ViewModel {
     }
     // swiftlint:enable function_body_length
 
-    func event(_ event: Event) {
-        switch event {
-        case .viewDidLoad:
-            start()
-            isViewLoaded = true
-        case .messageTextChanged(let text):
-            messageText = text
-        case .sendTapped:
-            sendMessage()
-        case .removeUploadTapped(let upload):
-            removeUpload(upload)
-        case .pickMediaTapped:
-            presentMediaPicker()
-        case .callBubbleTapped:
-            delegate?(.call)
-        case .fileTapped(let file):
-            fileTapped(file)
-        case .downloadTapped(let download):
-            downloadTapped(download)
-        case .choiceOptionSelected(let option, let messageId):
-            sendChoiceCardResponse(option, to: messageId)
-        case .chatScrolled(let bottomReached):
-            isChatScrolledToBottom.value = bottomReached
-        case .linkTapped(let url):
-            linkTapped(url)
-        case .customCardOptionSelected(let option, let messageId):
-            sendSelectedCustomCardOption(option, for: messageId)
-        }
-    }
-
     override func viewDidAppear() {
         super.viewDidAppear()
 
@@ -292,6 +262,38 @@ class ChatViewModel: EngagementViewModel, ViewModel {
             onEngagementTransferred()
         default:
             break
+        }
+    }
+}
+
+extension ChatViewModel {
+    func event(_ event: Event) {
+        switch event {
+        case .viewDidLoad:
+            start()
+            isViewLoaded = true
+        case .messageTextChanged(let text):
+            messageText = text
+        case .sendTapped:
+            sendMessage()
+        case .removeUploadTapped(let upload):
+            removeUpload(upload)
+        case .pickMediaTapped:
+            presentMediaPicker()
+        case .callBubbleTapped:
+            delegate?(.call)
+        case .fileTapped(let file):
+            fileTapped(file)
+        case .downloadTapped(let download):
+            downloadTapped(download)
+        case .choiceOptionSelected(let option, let messageId):
+            sendChoiceCardResponse(option, to: messageId)
+        case .chatScrolled(let bottomReached):
+            isChatScrolledToBottom.value = bottomReached
+        case .linkTapped(let url):
+            linkTapped(url)
+        case .customCardOptionSelected(let option, let messageId):
+            sendSelectedCustomCardOption(option, for: messageId)
         }
     }
 }


### PR DESCRIPTION
The current logic correctly identifies when to show the secure conversations title or the chat title. This logic is encapsulated into its own function so that it can be used to determine back button behavior. The whole props for the header are regenerated every time the new renderProps method (previously renderTitle) is called, so that it correctly identifies the different chat models and its actions.

MOB-1888