### PR TITLE
Add message divider for unread messages in secure transcript

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -428,6 +428,8 @@
 		AF0D26D82971912A00816CCB /* SecureConversations.SendMessageButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0D26D72971912A00816CCB /* SecureConversations.SendMessageButton.swift */; };
 		AF10ED8B29B7A4C000E85309 /* ChatViewModel+ChoiceCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF10ED8A29B7A4C000E85309 /* ChatViewModel+ChoiceCards.swift */; };
 		AF10ED8D29BA210500E85309 /* SecureConversations.MessagesWithUnreadCountLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF10ED8C29BA210500E85309 /* SecureConversations.MessagesWithUnreadCountLoader.swift */; };
+		AF10ED8F29BF849A00E85309 /* UnreadMessageDividerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF10ED8E29BF849A00E85309 /* UnreadMessageDividerView.swift */; };
+		AF10ED9129BF85C700E85309 /* UnreadMessageDividerStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF10ED9029BF85C700E85309 /* UnreadMessageDividerStyle.swift */; };
 		AF11F30728BE6F0C002ACEB4 /* UIAlertController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF11F30628BE6F0C002ACEB4 /* UIAlertController+Extensions.swift */; };
 		AF39330B29B2A6A00008B60D /* ChatViewModel.SecureConverstaions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF39330A29B2A6A00008B60D /* ChatViewModel.SecureConverstaions.swift */; };
 		AF3D520B2983235C00AD8E69 /* FileUploader.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D520A2983235C00AD8E69 /* FileUploader.Mock.swift */; };
@@ -1024,6 +1026,8 @@
 		AF0D26D72971912A00816CCB /* SecureConversations.SendMessageButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.SendMessageButton.swift; sourceTree = "<group>"; };
 		AF10ED8A29B7A4C000E85309 /* ChatViewModel+ChoiceCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatViewModel+ChoiceCards.swift"; sourceTree = "<group>"; };
 		AF10ED8C29BA210500E85309 /* SecureConversations.MessagesWithUnreadCountLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.MessagesWithUnreadCountLoader.swift; sourceTree = "<group>"; };
+		AF10ED8E29BF849A00E85309 /* UnreadMessageDividerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnreadMessageDividerView.swift; sourceTree = "<group>"; };
+		AF10ED9029BF85C700E85309 /* UnreadMessageDividerStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnreadMessageDividerStyle.swift; sourceTree = "<group>"; };
 		AF11F30628BE6F0C002ACEB4 /* UIAlertController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+Extensions.swift"; sourceTree = "<group>"; };
 		AF39330A29B2A6A00008B60D /* ChatViewModel.SecureConverstaions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.SecureConverstaions.swift; sourceTree = "<group>"; };
 		AF3D520A2983235C00AD8E69 /* FileUploader.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploader.Mock.swift; sourceTree = "<group>"; };
@@ -1833,6 +1837,8 @@
 				1A60AFDC25669A4200E53F53 /* ChatView.swift */,
 				1A60AFE725669C5000E53F53 /* ChatStyle.swift */,
 				9AB3402627FCDD92006E0FE2 /* ChatStyle.Accessibility.swift */,
+				AF10ED8E29BF849A00E85309 /* UnreadMessageDividerView.swift */,
+				AF10ED9029BF85C700E85309 /* UnreadMessageDividerStyle.swift */,
 			);
 			path = Chat;
 			sourceTree = "<group>";
@@ -3558,6 +3564,7 @@
 				9AB196D427C3D7FD00FD60AB /* Interactor.Environment.Mock.swift in Sources */,
 				7594098D298D38C2008B173A /* CallVisualizer.swift in Sources */,
 				1A0C9A7925C16F9700815406 /* Theme+AlertConfiguration.swift in Sources */,
+				AF10ED8F29BF849A00E85309 /* UnreadMessageDividerView.swift in Sources */,
 				1AC8AADD25D419CE00DAFE50 /* VideoStreamView.swift in Sources */,
 				1A4AD3C7256E863900468BFB /* ThemeColor.swift in Sources */,
 				756B8B1E2996BAEA001D2BB2 /* HeaderButton.Props.swift in Sources */,
@@ -3776,6 +3783,7 @@
 				AF3D520D2983B3DD00AD8E69 /* FileUploader.Environment.Interface.swift in Sources */,
 				1ABD6C5925B5758000D56EFA /* BubbleStyle.swift in Sources */,
 				C0D2F08B29A4E95700803B47 /* ConnectView.Mock.swift in Sources */,
+				AF10ED9129BF85C700E85309 /* UnreadMessageDividerStyle.swift in Sources */,
 				75AF8CF127DBB1F9009EEE2C /* SurveyViewController.View.swift in Sources */,
 				9AA64E142811B91C00FA56FF /* FontScaling.swift in Sources */,
 				C0D2F04629925C5A00803B47 /* VideoCallView.ConnectStatusView.swift in Sources */,

--- a/GliaWidgets/L10n.swift
+++ b/GliaWidgets/L10n.swift
@@ -472,8 +472,6 @@ public enum L10n {
     }
   }
   public enum Chat {
-    /// Messaging
-    public static let secureTranscriptTitle = L10n.tr("Localizable", "chat.secureTranscriptTitle", fallback: "Messaging")
     /// Chat
     public static let title = L10n.tr("Localizable", "chat.title", fallback: "Chat")
     public enum Accessibility {
@@ -689,6 +687,12 @@ public enum L10n {
       public static let photo = L10n.tr("Localizable", "chat.pickMedia.photo", fallback: "Photo Library")
       /// Take Photo or Video
       public static let takePhoto = L10n.tr("Localizable", "chat.pickMedia.takePhoto", fallback: "Take Photo or Video")
+    }
+    public enum SecureTranscript {
+      /// Messaging
+      public static let headerTitle = L10n.tr("Localizable", "chat.secureTranscript.headerTitle", fallback: "Messaging")
+      /// New Messages
+      public static let unreadMessageDividerTitle = L10n.tr("Localizable", "chat.secureTranscript.unreadMessageDividerTitle", fallback: "New Messages")
     }
     public enum Upgrade {
       public enum Audio {

--- a/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
+++ b/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
@@ -137,7 +137,9 @@ extension Glia {
                 sendSecureMessage: environment.coreSdk.sendSecureMessage,
                 createFileUploader: environment.createFileUploader,
                 createFileUploadListModel: environment.createFileUploadListModel,
-                uploadSecureFile: environment.coreSdk.uploadSecureFile
+                uploadSecureFile: environment.coreSdk.uploadSecureFile,
+                getSecureUnreadMessageCount: environment.coreSdk.getSecureUnreadMessageCount,
+                messagesWithUnreadCountLoaderScheduler: environment.messagesWithUnreadCountLoaderScheduler
             )
         )
         rootCoordinator?.delegate = { [weak self] event in

--- a/GliaWidgets/Resources/en.lproj/Localizable.strings
+++ b/GliaWidgets/Resources/en.lproj/Localizable.strings
@@ -95,7 +95,8 @@
 "chat.download.failed" = "Download failed";
 "chat.download.failed.separator" = " | ";
 "chat.download.failed.retry" = "Retry";
-"chat.secureTranscriptTitle" = "Messaging";
+"chat.secureTranscript.headerTitle" = "Messaging";
+"chat.secureTranscript.unreadMessageDividerTitle" = "New Messages";
 
 "chat.accessibility.upload.removeUpload.label" = "Remove upload";
 "chat.accessibility.upload.progress.percentValue" = "{uploadPercentValue}%%";

--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
@@ -274,7 +274,9 @@ extension SecureConversations.Coordinator {
                 sendSecureMessage: environment.sendSecureMessage,
                 queueIds: environment.queueIds,
                 listQueues: environment.listQueues,
-                secureUploadFile: environment.uploadSecureFile
+                secureUploadFile: environment.uploadSecureFile,
+                getSecureUnreadMessageCount: environment.getSecureUnreadMessageCount,
+                messagesWithUnreadCountLoaderScheduler: environment.messagesWithUnreadCountLoaderScheduler
             ),
             startWithSecureTranscriptFlow: true
         )
@@ -334,7 +336,8 @@ extension SecureConversations.Coordinator {
         var getCurrentEngagement: CoreSdkClient.GetCurrentEngagement
         var submitSurveyAnswer: CoreSdkClient.SubmitSurveyAnswer
         var interactor: Interactor
-
+        var getSecureUnreadMessageCount: CoreSdkClient.GetSecureUnreadMessageCount
+        var messagesWithUnreadCountLoaderScheduler: CoreSdkClient.ReactiveSwift.DateScheduler
     }
 
     enum DelegateEvent {

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
@@ -24,5 +24,7 @@ extension ChatCoordinator {
         var queueIds: [String]
         var listQueues: CoreSdkClient.ListQueues
         var secureUploadFile: CoreSdkClient.SecureConversationsUploadFile
+        var getSecureUnreadMessageCount: CoreSdkClient.GetSecureUnreadMessageCount
+        var messagesWithUnreadCountLoaderScheduler: CoreSdkClient.ReactiveSwift.DateScheduler
     }
 }

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
@@ -317,7 +317,9 @@ extension ChatCoordinator {
            uuid: environment.uuid,
            secureUploadFile: environment.secureUploadFile,
            fileUploadListStyle: viewFactory.theme.chatStyle.messageEntry.uploadList,
-           fetchSiteConfigurations: environment.fetchSiteConfigurations
+           fetchSiteConfigurations: environment.fetchSiteConfigurations,
+           getSecureUnreadMessageCount: environment.getSecureUnreadMessageCount,
+           messagesWithUnreadCountLoaderScheduler: environment.messagesWithUnreadCountLoaderScheduler
        )
     }
 }

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
@@ -1,6 +1,6 @@
 #if DEBUG
 extension EngagementCoordinator.Environment {
-    static let mock = Self.init(
+    static let mock = Self(
         fetchFile: { _, _, _ in },
         sendSelectedOptionValue: { _, _ in },
         uploadFileToEngagement: { _, _, _ in },
@@ -24,7 +24,9 @@ extension EngagementCoordinator.Environment {
         sendSecureMessage: { _, _, _, _ in .init() },
         createFileUploader: FileUploader.mock,
         createFileUploadListModel: SecureConversations.FileUploadListViewModel.mock(environment:),
-        uploadSecureFile: { _, _, _ in .mock }
+        uploadSecureFile: { _, _, _ in .mock },
+        getSecureUnreadMessageCount: { _ in },
+        messagesWithUnreadCountLoaderScheduler: CoreSdkClient.reactiveSwiftDateSchedulerMock
     )
 }
 #endif

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
@@ -26,5 +26,7 @@ extension EngagementCoordinator {
         var createFileUploader: FileUploader.Create
         var createFileUploadListModel: SecureConversations.FileUploadListViewModel.Create
         var uploadSecureFile: CoreSdkClient.SecureConversationsUploadFile
+        var getSecureUnreadMessageCount: CoreSdkClient.GetSecureUnreadMessageCount
+        var messagesWithUnreadCountLoaderScheduler: CoreSdkClient.ReactiveSwift.DateScheduler
     }
 }

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
@@ -232,7 +232,9 @@ extension EngagementCoordinator {
                 sendSecureMessage: environment.sendSecureMessage,
                 queueIds: [interactor.queueID],
                 listQueues: environment.listQueues,
-                secureUploadFile: environment.uploadSecureFile
+                secureUploadFile: environment.uploadSecureFile,
+                getSecureUnreadMessageCount: environment.getSecureUnreadMessageCount,
+                messagesWithUnreadCountLoaderScheduler: environment.messagesWithUnreadCountLoaderScheduler
             ),
             startWithSecureTranscriptFlow: false
         )
@@ -429,7 +431,9 @@ extension EngagementCoordinator {
                 uploadFileToEngagement: environment.uploadFileToEngagement,
                 getCurrentEngagement: environment.getCurrentEngagement,
                 submitSurveyAnswer: environment.submitSurveyAnswer,
-                interactor: interactor
+                interactor: interactor,
+                getSecureUnreadMessageCount: environment.getSecureUnreadMessageCount,
+                messagesWithUnreadCountLoaderScheduler: environment.messagesWithUnreadCountLoaderScheduler
             )
         )
 

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -358,4 +358,11 @@ extension MessageSender {
 extension CoreSdkClient.Cancellable {
     static let mock = CoreSdkClient.Cancellable()
 }
+
+extension CoreSdkClient {
+    static var reactiveSwiftDateSchedulerMock: CoreSdkClient.ReactiveSwift.DateScheduler {
+        CoreSdkClient.ReactiveSwift.TestScheduler()
+    }
+}
+
 #endif

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Interface.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Interface.swift
@@ -41,6 +41,7 @@ extension Glia {
         var createFileUploader: FileUploader.Create
         var createFileUploadListModel: SecureConversations.FileUploadListViewModel.Create
         var screenShareHandler: ScreenShareHandler
+        var messagesWithUnreadCountLoaderScheduler: CoreSdkClient.ReactiveSwift.DateScheduler
     }
 }
 

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Live.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Live.swift
@@ -28,7 +28,8 @@ extension Glia.Environment {
         bundleManaging: .live,
         createFileUploader: FileUploader.init(maximumUploads:environment:),
         createFileUploadListModel: SecureConversations.FileUploadListViewModel.init,
-        screenShareHandler: ScreenShareHandler()
+        screenShareHandler: ScreenShareHandler(),
+        messagesWithUnreadCountLoaderScheduler: CoreSdkClient.ReactiveSwift.QueueScheduler.main
     )
 }
 

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Mock.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Mock.swift
@@ -22,7 +22,8 @@ extension Glia.Environment {
         bundleManaging: .init { .main },
         createFileUploader: FileUploader.mock,
         createFileUploadListModel: SecureConversations.FileUploadListViewModel.mock(environment:),
-        screenShareHandler: .mock()
+        screenShareHandler: .mock(),
+        messagesWithUnreadCountLoaderScheduler: CoreSdkClient.reactiveSwiftDateSchedulerMock
     )
 }
 

--- a/GliaWidgets/Sources/Theme/Theme+Chat.swift
+++ b/GliaWidgets/Sources/Theme/Theme+Chat.swift
@@ -338,6 +338,15 @@ extension Theme {
             transferringImage: Asset.operatorTransferring.image,
             accessibility: .init(label: Accessibility.Message.UnreadMessagesIndicator.label)
         )
+
+        let unreadMessageDivider = UnreadMessageDividerStyle(
+            title: Chat.SecureTranscript.unreadMessageDividerTitle,
+            titleColor: Color.baseNormal,
+            titleFont: .systemFont(ofSize: 14),
+            lineColor: Color.primary,
+            accessibility: .unsupported
+        )
+
         return ChatStyle(
             header: header,
             connect: connect,
@@ -359,8 +368,9 @@ extension Theme {
                 visitor: Accessibility.visitorName,
                 isFontScalingEnabled: true
             ),
-            secureTranscriptTitle: Chat.secureTranscriptTitle,
-            secureTranscriptHeader: secureTranscriptHeader
+            secureTranscriptTitle: Chat.SecureTranscript.headerTitle,
+            secureTranscriptHeader: secureTranscriptHeader,
+            unreadMessageDivider: unreadMessageDivider
         )
     }
 

--- a/GliaWidgets/Sources/View/Chat/Cells/ChatItemCell.swift
+++ b/GliaWidgets/Sources/View/Chat/Cells/ChatItemCell.swift
@@ -11,6 +11,7 @@ class ChatItemCell: UITableViewCell {
         case choiceCard(ChoiceCardView)
         case customCard(CustomCardContainerView)
         case callUpgrade(ChatCallUpgradeView)
+        case unreadMessagesDivider(UnreadMessageDividerView)
 
         var view: UIView? {
             switch self {
@@ -29,6 +30,8 @@ class ChatItemCell: UITableViewCell {
             case .customCard(let view):
                 return view
             case .callUpgrade(let view):
+                return view
+            case let .unreadMessagesDivider(view):
                 return view
             }
         }

--- a/GliaWidgets/Sources/View/Chat/ChatStyle.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatStyle.swift
@@ -44,6 +44,9 @@ public class ChatStyle: EngagementStyle {
     /// Header style for secure messaging transcript.
     public var secureTranscriptHeader: HeaderStyle
 
+    /// Style for divider of unread messages in secure messaging transcript.
+    public var unreadMessageDivider: UnreadMessageDividerStyle
+
     ///
     /// - Parameters:
     ///   - header: Style of the view's header (navigation bar area) when the screen is displaying live chat.
@@ -64,7 +67,7 @@ public class ChatStyle: EngagementStyle {
     ///   - accessibility: Accessibility related properties.
     ///   - secureTranscriptTitle: Header title for secure messaging transcript.
     ///   - secureTranscriptHeader: Style of the view's header (navigation bar area) when the screen is displaying secure conversations.
-    ///
+    ///   - unreadMessageDivider: Style for divider of unread messages in secure messaging transcript.
     public init(
         header: HeaderStyle,
         connect: ConnectStyle,
@@ -83,7 +86,8 @@ public class ChatStyle: EngagementStyle {
         operatorTypingIndicator: OperatorTypingIndicatorStyle,
         accessibility: Accessibility = .unsupported,
         secureTranscriptTitle: String,
-        secureTranscriptHeader: HeaderStyle
+        secureTranscriptHeader: HeaderStyle,
+        unreadMessageDivider: UnreadMessageDividerStyle
     ) {
         self.title = title
         self.visitorMessage = visitorMessage
@@ -99,6 +103,7 @@ public class ChatStyle: EngagementStyle {
         self.accessibility = accessibility
         self.secureTranscriptTitle = secureTranscriptTitle
         self.secureTranscriptHeader = secureTranscriptHeader
+        self.unreadMessageDivider = unreadMessageDivider
 
         super.init(
             header: header,

--- a/GliaWidgets/Sources/View/Chat/ChatView.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatView.swift
@@ -445,6 +445,12 @@ extension ChatView {
                 animated: false
             )
             return .queueOperator(connectView)
+        case .unreadMessageDivider:
+            return .unreadMessagesDivider(
+                UnreadMessageDividerView(
+                    style: style.unreadMessageDivider
+                )
+            )
         }
     }
     // swiftlint:enable function_body_length

--- a/GliaWidgets/Sources/View/Chat/UnreadMessageDividerStyle.swift
+++ b/GliaWidgets/Sources/View/Chat/UnreadMessageDividerStyle.swift
@@ -1,0 +1,55 @@
+import UIKit
+
+/// Style for divider of unread messages in secure messaging transcript.
+public struct UnreadMessageDividerStyle: Equatable {
+    /// Message divider title.
+    public var title: String
+    /// Text color for message divider title.
+    public var titleColor: UIColor
+    /// Font for message divider title.
+    public var titleFont: UIFont
+    /// Line color for message divider.
+    public var lineColor: UIColor
+    /// Accessibility related properties.
+    public var accessibility: Accessibility
+
+    /// - Parameters:
+    ///   - title: Message divider title.
+    ///   - titleColor: Text color for message divider title.
+    ///   - titleFont: Font for message divider title.
+    ///   - lineColor: Line color for message divider.
+    ///   - accessibility: Accessibility properties for UnreadMessageDividerStyle.
+    public init(
+        title: String,
+        titleColor: UIColor,
+        titleFont: UIFont,
+        lineColor: UIColor,
+        accessibility: Accessibility
+    ) {
+        self.title = title
+        self.lineColor = lineColor
+        self.titleColor = titleColor
+        self.titleFont = titleFont
+        self.accessibility = accessibility
+    }
+}
+
+extension UnreadMessageDividerStyle {
+    /// Accessibility properties for UnreadMessageDividerStyle.
+    public struct Accessibility: Equatable {
+        /// Flag that provides font dynamic type by setting `adjustsFontForContentSizeCategory` for component that supports it.
+        public var isFontScalingEnabled: Bool
+
+        /// - Parameter isFontScalingEnabled: Flag that provides font dynamic type by setting `adjustsFontForContentSizeCategory` for component that supports it.
+        public init(
+            isFontScalingEnabled: Bool
+        ) {
+            self.isFontScalingEnabled = isFontScalingEnabled
+        }
+
+        /// Accessibility is not supported intentionally.
+        public static let unsupported = Self(
+            isFontScalingEnabled: false
+        )
+    }
+}

--- a/GliaWidgets/Sources/View/Chat/UnreadMessageDividerView.swift
+++ b/GliaWidgets/Sources/View/Chat/UnreadMessageDividerView.swift
@@ -1,0 +1,81 @@
+import Foundation
+import UIKit
+
+final class UnreadMessageDividerView: BaseView {
+    private let style: UnreadMessageDividerStyle
+    private let textLabel = UILabel().makeView()
+    private lazy var leadingLine = LineView(color: style.lineColor).makeView()
+    private lazy var trailingLine = LineView(color: style.lineColor).makeView()
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    @available(*, unavailable)
+    required init() {
+        fatalError("init() has not been implemented")
+    }
+
+    init(style: UnreadMessageDividerStyle) {
+        self.style = style
+        super.init()
+    }
+
+    override func setup() {
+        super.setup()
+        addSubview(leadingLine)
+        addSubview(textLabel)
+        addSubview(trailingLine)
+
+        textLabel.text = style.title
+        textLabel.font = style.titleFont
+        textLabel.textColor = style.titleColor
+        textLabel.textAlignment = .center
+        setFontScalingEnabled(
+            style.accessibility.isFontScalingEnabled,
+            for: textLabel
+        )
+    }
+
+    override func defineLayout() {
+        let lineHorizontalPadding = 18.0
+        let labelSpacing = 8.0
+        let lineVerticalPadding = 21.0
+
+        NSLayoutConstraint.activate([
+            textLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            textLabel.topAnchor.constraint(equalTo: topAnchor, constant: lineVerticalPadding),
+            textLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -lineVerticalPadding),
+
+            leadingLine.centerYAnchor.constraint(equalTo: textLabel.centerYAnchor),
+            leadingLine.leadingAnchor.constraint(equalTo: leadingAnchor, constant: lineHorizontalPadding),
+            leadingLine.trailingAnchor.constraint(equalTo: textLabel.leadingAnchor, constant: -labelSpacing),
+            leadingLine.heightAnchor.constraint(equalToConstant: 1),
+
+            trailingLine.centerYAnchor.constraint(equalTo: leadingLine.centerYAnchor),
+            trailingLine.leadingAnchor.constraint(equalTo: textLabel.trailingAnchor, constant: labelSpacing),
+            trailingLine.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -lineHorizontalPadding),
+            trailingLine.heightAnchor.constraint(equalTo: leadingLine.heightAnchor)
+        ])
+    }
+}
+
+extension UnreadMessageDividerView {
+    final class LineView: BaseView {
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        @available(*, unavailable)
+        required init() {
+            fatalError("init() has not been implemented")
+        }
+
+        required init(color: UIColor) {
+            super.init()
+            self.backgroundColor = color
+        }
+    }
+}

--- a/GliaWidgets/Sources/ViewModel/Chat/Data/ChatItem.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/Data/ChatItem.swift
@@ -64,5 +64,6 @@ extension ChatItem {
         case callUpgrade(ObservableValue<CallKind>, duration: ObservableValue<Int>)
         case operatorConnected(name: String?, imageUrl: String?)
         case transferring
+        case unreadMessageDivider
     }
 }

--- a/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
+++ b/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
@@ -59,6 +59,10 @@ extension EngagementCoordinator.Environment {
         uploadSecureFile: { _, _, _ in
             fail("\(Self.self).uploadSecureFile")
             return .mock
-        }
+        },
+        getSecureUnreadMessageCount: { _ in
+            fail("\(Self.self).getSecureUnreadMessageCount")
+        },
+        messagesWithUnreadCountLoaderScheduler: CoreSdkClient.reactiveSwiftDateSchedulerMock
     )
 }

--- a/GliaWidgetsTests/Glia.Environment.Failing.swift
+++ b/GliaWidgetsTests/Glia.Environment.Failing.swift
@@ -51,7 +51,8 @@ extension Glia.Environment {
             fail("\(Self.self).createFileUploadListModel")
             return .mock()
         },
-        screenShareHandler: .mock()
+        screenShareHandler: .mock(),
+        messagesWithUnreadCountLoaderScheduler: CoreSdkClient.reactiveSwiftDateSchedulerMock
     )
 }
 


### PR DESCRIPTION
Add message divider to indicate the presence of unread message in secure conversations transcript screen.

MOB-1734

<img src="https://user-images.githubusercontent.com/3148347/225246789-eb0d4c69-39ea-46df-aa8a-086be2e3c10a.png" width="428" height="926">

