### PR TITLE
Fix audio call layout issue

### DIFF
--- a/GliaWidgets/Sources/Component/Connect/ConnectView.swift
+++ b/GliaWidgets/Sources/Component/Connect/ConnectView.swift
@@ -233,7 +233,7 @@ extension ConnectView.State {
     var callTopPadding: CGFloat {
         switch self {
         case .initial, .queue, .connecting, .transferring:
-            return 32
+            return 0
         case .connected:
             return 14
         }

--- a/GliaWidgets/Sources/View/Call/CallView.swift
+++ b/GliaWidgets/Sources/View/Call/CallView.swift
@@ -318,7 +318,7 @@ class CallView: EngagementView {
             .fittingSizeLevel,
             for: .vertical
         )
-        bottomLabel.autoPinEdge(.bottom, to: .top, of: buttonBar, withOffset: -38)
+        bottomLabel.autoPinEdge(.bottom, to: .top, of: buttonBar, withOffset: 0)
         bottomLabel.autoMatch(.width, to: .width, of: self, withMultiplier: 0.6)
         bottomLabel.autoAlignAxis(toSuperviewAxis: .vertical)
         bottomLabel.autoPinEdge(


### PR DESCRIPTION
Audio Call had issues with laying out elements in landscape orientation. Most specifically in smaller devices. This PR fixes it.

MOB-742