### PR TITLE
Enable dynamic font type (ADA) for secure transcript message divider

### DIFF
--- a/GliaWidgets/Sources/Theme/Theme+Chat.swift
+++ b/GliaWidgets/Sources/Theme/Theme+Chat.swift
@@ -342,9 +342,9 @@ extension Theme {
         let unreadMessageDivider = UnreadMessageDividerStyle(
             title: Chat.SecureTranscript.unreadMessageDividerTitle,
             titleColor: Color.baseNormal,
-            titleFont: .systemFont(ofSize: 14),
+            titleFont: font.buttonLabel,
             lineColor: Color.primary,
-            accessibility: .unsupported
+            accessibility: .init(isFontScalingEnabled: true)
         )
 
         return ChatStyle(


### PR DESCRIPTION
Make sure that unread message divider text size is changing along with accessibility settings for text.

MOB-1755