### PR TITLE
Fix dismissing screen sharing screen

### DIFF
--- a/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
@@ -274,11 +274,12 @@ extension CallVisualizer {
             coordinator.delegate = { event in
                 switch event {
                 case .close:
-                    self.screenSharingCoordinator.unwrap {
-                        $0.viewController?.dismiss(animated: false)
+                    if let screenSharing = self.screenSharingCoordinator?.viewController {
+                        screenSharing.presentingViewController?.dismiss(animated: true)
                         self.screenSharingCoordinator = nil
+                    } else {
+                        viewController.dismiss(animated: true)
                     }
-                    viewController.dismiss(animated: true)
                 }
             }
 
@@ -300,6 +301,8 @@ private extension CallVisualizer.Coordinator {
                 case .started:
                     self?.createScreenShareBubbleView()
                 case .stopped:
+                    self?.screenSharingCoordinator?.viewController?.dismiss(animated: true)
+                    self?.screenSharingCoordinator = nil
                     self?.removeBubbleView()
                 }
             }

--- a/GliaWidgets/Sources/CallVisualizer/ScreenSharing/ViewModel/ScreenSharingViewModel.swift
+++ b/GliaWidgets/Sources/CallVisualizer/ScreenSharing/ViewModel/ScreenSharingViewModel.swift
@@ -15,14 +15,6 @@ extension CallVisualizer {
         ) {
             self.style = style
             self.environment = environment
-
-            environment
-                .screenShareHandler
-                .status
-                .addObserver(self) { [weak self] newStatus, _ in
-                    guard case .stopped = newStatus else { return }
-                    self?.delegate(.close)
-                }
         }
     }
 }

--- a/GliaWidgetsTests/CallVisualizer/ScreenSharing/ScreenSharingViewModelTests.swift
+++ b/GliaWidgetsTests/CallVisualizer/ScreenSharing/ScreenSharingViewModelTests.swift
@@ -44,9 +44,7 @@ final class ScreenSharingViewModelTests: XCTestCase {
         let props = viewModel.props()
 
         props.screenSharingViewProps.endScreenSharing.tap.execute()
-        XCTAssertEqual(calls, [.close])
-
         props.screenSharingViewProps.header.backButton?.tap()
-        XCTAssertEqual(calls, [.close, .close])
+        XCTAssertEqual(calls, [.close])
     }
 }


### PR DESCRIPTION
There was an issue when VideoCall screen was presented over ScreenSharing screen and user press "back" button, ScreenSharing screen was not dismissed along with VideoCall. 
This PR fixes it. 

MOB-1925