### PR TITLE
Add accessibility identifier for header

### DIFF
--- a/GliaWidgets/Sources/Component/Header/Header.swift
+++ b/GliaWidgets/Sources/Component/Header/Header.swift
@@ -70,6 +70,7 @@ final class Header: BaseView {
 
         titleLabel.text = props.title
         titleLabel.accessibilityLabel = props.title
+        titleLabel.accessibilityIdentifier = "header_view_title_label"
 
         effectView.isHidden = props.effect == .none
         titleLabel.font = props.style.titleFont


### PR DESCRIPTION
This will be used in acceptance tests to check if the header has changed from messaging to chat in secure conversations. As an added benefit, it can be used whenever checking the header is needed, and it will have the identifier `header_` and the title in lowercase appended.

MOB-1752