### PR TITLE
Clear ScreenShareHendler state on ending Live Engagement

### DIFF
--- a/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
@@ -250,7 +250,7 @@ private extension EngagementViewModel {
         } failure: { _ in
             self.engagementDelegate?(.finished)
         }
-        self.screenShareHandler.cleanUp()
+        self.screenShareHandler.stop()
     }
 
     private func closeTapped() {


### PR DESCRIPTION
The issue was introduced in [PR](https://github.com/salemove/ios-sdk-widgets/commit/5211cac7312e76fe3a4d9f8475ddff2e2d50ba81). 

Before `EngagementCoordinator` had own local `ScreenShareHandler` instance that was initialized on every Live engagement. So on the engagement start it has `.stopped` screen sharing state. 
When added passing `ScreenShareHandler` instance to `EngagementCoordinator` that is stored in `Glia.Environment`, after ending engagement with active screen sharing by operator, `ScreenShareHandler` instance keeps `.started` state. So when new subsequent engagement is started, "End screen sharing" button is shown.
To fix the wrong state need to call `ScreenShareHandler.stop()`, that turns itself to initial state, instead of `cleanUp()`, that cleans only `visitorState` value.

MOB-1997