### PR TITLE
Use secure download endpoint for secure messaging

### DIFF
--- a/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
+++ b/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
@@ -140,7 +140,8 @@ extension Glia {
                 uploadSecureFile: environment.coreSdk.uploadSecureFile,
                 getSecureUnreadMessageCount: environment.coreSdk.getSecureUnreadMessageCount,
                 messagesWithUnreadCountLoaderScheduler: environment.messagesWithUnreadCountLoaderScheduler,
-                secureMarkMessagesAsRead: environment.coreSdk.secureMarkMessagesAsRead
+                secureMarkMessagesAsRead: environment.coreSdk.secureMarkMessagesAsRead,
+                downloadSecureFile: environment.coreSdk.downloadSecureFile
             )
         )
         rootCoordinator?.delegate = { [weak self] event in

--- a/GliaWidgets/SecureConversations/SecureConversations.ChatWithTranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.ChatWithTranscriptModel.swift
@@ -359,7 +359,7 @@ extension SecureConversations {
             self.environment = environment
             self.downloader = FileDownloader(
                 environment: .init(
-                    fetchFile: environment.fetchFile,
+                    fetchFile: .fromSecureMessaging(environment.fetchFile),
                     fileManager: environment.fileManager,
                     data: environment.data,
                     date: environment.date,
@@ -376,7 +376,7 @@ extension SecureConversations {
             let uploader = FileUploader(
                 maximumUploads: Self.maximumUploads,
                 environment: .init(
-                    uploadFile: .toConversation(environment.secureUploadFile),
+                    uploadFile: .toSecureMessaging(environment.secureUploadFile),
                     fileManager: environment.fileManager,
                     data: environment.data,
                     date: environment.date,
@@ -804,7 +804,7 @@ extension SecureConversations {
 
 extension SecureConversations.TranscriptModel {
     struct Environment {
-        var fetchFile: CoreSdkClient.FetchFile
+        var fetchFile: CoreSdkClient.DownloadSecureFile
         var fileManager: FoundationBased.FileManager
         var data: FoundationBased.Data
         var date: () -> Date

--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
@@ -47,7 +47,7 @@ extension SecureConversations {
                     fileUploader: environment.createFileUploader(
                         SecureConversations.WelcomeViewModel.maximumUploads,
                         .init(
-                            uploadFile: .toConversation(environment.uploadSecureFile),
+                            uploadFile: .toSecureMessaging(environment.uploadSecureFile),
                             fileManager: environment.fileManager,
                             data: environment.data,
                             date: environment.date,
@@ -277,7 +277,8 @@ extension SecureConversations.Coordinator {
                 secureUploadFile: environment.uploadSecureFile,
                 getSecureUnreadMessageCount: environment.getSecureUnreadMessageCount,
                 messagesWithUnreadCountLoaderScheduler: environment.messagesWithUnreadCountLoaderScheduler,
-                secureMarkMessagesAsRead: environment.secureMarkMessagesAsRead
+                secureMarkMessagesAsRead: environment.secureMarkMessagesAsRead,
+                downloadSecureFile: environment.downloadSecureFile
             ),
             startWithSecureTranscriptFlow: true
         )
@@ -340,6 +341,7 @@ extension SecureConversations.Coordinator {
         var getSecureUnreadMessageCount: CoreSdkClient.GetSecureUnreadMessageCount
         var messagesWithUnreadCountLoaderScheduler: CoreSdkClient.ReactiveSwift.DateScheduler
         var secureMarkMessagesAsRead: CoreSdkClient.SecureMarkMessagesAsRead
+        var downloadSecureFile: CoreSdkClient.DownloadSecureFile
     }
 
     enum DelegateEvent {

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
@@ -27,5 +27,6 @@ extension ChatCoordinator {
         var getSecureUnreadMessageCount: CoreSdkClient.GetSecureUnreadMessageCount
         var messagesWithUnreadCountLoaderScheduler: CoreSdkClient.ReactiveSwift.DateScheduler
         var secureMarkMessagesAsRead: CoreSdkClient.SecureMarkMessagesAsRead
+        var downloadSecureFile: CoreSdkClient.DownloadSecureFile
     }
 }

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
@@ -298,7 +298,7 @@ extension ChatCoordinator {
         viewFactory: ViewFactory
     ) -> SecureConversations.TranscriptModel.Environment {
         SecureConversations.TranscriptModel.Environment(
-           fetchFile: environment.fetchFile,
+           fetchFile: environment.downloadSecureFile,
            fileManager: environment.fileManager,
            data: environment.data,
            date: environment.date,

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
@@ -27,7 +27,8 @@ extension EngagementCoordinator.Environment {
         uploadSecureFile: { _, _, _ in .mock },
         getSecureUnreadMessageCount: { _ in },
         messagesWithUnreadCountLoaderScheduler: CoreSdkClient.reactiveSwiftDateSchedulerMock,
-        secureMarkMessagesAsRead: { _ in .mock }
+        secureMarkMessagesAsRead: { _ in .mock },
+        downloadSecureFile: { _, _, _ in .mock }
     )
 }
 #endif

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
@@ -29,5 +29,6 @@ extension EngagementCoordinator {
         var getSecureUnreadMessageCount: CoreSdkClient.GetSecureUnreadMessageCount
         var messagesWithUnreadCountLoaderScheduler: CoreSdkClient.ReactiveSwift.DateScheduler
         var secureMarkMessagesAsRead: CoreSdkClient.SecureMarkMessagesAsRead
+        var downloadSecureFile: CoreSdkClient.DownloadSecureFile
     }
 }

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
@@ -235,7 +235,8 @@ extension EngagementCoordinator {
                 secureUploadFile: environment.uploadSecureFile,
                 getSecureUnreadMessageCount: environment.getSecureUnreadMessageCount,
                 messagesWithUnreadCountLoaderScheduler: environment.messagesWithUnreadCountLoaderScheduler,
-                secureMarkMessagesAsRead: environment.secureMarkMessagesAsRead
+                secureMarkMessagesAsRead: environment.secureMarkMessagesAsRead,
+                downloadSecureFile: environment.downloadSecureFile
             ),
             startWithSecureTranscriptFlow: false
         )
@@ -435,7 +436,8 @@ extension EngagementCoordinator {
                 interactor: interactor,
                 getSecureUnreadMessageCount: environment.getSecureUnreadMessageCount,
                 messagesWithUnreadCountLoaderScheduler: environment.messagesWithUnreadCountLoaderScheduler,
-                secureMarkMessagesAsRead: environment.secureMarkMessagesAsRead
+                secureMarkMessagesAsRead: environment.secureMarkMessagesAsRead,
+                downloadSecureFile: environment.downloadSecureFile
             )
         )
 

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -135,6 +135,15 @@ struct CoreSdkClient {
 
     typealias SecureMarkMessagesAsRead = (_ callback: @escaping (Result<Void, Error>) -> Void) -> Cancellable
     var secureMarkMessagesAsRead: SecureMarkMessagesAsRead
+
+    typealias DownloadSecureFile = (
+        _ file: EngagementFile,
+        _ progress: @escaping EngagementFileProgressBlock,
+        _ completion: @escaping (Result<EngagementFileData, Error>) -> Void
+    ) -> Cancellable
+
+    var downloadSecureFile: DownloadSecureFile
+
 }
 
 extension CoreSdkClient {

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
@@ -42,7 +42,8 @@ extension CoreSdkClient {
             sendSecureMessage: GliaCore.sharedInstance.secureConversations.send(secureMessage:attachment:queueIds:completion:),
             uploadSecureFile: GliaCore.sharedInstance.secureConversations.uploadFile(_:progress:completion:),
             getSecureUnreadMessageCount: GliaCore.sharedInstance.secureConversations.getUnreadMessageCount(completion:),
-            secureMarkMessagesAsRead: GliaCore.sharedInstance.secureConversations.markMessagesAsRead(completion:)
+            secureMarkMessagesAsRead: GliaCore.sharedInstance.secureConversations.markMessagesAsRead(completion:),
+            downloadSecureFile: GliaCore.sharedInstance.secureConversations.downloadFile(_:progress:completion:)
         )
     }()
 }

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -31,7 +31,8 @@ extension CoreSdkClient {
         sendSecureMessage: { _, _, _, _ in .mock },
         uploadSecureFile: { _, _, _ in .mock },
         getSecureUnreadMessageCount: { _ in },
-        secureMarkMessagesAsRead: { _ in .mock }
+        secureMarkMessagesAsRead: { _ in .mock },
+        downloadSecureFile: { _, _, _ in .mock }
     )
 }
 

--- a/GliaWidgets/Sources/Download/FileDownload.Environment.Interface.swift
+++ b/GliaWidgets/Sources/Download/FileDownload.Environment.Interface.swift
@@ -1,9 +1,41 @@
 extension FileDownload {
     struct Environment {
-        var fetchFile: CoreSdkClient.FetchFile
+        var fetchFile: FetchFile
         var fileManager: FoundationBased.FileManager
         var gcd: GCD
         var localFileThumbnailQueue: FoundationBased.OperationQueue
         var uiImage: UIKitBased.UIImage
     }
+}
+
+extension FileDownload.Environment {
+    enum FetchFile {
+        case fromEngagement(CoreSdkClient.FetchFile)
+        case fromSecureMessaging(CoreSdkClient.DownloadSecureFile)
+    }
+}
+extension FileDownload.Environment.FetchFile {
+    @discardableResult
+    func startWithFile(
+        _ file: CoreSdkClient.EngagementFile,
+        progress: @escaping CoreSdkClient.EngagementFileProgressBlock,
+        completion: @escaping (Result<CoreSdkClient.EngagementFileData, Error>) -> Void) -> CoreSdkClient.Salemove.Cancellable? {
+            switch self {
+            case let .fromSecureMessaging(fetch):
+                return fetch(file, progress, completion)
+            case let .fromEngagement(fetch):
+                fetch(file, progress) { data, error in
+                    switch (data, error) {
+                    case (.none, .none):
+                        break
+                    case let (_, .some(error)):
+                        completion(.failure(error))
+                    case let (.some(fileData), .none):
+                        completion(.success(fileData))
+                    }
+                }
+
+                return nil
+            }
+        }
 }

--- a/GliaWidgets/Sources/Download/FileDownload.Environment.Mock.swift
+++ b/GliaWidgets/Sources/Download/FileDownload.Environment.Mock.swift
@@ -1,7 +1,7 @@
 #if DEBUG
 extension FileDownload.Environment {
     static let mock = Self(
-        fetchFile: { _, _, _ in },
+        fetchFile: .fromEngagement({ _, _, _ in }),
         fileManager: .mock,
         gcd: .mock,
         localFileThumbnailQueue: .mock(),

--- a/GliaWidgets/Sources/Download/FileDownloader.swift
+++ b/GliaWidgets/Sources/Download/FileDownloader.swift
@@ -101,8 +101,11 @@ extension FileDownloader {
         _ storage: DataStorage,
         _ environment: FileDownload.Environment
     ) -> FileDownload
+
     struct Environment {
-        var fetchFile: CoreSdkClient.FetchFile
+        typealias FetchFile = FileDownload.Environment.FetchFile
+
+        var fetchFile: FetchFile
         var fileManager: FoundationBased.FileManager
         var data: FoundationBased.Data
         var date: () -> Date

--- a/GliaWidgets/Sources/Upload/FileUpload.Environment.Interface.swift
+++ b/GliaWidgets/Sources/Upload/FileUpload.Environment.Interface.swift
@@ -10,7 +10,7 @@ extension FileUpload {
 extension FileUpload.Environment {
     enum UploadFile {
         case toEngagement(CoreSdkClient.UploadFileToEngagement)
-        case toConversation(CoreSdkClient.SecureConversationsUploadFile)
+        case toSecureMessaging(CoreSdkClient.SecureConversationsUploadFile)
     }
 }
 
@@ -36,7 +36,7 @@ extension FileUpload.Environment.UploadFile {
             }
             return nil
 
-        case let .toConversation(uploadFile):
+        case let .toSecureMessaging(uploadFile):
             return uploadFile(file, progress, completion)
         }
     }

--- a/GliaWidgets/Sources/Upload/FileUpload.Environment.Mock.swift
+++ b/GliaWidgets/Sources/Upload/FileUpload.Environment.Mock.swift
@@ -7,6 +7,6 @@ extension FileUpload.Environment {
 }
 
 extension FileUpload.Environment.UploadFile {
-    static let mock = FileUploader.Environment.UploadFile.toConversation({ _, _, _ in .mock })
+    static let mock = FileUploader.Environment.UploadFile.toSecureMessaging({ _, _, _ in .mock })
 }
 #endif

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -115,7 +115,7 @@ class ChatViewModel: EngagementViewModel, ViewModel {
 
         self.downloader = FileDownloader(
             environment: .init(
-                fetchFile: environment.fetchFile,
+                fetchFile: .fromEngagement(environment.fetchFile),
                 fileManager: environment.fileManager,
                 data: environment.data,
                 date: environment.date,

--- a/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
+++ b/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
@@ -67,6 +67,10 @@ extension EngagementCoordinator.Environment {
         secureMarkMessagesAsRead: { _ in
             fail("\(Self.self).secureMarkMessagesAsRead")
             return .mock
+        },
+        downloadSecureFile: { _, _, _ in
+            fail("\(Self.self).downloadSecureFile")
+            return .mock
         }
     )
 }

--- a/GliaWidgetsTests/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/CoreSDKClient.Failing.swift
@@ -46,6 +46,10 @@ extension CoreSdkClient {
         secureMarkMessagesAsRead: { _ in
             fail("\(Self.self).secureMarkMessagesAsRead")
             return .mock
+        },
+        downloadSecureFile: { _, _, _ in
+            fail("\(Self.self).downloadSecureFile")
+            return .mock
         }
     )
 }

--- a/GliaWidgetsTests/Lib/Download/FileDownload.Environment.Failing.swift
+++ b/GliaWidgetsTests/Lib/Download/FileDownload.Environment.Failing.swift
@@ -2,9 +2,11 @@
 
 extension FileDownload.Environment {
     static let failing = Self(
-        fetchFile: { _, _, _ in
-            fail("\(Self.self).fetchFile")
-        },
+        fetchFile: .fromEngagement(
+            { _, _, _ in
+                fail("\(Self.self).fetchFile")
+            }
+        ),
         fileManager: .failing,
         gcd: .failing,
         localFileThumbnailQueue: .failing,


### PR DESCRIPTION
Use dedicated endpoint for downloading files in secure messaging instead of the one that is currently used for engagement.

MOB-1994