### PR TITLE
Devs want to make app more testable through dependency injection

### DIFF
--- a/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
+++ b/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
@@ -39,7 +39,8 @@ extension Glia {
                 gcd: environment.gcd,
                 imageViewCache: environment.imageViewCache,
                 timerProviding: environment.timerProviding,
-                uiApplication: environment.uiApplication
+                uiApplication: environment.uiApplication,
+                uiScreen: environment.uiScreen
             )
         )
         startRootCoordinator(

--- a/GliaWidgets/SecureConversations/FileUploadListView/SecureConversations.FilePreviewView.swift
+++ b/GliaWidgets/SecureConversations/FileUploadListView/SecureConversations.FilePreviewView.swift
@@ -27,8 +27,10 @@ extension SecureConversations {
         private let imageView = UIImageView()
         private let label = UILabel()
         private let kSize = CGSize(width: 52, height: 52)
+        private let environment: Environment
 
-        init() {
+        init(environment: Environment) {
+            self.environment = environment
             self.props = Props(style: .initial, kind: .none)
             super.init(frame: .zero)
             setup()
@@ -128,7 +130,7 @@ extension SecureConversations {
                 let request = QLThumbnailGenerator.Request(
                     fileAt: file.url,
                     size: kSize,
-                    scale: UIScreen.main.scale,
+                    scale: environment.uiScreen.scale(),
                     representationTypes: .lowQualityThumbnail
                 )
                 QLThumbnailGenerator.shared.generateRepresentations(for: request) { representation, _, _ in
@@ -229,4 +231,10 @@ extension SecureConversations.FilePreviewView.Kind {
 
 private extension FilePreviewStyle {
     static let initial = FileUploadStyle.initial.filePreview
+}
+
+extension SecureConversations.FilePreviewView {
+    struct Environment {
+        var uiScreen: UIKitBased.UIScreen
+    }
 }

--- a/GliaWidgets/SecureConversations/FileUploadListView/SecureConversations.FileUploadListView.swift
+++ b/GliaWidgets/SecureConversations/FileUploadListView/SecureConversations.FileUploadListView.swift
@@ -22,13 +22,15 @@ extension SecureConversations {
             return stackView.arrangedSubviews.compactMap { $0 as? FileUploadView }
         }
 
+        private let environment: Environment
         private let scrollView = UIScrollView()
         private let stackView = UIStackView()
         private var heightLayoutConstraint: NSLayoutConstraint!
 
         var cachedViews = IdCollection<FileUploadView.Props.Identifier, FileUploadView>()
 
-        init() {
+        init(environment: Environment) {
+            self.environment = environment
             super.init(frame: .zero)
             setup()
             layout()
@@ -141,7 +143,10 @@ extension SecureConversations {
                     #endif
                     continue
                 }
-                let uploadView = FileUploadView(props: uploadViewProps)
+                let uploadView = FileUploadView(
+                    props: uploadViewProps,
+                    environment: .init(uiScreen: environment.uiScreen)
+                )
                 addUploadView(uploadView)
                 cachedViews.append(item: uploadView, identified: id)
             }
@@ -179,5 +184,11 @@ extension SecureConversations.FileUploadListView.Style {
                 spacing = 4
             }
         }
+    }
+}
+
+extension SecureConversations.FileUploadListView {
+    struct Environment {
+        var uiScreen: UIKitBased.UIScreen
     }
 }

--- a/GliaWidgets/SecureConversations/FileUploadListView/SecureConversations.FileUploadView.swift
+++ b/GliaWidgets/SecureConversations/FileUploadListView/SecureConversations.FileUploadView.swift
@@ -24,7 +24,7 @@ extension SecureConversations {
         private let contentView = UIView()
         private let infoLabel = UILabel()
         private let stateLabel = UILabel()
-        private let filePreviewView = FilePreviewView()
+        private let filePreviewView: FilePreviewView
         private let progressView = UIProgressView()
         let removeButton = UIButton()
 
@@ -36,7 +36,8 @@ extension SecureConversations {
             }
         }
 
-        init(props: Props) {
+        init(props: Props, environment: Environment) {
+            filePreviewView = .init(environment: .init(uiScreen: environment.uiScreen))
             self.props = props
             super.init(frame: .zero)
             setup()
@@ -406,5 +407,11 @@ extension SecureConversations.FileUploadView.Props {
                 self = .generic
             }
         }
+    }
+}
+
+extension SecureConversations.FileUploadView {
+    struct Environment {
+        var uiScreen: UIKitBased.UIScreen
     }
 }

--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
@@ -77,7 +77,11 @@ extension SecureConversations {
             let controller = SecureConversations.WelcomeViewController(
                 viewFactory: viewFactory,
                 props: viewModel.props(),
-                environment: .init(gcd: environment.gcd)
+                environment: .init(
+                    gcd: environment.gcd,
+                    uiScreen: environment.uiScreen,
+                    notificationCenter: environment.notificationCenter
+                )
             )
 
             viewModel.delegate = { [weak self, weak controller] event in
@@ -324,6 +328,8 @@ extension SecureConversations.Coordinator {
         var uiImage: UIKitBased.UIImage
         var uuid: () -> UUID
         var uiApplication: UIKitBased.UIApplication
+        var uiScreen: UIKitBased.UIScreen
+        var notificationCenter: FoundationBased.NotificationCenter
         var createFileUploadListModel: SecureConversations.FileUploadListViewModel.Create
         var viewFactory: ViewFactory
         var fetchFile: CoreSdkClient.FetchFile

--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeView.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeView.swift
@@ -7,6 +7,8 @@ extension SecureConversations {
     final class WelcomeView: BaseView {
         struct Environemnt {
             let gcd: GCD
+            let uiScreen: UIKitBased.UIScreen
+            let notificationCenter: FoundationBased.NotificationCenter
         }
         static let sideMargin = 24.0
         static let filePickerButtonSize = 44.0
@@ -121,7 +123,7 @@ extension SecureConversations {
                 stackView.spacing = 5
             }
 
-        let fileUploadListView = SecureConversations.FileUploadListView().makeView()
+        let fileUploadListView: FileUploadListView
         let environment: Environemnt
 
         // Since some of the reusable views require style
@@ -133,6 +135,7 @@ extension SecureConversations {
             self.header = Header(props: props.headerProps)
             self.props = props
             self.environment = environment
+            self.fileUploadListView = .init(environment: .init(uiScreen: environment.uiScreen)).makeView()
             super.init()
             // Hide warning stack initially.
             setWarningStackHidden(true)
@@ -773,7 +776,7 @@ extension SecureConversations.WelcomeView.MessageTextView: UITextViewDelegate {
 // MARK: - Keyboard handling in WelcomeView
 extension SecureConversations.WelcomeView {
     func subscribeToNotification(_ notification: NSNotification.Name, selector: Selector) {
-        NotificationCenter.default.addObserver(
+        environment.notificationCenter.addObserver(
             self,
             selector: selector,
             name: notification,

--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewController.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewController.swift
@@ -5,6 +5,8 @@ extension SecureConversations {
     final class WelcomeViewController: UIViewController {
         struct Environemnt {
             let gcd: GCD
+            let uiScreen: UIKitBased.UIScreen
+            let notificationCenter: FoundationBased.NotificationCenter
         }
         var props: Props {
             didSet {
@@ -51,7 +53,11 @@ extension SecureConversations {
             } else {
                 welcomeView = viewFactory.makeSecureConversationsWelcomeView(
                     props: props,
-                    environment: .init(gcd: environment.gcd)
+                    environment: .init(
+                        gcd: environment.gcd,
+                        uiScreen: environment.uiScreen,
+                        notificationCenter: environment.notificationCenter
+                    )
                 )
                 view = welcomeView
             }

--- a/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
+++ b/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
@@ -27,7 +27,8 @@ public final class CallVisualizer {
                 gcd: environment.gcd,
                 imageViewCache: environment.imageViewCache,
                 timerProviding: environment.timerProviding,
-                uiApplication: environment.uiApplication
+                uiApplication: environment.uiApplication,
+                uiScreen: environment.uiScreen
             )
         )
         return Coordinator(

--- a/GliaWidgets/Sources/CallVisualizer/VideoCall/Coordinator/VideoCallCoordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VideoCall/Coordinator/VideoCallCoordinator.swift
@@ -61,7 +61,10 @@ extension CallVisualizer {
             let viewController = VideoCallViewController(
                 props: viewModel.makeProps(),
                 environment: .init(
-                    videoCallView: .init(gcd: environment.gcd),
+                    videoCallView: .init(
+                        gcd: environment.gcd,
+                        uiScreen: environment.uiScreen
+                    ),
                     uiApplication: environment.uiApplication,
                     uiScreen: environment.uiScreen,
                     uiDevice: environment.uiDevice,

--- a/GliaWidgets/Sources/CallVisualizer/VideoCall/View/VideoCallView.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VideoCall/View/VideoCallView.swift
@@ -332,7 +332,7 @@ private extension CallVisualizer.VideoCallView {
 
     func setLocalVideoFrame(isVisible: Bool) {
         if isVisible {
-            let screenSize: CGRect = UIScreen.main.bounds
+            let screenSize: CGRect = environment.uiScreen.bounds()
 
             let size = CGSize(
                 width: screenSize.width * 0.3,
@@ -350,7 +350,7 @@ private extension CallVisualizer.VideoCallView {
     }
 
     func adjustLocalVideoFrameAfterOrientationChange() {
-        let screenSize: CGRect = UIScreen.main.bounds
+        let screenSize: CGRect = environment.uiScreen.bounds()
 
         let size = CGSize(
             width: screenSize.width * 0.3,
@@ -405,5 +405,6 @@ private extension CallVisualizer.VideoCallView {
 extension CallVisualizer.VideoCallView {
     struct Environment {
         let gcd: GCD
+        let uiScreen: UIKitBased.UIScreen
     }
 }

--- a/GliaWidgets/Sources/CallVisualizer/VideoCall/ViewModel/VideoCallViewModel.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VideoCall/ViewModel/VideoCallViewModel.swift
@@ -83,12 +83,12 @@ extension CallVisualizer {
             )
 
             if #available(iOS 13.0, *) {
-                let windows = UIApplication.shared.windows
+                let windows = environment.uiApplication.windows()
                 interfaceOrientation = windows.first(where: {
                     $0.isKeyWindow
                 })?.windowScene?.interfaceOrientation ?? .portrait
             } else {
-                interfaceOrientation = UIApplication.shared.statusBarOrientation
+                interfaceOrientation = environment.uiApplication.statusBarOrientation()
             }
 
             connectOperatorSize = .init(size: .normal, animated: true)
@@ -123,7 +123,7 @@ extension CallVisualizer {
                 self?.onScreenSharingStatusChange(status)
             }
 
-            NotificationCenter.default.addObserver(
+            environment.notificationCenter.addObserver(
                 self,
                 selector: #selector(handleDeviceOrientationDidChange),
                 name: UIDevice.orientationDidChangeNotification,
@@ -317,12 +317,12 @@ private extension CallVisualizer.VideoCallViewModel {
 
     func handleOrientationChange() {
         if #available(iOS 13.0, *) {
-            let windows = UIApplication.shared.windows
+            let windows = environment.uiApplication.windows()
             interfaceOrientation = windows.first(where: {
                 $0.isKeyWindow
             })?.windowScene?.interfaceOrientation ?? .portrait
         } else {
-            interfaceOrientation = UIApplication.shared.statusBarOrientation
+            interfaceOrientation = environment.uiApplication.statusBarOrientation()
         }
     }
 

--- a/GliaWidgets/Sources/Component/Bubble/BubbleWindow.swift
+++ b/GliaWidgets/Sources/Component/Bubble/BubbleWindow.swift
@@ -7,28 +7,35 @@ class BubbleWindow: UIWindow {
     }
     var tap: (() -> Void)?
 
+    private let environment: Environment
     private let bubbleView: BubbleView
     private let kSize = CGSize(width: 80, height: 80)
     private let kBubbleInset: CGFloat = 10
     private let kEdgeInset: CGFloat = 0
     private var initialFrame: CGRect {
-        let bounds = UIApplication.shared.windows.first?.frame ?? UIScreen.main.bounds
-        let safeAreaInsets = UIApplication.shared.windows.first?.safeAreaInsets ?? .zero
+        let bounds = environment.uiApplication.windows().first?.frame ?? environment.uiScreen.bounds()
+        let safeAreaInsets = environment.uiApplication.windows().first?.safeAreaInsets ?? .zero
         let origin = CGPoint(x: bounds.width - kSize.width - safeAreaInsets.right - kEdgeInset,
                              y: bounds.height - kSize.height - safeAreaInsets.bottom - kEdgeInset)
         return CGRect(origin: origin, size: kSize)
     }
 
     @available(iOS 13.0, *)
-    init(bubbleView: BubbleView, windowScene: UIWindowScene) {
+    init(
+        bubbleView: BubbleView,
+        environment: Environment,
+        windowScene: UIWindowScene
+    ) {
         self.bubbleView = bubbleView
+        self.environment = environment
         super.init(windowScene: windowScene)
         setup()
         layout()
     }
 
-    init(bubbleView: BubbleView) {
+    init(bubbleView: BubbleView, environment: Environment) {
         self.bubbleView = bubbleView
+        self.environment = environment
         super.init(frame: .zero)
         setup()
         layout()
@@ -63,8 +70,8 @@ class BubbleWindow: UIWindow {
                                   bottom: -kEdgeInset,
                                   right: -kEdgeInset)
         let insetFrame = frame.inset(by: insets)
-        let boundsInsets = UIApplication.shared.windows.first?.safeAreaInsets ?? .zero
-        let bounds = UIScreen.main.bounds.inset(by: boundsInsets)
+        let boundsInsets = environment.uiApplication.windows().first?.safeAreaInsets ?? .zero
+        let bounds = environment.uiScreen.bounds().inset(by: boundsInsets)
 
         if bounds.contains(insetFrame) {
             self.frame = frame
@@ -92,5 +99,12 @@ private class BubbleViewController: UIViewController {
         view.addSubview(bubbleView)
         bubbleView.autoPinEdgesToSuperviewEdges(
             with: UIEdgeInsets(top: edgeInset, left: edgeInset, bottom: edgeInset, right: edgeInset))
+    }
+}
+
+extension BubbleWindow {
+    struct Environment {
+        var uiScreen: UIKitBased.UIScreen
+        var uiApplication: UIKitBased.UIApplication
     }
 }

--- a/GliaWidgets/Sources/Component/ImageView/File/FilePreviewView.swift
+++ b/GliaWidgets/Sources/Component/ImageView/File/FilePreviewView.swift
@@ -19,9 +19,11 @@ class FilePreviewView: UIView {
     private let label = UILabel()
     private let style: FilePreviewStyle
     private let kSize = CGSize(width: 52, height: 52)
+    private let environment: Environment
 
-    init(with style: FilePreviewStyle) {
+    init(with style: FilePreviewStyle, environment: Environment) {
         self.style = style
+        self.environment = environment
         super.init(frame: .zero)
         setup()
         layout()
@@ -107,7 +109,7 @@ class FilePreviewView: UIView {
             let request = QLThumbnailGenerator.Request(
                 fileAt: file.url,
                 size: kSize,
-                scale: UIScreen.main.scale,
+                scale: environment.uiScreen.scale(),
                 representationTypes: .lowQualityThumbnail
             )
             QLThumbnailGenerator.shared.generateRepresentations(for: request) { representation, _, _ in
@@ -121,5 +123,11 @@ class FilePreviewView: UIView {
             let image = UIImage(contentsOfFile: file.url.path)?.resized(to: kSize)
             completion(image)
         }
+    }
+}
+
+extension FilePreviewView {
+    struct Environment {
+        var uiScreen: UIKitBased.UIScreen
     }
 }

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
@@ -149,7 +149,8 @@ extension EngagementCoordinator {
         let presentSurvey = { [weak self] (engagementId: String, survey: CoreSdkClient.Survey) in
             guard let self = self else { return }
             let viewController = Survey.ViewController(
-                viewFactory: self.viewFactory
+                viewFactory: self.viewFactory,
+                environment: .init(notificationCenter: self.environment.notificationCenter)
             )
             viewController.props = .live(
                 sdkSurvey: survey,
@@ -382,20 +383,32 @@ extension EngagementCoordinator {
                     bubbleView: bubbleView,
                     delegate: self,
                     sceneProvider: sceneProvider,
-                    features: features
+                    features: features,
+                    environment: .init(
+                        uiApplication: environment.uiApplication,
+                        uiScreen: environment.uiScreen
+                    )
                 )
             } else {
                 return GliaViewController(
                     bubbleView: bubbleView,
                     delegate: self,
-                    features: features
+                    features: features,
+                    environment: .init(
+                        uiApplication: environment.uiApplication,
+                        uiScreen: environment.uiScreen
+                    )
                 )
             }
         } else {
             return GliaViewController(
                 bubbleView: bubbleView,
                 delegate: self,
-                features: features
+                features: features,
+                environment: .init(
+                    uiApplication: environment.uiApplication,
+                    uiScreen: environment.uiScreen
+                )
             )
         }
     }
@@ -421,6 +434,8 @@ extension EngagementCoordinator {
                 uiImage: environment.uiImage,
                 uuid: environment.uuid,
                 uiApplication: environment.uiApplication,
+                uiScreen: environment.uiScreen,
+                notificationCenter: environment.notificationCenter,
                 createFileUploadListModel: environment.createFileUploadListModel,
                 viewFactory: viewFactory,
                 fetchFile: environment.fetchFile,

--- a/GliaWidgets/Sources/UIKitBased/UIKitBased.Interface.swift
+++ b/GliaWidgets/Sources/UIKitBased/UIKitBased.Interface.swift
@@ -11,6 +11,7 @@ enum UIKitBased {
         var preferredContentSizeCategory: () -> UIContentSizeCategory
         var isIdleTimerDisabled: (Bool) -> Void
         var windows: () -> [UIKit.UIWindow]
+        var statusBarOrientation: () -> UIInterfaceOrientation
     }
 
     struct UIDevice {
@@ -21,5 +22,7 @@ enum UIKitBased {
     struct UIScreen {
         var brightness: () -> CGFloat
         var setBrightness: (CGFloat) -> Void
+        var bounds: () -> CGRect
+        var scale: () -> CGFloat
     }
 }

--- a/GliaWidgets/Sources/UIKitBased/UIKitBased.Live.swift
+++ b/GliaWidgets/Sources/UIKitBased/UIKitBased.Live.swift
@@ -10,7 +10,8 @@ extension UIKitBased.UIApplication {
         canOpenURL: UIApplication.shared.canOpenURL,
         preferredContentSizeCategory: { UIApplication.shared.preferredContentSizeCategory },
         isIdleTimerDisabled: { UIApplication.shared.isIdleTimerDisabled = $0 },
-        windows: { UIApplication.shared.windows }
+        windows: { UIApplication.shared.windows },
+        statusBarOrientation: { UIApplication.shared.statusBarOrientation }
     )
 }
 
@@ -24,6 +25,8 @@ extension UIKitBased.UIDevice {
 extension UIKitBased.UIScreen {
     static let live = Self.init(
         brightness: { UIScreen.main.brightness },
-        setBrightness: { UIScreen.main.brightness = $0 }
+        setBrightness: { UIScreen.main.brightness = $0 },
+        bounds: { UIScreen.main.bounds },
+        scale: { UIScreen.main.scale }
     )
 }

--- a/GliaWidgets/Sources/UIKitBased/UIKitBased.Mock.swift
+++ b/GliaWidgets/Sources/UIKitBased/UIKitBased.Mock.swift
@@ -13,7 +13,8 @@ extension UIKitBased.UIApplication {
         canOpenURL: { _ in false },
         preferredContentSizeCategory: { .unspecified },
         isIdleTimerDisabled: { _ in },
-        windows: { .init() }
+        windows: { .init() },
+        statusBarOrientation: { .portrait }
     )
 }
 
@@ -35,7 +36,9 @@ extension UIKitBased.UIDevice {
 extension UIKitBased.UIScreen {
     static let mock = Self.init(
         brightness: { .init() },
-        setBrightness: { _ in }
+        setBrightness: { _ in },
+        bounds: { UIScreen.main.bounds },
+        scale: { .init() }
     )
 }
 #endif

--- a/GliaWidgets/Sources/View/Call/CallView.swift
+++ b/GliaWidgets/Sources/View/Call/CallView.swift
@@ -123,7 +123,8 @@ class CallView: EngagementView {
                 gcd: environment.gcd,
                 imageViewCache: environment.imageViewCache,
                 timerProviding: environment.timerProviding,
-                uiApplication: environment.uiApplication
+                uiApplication: environment.uiApplication,
+                uiScreen: environment.uiScreen
             ),
             headerProps: props.header
         )
@@ -403,13 +404,9 @@ class CallView: EngagementView {
 
     private func hideLandscapeBarsAfterDelay() {
         guard mode == .video else { return }
-        hideBarsWorkItem?.cancel()
-        let hideBarsWorkItem = DispatchWorkItem { self.hideLandscapeBars() }
-        self.hideBarsWorkItem = hideBarsWorkItem
-        DispatchQueue.main.asyncAfter(
-            deadline: .now() + kBarsHideDelay,
-            execute: hideBarsWorkItem
-        )
+        environment.gcd.mainQueue.asyncAfterDeadline(.now() + kBarsHideDelay) {
+            self.hideLandscapeBars()
+        }
     }
 
     @objc private func tap() {
@@ -426,7 +423,7 @@ class CallView: EngagementView {
 extension CallView {
     private func setLocalVideoFrame(isVisible: Bool) {
         if isVisible {
-            let screenSize: CGRect = UIScreen.main.bounds
+            let screenSize: CGRect = environment.uiScreen.bounds()
 
             let size = CGSize(
                 width: screenSize.width * 0.3,
@@ -444,7 +441,7 @@ extension CallView {
     }
 
     private func adjustLocalVideoFrameAfterOrientationChange() {
-        let screenSize: CGRect = UIScreen.main.bounds
+        let screenSize: CGRect = environment.uiScreen.bounds()
 
         let size = CGSize(
             width: screenSize.width * 0.3,
@@ -504,5 +501,6 @@ extension CallView {
         var imageViewCache: ImageView.Cache
         var timerProviding: FoundationBased.Timer.Providing
         var uiApplication: UIKitBased.UIApplication
+        var uiScreen: UIKitBased.UIScreen
     }
 }

--- a/GliaWidgets/Sources/View/Chat/ChatView.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatView.swift
@@ -66,7 +66,8 @@ class ChatView: EngagementView {
             with: style.messageEntry,
             environment: .init(
                 gcd: environment.gcd,
-                uiApplication: environment.uiApplication
+                uiApplication: environment.uiApplication,
+                uiScreen: environment.uiScreen
             )
         )
         self.unreadMessageIndicatorView = UnreadMessageIndicatorView(
@@ -93,7 +94,8 @@ class ChatView: EngagementView {
                 gcd: environment.gcd,
                 imageViewCache: environment.imageViewCache,
                 timerProviding: environment.timerProviding,
-                uiApplication: environment.uiApplication
+                uiApplication: environment.uiApplication,
+                uiScreen: environment.uiScreen
             ),
             headerProps: props.header
         )
@@ -307,7 +309,8 @@ extension ChatView {
             return .queueOperator(connectView)
         case .outgoingMessage(let message):
             let view = VisitorChatMessageView(
-                with: style.visitorMessage
+                with: style.visitorMessage,
+                environment: .init(uiScreen: environment.uiScreen)
             )
             view.appendContent(
                 .text(
@@ -332,7 +335,8 @@ extension ChatView {
             return .outgoingMessage(view)
         case .visitorMessage(let message, let status):
             let view = VisitorChatMessageView(
-                with: style.visitorMessage
+                with: style.visitorMessage,
+                environment: .init(uiScreen: environment.uiScreen)
             )
             view.appendContent(
                 .text(
@@ -498,7 +502,8 @@ extension ChatView {
                 data: environment.data,
                 uuid: environment.uuid,
                 gcd: environment.gcd,
-                imageViewCache: environment.imageViewCache
+                imageViewCache: environment.imageViewCache,
+                uiScreen: environment.uiScreen
             )
         )
         view.appendContent(
@@ -537,7 +542,8 @@ extension ChatView {
                 data: environment.data,
                 uuid: environment.uuid,
                 gcd: environment.gcd,
-                imageViewCache: environment.imageViewCache
+                imageViewCache: environment.imageViewCache,
+                uiScreen: environment.uiScreen
             )
         )
         let choiceCard = ChoiceCard(with: message, isActive: isActive)

--- a/GliaWidgets/Sources/View/Chat/Entry/ChatMessageEntryView.swift
+++ b/GliaWidgets/Sources/View/Chat/Entry/ChatMessageEntryView.swift
@@ -66,7 +66,9 @@ class ChatMessageEntryView: BaseView {
     ) {
         self.style = style
         self.environment = environment
-        uploadListView = SecureConversations.FileUploadListView()
+        uploadListView = SecureConversations.FileUploadListView(
+            environment: .init(uiScreen: environment.uiScreen)
+        )
         pickMediaButton = MessageButton(with: style.mediaButton)
         sendButton = MessageButton(with: style.sendButton)
         isChoiceCardModeEnabled = false
@@ -265,6 +267,7 @@ extension ChatMessageEntryView {
     struct Environment {
         var gcd: GCD
         var uiApplication: UIKitBased.UIApplication
+        var uiScreen: UIKitBased.UIScreen
     }
 }
 

--- a/GliaWidgets/Sources/View/Chat/Message/ChatMessageView.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/ChatMessageView.swift
@@ -8,13 +8,16 @@ class ChatMessageView: BaseView {
     var linkTapped: ((URL) -> Void)?
 
     private let contentAlignment: ChatMessageContentAlignment
+    private let environment: Environment
 
     init(
         with style: ChatMessageStyle,
-        contentAlignment: ChatMessageContentAlignment
+        contentAlignment: ChatMessageContentAlignment,
+        environment: Environment
     ) {
         self.style = style
         self.contentAlignment = contentAlignment
+        self.environment = environment
         super.init()
     }
 
@@ -107,6 +110,7 @@ class ChatMessageView: BaseView {
                     with: style.fileDownload,
                     content: .localFile(file),
                     accessibilityProperties: accessibilityProperties,
+                    environment: .init(uiScreen: environment.uiScreen),
                     tap: { [weak self] in self?.fileTapped?(file) }
                 )
             }
@@ -131,9 +135,16 @@ class ChatMessageView: BaseView {
                     with: style.fileDownload,
                     content: .download(download),
                     accessibilityProperties: accessibilityProperties,
+                    environment: .init(uiScreen: environment.uiScreen),
                     tap: { [weak self] in self?.downloadTapped?(download) }
                 )
             }
         }
+    }
+}
+
+extension ChatMessageView {
+    struct Environment {
+        var uiScreen: UIKitBased.UIScreen
     }
 }

--- a/GliaWidgets/Sources/View/Chat/Message/Content/ChoiceCard/ChoiceCardView.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/Content/ChoiceCard/ChoiceCardView.swift
@@ -18,7 +18,8 @@ final class ChoiceCardView: OperatorChatMessageView {
                 data: environment.data,
                 uuid: environment.uuid,
                 gcd: environment.gcd,
-                imageViewCache: environment.imageViewCache
+                imageViewCache: environment.imageViewCache,
+                uiScreen: environment.uiScreen
             )
         )
     }
@@ -108,6 +109,7 @@ extension ChoiceCardView {
         var uuid: () -> UUID
         var gcd: GCD
         var imageViewCache: ImageView.Cache
+        var uiScreen: UIKitBased.UIScreen
     }
 }
 

--- a/GliaWidgets/Sources/View/Chat/Message/Content/File/Download/ChatFileDownloadContentView.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/Content/File/Download/ChatFileDownloadContentView.swift
@@ -13,10 +13,14 @@ class ChatFileDownloadContentView: ChatFileContentView {
         with style: ChatFileDownloadStyle,
         content: Content,
         accessibilityProperties: ChatFileContentView.AccessibilityProperties,
+        environment: Environment,
         tap: @escaping () -> Void
     ) {
         self.style = style
-        self.filePreviewView = FilePreviewView(with: style.filePreview)
+        self.filePreviewView = FilePreviewView(
+            with: style.filePreview,
+            environment: .init(uiScreen: environment.uiScreen)
+        )
         super.init(
             with: style,
             content: content,
@@ -232,4 +236,10 @@ class ChatFileDownloadContentView: ChatFileContentView {
         }
     }
     // swiftlint:enable function_body_length
+}
+
+extension ChatFileDownloadContentView {
+    struct Environment {
+        var uiScreen: UIKitBased.UIScreen
+    }
 }

--- a/GliaWidgets/Sources/View/Chat/Message/OperatorChatMessageView.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/OperatorChatMessageView.swift
@@ -39,7 +39,8 @@ class OperatorChatMessageView: ChatMessageView {
         self.environment = environment
         super.init(
             with: style,
-            contentAlignment: .left
+            contentAlignment: .left,
+            environment: .init(uiScreen: environment.uiScreen)
         )
         setup()
         layout()
@@ -77,5 +78,6 @@ extension OperatorChatMessageView {
         var uuid: () -> UUID
         var gcd: GCD
         var imageViewCache: ImageView.Cache
+        var uiScreen: UIKitBased.UIScreen
     }
 }

--- a/GliaWidgets/Sources/View/Chat/Message/VisitorChatMessageView.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/VisitorChatMessageView.swift
@@ -10,11 +10,13 @@ class VisitorChatMessageView: ChatMessageView {
     private let kInsets = UIEdgeInsets(top: 2, left: 88, bottom: 2, right: 16)
 
     init(
-        with style: VisitorChatMessageStyle
+        with style: VisitorChatMessageStyle,
+        environment: Environment
     ) {
         super.init(
             with: style,
-            contentAlignment: .right
+            contentAlignment: .right,
+            environment: .init(uiScreen: environment.uiScreen)
         )
 
         setup(style: style)

--- a/GliaWidgets/Sources/View/EngagementView.swift
+++ b/GliaWidgets/Sources/View/EngagementView.swift
@@ -54,5 +54,6 @@ extension EngagementView {
         var imageViewCache: ImageView.Cache
         var timerProviding: FoundationBased.Timer.Providing
         var uiApplication: UIKitBased.UIApplication
+        var uiScreen: UIKitBased.UIScreen
     }
 }

--- a/GliaWidgets/Sources/ViewController/GliaViewController.Mock.swift
+++ b/GliaWidgets/Sources/ViewController/GliaViewController.Mock.swift
@@ -8,7 +8,11 @@ extension GliaViewController {
         .init(
             bubbleView: bubbleView,
             delegate: delegate,
-            features: features
+            features: features,
+            environment: .init(
+                uiApplication: .mock,
+                uiScreen: .mock
+            )
         )
     }
 }

--- a/GliaWidgets/Sources/ViewController/GliaViewController.swift
+++ b/GliaWidgets/Sources/ViewController/GliaViewController.swift
@@ -20,15 +20,18 @@ class GliaViewController: UIViewController {
     private var sceneProvider: SceneProvider?
     private var animationImageView: UIImageView?
     private let features: Features
+    private let environment: Environment
 
     init(
         bubbleView: BubbleView,
         delegate: GliaViewControllerDelegate?,
-        features: Features
+        features: Features,
+        environment: Environment
     ) {
         self.bubbleView = bubbleView
         self.delegate = delegate
         self.features = features
+        self.environment = environment
         super.init(nibName: nil, bundle: nil)
         setup()
     }
@@ -38,12 +41,14 @@ class GliaViewController: UIViewController {
         bubbleView: BubbleView?,
         delegate: GliaViewControllerDelegate?,
         sceneProvider: SceneProvider,
-        features: Features
+        features: Features,
+        environment: Environment
     ) {
         self.bubbleView = bubbleView
         self.delegate = delegate
         self.sceneProvider = sceneProvider
         self.features = features
+        self.environment = environment
         super.init(nibName: nil, bundle: nil)
         setup()
     }
@@ -114,13 +119,29 @@ class GliaViewController: UIViewController {
             if let windowScene = windowScene() {
                 return BubbleWindow(
                     bubbleView: bubbleView,
+                    environment: .init(
+                        uiScreen: environment.uiScreen,
+                        uiApplication: environment.uiApplication
+                    ),
                     windowScene: windowScene
                 )
             } else {
-                return BubbleWindow(bubbleView: bubbleView)
+                return BubbleWindow(
+                    bubbleView: bubbleView,
+                    environment: .init(
+                        uiScreen: environment.uiScreen,
+                        uiApplication: environment.uiApplication
+                    )
+                )
             }
         } else {
-            return BubbleWindow(bubbleView: bubbleView)
+            return BubbleWindow(
+                bubbleView: bubbleView,
+                environment: .init(
+                    uiScreen: environment.uiScreen,
+                    uiApplication: environment.uiApplication
+                )
+            )
         }
     }
 
@@ -159,5 +180,12 @@ extension GliaViewController: UIViewControllerTransitioningDelegate {
             originCenterPoint: bubbleWindow?.center ?? view.center,
             transitionMode: .dismiss
         )
+    }
+}
+
+extension GliaViewController {
+    struct Environment {
+        var uiApplication: UIKitBased.UIApplication
+        var uiScreen: UIKitBased.UIScreen
     }
 }

--- a/GliaWidgets/Sources/ViewController/Survey/SurveyViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Survey/SurveyViewController.swift
@@ -26,6 +26,7 @@ extension Survey {
         }
 
         let viewFactory: ViewFactory
+        private let environment: Environment
 
         var props: Props {
             didSet { render() }
@@ -36,9 +37,11 @@ extension Survey {
 
         init(
             viewFactory: ViewFactory,
+            environment: Environment,
             props: Props = .init()
         ) {
             self.viewFactory = viewFactory
+            self.environment = environment
             self.props = props
             self.theme = viewFactory.theme
             super.init(nibName: nil, bundle: nil)
@@ -145,7 +148,7 @@ extension Survey.QuestionPropsProtocol {
 
 extension Survey.ViewController {
     func subscribeToNotification(_ notification: NSNotification.Name, selector: Selector) {
-        NotificationCenter.default.addObserver(
+        environment.notificationCenter.addObserver(
             self,
             selector: selector,
             name: notification,
@@ -177,5 +180,11 @@ extension Survey.ViewController {
                 self.view.layoutIfNeeded()
             }
         }
+    }
+}
+
+extension Survey.ViewController {
+    struct Environment {
+        var notificationCenter: FoundationBased.NotificationCenter
     }
 }

--- a/GliaWidgets/Sources/ViewFactory/ViewFactory.Environment.Interface.swift
+++ b/GliaWidgets/Sources/ViewFactory/ViewFactory.Environment.Interface.swift
@@ -8,5 +8,6 @@ extension ViewFactory {
         var imageViewCache: ImageView.Cache
         var timerProviding: FoundationBased.Timer.Providing
         var uiApplication: UIKitBased.UIApplication
+        var uiScreen: UIKitBased.UIScreen
     }
 }

--- a/GliaWidgets/Sources/ViewFactory/ViewFactory.Environment.Mock.swift
+++ b/GliaWidgets/Sources/ViewFactory/ViewFactory.Environment.Mock.swift
@@ -6,7 +6,8 @@ extension ViewFactory.Environment {
         gcd: .mock,
         imageViewCache: .mock,
         timerProviding: .mock,
-        uiApplication: .mock
+        uiApplication: .mock,
+        uiScreen: .mock
     )
 }
 #endif

--- a/GliaWidgets/Sources/ViewFactory/ViewFactory.swift
+++ b/GliaWidgets/Sources/ViewFactory/ViewFactory.swift
@@ -30,7 +30,8 @@ class ViewFactory {
                 gcd: environment.gcd,
                 imageViewCache: environment.imageViewCache,
                 timerProviding: environment.timerProviding,
-                uiApplication: environment.uiApplication
+                uiApplication: environment.uiApplication,
+                uiScreen: environment.uiScreen
             ),
             props: Self.chatHeaderProps(
                 theme: theme,
@@ -78,7 +79,8 @@ class ViewFactory {
                 gcd: environment.gcd,
                 imageViewCache: environment.imageViewCache,
                 timerProviding: environment.timerProviding,
-                uiApplication: environment.uiApplication
+                uiApplication: environment.uiApplication,
+                uiScreen: environment.uiScreen
             ),
             props: Self.callHeaderProps(
                 theme: theme,

--- a/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/VIdeoCallView.Environment.Mock.swift
+++ b/GliaWidgetsTests/CallVisualizer/VideoCall/Mocks/VIdeoCallView.Environment.Mock.swift
@@ -3,7 +3,7 @@
 import Foundation
 
 extension CallVisualizer.VideoCallView.Environment {
-    static let mock = Self(gcd: .mock)
+    static let mock = Self(gcd: .mock, uiScreen: .mock)
 }
 
 #endif

--- a/GliaWidgetsTests/Factory/ViewFactory.Environment.Failing.swift
+++ b/GliaWidgetsTests/Factory/ViewFactory.Environment.Failing.swift
@@ -10,6 +10,7 @@ extension ViewFactory.Environment {
         gcd: .failing,
         imageViewCache: .failing,
         timerProviding: .failing,
-        uiApplication: .failing
+        uiApplication: .failing,
+        uiScreen: .failing
     )
 }

--- a/GliaWidgetsTests/UIKitBased.Failing.swift
+++ b/GliaWidgetsTests/UIKitBased.Failing.swift
@@ -28,6 +28,10 @@ extension UIKitBased.UIApplication {
         windows: {
             fail("\(Self.self).window")
             return []
+        },
+        statusBarOrientation: {
+            fail("\(Self.self).statusBarOrientation")
+            return .portrait
         }
     )
 }
@@ -41,6 +45,14 @@ extension UIKitBased.UIScreen {
         setBrightness: { _ in
             fail("\(Self.self).setBrightness")
             return
+        },
+        bounds: {
+            fail("\(Self.self).bounds")
+            return CGRect()
+        },
+        scale: {
+            fail("\(Self.self).scale")
+            return 0.0
         }
     )
 }

--- a/SnapshotTests/SecureConversationsWelcomeScreenTests.swift
+++ b/SnapshotTests/SecureConversationsWelcomeScreenTests.swift
@@ -14,7 +14,7 @@ class SecureConversationsWelcomeScreenTests: SnapshotTestCase {
         let viewController = SecureConversations.WelcomeViewController(
             viewFactory: .mock(theme: theme, messageRenderer: nil, environment: .mock),
             props: .welcome(props),
-            environment: .init(gcd: .live)
+            environment: .init(gcd: .live, uiScreen: .mock, notificationCenter: .mock)
         )
         viewController.view.frame = UIScreen.main.bounds
 
@@ -36,7 +36,7 @@ class SecureConversationsWelcomeScreenTests: SnapshotTestCase {
         let viewController = SecureConversations.WelcomeViewController(
             viewFactory: .mock(theme: theme, messageRenderer: nil, environment: .mock),
             props: .welcome(props),
-            environment: .init(gcd: .live)
+            environment: .init(gcd: .live, uiScreen: .mock, notificationCenter: .mock)
         )
         viewController.view.frame = UIScreen.main.bounds
 
@@ -52,7 +52,7 @@ class SecureConversationsWelcomeScreenTests: SnapshotTestCase {
         let viewController = SecureConversations.WelcomeViewController(
             viewFactory: .mock(theme: theme, messageRenderer: nil, environment: .mock),
             props: .welcome(props),
-            environment: .init(gcd: .live)
+            environment: .init(gcd: .live, uiScreen: .mock, notificationCenter: .mock)
         )
         viewController.view.frame = UIScreen.main.bounds
 

--- a/SnapshotTests/SurveyViewControllerVoiceOverTests.swift
+++ b/SnapshotTests/SurveyViewControllerVoiceOverTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 class SurveyViewControllerVoiceOverTests: SnapshotTestCase {
     func test_emptySurvey() {
-        let viewController = Survey.ViewController(viewFactory: .mock(), props: .emptyPropsMock())
+        let viewController = Survey.ViewController(viewFactory: .mock(), environment: .init(notificationCenter: .mock), props: .emptyPropsMock())
         viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
@@ -15,7 +15,7 @@ class SurveyViewControllerVoiceOverTests: SnapshotTestCase {
     }
 
     func test_filledSurvey() {
-        let viewController = Survey.ViewController(viewFactory: .mock(), props: .filledPropsMock())
+        let viewController = Survey.ViewController(viewFactory: .mock(), environment: .init(notificationCenter: .mock), props: .filledPropsMock())
         viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
@@ -25,7 +25,7 @@ class SurveyViewControllerVoiceOverTests: SnapshotTestCase {
     }
 
     func test_emptySurveyErrorState() {
-        let viewController = Survey.ViewController(viewFactory: .mock(), props: .errorPropsMock())
+        let viewController = Survey.ViewController(viewFactory: .mock(), environment: .init(notificationCenter: .mock), props: .errorPropsMock())
         viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,


### PR DESCRIPTION
WidgetSDK uses various components, such as NotificationCenter, UIApplication, UIDevice etc. But they are declared within views and view models, making it hard to test them. This PR make mocking available.

MOB-1995