### PR TITLE
Fix set of issues related to upgrade from secure transcript to chat

### DIFF
--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
@@ -281,7 +281,8 @@ extension SecureConversations.Coordinator {
                 messagesWithUnreadCountLoaderScheduler: environment.messagesWithUnreadCountLoaderScheduler,
                 secureMarkMessagesAsRead: environment.secureMarkMessagesAsRead,
                 downloadSecureFile: environment.downloadSecureFile,
-                isAuthenticated: environment.isAuthenticated
+                isAuthenticated: environment.isAuthenticated,
+                interactor: environment.interactor
             ),
             startWithSecureTranscriptFlow: true
         )

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
@@ -29,5 +29,6 @@ extension ChatCoordinator {
         var secureMarkMessagesAsRead: CoreSdkClient.SecureMarkMessagesAsRead
         var downloadSecureFile: CoreSdkClient.DownloadSecureFile
         var isAuthenticated: () -> Bool
+        var interactor: Interactor
     }
 }

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
@@ -281,7 +281,7 @@ extension ChatCoordinator {
                 )
             case .pickFile(let pickerEvent):
                 self?.presentFilePickerController(with: pickerEvent)
-            case let .awaitUpgradeToChatEngagement(transcriptModel):
+            case let .upgradeToChatEngagement(transcriptModel):
                 guard let self, let controller = controller() else {
                     return
                 }
@@ -321,7 +321,8 @@ extension ChatCoordinator {
            fetchSiteConfigurations: environment.fetchSiteConfigurations,
            getSecureUnreadMessageCount: environment.getSecureUnreadMessageCount,
            messagesWithUnreadCountLoaderScheduler: environment.messagesWithUnreadCountLoaderScheduler,
-           secureMarkMessagesAsRead: environment.secureMarkMessagesAsRead
+           secureMarkMessagesAsRead: environment.secureMarkMessagesAsRead,
+           interactor: environment.interactor
        )
     }
 }

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
@@ -237,7 +237,8 @@ extension EngagementCoordinator {
                 messagesWithUnreadCountLoaderScheduler: environment.messagesWithUnreadCountLoaderScheduler,
                 secureMarkMessagesAsRead: environment.secureMarkMessagesAsRead,
                 downloadSecureFile: environment.downloadSecureFile,
-                isAuthenticated: environment.isAuthenticated
+                isAuthenticated: environment.isAuthenticated,
+                interactor: interactor
             ),
             startWithSecureTranscriptFlow: false
         )

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.SecureConverstaions.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.SecureConverstaions.swift
@@ -2,7 +2,9 @@ extension ChatViewModel {
     func migrate(from transcript: SecureConversations.TranscriptModel) {
         sections = transcript.sections
         isViewLoaded = transcript.isViewLoaded
-        enqueue(mediaType: .text)
+        // Keep state of view-model in sync with Interactor.
+        interactorEvent(.stateChanged(interactor.state))
+        action?(.scrollToBottom(animated: true))
         // Set view active, to avoid unread message button
         // to be shown.
         isViewActive.value = true

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -501,10 +501,13 @@ extension ChatViewModel {
 
             pendingMessages.append(pendingMessage)
 
-            let queueItem = ChatItem(kind: .queueOperator)
+            // Avoid showing enqueud operator according to parameter.
+            if !shouldSkipEnqueueingState {
+                let queueItem = ChatItem(kind: .queueOperator)
+                queueOperatorSection.set([queueItem])
+                action?(.refreshSection(queueOperatorSection.index))
+            }
 
-            queueOperatorSection.set([queueItem])
-            action?(.refreshSection(2))
             action?(.scrollToBottom(animated: true))
         }
     }


### PR DESCRIPTION
These changes address the following issues:
   * Sending a message from welcome screen and navigating to chat transcript doesn't show operator messages (MOB-2002)
   * Queue ticket gets cancelled when sending a message from secure conversations chat transcript (MOB-1990)
   * Incorrect message positioning when sending multiple messages before starting engagement (MOB-2018)
   * Secure messaging flow does not work in case of restored engagement

The key point is to evaluate `InteractorState` and based on that do enqueueing, upgrading etc.

MOB-2002