### PR TITLE
Fix incorrect message when opening SC while unauthenticated

### DIFF
--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.swift
@@ -76,7 +76,7 @@ extension SecureConversations {
                     )
                 case .success(.unavailable(.unauthenticated)):
                     self.availabilityStatus = .unavailable(.unauthenticated)
-                    let configuration = self.environment.alertConfiguration.unavailableMessageCenter
+                    let configuration = self.environment.alertConfiguration.unavailableMessageCenterForBeingUnauthenticated
                     self.delegate?(
                         .showAlertAsView(
                             configuration,


### PR DESCRIPTION
Everything was correct, but the configuration sent to the alert was the same as the one that is shown when secure conversations are unavailable because the queue doesn't support it.

MOB-2032