### PR TITLE
Fix for counting messages only from operator as unread

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -442,6 +442,7 @@
 		AF3D520B2983235C00AD8E69 /* FileUploader.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D520A2983235C00AD8E69 /* FileUploader.Mock.swift */; };
 		AF3D520D2983B3DD00AD8E69 /* FileUploader.Environment.Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D520C2983B3DD00AD8E69 /* FileUploader.Environment.Interface.swift */; };
 		AF3D520F2983BC5600AD8E69 /* FileUploader.Environment.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D520E2983BC5600AD8E69 /* FileUploader.Environment.Mock.swift */; };
+		AF4D821C29D6E572007763F8 /* TranscriptModel.dividedChatItemsForUnreadCountTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4D821B29D6E572007763F8 /* TranscriptModel.dividedChatItemsForUnreadCountTests.swift */; };
 		AF6AB34B2989517100003645 /* FileUploader.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6AB34A2989517100003645 /* FileUploader.Failing.swift */; };
 		AF6AB34D298A9F2500003645 /* SecureConversations.FileUploadListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6AB34C298A9F2500003645 /* SecureConversations.FileUploadListViewModel.swift */; };
 		AF6AB34F298AA02400003645 /* SecureConversations.FileUploadListViewModel.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6AB34E298AA02400003645 /* SecureConversations.FileUploadListViewModel.Environment.swift */; };
@@ -1048,6 +1049,7 @@
 		AF3D520A2983235C00AD8E69 /* FileUploader.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploader.Mock.swift; sourceTree = "<group>"; };
 		AF3D520C2983B3DD00AD8E69 /* FileUploader.Environment.Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploader.Environment.Interface.swift; sourceTree = "<group>"; };
 		AF3D520E2983BC5600AD8E69 /* FileUploader.Environment.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploader.Environment.Mock.swift; sourceTree = "<group>"; };
+		AF4D821B29D6E572007763F8 /* TranscriptModel.dividedChatItemsForUnreadCountTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptModel.dividedChatItemsForUnreadCountTests.swift; sourceTree = "<group>"; };
 		AF6AB34A2989517100003645 /* FileUploader.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploader.Failing.swift; sourceTree = "<group>"; };
 		AF6AB34C298A9F2500003645 /* SecureConversations.FileUploadListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FileUploadListViewModel.swift; sourceTree = "<group>"; };
 		AF6AB34E298AA02400003645 /* SecureConversations.FileUploadListViewModel.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FileUploadListViewModel.Environment.swift; sourceTree = "<group>"; };
@@ -2895,6 +2897,7 @@
 			isa = PBXGroup;
 			children = (
 				AFEF5C7329929A8D005C3D8D /* SecureConversations.FileUploadListViewModel.Environment.Failing.swift */,
+				AF4D821B29D6E572007763F8 /* TranscriptModel.dividedChatItemsForUnreadCountTests.swift */,
 			);
 			path = SecureConversations;
 			sourceTree = "<group>";
@@ -4042,6 +4045,7 @@
 				C096B40B297EBDE400F0C552 /* VisitorCodeTests.swift in Sources */,
 				9ACC25D427B474E800BC5335 /* Glia.Environment.Failing.swift in Sources */,
 				9A8130C227D9095200220BBD /* FileDownload.Failing.swift in Sources */,
+				AF4D821C29D6E572007763F8 /* TranscriptModel.dividedChatItemsForUnreadCountTests.swift in Sources */,
 				9A19927027D3BCAE00161AAE /* GCD.Failing.swift in Sources */,
 				9A8130C427D9099F00220BBD /* FileDownload.Environment.Failing.swift in Sources */,
 				7512A5A727C3926500319DF1 /* GliaTests.swift in Sources */,

--- a/GliaWidgetsTests/SecureConversations/TranscriptModel.dividedChatItemsForUnreadCountTests.swift
+++ b/GliaWidgetsTests/SecureConversations/TranscriptModel.dividedChatItemsForUnreadCountTests.swift
@@ -1,0 +1,226 @@
+@testable import GliaWidgets
+import XCTest
+
+final class SecureConversationsTranscriptModelTests: XCTestCase {
+    // Since ChatItem does not conform to Equatable,
+    // one of the ways to evaluate if it is the exact
+    // item is by doing identity check.
+    // We declare items to be checked here in order to
+    // reuse them for different cases.
+    let divider = ChatItem(kind: .unreadMessageDivider)
+    let operatorMessage = ChatItem(kind: .operatorMessage(.mock(), showsImage: false, imageUrl: nil))
+    let visitorMessage = ChatItem(kind: .visitorMessage(.mock(), status: ""))
+
+    func testDividerTakesIntoAccountOnlyOperatorMessages() {
+        let unreadCount = 1
+
+        let messageItems: [ChatItem] = [
+         visitorMessage,
+         visitorMessage,
+         visitorMessage,
+         visitorMessage,
+         visitorMessage,
+         visitorMessage,
+         visitorMessage,
+         visitorMessage,
+         visitorMessage,
+         visitorMessage,
+         visitorMessage,
+         visitorMessage,
+         operatorMessage,
+         visitorMessage,
+        ]
+
+        let expected = [
+            visitorMessage,
+            visitorMessage,
+            visitorMessage,
+            visitorMessage,
+            visitorMessage,
+            visitorMessage,
+            visitorMessage,
+            visitorMessage,
+            visitorMessage,
+            visitorMessage,
+            visitorMessage,
+            visitorMessage,
+            divider,
+            operatorMessage,
+            visitorMessage,
+        ]
+
+        let result = SecureConversations.TranscriptModel.dividedChatItemsForUnreadCount(
+            chatItems: messageItems,
+            unreadCount: unreadCount,
+            divider: divider
+        )
+
+        XCTAssertEqual(result.map(describe), expected.map(describe))
+    }
+
+    func testDividerIsPlacedAtStart() {
+        let unreadCount = 6
+
+        let messageItems: [ChatItem] = [
+         operatorMessage,
+         operatorMessage,
+         operatorMessage,
+         operatorMessage,
+         operatorMessage,
+         visitorMessage,
+         visitorMessage,
+         operatorMessage
+        ]
+
+        let expected = [
+            divider,
+            operatorMessage,
+            operatorMessage,
+            operatorMessage,
+            operatorMessage,
+            operatorMessage,
+            visitorMessage,
+            visitorMessage,
+            operatorMessage,
+        ]
+
+        let result = SecureConversations.TranscriptModel.dividedChatItemsForUnreadCount(
+            chatItems: messageItems,
+            unreadCount: unreadCount,
+            divider: divider
+        )
+
+        XCTAssertEqual(result.map(describe), expected.map(describe))
+    }
+
+    func testDividerIsPlacedInTheMiddle() {
+        let unreadCount = 3
+        let messageItems: [ChatItem] = [
+         operatorMessage,
+         operatorMessage,
+         operatorMessage,
+         operatorMessage,
+         operatorMessage,
+         visitorMessage,
+         visitorMessage,
+         operatorMessage
+        ]
+
+        let expected = [
+            operatorMessage,
+            operatorMessage,
+            operatorMessage,
+            divider,
+            operatorMessage,
+            operatorMessage,
+            visitorMessage,
+            visitorMessage,
+            operatorMessage
+        ]
+
+        let result = SecureConversations.TranscriptModel.dividedChatItemsForUnreadCount(
+            chatItems: messageItems,
+            unreadCount: unreadCount,
+            divider: divider
+        )
+
+        XCTAssertEqual(result.map(describe), expected.map(describe))
+    }
+
+    func testDividerRespectsMessageListSize() {
+        let unreadCount = Int.max
+        let messageItems: [ChatItem] = [
+         operatorMessage,
+         operatorMessage,
+         operatorMessage,
+         operatorMessage,
+         operatorMessage,
+         visitorMessage,
+         visitorMessage,
+         operatorMessage
+        ]
+
+        let expected = [
+            divider,
+            operatorMessage,
+            operatorMessage,
+            operatorMessage,
+            operatorMessage,
+            operatorMessage,
+            visitorMessage,
+            visitorMessage,
+            operatorMessage
+        ]
+
+        let result = SecureConversations.TranscriptModel.dividedChatItemsForUnreadCount(
+            chatItems: messageItems,
+            unreadCount: unreadCount,
+            divider: divider
+        )
+
+        XCTAssertEqual(result.map(describe), expected.map(describe))
+    }
+
+    func testDividerIsNotAddedForZeroUnreadCount() {
+        let unreadCount = 0
+        let messageItems: [ChatItem] = [
+         operatorMessage,
+         operatorMessage,
+         operatorMessage,
+         operatorMessage,
+         operatorMessage,
+         visitorMessage,
+         visitorMessage,
+         operatorMessage
+        ]
+
+        let expected = messageItems
+
+        let result = SecureConversations.TranscriptModel.dividedChatItemsForUnreadCount(
+            chatItems: messageItems,
+            unreadCount: unreadCount,
+            divider: divider
+        )
+
+        XCTAssertEqual(result.map(describe), expected.map(describe))
+    }
+
+    func testDividerIsNotAddedForNegativeUnreadCount() {
+        let unreadCount = Int.min
+        let messageItems: [ChatItem] = [
+         operatorMessage,
+         operatorMessage,
+         operatorMessage,
+         operatorMessage,
+         operatorMessage,
+         visitorMessage,
+         visitorMessage,
+         operatorMessage
+        ]
+
+        let expected = messageItems
+
+        let result = SecureConversations.TranscriptModel.dividedChatItemsForUnreadCount(
+            chatItems: messageItems,
+            unreadCount: unreadCount,
+            divider: divider
+        )
+
+        XCTAssertEqual(result.map(describe), expected.map(describe))
+    }
+
+    /// Returns simplified representation of ChatItem to ease
+    /// its comparison in tests, specifically in equality assertions, where
+    /// o - operator message, v - visitor message, --- - divider.
+    func describe(_ item: ChatItem) -> String {
+        if item === operatorMessage {
+            return "o"
+        } else if item === visitorMessage {
+            return "v"
+        } else if item === divider {
+            return "---"
+        } else {
+            return ""
+        }
+    }
+}


### PR DESCRIPTION
Initially unread messages divider was placed incorrectly when there were visitor messages in the mix. These changes address the issue by only counting messages from operator as unread.

MOB-2031