### PR TITLE
Choose download endpoint based on supplied URL

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -442,6 +442,7 @@
 		AF29810B29E0478E0005BD55 /* TranscriptModel.Environment.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF29810A29E0478E0005BD55 /* TranscriptModel.Environment.Failing.swift */; };
 		AF29811029E06E830005BD55 /* Availability.Environment.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF29810F29E06E830005BD55 /* Availability.Environment.Failing.swift */; };
 		AF29811229E42F3C0005BD55 /* AvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF29811129E42F3C0005BD55 /* AvailabilityTests.swift */; };
+		AF29811529E6D76A0005BD55 /* FileDownloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF29811429E6D76A0005BD55 /* FileDownloadTests.swift */; };
 		AF39330B29B2A6A00008B60D /* ChatViewModel.SecureConverstaions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF39330A29B2A6A00008B60D /* ChatViewModel.SecureConverstaions.swift */; };
 		AF3D520B2983235C00AD8E69 /* FileUploader.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D520A2983235C00AD8E69 /* FileUploader.Mock.swift */; };
 		AF3D520D2983B3DD00AD8E69 /* FileUploader.Environment.Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D520C2983B3DD00AD8E69 /* FileUploader.Environment.Interface.swift */; };
@@ -1053,6 +1054,7 @@
 		AF29810A29E0478E0005BD55 /* TranscriptModel.Environment.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptModel.Environment.Failing.swift; sourceTree = "<group>"; };
 		AF29810F29E06E830005BD55 /* Availability.Environment.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Availability.Environment.Failing.swift; sourceTree = "<group>"; };
 		AF29811129E42F3C0005BD55 /* AvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailabilityTests.swift; sourceTree = "<group>"; };
+		AF29811429E6D76A0005BD55 /* FileDownloadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDownloadTests.swift; sourceTree = "<group>"; };
 		AF39330A29B2A6A00008B60D /* ChatViewModel.SecureConverstaions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.SecureConverstaions.swift; sourceTree = "<group>"; };
 		AF3D520A2983235C00AD8E69 /* FileUploader.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploader.Mock.swift; sourceTree = "<group>"; };
 		AF3D520C2983B3DD00AD8E69 /* FileUploader.Environment.Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploader.Environment.Interface.swift; sourceTree = "<group>"; };
@@ -2309,6 +2311,7 @@
 			isa = PBXGroup;
 			children = (
 				7512A57627BE8A6700319DF1 /* InteractorTests.swift */,
+				AF29811429E6D76A0005BD55 /* FileDownloadTests.swift */,
 				7512A57927BF9FCD00319DF1 /* ChatViewModelTests.swift */,
 				7512A5A627C3926500319DF1 /* GliaTests.swift */,
 				EB9ADB50280EBD4E00FAE8A4 /* InteractorStateTests.swift */,
@@ -4055,6 +4058,7 @@
 				EB03B00E27FFF6DD0058F6B1 /* CallViewTests.swift in Sources */,
 				AF29810929E045CE0005BD55 /* TranscriptModelTests.swift in Sources */,
 				7512A57727BE8A6700319DF1 /* InteractorTests.swift in Sources */,
+				AF29811529E6D76A0005BD55 /* FileDownloadTests.swift in Sources */,
 				C096B40B297EBDE400F0C552 /* VisitorCodeTests.swift in Sources */,
 				9ACC25D427B474E800BC5335 /* Glia.Environment.Failing.swift in Sources */,
 				9A8130C227D9095200220BBD /* FileDownload.Failing.swift in Sources */,

--- a/GliaWidgets/SecureConversations/SecureConversations.ChatWithTranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.ChatWithTranscriptModel.swift
@@ -351,7 +351,8 @@ extension SecureConversations {
             self.environment = environment
             self.downloader = FileDownloader(
                 environment: .init(
-                    fetchFile: .fromSecureMessaging(environment.fetchFile),
+                    fetchFile: environment.fetchFile,
+                    downloadSecureFile: environment.downloadSecureFile,
                     fileManager: environment.fileManager,
                     data: environment.data,
                     date: environment.date,
@@ -803,7 +804,8 @@ extension SecureConversations {
 
 extension SecureConversations.TranscriptModel {
     struct Environment {
-        var fetchFile: CoreSdkClient.DownloadSecureFile
+        var fetchFile: CoreSdkClient.FetchFile
+        var downloadSecureFile: CoreSdkClient.DownloadSecureFile
         var fileManager: FoundationBased.FileManager
         var data: FoundationBased.Data
         var date: () -> Date

--- a/GliaWidgets/Sources/Coordinators/Call/CallCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Call/CallCoordinator.swift
@@ -63,6 +63,7 @@ private extension CallCoordinator {
             screenShareHandler: screenShareHandler,
             environment: .init(
                 fetchFile: environment.fetchFile,
+                downloadSecureFile: environment.downloadSecureFile,
                 sendSelectedOptionValue: environment.sendSelectedOptionValue,
                 uploadFileToEngagement: environment.uploadFileToEngagement,
                 fileManager: environment.fileManager,
@@ -130,6 +131,7 @@ private extension CallCoordinator {
 extension CallCoordinator {
     struct Environment {
         var fetchFile: CoreSdkClient.FetchFile
+        var downloadSecureFile: CoreSdkClient.DownloadSecureFile
         var sendSelectedOptionValue: CoreSdkClient.SendSelectedOptionValue
         var uploadFileToEngagement: CoreSdkClient.UploadFileToEngagement
         var fileManager: FoundationBased.FileManager

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
@@ -206,6 +206,7 @@ extension ChatCoordinator {
     ) -> ChatViewModel.Environment {
         ChatViewModel.Environment(
             fetchFile: environment.fetchFile,
+            downloadSecureFile: environment.downloadSecureFile,
             sendSelectedOptionValue: environment.sendSelectedOptionValue,
             uploadFileToEngagement: environment.uploadFileToEngagement,
             fileManager: environment.fileManager,
@@ -299,7 +300,8 @@ extension ChatCoordinator {
         viewFactory: ViewFactory
     ) -> SecureConversations.TranscriptModel.Environment {
         SecureConversations.TranscriptModel.Environment(
-           fetchFile: environment.downloadSecureFile,
+           fetchFile: environment.fetchFile,
+           downloadSecureFile: environment.downloadSecureFile,
            fileManager: environment.fileManager,
            data: environment.data,
            date: environment.date,

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
@@ -312,6 +312,7 @@ extension EngagementCoordinator {
             startAction: startAction,
             environment: .init(
                 fetchFile: environment.fetchFile,
+                downloadSecureFile: environment.downloadSecureFile,
                 sendSelectedOptionValue: environment.sendSelectedOptionValue,
                 uploadFileToEngagement: environment.uploadFileToEngagement,
                 fileManager: environment.fileManager,

--- a/GliaWidgets/Sources/Download/FileDownload.Environment.Interface.swift
+++ b/GliaWidgets/Sources/Download/FileDownload.Environment.Interface.swift
@@ -1,6 +1,7 @@
 extension FileDownload {
     struct Environment {
-        var fetchFile: FetchFile
+        var fetchFile: CoreSdkClient.FetchFile
+        var downloadSecureFile: CoreSdkClient.DownloadSecureFile
         var fileManager: FoundationBased.FileManager
         var gcd: GCD
         var localFileThumbnailQueue: FoundationBased.OperationQueue
@@ -38,4 +39,22 @@ extension FileDownload.Environment.FetchFile {
                 return nil
             }
         }
+
+    static func fetchForEngagementFile(
+        _ file: CoreSdkClient.EngagementFile,
+        environment: Environment
+    ) -> FileDownload.Environment.FetchFile {
+        guard let components = file.url
+            .flatMap({ url in URLComponents(url: url, resolvingAgainstBaseURL: false) }),
+            components.path.starts(with: "/messaging/files/") else {
+            return .fromEngagement(environment.fetchFile)
+        }
+
+        return .fromSecureMessaging(environment.downloadSecureFile)
+    }
+
+    struct Environment {
+        var fetchFile: CoreSdkClient.FetchFile
+        var downloadSecureFile: CoreSdkClient.DownloadSecureFile
+    }
 }

--- a/GliaWidgets/Sources/Download/FileDownload.Environment.Mock.swift
+++ b/GliaWidgets/Sources/Download/FileDownload.Environment.Mock.swift
@@ -1,7 +1,8 @@
 #if DEBUG
 extension FileDownload.Environment {
     static let mock = Self(
-        fetchFile: .fromEngagement({ _, _, _ in }),
+        fetchFile: { _, _, _ in },
+        downloadSecureFile: { _, _, _ in .mock },
         fileManager: .mock,
         gcd: .mock,
         localFileThumbnailQueue: .mock(),

--- a/GliaWidgets/Sources/Download/FileDownloader.swift
+++ b/GliaWidgets/Sources/Download/FileDownloader.swift
@@ -68,6 +68,7 @@ class FileDownloader {
                 storage,
                 .init(
                     fetchFile: environment.fetchFile,
+                    downloadSecureFile: environment.downloadSecureFile,
                     fileManager: environment.fileManager,
                     gcd: environment.gcd,
                     localFileThumbnailQueue: environment.localFileThumbnailQueue,
@@ -103,9 +104,8 @@ extension FileDownloader {
     ) -> FileDownload
 
     struct Environment {
-        typealias FetchFile = FileDownload.Environment.FetchFile
-
-        var fetchFile: FetchFile
+        var fetchFile: CoreSdkClient.FetchFile
+        var downloadSecureFile: CoreSdkClient.DownloadSecureFile
         var fileManager: FoundationBased.FileManager
         var data: FoundationBased.Data
         var date: () -> Date

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Environment.Interface.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Environment.Interface.swift
@@ -3,6 +3,7 @@ import Foundation
 extension EngagementViewModel {
     struct Environment {
         var fetchFile: CoreSdkClient.FetchFile
+        var downloadSecureFile: CoreSdkClient.DownloadSecureFile
         var sendSelectedOptionValue: CoreSdkClient.SendSelectedOptionValue
         var uploadFileToEngagement: CoreSdkClient.UploadFileToEngagement
         var fileManager: FoundationBased.FileManager

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Environment.Mock.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Environment.Mock.swift
@@ -5,6 +5,7 @@ import Foundation
 extension ChatViewModel.Environment {
     static let mock = Self(
         fetchFile: { _, _, _ in },
+        downloadSecureFile: { _, _, _ in .mock },
         sendSelectedOptionValue: { _, _ in },
         uploadFileToEngagement: { _, _, _ in },
         fileManager: .mock,

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -115,7 +115,8 @@ class ChatViewModel: EngagementViewModel, ViewModel {
 
         self.downloader = FileDownloader(
             environment: .init(
-                fetchFile: .fromEngagement(environment.fetchFile),
+                fetchFile: environment.fetchFile,
+                downloadSecureFile: environment.downloadSecureFile,
                 fileManager: environment.fileManager,
                 data: environment.data,
                 date: environment.date,

--- a/GliaWidgetsTests/Lib/Download/FileDownload.Environment.Failing.swift
+++ b/GliaWidgetsTests/Lib/Download/FileDownload.Environment.Failing.swift
@@ -2,11 +2,11 @@
 
 extension FileDownload.Environment {
     static let failing = Self(
-        fetchFile: .fromEngagement(
-            { _, _, _ in
-                fail("\(Self.self).fetchFile")
-            }
-        ),
+        fetchFile: { _, _, _ in fail("\(Self.self).fetchFile") },
+        downloadSecureFile: { _, _, _ in
+            fail("\(Self.self).downloadSecureFile")
+            return .mock
+        },
         fileManager: .failing,
         gcd: .failing,
         localFileThumbnailQueue: .failing,

--- a/GliaWidgetsTests/SecureConversations/TranscriptModel.Environment.Failing.swift
+++ b/GliaWidgetsTests/SecureConversations/TranscriptModel.Environment.Failing.swift
@@ -2,8 +2,11 @@
 
 extension SecureConversations.TranscriptModel.Environment {
     static let failing = SecureConversations.TranscriptModel.Environment(
-        fetchFile: { file, progress, completion in
+        fetchFile: { _, _, _ in
             fail("\(Self.self).fetchFile")
+        },
+        downloadSecureFile: { _, _, _ in
+            fail("\(Self.self).downloadSecureFile")
             return .mock
         },
         fileManager: .failing,

--- a/GliaWidgetsTests/Sources/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModelTests.swift
@@ -28,6 +28,7 @@ class ChatViewModelTests: XCTestCase {
             shouldSkipEnqueueingState: false,
             environment: .init(
                 fetchFile: { _, _, _ in },
+                downloadSecureFile: { _, _, _ in .mock },
                 sendSelectedOptionValue: { _, _ in
                     calls.append(.sendSelectedOptionValue)
                 },

--- a/GliaWidgetsTests/Sources/FileDownloadTests.swift
+++ b/GliaWidgetsTests/Sources/FileDownloadTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+@testable import GliaWidgets
+import XCTest
+
+class FileDownloadTests: XCTestCase {
+    typealias FetchFile = FileDownload.Environment.FetchFile
+
+    func testFetchForEngagementFileChoosesRespectiveEndpoint() throws {
+        let mockId = UUID.mock.uuidString
+        let engagementFileUrl = try XCTUnwrap(
+            URL(string: "https://mock.mock.mock.moc/engagements/\(mockId)/files/\(mockId)")
+        )
+        let secureMessagingFileUrl = try XCTUnwrap(
+            URL(string: "https://mock.mock.mock.moc/messaging/files/\(mockId)")
+        )
+
+        let generalFileUrl = try XCTUnwrap(
+            URL(string: "https://mock.mock.mock.moc")
+        )
+        
+        enum Fetch: Equatable {
+            case engagement
+            case secureMessaging
+        }
+        
+        let env = FetchFile.Environment(
+            fetchFile: { _, _, _ in },
+            downloadSecureFile: { _, _, _ in .mock }
+        )
+
+        func evaluateFile(_ file: CoreSdkClient.EngagementFile) -> Fetch {
+            switch FetchFile.fetchForEngagementFile(file, environment: env) {
+            case .fromEngagement:
+                return .engagement
+            case .fromSecureMessaging:
+                return .secureMessaging
+            }
+        }
+
+        XCTAssertEqual(evaluateFile(.init(url: engagementFileUrl)), .engagement)
+        XCTAssertEqual(evaluateFile(.init(url: secureMessagingFileUrl)), .secureMessaging)
+        XCTAssertEqual(evaluateFile(.init(url: generalFileUrl)), .engagement)
+    }
+}

--- a/GliaWidgetsTests/ViewModel/Chat/ChatViewModel.Environment.Failing.swift
+++ b/GliaWidgetsTests/ViewModel/Chat/ChatViewModel.Environment.Failing.swift
@@ -8,6 +8,10 @@ extension ChatViewModel.Environment {
             fetchFile: { _, _, _ in
                 fail("\(Self.self).fetchFile")
             },
+            downloadSecureFile: { _, _, _ in
+                fail("\(Self.self).downloadSecureFile")
+                return .mock
+            },
             sendSelectedOptionValue: { _, _ in
                 fail("\(Self.self).sendSelectedOptionValue")
             },


### PR DESCRIPTION
Add ability for file download decide at runtime which endpoint to use based on provided URL. This is needed because secure download endpoint fails for files that were uploaded during engagement.

MOB-2051