### PR TITLE
Add support for showing operator image in chat transcript

### DIFF
--- a/GliaWidgets/Sources/ViewModel/Chat/Data/ChatItem.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/Data/ChatItem.swift
@@ -42,9 +42,9 @@ class ChatItem {
                 isActive: !fromHistory
             )
         case .operator:
-            kind = message.isChoiceCard
-                ? .choiceCard(message, showsImage: false, imageUrl: nil, isActive: !fromHistory)
-                : .operatorMessage(message, showsImage: false, imageUrl: nil)
+            kind = message.isChoiceCard ?
+                .choiceCard(message, showsImage: false, imageUrl: nil, isActive: !fromHistory) :
+                .operatorMessage(message, showsImage: false, imageUrl: message.operator?.pictureUrl)
         case .omniguide, .system, .unknown:
             return nil
         }

--- a/GliaWidgets/Sources/ViewModel/Chat/Data/ChatMessage.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/Data/ChatMessage.swift
@@ -57,7 +57,15 @@ class ChatMessage: Codable {
          operator salemoveOperator: CoreSdkClient.Operator? = nil) {
         id = message.id
         self.queueID = queueID
-        self.operator = salemoveOperator.map { ChatOperator(with: $0) }
+
+        if let salemoveOperator = salemoveOperator {
+            self.operator = ChatOperator(with: salemoveOperator)
+        } else if let name = message.sender.name {
+            self.operator = ChatOperator(name: name, pictureUrl: message.sender.picture?.url)
+        } else {
+            self.operator = nil
+        }
+
         sender = ChatMessageSender(with: message.sender)
         content = message.content
         attachment = ChatAttachment(with: message.attachment)


### PR DESCRIPTION
In case there is no `SalemoveOperator`, that is, when there is no engaged operator because the engagement hasn’t started yet, then the chat sender information is used to figure out the operator for the chat message. The main goal is to have it show a picture on secure transcripts, where right now the picture is completely missing.

MOB-2017