### PR TITLE
Add support for rendering chat transcript system messages

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -190,6 +190,8 @@
 		3189DD9429DEFAC600D68E9F /* SecureConversations.WelcomeViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3189DD9329DEFAC600D68E9F /* SecureConversations.WelcomeViewModelSpec.swift */; };
 		3189DD9629E4331200D68E9F /* SecureConversations.WelcomeViewModel.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3189DD9529E4331200D68E9F /* SecureConversations.WelcomeViewModel.Mock.swift */; };
 		3197F7AD29E6A5C8008EE9F7 /* SecureConversations.FileUploadListView.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3197F7AC29E6A5C8008EE9F7 /* SecureConversations.FileUploadListView.Mock.swift */; };
+		3197F7AF29E95527008EE9F7 /* SystemMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3197F7AE29E95527008EE9F7 /* SystemMessageView.swift */; };
+		3197F7B129E958F4008EE9F7 /* SystemMessageStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3197F7B029E958F4008EE9F7 /* SystemMessageStyle.swift */; };
 		31DB0C01287C2EFC00FB288E /* StaticValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31DB0C00287C2EFC00FB288E /* StaticValues.swift */; };
 		6B2BFCE2274297F100B68506 /* SettingsSwitchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B2BFCE1274297F100B68506 /* SettingsSwitchCell.swift */; };
 		6B48213E2735873300F2900A /* Feature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B48213D2735873300F2900A /* Feature.swift */; };
@@ -800,6 +802,8 @@
 		3189DD9329DEFAC600D68E9F /* SecureConversations.WelcomeViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.WelcomeViewModelSpec.swift; sourceTree = "<group>"; };
 		3189DD9529E4331200D68E9F /* SecureConversations.WelcomeViewModel.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.WelcomeViewModel.Mock.swift; sourceTree = "<group>"; };
 		3197F7AC29E6A5C8008EE9F7 /* SecureConversations.FileUploadListView.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FileUploadListView.Mock.swift; sourceTree = "<group>"; };
+		3197F7AE29E95527008EE9F7 /* SystemMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMessageView.swift; sourceTree = "<group>"; };
+		3197F7B029E958F4008EE9F7 /* SystemMessageStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMessageStyle.swift; sourceTree = "<group>"; };
 		31DB0C00287C2EFC00FB288E /* StaticValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticValues.swift; sourceTree = "<group>"; };
 		6304CD1CAD1108C78C7B11BF /* Pods-GliaWidgetsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GliaWidgetsTests.release.xcconfig"; path = "Target Support Files/Pods-GliaWidgetsTests/Pods-GliaWidgetsTests.release.xcconfig"; sourceTree = "<group>"; };
 		6B2BFCE1274297F100B68506 /* SettingsSwitchCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSwitchCell.swift; sourceTree = "<group>"; };
@@ -2024,6 +2028,8 @@
 				1A60B02C256BF7FF00E53F53 /* OperatorChatMessageView.swift */,
 				1A38A8A7258B652B0089DE7B /* OperatorChatMessageStyle.swift */,
 				845E2F6F283CF94100C04D56 /* VisitorChatMessageStyle.Accessibility.swift */,
+				3197F7AE29E95527008EE9F7 /* SystemMessageView.swift */,
+				3197F7B029E958F4008EE9F7 /* SystemMessageStyle.swift */,
 			);
 			path = Message;
 			sourceTree = "<group>";
@@ -3670,6 +3676,7 @@
 				75940962298D3889008B173A /* MessageMetadata.swift in Sources */,
 				7594094D298D37E8008B173A /* Glia.Environment.Mock.swift in Sources */,
 				1A60AFB9256682AF00E53F53 /* FlowCoordinator.swift in Sources */,
+				3197F7B129E958F4008EE9F7 /* SystemMessageStyle.swift in Sources */,
 				3100D92C296E946600DEC9CE /* SecureConversations.ConfirmationViewController.swift in Sources */,
 				9A8130BB27D7A41000220BBD /* FileUpload.Environment.Interface.swift in Sources */,
 				3100D92B296E946600DEC9CE /* SecureConversations+ConfirmationStyle.swift in Sources */,
@@ -3831,6 +3838,7 @@
 				845E2F98283FC9A900C04D56 /* Theme.Survey.OptionButton.swift in Sources */,
 				84265E60298D7B2900D65842 /* ScreenSharingCoordinator+Environment.swift in Sources */,
 				9AB196DC27C3FFCC00FD60AB /* Call.Environment.Interface.swift in Sources */,
+				3197F7AF29E95527008EE9F7 /* SystemMessageView.swift in Sources */,
 				755D186729A6A4FA0009F5E8 /* WelcomeStyle+SubtitleStyle.swift in Sources */,
 				C49A29EA2614A32600819269 /* ChatMessageContent.swift in Sources */,
 				75940961298D3889008B173A /* ChatMessageRenderer.Interface.swift in Sources */,

--- a/GliaWidgets/Sources/Theme/Theme+Chat.swift
+++ b/GliaWidgets/Sources/Theme/Theme+Chat.swift
@@ -347,6 +347,12 @@ extension Theme {
             accessibility: .init(isFontScalingEnabled: true)
         )
 
+        let systemMessage = SystemMessageStyle(
+            text: operatorText,
+            imageFile: operatorImageFile,
+            fileDownload: fileDownload
+        )
+
         return ChatStyle(
             header: header,
             connect: connect,
@@ -370,7 +376,8 @@ extension Theme {
             ),
             secureTranscriptTitle: Chat.SecureTranscript.headerTitle,
             secureTranscriptHeader: secureTranscriptHeader,
-            unreadMessageDivider: unreadMessageDivider
+            unreadMessageDivider: unreadMessageDivider,
+            systemMessage: systemMessage
         )
     }
 

--- a/GliaWidgets/Sources/View/Chat/Cells/ChatItemCell.swift
+++ b/GliaWidgets/Sources/View/Chat/Cells/ChatItemCell.swift
@@ -12,6 +12,7 @@ class ChatItemCell: UITableViewCell {
         case customCard(CustomCardContainerView)
         case callUpgrade(ChatCallUpgradeView)
         case unreadMessagesDivider(UnreadMessageDividerView)
+        case systemMessage(SystemMessageView)
 
         var view: UIView? {
             switch self {
@@ -32,6 +33,8 @@ class ChatItemCell: UITableViewCell {
             case .callUpgrade(let view):
                 return view
             case let .unreadMessagesDivider(view):
+                return view
+            case let .systemMessage(view):
                 return view
             }
         }

--- a/GliaWidgets/Sources/View/Chat/ChatStyle.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatStyle.swift
@@ -47,6 +47,8 @@ public class ChatStyle: EngagementStyle {
     /// Style for divider of unread messages in secure messaging transcript.
     public var unreadMessageDivider: UnreadMessageDividerStyle
 
+    public var systemMessage: SystemMessageStyle
+
     ///
     /// - Parameters:
     ///   - header: Style of the view's header (navigation bar area) when the screen is displaying live chat.
@@ -87,7 +89,8 @@ public class ChatStyle: EngagementStyle {
         accessibility: Accessibility = .unsupported,
         secureTranscriptTitle: String,
         secureTranscriptHeader: HeaderStyle,
-        unreadMessageDivider: UnreadMessageDividerStyle
+        unreadMessageDivider: UnreadMessageDividerStyle,
+        systemMessage: SystemMessageStyle
     ) {
         self.title = title
         self.visitorMessage = visitorMessage
@@ -104,6 +107,7 @@ public class ChatStyle: EngagementStyle {
         self.secureTranscriptTitle = secureTranscriptTitle
         self.secureTranscriptHeader = secureTranscriptHeader
         self.unreadMessageDivider = unreadMessageDivider
+        self.systemMessage = systemMessage
 
         super.init(
             header: header,

--- a/GliaWidgets/Sources/View/Chat/ChatView.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatView.swift
@@ -462,6 +462,8 @@ extension ChatView {
                     style: style.unreadMessageDivider
                 )
             )
+        case .systemMessage(let message):
+            return systemMessageContent(message)
         }
     }
     // swiftlint:enable function_body_length
@@ -552,6 +554,29 @@ extension ChatView {
         view.onOptionTapped = { self.choiceOptionSelected($0, message.id) }
         view.appendContent(.choiceCard(choiceCard), animated: false)
         return .choiceCard(view)
+    }
+
+    private func systemMessageContent(_ message: ChatMessage) -> ChatItemCell.Content {
+        let view = SystemMessageView(
+            with: style.systemMessage,
+            environment: .init(
+                uiScreen: environment.uiScreen
+            )
+        )
+
+        view.appendContent(
+            .text(
+                message.content,
+                accessibility: Self.operatorAccessibilityMessage(
+                    for: message,
+                    operator: style.accessibility.operator,
+                    isFontScalingEnabled: style.accessibility.isFontScalingEnabled
+                )
+            ),
+            animated: false
+        )
+
+        return .systemMessage(view)
     }
 }
 

--- a/GliaWidgets/Sources/View/Chat/Message/SystemMessageStyle.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/SystemMessageStyle.swift
@@ -1,0 +1,45 @@
+import UIKit
+
+/// Style of a system message.
+final public class SystemMessageStyle: ChatMessageStyle {
+    /// - Parameters:
+    ///   - text: Style of the text content.
+    ///   - imageFile: Style of the image content.
+    ///   - fileDownload: Style of the downloadable file content.
+    override public init(
+        text: ChatTextContentStyle,
+        imageFile: ChatImageFileContentStyle,
+        fileDownload: ChatFileDownloadStyle
+    ) {
+        super.init(
+            text: text,
+            imageFile: imageFile,
+            fileDownload: fileDownload
+        )
+    }
+
+    func apply(
+        configuration: RemoteConfiguration.MessageBalloon?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
+        configuration?.background?.cornerRadius
+            .unwrap { text.cornerRadius = $0 }
+
+        configuration?.background?.color?.value
+            .map { UIColor(hex: $0) }
+            .first
+            .unwrap {
+                text.backgroundColor = $0
+            }
+
+        UIFont.convertToFont(
+            uiFont: assetsBuilder.fontBuilder(configuration?.text?.font),
+            textStyle: text.textStyle
+        ).unwrap { text.textFont = $0 }
+
+        configuration?.text?.foreground?.value
+            .map { UIColor(hex: $0) }
+            .first
+            .unwrap { text.textColor = $0 }
+    }
+}

--- a/GliaWidgets/Sources/View/Chat/Message/SystemMessageView.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/SystemMessageView.swift
@@ -1,0 +1,44 @@
+import UIKit
+
+final class SystemMessageView: ChatMessageView {
+    private let viewStyle: SystemMessageStyle
+    private let kInsets = UIEdgeInsets(top: 2, left: 10, bottom: 2, right: 96)
+    private let kOperatorImageViewSize = CGSize(width: 28, height: 28)
+    private let environment: Environment
+
+    init(
+        with style: SystemMessageStyle,
+        environment: Environment
+    ) {
+        viewStyle = style
+        self.environment = environment
+        super.init(
+            with: style,
+            contentAlignment: .left,
+            environment: .init(uiScreen: environment.uiScreen)
+        )
+        setup()
+        layout()
+    }
+
+    required init() {
+        fatalError("init() has not been implemented")
+    }
+
+    private func layout() {
+        addSubview(contentViews)
+        contentViews.autoPinEdge(toSuperviewEdge: .left, withInset: kInsets.left)
+        contentViews.autoPinEdge(toSuperviewEdge: .top, withInset: kInsets.top)
+        contentViews.autoPinEdge(toSuperviewEdge: .right, withInset: kInsets.right, relation: .greaterThanOrEqual)
+
+        NSLayoutConstraint.autoSetPriority(.required) {
+            contentViews.autoPinEdge(toSuperviewEdge: .bottom, withInset: kInsets.bottom)
+        }
+    }
+}
+
+extension SystemMessageView {
+    struct Environment {
+        var uiScreen: UIKitBased.UIScreen
+    }
+}

--- a/GliaWidgets/Sources/ViewModel/Chat/Data/ChatItem.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/Data/ChatItem.swift
@@ -45,7 +45,9 @@ class ChatItem {
             kind = message.isChoiceCard ?
                 .choiceCard(message, showsImage: false, imageUrl: nil, isActive: !fromHistory) :
                 .operatorMessage(message, showsImage: false, imageUrl: message.operator?.pictureUrl)
-        case .omniguide, .system, .unknown:
+        case .system:
+            kind = .systemMessage(message)
+        case .omniguide, .unknown:
             return nil
         }
     }
@@ -65,5 +67,6 @@ extension ChatItem {
         case operatorConnected(name: String?, imageUrl: String?)
         case transferring
         case unreadMessageDivider
+        case systemMessage(ChatMessage)
     }
 }


### PR DESCRIPTION
Add the design and rendering for system messages that come from chat transcript only. This works for both live chat transcript and secure conversations chat transcript, because they both use the same `ChatView`. Nothing has been done to render system messages that come from web socket yet to keep the commit small.

MOB-2040