### PR TITLE
Prevent starting engagement during ongoing one

### DIFF
--- a/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
+++ b/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
@@ -29,6 +29,10 @@ extension Glia {
     ) throws {
         guard engagement == .none else { throw GliaError.engagementExists }
         guard let interactor = self.interactor else { throw GliaError.sdkIsNotConfigured }
+        if let engagement = environment.coreSdk.getCurrentEngagement(),
+            engagement.source == .callVisualizer {
+            throw GliaError.callVisualizerEngagementExists
+        }
 
         let viewFactory = ViewFactory(
             with: theme,

--- a/GliaWidgets/Public/GliaError.swift
+++ b/GliaWidgets/Public/GliaError.swift
@@ -3,4 +3,5 @@ public enum GliaError: Error {
     case engagementExists
     case engagementNotExist
     case sdkIsNotConfigured
+    case callVisualizerEngagementExists
 }


### PR DESCRIPTION
Previously we didn't check CallVisualizer engagement existence on `startEngagement` call. This led to unexpected behaviour of SDK. This PR fixes it.

Also added tests for all exceptions that can be thrown on `startEngagement` call.

MOB-2087