### PR TITLE
Update secure message response to use socket based message

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -468,6 +468,7 @@
 		AFA2FDF8289080FA00428E6D /* UserImageStyle.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA2FDF7289080FA00428E6D /* UserImageStyle.Mock.swift */; };
 		AFA2FDFA2890827E00428E6D /* BadgeStyle.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA2FDF92890827E00428E6D /* BadgeStyle.Mock.swift */; };
 		AFA2FDFC289082F500428E6D /* OnHoldOverlayStyle.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA2FDFB289082F500428E6D /* OnHoldOverlayStyle.Mock.swift */; };
+		AFA5E96229F2CF9400F13DB7 /* TranscriptModel.DividedChatItemsForUnreadCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA5E96129F2CF9400F13DB7 /* TranscriptModel.DividedChatItemsForUnreadCount.swift */; };
 		AFAB409229798BD4007F96CC /* SecureConversations.FileUploadListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFAB409129798BD4007F96CC /* SecureConversations.FileUploadListView.swift */; };
 		AFBBF5782851C391004993B3 /* Glia.Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBBF5772851C391004993B3 /* Glia.Deprecated.swift */; };
 		AFBBF57A28522591004993B3 /* Configuration.Unavailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBBF57928522591004993B3 /* Configuration.Unavailable.swift */; };
@@ -1086,6 +1087,7 @@
 		AFA2FDF7289080FA00428E6D /* UserImageStyle.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserImageStyle.Mock.swift; sourceTree = "<group>"; };
 		AFA2FDF92890827E00428E6D /* BadgeStyle.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeStyle.Mock.swift; sourceTree = "<group>"; };
 		AFA2FDFB289082F500428E6D /* OnHoldOverlayStyle.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnHoldOverlayStyle.Mock.swift; sourceTree = "<group>"; };
+		AFA5E96129F2CF9400F13DB7 /* TranscriptModel.DividedChatItemsForUnreadCount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptModel.DividedChatItemsForUnreadCount.swift; sourceTree = "<group>"; };
 		AFAB409129798BD4007F96CC /* SecureConversations.FileUploadListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FileUploadListView.swift; sourceTree = "<group>"; };
 		AFBBF5772851C391004993B3 /* Glia.Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Glia.Deprecated.swift; sourceTree = "<group>"; };
 		AFBBF57928522591004993B3 /* Configuration.Unavailable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.Unavailable.swift; sourceTree = "<group>"; };
@@ -2291,6 +2293,7 @@
 				AF0D26D72971912A00816CCB /* SecureConversations.SendMessageButton.swift */,
 				AFC40C1B29965F0F001B4C53 /* SecureConversations.ChatWithTranscriptModel.swift */,
 				AF10ED8C29BA210500E85309 /* SecureConversations.MessagesWithUnreadCountLoader.swift */,
+				AFA5E96129F2CF9400F13DB7 /* TranscriptModel.DividedChatItemsForUnreadCount.swift */,
 				3115D45B29A4FD3F00D99561 /* SecureConversations.Availability.swift */,
 			);
 			path = SecureConversations;
@@ -3812,6 +3815,7 @@
 				C0D2F07F29A4E59200803B47 /* CallButtonBarStyle.Mock.swift in Sources */,
 				755D187F29A6B1B90009F5E8 /* Glia+StartEngagement.swift in Sources */,
 				1A60B0192567FC8A00E53F53 /* ButtonKind.swift in Sources */,
+				AFA5E96229F2CF9400F13DB7 /* TranscriptModel.DividedChatItemsForUnreadCount.swift in Sources */,
 				C42463742673ABE10082C135 /* ScreenShareHandler.Interface.swift in Sources */,
 				3100EEFD293F757E00D57F71 /* SecureConversations.WelcomeStyle.swift in Sources */,
 				755D187729A6A6D70009F5E8 /* WelcomeStyle+MessageWarningStyle.swift in Sources */,

--- a/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
+++ b/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
@@ -157,7 +157,9 @@ extension Glia {
                         debugPrint(#function, "isAuthenticated:", error.localizedDescription)
                         return false
                     }
-                }
+                },
+                startSocketObservation: environment.coreSdk.startSocketObservation,
+                stopSocketObservation: environment.coreSdk.stopSocketObservation
             )
         )
         rootCoordinator?.delegate = { [weak self] event in

--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
@@ -286,7 +286,9 @@ extension SecureConversations.Coordinator {
                 secureMarkMessagesAsRead: environment.secureMarkMessagesAsRead,
                 downloadSecureFile: environment.downloadSecureFile,
                 isAuthenticated: environment.isAuthenticated,
-                interactor: environment.interactor
+                interactor: environment.interactor,
+                startSocketObservation: environment.startSocketObservation,
+                stopSocketObservation: environment.stopSocketObservation
             ),
             startWithSecureTranscriptFlow: true
         )
@@ -305,10 +307,7 @@ extension SecureConversations.Coordinator {
         pushCoordinator(coordinator)
 
         let viewController = coordinator.start()
-        navigationPresenter.push(
-            viewController,
-            replacingLast: true
-        )
+        navigationPresenter.push(viewController, replacingLast: true)
 
         return viewController
     }
@@ -353,6 +352,8 @@ extension SecureConversations.Coordinator {
         var secureMarkMessagesAsRead: CoreSdkClient.SecureMarkMessagesAsRead
         var downloadSecureFile: CoreSdkClient.DownloadSecureFile
         var isAuthenticated: () -> Bool
+        var startSocketObservation: CoreSdkClient.StartSocketObservation
+        var stopSocketObservation: CoreSdkClient.StopSocketObservation
     }
 
     enum DelegateEvent {

--- a/GliaWidgets/SecureConversations/TranscriptModel.DividedChatItemsForUnreadCount.swift
+++ b/GliaWidgets/SecureConversations/TranscriptModel.DividedChatItemsForUnreadCount.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+extension SecureConversations.TranscriptModel {
+    static func dividedChatItemsForUnreadCount(
+        chatItems: [ChatItem],
+        unreadCount: Int,
+        divider: ChatItem
+    ) -> [ChatItem] {
+        var tail: [ChatItem] = []
+        var unreadCount = unreadCount
+        var head = chatItems
+        var dividerIndex: Int?
+        while unreadCount > 0 {
+            // Remove messages from the end of list.
+            // In case list has ended, that means unread count
+            // is larger than list size, so we break to prevent
+            // infinite loop.
+            guard let item = head.popLast() else {
+                break
+            }
+            // Removed items are placed into separate list,
+            // to be later combined with initial one.
+            tail.insert(item, at: 0)
+
+            // We treat only operator messages
+            // eligible to be counted as unread.
+            if item.isOperatorMessage {
+                // Update divider insertion index with
+                // next relevant one.
+                dividerIndex = head.endIndex
+                unreadCount -= 1
+            }
+        }
+
+        // At this point we have finished search for insertion
+        // index for divider, so we combine two lists together.
+        var result = head + tail
+
+        // Make sure that divider index is within safe bounds
+        // before performing the insertion.
+        if let dividerIndex, dividerIndex <= result.endIndex {
+            result.insert(divider, at: dividerIndex)
+        }
+
+        return result
+    }
+}

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
@@ -30,5 +30,7 @@ extension ChatCoordinator {
         var downloadSecureFile: CoreSdkClient.DownloadSecureFile
         var isAuthenticated: () -> Bool
         var interactor: Interactor
+        var startSocketObservation: CoreSdkClient.StartSocketObservation
+        var stopSocketObservation: CoreSdkClient.StopSocketObservation
     }
 }

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
@@ -324,7 +324,9 @@ extension ChatCoordinator {
            getSecureUnreadMessageCount: environment.getSecureUnreadMessageCount,
            messagesWithUnreadCountLoaderScheduler: environment.messagesWithUnreadCountLoaderScheduler,
            secureMarkMessagesAsRead: environment.secureMarkMessagesAsRead,
-           interactor: environment.interactor
+           interactor: environment.interactor,
+           startSocketObservation: environment.startSocketObservation,
+           stopSocketObservation: environment.stopSocketObservation
        )
     }
 }

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
@@ -32,7 +32,9 @@ extension EngagementCoordinator.Environment {
         messagesWithUnreadCountLoaderScheduler: CoreSdkClient.reactiveSwiftDateSchedulerMock,
         secureMarkMessagesAsRead: { _ in .mock },
         downloadSecureFile: { _, _, _ in .mock },
-        isAuthenticated: { false }
+        isAuthenticated: { false },
+        startSocketObservation: {},
+        stopSocketObservation: {}
     )
 }
 #endif

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
@@ -34,5 +34,7 @@ extension EngagementCoordinator {
         var secureMarkMessagesAsRead: CoreSdkClient.SecureMarkMessagesAsRead
         var downloadSecureFile: CoreSdkClient.DownloadSecureFile
         var isAuthenticated: () -> Bool
+        var startSocketObservation: CoreSdkClient.StartSocketObservation
+        var stopSocketObservation: CoreSdkClient.StopSocketObservation
     }
 }

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
@@ -242,7 +242,9 @@ extension EngagementCoordinator {
                 secureMarkMessagesAsRead: environment.secureMarkMessagesAsRead,
                 downloadSecureFile: environment.downloadSecureFile,
                 isAuthenticated: environment.isAuthenticated,
-                interactor: interactor
+                interactor: interactor,
+                startSocketObservation: environment.startSocketObservation,
+                stopSocketObservation: environment.stopSocketObservation
             ),
             startWithSecureTranscriptFlow: false
         )
@@ -462,7 +464,9 @@ extension EngagementCoordinator {
                 messagesWithUnreadCountLoaderScheduler: environment.messagesWithUnreadCountLoaderScheduler,
                 secureMarkMessagesAsRead: environment.secureMarkMessagesAsRead,
                 downloadSecureFile: environment.downloadSecureFile,
-                isAuthenticated: environment.isAuthenticated
+                isAuthenticated: environment.isAuthenticated,
+                startSocketObservation: environment.startSocketObservation,
+                stopSocketObservation: environment.stopSocketObservation
             )
         )
 

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -143,6 +143,12 @@ struct CoreSdkClient {
     ) -> Cancellable
 
     var downloadSecureFile: DownloadSecureFile
+
+    typealias StartSocketObservation = () -> Void
+    var startSocketObservation: StartSocketObservation
+
+    typealias StopSocketObservation = () -> Void
+    var stopSocketObservation: StopSocketObservation
 }
 
 extension CoreSdkClient {

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
@@ -43,7 +43,9 @@ extension CoreSdkClient {
             uploadSecureFile: GliaCore.sharedInstance.secureConversations.uploadFile(_:progress:completion:),
             getSecureUnreadMessageCount: GliaCore.sharedInstance.secureConversations.getUnreadMessageCount(completion:),
             secureMarkMessagesAsRead: GliaCore.sharedInstance.secureConversations.markMessagesAsRead(completion:),
-            downloadSecureFile: GliaCore.sharedInstance.secureConversations.downloadFile(_:progress:completion:)
+            downloadSecureFile: GliaCore.sharedInstance.secureConversations.downloadFile(_:progress:completion:),
+            startSocketObservation: GliaCore.sharedInstance.startSocketObservation,
+            stopSocketObservation: GliaCore.sharedInstance.stopSocketObservation
         )
     }()
 }

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -32,7 +32,9 @@ extension CoreSdkClient {
         uploadSecureFile: { _, _, _ in .mock },
         getSecureUnreadMessageCount: { _ in },
         secureMarkMessagesAsRead: { _ in .mock },
-        downloadSecureFile: { _, _, _ in .mock }
+        downloadSecureFile: { _, _, _ in .mock },
+        startSocketObservation: {},
+        stopSocketObservation: {}
     )
 }
 

--- a/GliaWidgets/Sources/IdCollection/IdCollection.swift
+++ b/GliaWidgets/Sources/IdCollection/IdCollection.swift
@@ -1,5 +1,3 @@
-// TODO: Add unit tests
-// MOB-1841
 /// Collection that allows easier access by element identifier.
 struct IdCollection<Identifier: Hashable, Item: Equatable>: Equatable & Collection {
 

--- a/GliaWidgets/Sources/ViewModel/Chat/Data/OutgoingMessage.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/Data/OutgoingMessage.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class OutgoingMessage {
+class OutgoingMessage: Equatable {
     let id = UUID().uuidString
     let content: String
     let files: [LocalFile]
@@ -11,5 +11,11 @@ class OutgoingMessage {
     ) {
         self.content = content
         self.files = files
+    }
+
+    static func == (lhs: OutgoingMessage, rhs: OutgoingMessage) -> Bool {
+        lhs.id == rhs.id &&
+        lhs.content == rhs.content &&
+        lhs.files == rhs.files
     }
 }

--- a/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
+++ b/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
@@ -78,6 +78,12 @@ extension EngagementCoordinator.Environment {
         isAuthenticated: {
             fail("\(Self.self).isAuthenticated")
             return false
+        },
+        startSocketObservation: {
+            fail("\(Self.self).startSocketObservation")
+        },
+        stopSocketObservation: {
+            fail("\(Self.self).stopSocketObservation")
         }
     )
 }

--- a/GliaWidgetsTests/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/CoreSDKClient.Failing.swift
@@ -50,6 +50,12 @@ extension CoreSdkClient {
         downloadSecureFile: { _, _, _ in
             fail("\(Self.self).downloadSecureFile")
             return .mock
+        },
+        startSocketObservation: {
+            fail("\(Self.self).startSocketObservation")
+        },
+        stopSocketObservation: {
+            fail("\(Self.self).stopSocketObservation")
         }
     )
 }

--- a/GliaWidgetsTests/SecureConversations/TranscriptModel.Environment.Failing.swift
+++ b/GliaWidgetsTests/SecureConversations/TranscriptModel.Environment.Failing.swift
@@ -62,6 +62,12 @@ extension SecureConversations.TranscriptModel.Environment {
             fail("\(Self.self).secureMarkMessagesAsRead")
             return .mock
         },
-        interactor: .mock()
+        interactor: .mock(),
+        startSocketObservation: {
+            fail("\(Self.self).startSocketObservation")
+        },
+        stopSocketObservation: {
+            fail("\(Self.self).stopSocketObservation")
+        }
     )
 }

--- a/GliaWidgetsTests/SecureConversations/TranscriptModelTests.swift
+++ b/GliaWidgetsTests/SecureConversations/TranscriptModelTests.swift
@@ -56,6 +56,7 @@ final class TranscriptModelTests: XCTestCase {
         modelEnv.listQueues = { _ in }
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.getSecureUnreadMessageCount = { _ in }
+        modelEnv.startSocketObservation = {}
         let site = try CoreSdkClient.Site.mock(allowedFileSenders: .mock(visitor: true))
         modelEnv.fetchSiteConfigurations = { callback in
             callback(.success(site))
@@ -100,7 +101,9 @@ final class TranscriptModelTests: XCTestCase {
             calls.append(.loadSiteConfiguration)
         }
 
-        modelEnv.getSecureUnreadMessageCount = { _ in calls.append(.getSecureUnreadMessageCount) }
+        modelEnv.getSecureUnreadMessageCount = { _ in calls.append(.getSecureUnreadMessageCount)
+        }
+        modelEnv.startSocketObservation = {}
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
             queueIds: modelEnv.queueIds,
@@ -129,6 +132,7 @@ final class TranscriptModelTests: XCTestCase {
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
         modelEnv.getSecureUnreadMessageCount = { _ in  }
+        modelEnv.startSocketObservation = {}
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
             queueIds: modelEnv.queueIds,
@@ -311,6 +315,7 @@ final class TranscriptModelTests: XCTestCase {
         modelEnv.listQueues = { _ in }
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
+        modelEnv.startSocketObservation = {}
         enum Call: Equatable { case getSecureUnreadMessageCount }
         var calls: [Call] = []
         modelEnv.getSecureUnreadMessageCount = { _ in
@@ -350,6 +355,7 @@ final class TranscriptModelTests: XCTestCase {
         modelEnv.getSecureUnreadMessageCount = { callback in
             callback(.success(1))
         }
+        modelEnv.startSocketObservation = {}
         modelEnv.gcd.mainQueue.asyncAfterDeadline = { _, callback in }
         modelEnv.loadChatMessagesFromHistory = { true }
         let scheduler = CoreSdkClient.ReactiveSwift.TestScheduler()


### PR DESCRIPTION
Attachment is missing in secure message response for REST API call when message is sent. We fallback on response from socket because of this.

MOB-2042