### PR TITLE
Add non-scrolling behaviour for attachments on Welcome screen

### DIFF
--- a/GliaWidgets/SecureConversations/FileUploadListView/SecureConversations.FileUploadListView.swift
+++ b/GliaWidgets/SecureConversations/FileUploadListView/SecureConversations.FileUploadListView.swift
@@ -6,12 +6,14 @@ extension SecureConversations {
             let maxUnscrollableViews: Int
             let style: FileUploadListView.Style
             let uploads: IdCollection<FileUploadView.Props.Identifier, FileUploadView.Props>
+            let isScrollingEnabled: Bool
         }
 
         var props: Props = .init(
             maxUnscrollableViews: 2,
             style: .chat(.initial),
-            uploads: .init()
+            uploads: .init(),
+            isScrollingEnabled: false
         ) {
             didSet {
                 renderProps()
@@ -158,6 +160,7 @@ extension SecureConversations {
 
             let style = Style.Properties(style: props.style)
             stackView.spacing = style.spacing
+            scrollView.isScrollEnabled = props.isScrollingEnabled
         }
     }
 }

--- a/GliaWidgets/SecureConversations/FileUploadListView/SecureConversations.FileUploadListViewModel.Environment.swift
+++ b/GliaWidgets/SecureConversations/FileUploadListView/SecureConversations.FileUploadListViewModel.Environment.swift
@@ -2,7 +2,23 @@ extension SecureConversations.FileUploadListViewModel {
     struct Environment {
         var uploader: FileUploader
         var style: SecureConversations.FileUploadListView.Style
-        var uiApplication: UIKitBased.UIApplication
+        var scrollingBehaviour: ScrollingBehaviour
+    }
+}
+
+extension SecureConversations.FileUploadListViewModel.Environment {
+    enum ScrollingBehaviour {
+        case scrolling(UIKitBased.UIApplication)
+        case nonScrolling
+
+        var isScrollingEnabled: Bool {
+            switch self {
+            case .scrolling:
+                return true
+            case .nonScrolling:
+                return false
+            }
+        }
     }
 }
 
@@ -15,7 +31,7 @@ extension SecureConversations.FileUploadListViewModel.Environment {
         .init(
             uploader: .mock(),
             style: .chat(.mock),
-            uiApplication: .mock
+            scrollingBehaviour: .scrolling(.mock)
         )
     }
 }

--- a/GliaWidgets/SecureConversations/FileUploadListView/SecureConversations.FileUploadListViewModel.swift
+++ b/GliaWidgets/SecureConversations/FileUploadListView/SecureConversations.FileUploadListViewModel.swift
@@ -64,7 +64,7 @@ extension SecureConversations {
             }
 
             // There is a case, where state is already set to `.uploading` case,
-            // that's why we evaluate state immediatelty.
+            // that's why we evaluate state immediately.
             handleState(upload.state.value, instance: instance)
         }
 
@@ -99,7 +99,8 @@ extension SecureConversations {
             let props = FileUploadListView.Props(
                 maxUnscrollableViews: maxUnscrollableViews,
                 style: environment.style,
-                uploads: uploads
+                uploads: uploads,
+                isScrollingEnabled: environment.scrollingBehaviour.isScrollingEnabled
             )
             return props
         }
@@ -107,11 +108,28 @@ extension SecureConversations {
 }
 
 extension SecureConversations.FileUploadListViewModel {
+    /// Represents number of visible uploads at once, avoiding
+    /// to involve scrolling. If number of uploads is greater than
+    /// this value, user will have to scroll to see the rest of the uploads.
     var maxUnscrollableViews: Int {
-        if environment.uiApplication.preferredContentSizeCategory() <= .accessibilityMedium {
-            return .maxUnscrollableViewsOnDefaultContentSizeCategory
-        } else {
-            return .maxUnscrollableViewsOnLargeContentSizeCategory
+        switch environment.scrollingBehaviour {
+        // For non-scrolling behaviour we allow
+        // unlimited number of uploads to be visible
+        // at once.
+        case .nonScrolling:
+            return .max
+        // For scrolling behaviour we base
+        // number of visible uploads that do not
+        // involve scrolling, on the font content size
+        // category. These numbers are represented by
+        // constants `Int.maxUnscrollableViewsOnDefaultContentSizeCategory`
+        // and `Int.maxUnscrollableViewsOnLargeContentSizeCategory`.
+        case let .scrolling(application):
+            if application.preferredContentSizeCategory() <= .accessibilityMedium {
+                return .maxUnscrollableViewsOnDefaultContentSizeCategory
+            } else {
+                return .maxUnscrollableViewsOnLargeContentSizeCategory
+            }
         }
     }
 }

--- a/GliaWidgets/SecureConversations/SecureConversations.ChatWithTranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.ChatWithTranscriptModel.swift
@@ -387,7 +387,7 @@ extension SecureConversations {
                 .init(
                     uploader: uploader,
                     style: .chat(environment.fileUploadListStyle),
-                    uiApplication: environment.uiApplication
+                    scrollingBehaviour: .scrolling(environment.uiApplication)
                 )
             )
 

--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
@@ -59,7 +59,9 @@ extension SecureConversations {
                     ),
                     uiApplication: environment.uiApplication,
                     createFileUploadListModel: environment.createFileUploadListModel,
-                    fetchSiteConfigurations: environment.fetchSiteConfigurations
+                    fetchSiteConfigurations: environment.fetchSiteConfigurations,
+                    startSocketObservation: environment.startSocketObservation,
+                    stopSocketObservation: environment.stopSocketObservation
                 ),
                 availability: .init(
                     environment: .init(

--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.swift
@@ -47,7 +47,7 @@ extension SecureConversations {
                 .init(
                     uploader: environment.fileUploader,
                     style: .messageCenter(environment.welcomeStyle.attachmentListStyle),
-                    uiApplication: environment.uiApplication
+                    scrollingBehaviour: .nonScrolling
                 )
             )
             self.availability = availability
@@ -61,6 +61,7 @@ extension SecureConversations {
 
             checkSecureConversationsAvailability()
             loadAttachmentAvailability()
+            environment.startSocketObservation()
         }
 
         private func checkSecureConversationsAvailability() {
@@ -104,6 +105,10 @@ extension SecureConversations {
 
         func reportChange() {
             delegate?(.renderProps(props()))
+        }
+
+        deinit {
+            environment.stopSocketObservation()
         }
     }
 }
@@ -407,6 +412,8 @@ extension SecureConversations.WelcomeViewModel {
         var uiApplication: UIKitBased.UIApplication
         var createFileUploadListModel: SecureConversations.FileUploadListViewModel.Create
         var fetchSiteConfigurations: CoreSdkClient.FetchSiteConfigurations
+        var startSocketObservation: CoreSdkClient.StartSocketObservation
+        var stopSocketObservation: CoreSdkClient.StopSocketObservation
     }
 }
 

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -97,7 +97,7 @@ class ChatViewModel: EngagementViewModel, ViewModel {
             .init(
                 uploader: uploader,
                 style: .chat(environment.fileUploadListStyle),
-                uiApplication: environment.uiApplication
+                scrollingBehaviour: .scrolling(environment.uiApplication)
             )
         )
 

--- a/GliaWidgetsTests/SecureConversations/SecureConversations.FileUploadListView.Mock.swift
+++ b/GliaWidgetsTests/SecureConversations/SecureConversations.FileUploadListView.Mock.swift
@@ -7,6 +7,7 @@ extension SecureConversations.FileUploadListView.Props {
         style: SecureConversations.FileUploadListView.Style.chat(
             FileUploadListStyle(item: FileUploadStyle.initial)
         ),
-        uploads: .init([])
+        uploads: .init([]),
+        isScrollingEnabled: false
     )
 }

--- a/GliaWidgetsTests/SecureConversations/SecureConversations.FileUploadListViewModel.Environment.Failing.swift
+++ b/GliaWidgetsTests/SecureConversations/SecureConversations.FileUploadListViewModel.Environment.Failing.swift
@@ -4,6 +4,7 @@ extension SecureConversations.FileUploadListViewModel.Environment {
     static let failing = SecureConversations.FileUploadListViewModel.Environment(
         uploader: .failing,
         style: .chat(.mock),
-        uiApplication: .failing
+        scrollingBehaviour: .scrolling(.failing)
+
     )
 }

--- a/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.Mock.swift
+++ b/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.Mock.swift
@@ -20,7 +20,9 @@ extension SecureConversations.WelcomeViewModel.Environment {
         fileUploader: .mock(),
         uiApplication: .mock,
         createFileUploadListModel: { _ in .mock() },
-        fetchSiteConfigurations: { _ in }
+        fetchSiteConfigurations: { _ in },
+        startSocketObservation: {},
+        stopSocketObservation: {}
     )
 }
 

--- a/GliaWidgetsTests/Sources/FileUploadListViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/FileUploadListViewModelTests.swift
@@ -7,16 +7,15 @@ final class FileUploadListViewModelTests: XCTestCase {
 
     func test_maxUnscrollableViewsWithMediumPreferredContentSizeCategory() throws {
         func testCase(input: (category: UIContentSizeCategory, maxViewCount: Int)) throws {
+            var application: UIKitBased.UIApplication = .failing
+            application.preferredContentSizeCategory = {
+                return input.category
+            }
             var environment: SecureConversations.FileUploadListViewModel.Environment = .init(
                 uploader: .mock(),
                 style: .chat(.mock),
-                uiApplication: .failing
+                scrollingBehaviour: .scrolling(application)
             )
-
-
-            environment.uiApplication.preferredContentSizeCategory = {
-                return input.category
-            }
 
             viewModel = .mock(environment: environment)
 

--- a/SnapshotTests/SecureConversationsWelcomeScreenTests.swift
+++ b/SnapshotTests/SecureConversationsWelcomeScreenTests.swift
@@ -114,7 +114,8 @@ class SecureConversationsWelcomeScreenTests: SnapshotTestCase {
             fileUploadListProps: .init(
                 maxUnscrollableViews: 3,
                 style: .chat(.mock),
-                uploads: .init(uploads)
+                uploads: .init(uploads),
+                isScrollingEnabled: true
             ),
             headerProps: headerProps,
             isUiHidden: false


### PR DESCRIPTION
Disable scrolling for attachments on Message Center Welcome screen in favour of scrolling the whole screen.

MOB-2099