### PR TITLE
Add unit test for covering 'migrate' method in ChatViewModel

### DIFF
--- a/GliaWidgetsTests/SecureConversations/SecureConversations.FileUploadListViewModel.Environment.Failing.swift
+++ b/GliaWidgetsTests/SecureConversations/SecureConversations.FileUploadListViewModel.Environment.Failing.swift
@@ -5,6 +5,17 @@ extension SecureConversations.FileUploadListViewModel.Environment {
         uploader: .failing,
         style: .chat(.mock),
         scrollingBehaviour: .scrolling(.failing)
-
     )
+
+    static func failing(
+        uploader: FileUploader = .failing,
+        style: SecureConversations.FileUploadListView.Style = .chat(.mock),
+        scrollingBehaviour: ScrollingBehaviour = .scrolling(.failing)
+    ) -> SecureConversations.FileUploadListViewModel.Environment{
+        .init(
+            uploader: uploader,
+            style: style,
+            scrollingBehaviour: scrollingBehaviour
+        )
+    }
 }


### PR DESCRIPTION
Add unit test for covering 'migrate' method in ChatViewModel, specifically that uploads are migrated along with other expected fields.

MOB-2108