### PR TITLE
Prevent file list view from cut-off on Secure Welcome screen

### DIFF
--- a/GliaWidgets/SecureConversations/FileUploadListView/SecureConversations.FileUploadListView.swift
+++ b/GliaWidgets/SecureConversations/FileUploadListView/SecureConversations.FileUploadListView.swift
@@ -89,7 +89,8 @@ extension SecureConversations {
             let height = uploadViews
                 .prefix(props.maxUnscrollableViews)
                 .reduce(CGFloat.zero) { result, view in
-                    result + view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height
+                    result + view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height +
+                    stackView.spacing
                 }
 
             heightLayoutConstraint.constant = height


### PR DESCRIPTION
Take into account spacing of stack view for file list view to prevent it from being cut off.

<img src="https://user-images.githubusercontent.com/3148347/234915358-bde0191e-e344-4a96-a0ee-49815e2ca7ba.png" width="428" height="926">


MOB-2126