### PR TITLE
Fix attachment picker distortion when placed at top of the screen

### DIFF
--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
@@ -115,12 +115,6 @@ extension SecureConversations {
                 controller?.presentPopover(
                     with: style.pickMediaStyle,
                     from: originView,
-                    // Designs use 'up' arrow, but currently
-                    // it seems like there is a bug in
-                    // AttachmentSourceListView, that makes
-                    // it render incorrectly with 'up' arrow.
-                    // That is why using 'down' arrow for now.
-                    arrowDirections: .down,
                     itemSelected: { [weak controller] kind in
                         controller?.dismiss(animated: true)
                         callback(kind)

--- a/GliaWidgets/Sources/ViewController/Common/Popover/PopoverPresenter.swift
+++ b/GliaWidgets/Sources/ViewController/Common/Popover/PopoverPresenter.swift
@@ -1,22 +1,74 @@
 import UIKit
 
 protocol PopoverPresenter where Self: UIViewController {
-    func presentPopover(with style: AttachmentSourceListStyle,
-                        from sourceView: UIView,
-                        arrowDirections: UIPopoverArrowDirection,
-                        itemSelected: @escaping (AttachmentSourceItemKind) -> Void)
+    func presentPopover(
+        with style: AttachmentSourceListStyle,
+        from sourceView: UIView,
+        arrowDirections: UIPopoverArrowDirection?,
+        itemSelected: @escaping (AttachmentSourceItemKind) -> Void
+    )
 }
 
 extension PopoverPresenter {
-    func presentPopover(with style: AttachmentSourceListStyle,
-                        from sourceView: UIView,
-                        arrowDirections: UIPopoverArrowDirection,
-                        itemSelected: @escaping (AttachmentSourceItemKind) -> Void) {
-        let listLiew = AttachmentSourceListView(with: style)
-        listLiew.itemTapped = { itemSelected($0) }
-        let controller = PopoverViewController(with: listLiew,
-                                               presentFrom: sourceView,
-                                               arrowDirections: arrowDirections)
+    func presentPopover(
+        with style: AttachmentSourceListStyle,
+        from sourceView: UIView,
+        arrowDirections: UIPopoverArrowDirection? = nil,
+        itemSelected: @escaping (AttachmentSourceItemKind) -> Void
+    ) {
+        let listView = AttachmentSourceListView(with: style)
+        listView.itemTapped = { itemSelected($0) }
+
+        let edgeInsets: UIEdgeInsets
+
+        let adjustedArrowDirection: UIPopoverArrowDirection
+
+        // In case `arrowDirections` is passed, use it as is,
+        // otherwise do the figuring out.
+        if let arrowDirections {
+            adjustedArrowDirection = arrowDirections
+        } else {
+            // We need to decide how to display `listView`.
+            // We can't get size from list view, but
+            // know the size of window and position of sourceView
+            // in global space. Based on this we can provide arrow directions
+            // for popover. For now this are only vertical direction, because
+            // it seem sufficient for the given scenarios, but this logic can
+            // be adjusted for horizontal direction as well.
+            if let window = sourceView.window,
+               let globalPosition = sourceView.superview?.convert(sourceView.frame.origin, to: window) {
+                if globalPosition.y > window.bounds.midY {
+                    adjustedArrowDirection = .down
+                } else if globalPosition.y < window.bounds.midY {
+                    adjustedArrowDirection = .up
+                } else {
+                    adjustedArrowDirection = .any
+                }
+            } else {
+                adjustedArrowDirection = .any
+            }
+        }
+
+        // Depending on single arrowDirection we need to adjust insets.
+        // Note, this will work on only *one* item of `arrowDirections` set.
+        // For now this seems to be sufficient.
+        switch adjustedArrowDirection {
+        case .right:
+            edgeInsets = .init(top: 0, left: 0, bottom: 0, right: 15)
+        case .up:
+            edgeInsets = .init(top: 15, left: 0, bottom: -10, right: 0)
+        case .down, .any, .unknown:
+            edgeInsets = .zero
+        default:
+            edgeInsets = .zero
+        }
+
+        let controller = PopoverViewController(
+            with: listView,
+            presentFrom: sourceView,
+            arrowDirections: adjustedArrowDirection,
+            contentInsets: edgeInsets
+        )
         present(controller, animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
Address attachment picker popover being incorrectly displayed when presented on top part of the screen. This is done by dynamically determining arrow direction for popover, based on source view for it in global coordinate system. Theses changes address only vertical direction.

<img src="https://user-images.githubusercontent.com/3148347/235202745-617d0161-970c-4fe7-9202-98a0417267b2.png" width="428" height="926">


<img src="https://user-images.githubusercontent.com/3148347/235202967-e04c6d7e-44a6-48db-8d07-53948b182374.png" width="463" height="214">

MOB-2127