### PR TITLE
Fix incorrect scroll on welcome screen with attachments for keyboard

### DIFF
--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeView.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeView.swift
@@ -809,12 +809,10 @@ extension SecureConversations.WelcomeView {
             }
             let bottomOffset = CGPoint(
                 x: 0,
-                y: scrollView.contentSize.height - scrollView.bounds.height + scrollView.contentInset.bottom +
-                // Take file upload list into account, so that text view would be accessible,
-                // when keyboard appears.
-                fileUploadListView.frame.height == .zero
-                ? 0
-                : (messageTextView.frame.height - fileUploadListView.frame.height)
+                // Scroll content to the location of message text view,
+                // so that it would become visible initially when keyboard
+                // is shown, for portrait and landscape screen orientations.
+                y: messageTextView.frame.origin.y
             )
             scrollView.setContentOffset(
                 bottomOffset,


### PR DESCRIPTION
Address issue with incorrect content scrolling offset when on welcome screen several attachments are added and keyboard is presented.

MOB-2128

<img src="https://user-images.githubusercontent.com/3148347/235706634-9317683e-7e1d-4c51-95fb-2956b096fe7f.png" width="375" height="667">

<img src="https://user-images.githubusercontent.com/3148347/235707858-82c2fa20-ebf3-45a9-81d8-f91fc282dc60.png" height="375" width="667">

