### PR TITLE
Fix attachment not being sent from welcome screen while on engagement

### DIFF
--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
@@ -61,7 +61,10 @@ extension SecureConversations {
                     createFileUploadListModel: environment.createFileUploadListModel,
                     fetchSiteConfigurations: environment.fetchSiteConfigurations,
                     startSocketObservation: environment.startSocketObservation,
-                    stopSocketObservation: environment.stopSocketObservation
+                    stopSocketObservation: environment.stopSocketObservation,
+                    getCurrentEngagement: environment.getCurrentEngagement,
+                    uploadSecureFile: environment.uploadSecureFile,
+                    uploadFileToEngagement: environment.uploadFileToEngagement
                 ),
                 availability: .init(
                     environment: .init(

--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.swift
@@ -414,6 +414,9 @@ extension SecureConversations.WelcomeViewModel {
         var fetchSiteConfigurations: CoreSdkClient.FetchSiteConfigurations
         var startSocketObservation: CoreSdkClient.StartSocketObservation
         var stopSocketObservation: CoreSdkClient.StopSocketObservation
+        var getCurrentEngagement: CoreSdkClient.GetCurrentEngagement
+        var uploadSecureFile: CoreSdkClient.SecureConversationsUploadFile
+        var uploadFileToEngagement: CoreSdkClient.UploadFileToEngagement
     }
 }
 
@@ -514,6 +517,7 @@ extension SecureConversations.WelcomeViewModel {
 // MARK: - Upload releated methods
 extension SecureConversations.WelcomeViewModel {
     private func addUpload(with url: URL) {
+        determineFileUploadEndpoint()
         fileUploadListModel.addUpload(with: url)
     }
 
@@ -521,10 +525,19 @@ extension SecureConversations.WelcomeViewModel {
         with data: Data,
         format: MediaFormat
     ) {
+        determineFileUploadEndpoint()
         fileUploadListModel.addUpload(
             with: data,
             format: format
         )
+    }
+
+    private func determineFileUploadEndpoint() {
+        let isEngagementOngoing = environment.getCurrentEngagement() != nil
+        fileUploadListModel.environment.uploader.environment.uploadFile =
+        isEngagementOngoing ?
+            .toEngagement(environment.uploadFileToEngagement) :
+            .toSecureMessaging(environment.uploadSecureFile)
     }
 
     private func removeUpload(_ upload: FileUpload) {

--- a/GliaWidgets/Sources/Upload/FileUploader.swift
+++ b/GliaWidgets/Sources/Upload/FileUploader.swift
@@ -56,7 +56,7 @@ class FileUploader {
 
     var storage: FileSystemStorage
     private let maximumUploads: Int
-    private let environment: Environment
+    var environment: Environment
 
     init(maximumUploads: Int, environment: Environment) {
         self.maximumUploads = maximumUploads

--- a/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.Mock.swift
+++ b/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.Mock.swift
@@ -22,7 +22,10 @@ extension SecureConversations.WelcomeViewModel.Environment {
         createFileUploadListModel: { _ in .mock() },
         fetchSiteConfigurations: { _ in },
         startSocketObservation: {},
-        stopSocketObservation: {}
+        stopSocketObservation: {},
+        getCurrentEngagement: { .mock() },
+        uploadSecureFile: { _, _, _ in .mock },
+        uploadFileToEngagement: { _, _, _ in }
     )
 }
 


### PR DESCRIPTION
When sending an image from the welcome screen, we need to know if an engagement is ongoing or not. If an attachment is sent to the secure messaging endpoint while on an engagement, it doesn't arrive. Thus, we check for the current engagement every time a file is uploaded. This cannot be done only on the init of the environment, because the status of the ongoing engagement can change between the moment that the screen is shown and files are uploaded.

MOB-2164