### PR TITLE
Address truncated text and misalignment for large font type

### DIFF
--- a/GliaWidgets/Sources/Component/AttachmentList/Item/AttachmentSourceItemView.swift
+++ b/GliaWidgets/Sources/Component/AttachmentList/Item/AttachmentSourceItemView.swift
@@ -25,6 +25,8 @@ class AttachmentSourceItemView: UIView {
         titleLabel.text = style.title
         titleLabel.font = style.titleFont
         titleLabel.textColor = style.titleColor
+        titleLabel.numberOfLines = 0
+        titleLabel.lineBreakMode = .byWordWrapping
 
         accessibilityTraits = .button
         accessibilityLabel = style.title

--- a/GliaWidgets/Sources/Component/Connect/ConnectView.swift
+++ b/GliaWidgets/Sources/Component/Connect/ConnectView.swift
@@ -36,8 +36,7 @@ final class ConnectView: BaseView {
     private let environment: Environment
     private lazy var stackView = UIStackView.make(
         .vertical,
-        spacing: State.initial.chatContentSpacing,
-        distribution: .fillProportionally
+        spacing: State.initial.chatContentSpacing
     )(
         operatorView,
         statusView

--- a/GliaWidgets/Sources/Component/Connect/Status/ConnectStatusView.swift
+++ b/GliaWidgets/Sources/Component/Connect/Status/ConnectStatusView.swift
@@ -2,8 +2,8 @@ import UIKit
 
 final class ConnectStatusView: BaseView {
     private let stackView = UIStackView()
-    private let firstLabel = UILabel()
-    private let secondLabel = UILabel()
+    private let firstLabel = UILabel().makeView()
+    private let secondLabel = UILabel().makeView()
 
     override func setup() {
         super.setup()
@@ -19,16 +19,24 @@ final class ConnectStatusView: BaseView {
         addSubview(stackView)
         stackView.addArrangedSubviews([firstLabel, secondLabel])
         stackView.autoPinEdgesToSuperviewEdges()
+        NSLayoutConstraint.activate([
+            firstLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
+            firstLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
+            secondLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
+            secondLabel.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
     }
 
     func setStyle(_ style: ConnectStatusStyle) {
         firstLabel.font = style.firstTextFont
         firstLabel.textColor = style.firstTextFontColor
         firstLabel.numberOfLines = 0
+        firstLabel.lineBreakMode = .byWordWrapping
 
         secondLabel.font = style.secondTextFont
         secondLabel.textColor = style.secondTextFontColor
         secondLabel.numberOfLines = 0
+        secondLabel.lineBreakMode = .byWordWrapping
 
         firstLabel.accessibilityHint = style.accessibility.firstTextHint
         secondLabel.accessibilityHint = style.accessibility.secondTextHint

--- a/GliaWidgets/Sources/View/Chat/Entry/ChatMessageEntryView.swift
+++ b/GliaWidgets/Sources/View/Chat/Entry/ChatMessageEntryView.swift
@@ -51,7 +51,7 @@ class ChatMessageEntryView: BaseView {
     private let separator = UIView()
     private let messageContainerView = UIView()
     private let textView = UITextView()
-    private let placeholderLabel = UILabel()
+    private let placeholderLabel = UILabel().makeView()
     private let sendButton: MessageButton
     private let buttonsStackView = UIStackView()
     private var textViewHeightConstraint: NSLayoutConstraint?
@@ -122,6 +122,7 @@ class ChatMessageEntryView: BaseView {
 
         placeholderLabel.font = style.placeholderFont
         placeholderLabel.textColor = style.placeholderColor
+        placeholderLabel.isUserInteractionEnabled = false
         updatePlaceholderText()
 
         pickMediaButton.tap = { [weak self] in self?.pickMediaTapped?() }
@@ -158,15 +159,19 @@ class ChatMessageEntryView: BaseView {
             toSize: kMinTextViewHeight
         )
 
-        textView.autoPinEdge(toSuperviewEdge: .left, withInset: 16)
+        textView.autoPinEdge(toSuperviewEdge: .leading, withInset: 16)
         textView.autoPinEdge(toSuperviewEdge: .top, withInset: 13)
         textView.autoPinEdge(toSuperviewEdge: .bottom, withInset: 13)
-        textView.autoPinEdge(toSuperviewEdge: .right, withInset: 8)
+        textView.autoPinEdge(toSuperviewEdge: .trailing, withInset: 8)
 
-        textView.addSubview(placeholderLabel)
-        placeholderLabel.autoPinEdge(toSuperviewEdge: .left)
-        placeholderLabel.autoPinEdge(toSuperviewEdge: .top)
-        placeholderLabel.autoPinEdge(toSuperviewEdge: .right)
+        messageContainerView.addSubview(placeholderLabel)
+        placeholderLabel.numberOfLines = 0
+
+        NSLayoutConstraint.activate([
+            placeholderLabel.leadingAnchor.constraint(equalTo: textView.leadingAnchor),
+            placeholderLabel.trailingAnchor.constraint(equalTo: textView.trailingAnchor),
+            placeholderLabel.topAnchor.constraint(equalTo: textView.topAnchor)
+        ])
 
         separator.autoSetDimension(.height, toSize: 1)
         separator.autoPinEdgesToSuperviewEdges(with: .zero, excludingEdge: .bottom)
@@ -214,7 +219,10 @@ class ChatMessageEntryView: BaseView {
             height: CGFloat.greatestFiniteMagnitude
         )
 
-        var newHeight = textView.sizeThatFits(size).height
+        // We need to take into account larger height
+        // of text view or placeholder label for
+        // updated text entry height.
+        var newHeight = max(textView.sizeThatFits(size).height, placeholderLabel.sizeThatFits(size).height)
 
         textView.isScrollEnabled = newHeight > kMaxTextViewHeight
 

--- a/GliaWidgets/Sources/ViewController/Survey/SurveyViewController.View.swift
+++ b/GliaWidgets/Sources/ViewController/Survey/SurveyViewController.View.swift
@@ -29,9 +29,16 @@ extension Survey {
         }
         let cancelButton = UIButton(type: .custom).make {
             $0.setTitle(L10n.Survey.Action.cancel, for: .normal)
+            $0.titleLabel?.numberOfLines = 0
+            // Using `byWordWrapping` prevents button text
+            // from getting truncated, for example for large
+            // dynamic font types.
+            $0.titleLabel?.lineBreakMode = .byWordWrapping
         }
         let submitButton = UIButton(type: .custom).make {
             $0.setTitle(L10n.Survey.Action.submit, for: .normal)
+            $0.titleLabel?.numberOfLines = 0
+            $0.titleLabel?.lineBreakMode = .byWordWrapping
         }
         lazy var buttonStackView = UIStackView.make(.horizontal, spacing: 16)(
             cancelButton,
@@ -97,9 +104,10 @@ extension Survey {
                 buttonStackView.leadingAnchor.constraint(equalTo: buttonContainer.leadingAnchor, constant: Self.contentPadding),
                 buttonStackView.trailingAnchor.constraint(equalTo: buttonContainer.trailingAnchor, constant: -Self.contentPadding),
 
-                cancelButton.heightAnchor.constraint(equalToConstant: 44),
-                submitButton.heightAnchor.constraint(equalToConstant: 44),
-                cancelButton.widthAnchor.constraint(equalTo: submitButton.widthAnchor)
+                cancelButton.heightAnchor.constraint(greaterThanOrEqualToConstant: 44),
+                submitButton.heightAnchor.constraint(greaterThanOrEqualToConstant: 44),
+                cancelButton.widthAnchor.constraint(lessThanOrEqualTo: submitButton.widthAnchor),
+                submitButton.widthAnchor.constraint(lessThanOrEqualTo: cancelButton.widthAnchor)
             ])
         }
 


### PR DESCRIPTION
Fix text truncation and misalignment when dynamic font type is adjusted to largest category.
Note that text will [break to next line](https://user-images.githubusercontent.com/3148347/236902144-71522590-1c0e-459e-82f5-f8a3b3d466e7.png) if it does not fit in on one line to prevent truncation and to favour full text instead of truncation.

MOB-2173


<img src="https://user-images.githubusercontent.com/3148347/236902514-9099ad43-3402-4418-a7b5-d16e8c1366f2.png" width="428" height="926">

<img src="https://user-images.githubusercontent.com/3148347/236902334-5f738c9a-dedf-4be2-be95-5cb5a0accdeb.png" width="428" height="926">

<img src="https://user-images.githubusercontent.com/3148347/236902144-71522590-1c0e-459e-82f5-f8a3b3d466e7.png" width="428" height="926">

<img src="https://user-images.githubusercontent.com/3148347/236901899-b9698fbe-66a5-4a1a-b1fb-4a887edb7d94.png" width="428" height="926">
