### PR TITLE
Avoid presenting survey in welcome and confirmation screen

### DIFF
--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
@@ -105,7 +105,7 @@ extension SecureConversations {
             case .backTapped:
                 delegate?(.backTapped)
             case .closeTapped:
-                delegate?(.closeTapped)
+                delegate?(.closeTapped(.doNotPresentSurvey))
             // Bind changes in view model to view controller.
             case let .renderProps(props):
                 controller?.props = props
@@ -171,7 +171,7 @@ extension SecureConversations {
             viewModel.delegate = { [weak self, weak controller] event in
                 switch event {
                 case .closeTapped:
-                    self?.delegate?(.closeTapped)
+                    self?.delegate?(.closeTapped(.doNotPresentSurvey))
                 // Bind changes in view model to view controller.
                 case let .renderProps(props):
                     controller?.props = props
@@ -292,7 +292,7 @@ extension SecureConversations.Coordinator {
             case .back:
                 self?.delegate?(.backTapped)
             case .finished:
-                self?.delegate?(.closeTapped)
+                self?.delegate?(.closeTapped(.presentSurvey))
             default:
                 self?.delegate?(.chat(event))
             }
@@ -352,8 +352,13 @@ extension SecureConversations.Coordinator {
 
     enum DelegateEvent {
         case backTapped
-        case closeTapped
+        case closeTapped(SurveyPresentation)
         case chat(ChatCoordinator.DelegateEvent)
+
+        enum SurveyPresentation {
+            case presentSurvey
+            case doNotPresentSurvey
+        }
     }
 }
 


### PR DESCRIPTION
The issue happened because the coordinator called `end()` for all screens, even if they are welcome and confirmation, which should never be in a situation where they need to present a survey. Thus, a new enum was created called `SurveyPresentation`, which determines if the screen needs to present a survey. This is an enum and not a boolean because it's an associated value in an enum, so it's more descriptive.

I attempted and fail to crete unit tests for this but I failed and lost time because `EngagementCoordinator` is complicated to test correctly.

MOB-2163