### PR TITLE
Fix VoiceOver to read all messages in sequence

### DIFF
--- a/GliaWidgets/Sources/View/Chat/Message/ChatMessageView.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/ChatMessageView.swift
@@ -68,12 +68,7 @@ class ChatMessageView: BaseView {
     func appendContentView(_ contentView: UIView, animated: Bool) {
         contentViews.addArrangedSubview(contentView)
         contentView.isHidden = animated
-
-        // Make sure that order of accessible elements is preserved the same way
-        // as it is displayed. Otherwise, for example message sent along with attachment is read
-        // by VoiceOver after attachment, even though it is situated above attachment.
         contentViews.accessibilityElements?.append(contentView)
-
         if animated {
             contentViews.layoutIfNeeded()
             UIView.animate(withDuration: 0.3) {
@@ -87,9 +82,6 @@ class ChatMessageView: BaseView {
         super.setup()
         contentViews.axis = .vertical
         contentViews.spacing = 4
-        // Add empty list of accessible elements to be populated later,
-        // as visual elements are added to `contentViews`.
-        contentViews.accessibilityElements = []
     }
 
     private func contentViews(

--- a/GliaWidgets/Sources/View/Chat/Message/Content/ChoiceCard/ChoiceCardView.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/Content/ChoiceCard/ChoiceCardView.swift
@@ -78,6 +78,7 @@ final class ChoiceCardView: OperatorChatMessageView {
         )
         textView.text = choiceCard.text
         stackView.addArrangedSubview(textView)
+        setupAccessibilityProperties(for: textView)
 
         guard let options = choiceCard.options else { return containerView }
 
@@ -117,5 +118,10 @@ extension ChoiceCardView {
     func setupAccessibilityProperties(for imageView: ImageView) {
         imageView.isAccessibilityElement = true
         imageView.accessibilityLabel = viewStyle.accessibility.imageLabel
+    }
+
+    func setupAccessibilityProperties(for textView: ChatTextContentView) {
+        textView.accessibilityLabel = textView.text
+        textView.isAccessibilityElement = true
     }
 }


### PR DESCRIPTION
The voiceover didn't read any tableview cells that weren't visible, and jumped ahead to the text entry field and buttons below. This PR fixes this issue.

MOB-1982