### PR TITLE
Simulate welcome messages arrive after engagement start event

### DIFF
--- a/GliaWidgets/Sources/Coordinators/Call/CallCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Call/CallCoordinator.swift
@@ -81,7 +81,9 @@ private extension CallCoordinator {
                 uiApplication: environment.uiApplication,
                 fetchChatHistory: environment.fetchChatHistory,
                 fileUploadListStyle: viewFactory.theme.chatStyle.messageEntry.uploadList,
-                createFileUploadListModel: environment.createFileUploadListModel
+                createFileUploadListModel: environment.createFileUploadListModel,
+                startSocketObservation: environment.startSocketObservation,
+                stopSocketObservation: environment.stopSocketObservation
             ),
             call: call,
             unreadMessages: unreadMessages,
@@ -153,5 +155,7 @@ extension CallCoordinator {
         var notificationCenter: FoundationBased.NotificationCenter
         var fetchChatHistory: CoreSdkClient.FetchChatHistory
         var createFileUploadListModel: SecureConversations.FileUploadListViewModel.Create
+        var startSocketObservation: CoreSdkClient.StartSocketObservation
+        var stopSocketObservation: CoreSdkClient.StopSocketObservation
     }
 }

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
@@ -224,7 +224,9 @@ extension ChatCoordinator {
             uiApplication: environment.uiApplication,
             fetchChatHistory: environment.fetchChatHistory,
             fileUploadListStyle: viewFactory.theme.chatStyle.messageEntry.uploadList,
-            createFileUploadListModel: environment.createFileUploadListModel
+            createFileUploadListModel: environment.createFileUploadListModel,
+            startSocketObservation: environment.startSocketObservation,
+            stopSocketObservation: environment.stopSocketObservation
         )
     }
 }

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
@@ -346,7 +346,9 @@ extension EngagementCoordinator {
                 uiDevice: environment.uiDevice,
                 notificationCenter: environment.notificationCenter,
                 fetchChatHistory: environment.fetchChatHistory,
-                createFileUploadListModel: environment.createFileUploadListModel
+                createFileUploadListModel: environment.createFileUploadListModel,
+                startSocketObservation: environment.startSocketObservation,
+                stopSocketObservation: environment.stopSocketObservation
             )
         )
         coordinator.delegate = { [weak self] event in

--- a/GliaWidgets/Sources/Interactor/Interactor.swift
+++ b/GliaWidgets/Sources/Interactor/Interactor.swift
@@ -350,7 +350,12 @@ extension Interactor: CoreSdkClient.Interactable {
     }
 
     func receive(message: CoreSdkClient.Message) {
-        notify(.receivedMessage(message))
+        let allowed: [CoreSdkClient.MessageSender.SenderType] = [.visitor, .system]
+
+        // Only process visitor and system messages while on secure transcript (engagement is nil).
+        if (currentEngagement == nil && allowed.contains(message.sender.type)) || currentEngagement != nil  {
+            notify(.receivedMessage(message))
+        }
     }
 
     func start() {
@@ -362,7 +367,6 @@ extension Interactor: CoreSdkClient.Interactable {
     }
 
     func start(engagement: CoreSdkClient.Engagement) {
-
         switch engagement.source {
         case .coreEngagement:
             start()

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Environment.Interface.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Environment.Interface.swift
@@ -22,5 +22,7 @@ extension EngagementViewModel {
         var fetchChatHistory: CoreSdkClient.FetchChatHistory
         var fileUploadListStyle: FileUploadListStyle
         var createFileUploadListModel: SecureConversations.FileUploadListViewModel.Create
+        var startSocketObservation: CoreSdkClient.StartSocketObservation
+        var stopSocketObservation: CoreSdkClient.StopSocketObservation
     }
 }

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Environment.Mock.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Environment.Mock.swift
@@ -29,7 +29,9 @@ extension ChatViewModel.Environment {
         uiApplication: .mock,
         fetchChatHistory: { _ in },
         fileUploadListStyle: .initial,
-        createFileUploadListModel: SecureConversations.FileUploadListViewModel.mock(environment:)
+        createFileUploadListModel: SecureConversations.FileUploadListViewModel.mock(environment:),
+        startSocketObservation: { },
+        stopSocketObservation: { }
     )
 }
 #endif

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.SecureConverstaions.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.SecureConverstaions.swift
@@ -1,3 +1,5 @@
+import SalemoveSDK
+
 extension ChatViewModel {
     func migrate(from transcript: SecureConversations.TranscriptModel) {
         sections = transcript.sections
@@ -25,5 +27,10 @@ extension ChatViewModel {
         // Set view active, to avoid unread message button
         // to be shown.
         isViewActive.value = true
+
+        environment.stopSocketObservation()
+        loadHistory(appendingToMessageSection: true) { [weak self] _ in
+            self?.environment.startSocketObservation()
+        }
     }
 }

--- a/GliaWidgets/Sources/ViewModel/Chat/Data/ChatItem.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/Data/ChatItem.swift
@@ -12,6 +12,25 @@ class ChatItem {
         }
     }
 
+    var id: String? {
+        switch kind {
+        case .operatorMessage(let chatMessage, _, _):
+            return chatMessage.id
+        case .outgoingMessage(let outgoingMessage):
+            return outgoingMessage.id
+        case .visitorMessage(let chatMessage, _):
+            return chatMessage.id
+        case .choiceCard(let chatMessage, _, _, _):
+            return chatMessage.id
+        case .customCard(let chatMessage, _, _, _):
+            return chatMessage.id
+        case .systemMessage(let chatMessage):
+            return chatMessage.id
+        case .callUpgrade, .queueOperator, .operatorConnected, .transferring, .unreadMessageDivider:
+            return nil
+        }
+    }
+
     let kind: Kind
 
     init(
@@ -68,5 +87,22 @@ extension ChatItem {
         case transferring
         case unreadMessageDivider
         case systemMessage(ChatMessage)
+    }
+}
+
+extension ChatItem: Equatable {
+    static func == (lhs: ChatItem, rhs: ChatItem) -> Bool {
+        guard let lhsId = lhs.id, let rhsId = rhs.id else { return false }
+
+        switch (lhs.kind, rhs.kind) {
+        case (.operatorMessage, .operatorMessage),
+            (.outgoingMessage, .outgoingMessage),
+            (.visitorMessage, .visitorMessage),
+            (.choiceCard, .choiceCard),
+            (.customCard, .customCard),
+            (.systemMessage, .systemMessage):
+            return lhsId == rhsId
+        default: return false
+        }
     }
 }

--- a/GliaWidgetsTests/Sources/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModelTests.swift
@@ -56,7 +56,9 @@ class ChatViewModelTests: XCTestCase {
                 fileUploadListStyle: .mock,
                 createFileUploadListModel: { _ in
                     .mock()
-                }
+                },
+                startSocketObservation: { },
+                stopSocketObservation: { }
             )
         )
 
@@ -436,6 +438,7 @@ class ChatViewModelTests: XCTestCase {
             .mock(environment: $0)
         }
         chatViewModelEnv.uiApplication.preferredContentSizeCategory = { .unspecified }
+        chatViewModelEnv.fetchChatHistory = { _ in }
         let chatViewModel = ChatViewModel.mock(environment: chatViewModelEnv)
         var calls: [Call] = []
         chatViewModel.action = { action in

--- a/GliaWidgetsTests/ViewModel/Chat/ChatViewModel.Environment.Failing.swift
+++ b/GliaWidgetsTests/ViewModel/Chat/ChatViewModel.Environment.Failing.swift
@@ -52,7 +52,9 @@ extension ChatViewModel.Environment {
             createFileUploadListModel: { _ in
                 fail("\(Self.self).createFileUploadListModel")
                 return .mock()
-            }
+            },
+            startSocketObservation: { },
+            stopSocketObservation: { }
         )
     }
 }


### PR DESCRIPTION
The backend sends us messages in the incorrect order. However, product still wants us to show them correctly. Thus, what is done is the following:

1. Have socket only listen for visitor and system messages.
2. When the engagement starts, have the chat transcript downloaded.
3. Determine which operator messages are new, and add those to the messages section, not the history section.
4. Restart the socket observation.

This code is incredibly hacky, but as long as we are required to do this from our side, all solutions will be hacky. Please help me make it as clean as an abomination like this allows.

Note that this fix only works 100% well with Igor's PR in ios-sdk about message duplication. Otherwise, welcome messages are duplicated. However you can still see that all duplicated welcome messages are correctly added after the operator header.

MOB-2183