### PR TITLE
Avoid last message being cut off when clearing unread message divider

### DIFF
--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.ChatWithTranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.ChatWithTranscriptModel.swift
@@ -861,8 +861,10 @@ extension SecureConversations.TranscriptModel {
     }
 
     func markMessagesAsRead() {
+        let mainQueue = environment.gcd.mainQueue
         let dispatchTime: DispatchTime = .now() + .seconds(Self.markUnreadMessagesDelaySeconds)
-        environment.gcd.mainQueue.asyncAfterDeadline(dispatchTime) { [environment, weak historySection, action] in
+
+        mainQueue.asyncAfterDeadline(dispatchTime) { [environment, weak historySection, action, weak self] in
             _ = environment.secureMarkMessagesAsRead { result in
                 switch result {
                 case .success:
@@ -877,6 +879,10 @@ extension SecureConversations.TranscriptModel {
                     })
 
                     action?(.refreshSection(historySection.index, animated: true))
+
+                    if self?.isChatScrolledToBottom.value ?? false {
+                        action?(.scrollToBottom(animated: true))
+                    }
                 case .failure:
                     break
                 }


### PR DESCRIPTION
When the unread message divider was disappearing, the scroll view wasn't going to the bottom again (if already at the bottom). With this commit, if the visitor is at the bottom, then the scroll view is scrolled to the bottom. If not, then the default behavior is that it more or less keeps its place, taking into consideration that the unread message divider has disappeared.

MOB-2193