### PR TITLE
Remove not needed accessibility modifier

### DIFF
--- a/GliaWidgets/Sources/View/Chat/Message/ChatMessageView.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/ChatMessageView.swift
@@ -68,7 +68,6 @@ class ChatMessageView: BaseView {
     func appendContentView(_ contentView: UIView, animated: Bool) {
         contentViews.addArrangedSubview(contentView)
         contentView.isHidden = animated
-        contentViews.accessibilityElements?.append(contentView)
         if animated {
             contentViews.layoutIfNeeded()
             UIView.animate(withDuration: 0.3) {


### PR DESCRIPTION
Since accessibilityElements is an optional array, this line didn't execute anything and can therefore be removed