### PR TITLE
Make old deprecated methods unavailable

### DIFF
--- a/GliaWidgets/Asset.swift
+++ b/GliaWidgets/Asset.swift
@@ -15,7 +15,7 @@ private let bundleManaging: BundleManaging = .live
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-@available(*, deprecated, renamed: "ImageAsset")
+@available(*, unavailable, renamed: "ImageAsset")
 public typealias AssetType = ImageAsset
 
 public struct ImageAsset {
@@ -132,14 +132,14 @@ public enum Asset {
       spinner,
     ]
     // swiftlint:enable trailing_comma
-    @available(*, deprecated, renamed: "allImages")
+    @available(*, unavailable, renamed: "allImages")
     public static let allValues: [AssetType] = allImages
 }
 // swiftlint:enable identifier_name line_length nesting type_body_length type_name
 
 public extension Image {
   @available(iOS 1.0, tvOS 1.0, watchOS 1.0, *)
-  @available(OSX, deprecated,
+  @available(OSX, unavailable,
     message: "This initializer is unsafe on macOS, please use the ImageAsset.image property")
   convenience init!(asset: ImageAsset) {
     #if os(iOS) || os(tvOS)

--- a/GliaWidgets/Public/Glia/Glia.Deprecated.swift
+++ b/GliaWidgets/Public/Glia/Glia.Deprecated.swift
@@ -18,7 +18,7 @@ extension Glia {
     }
 
     /// Deprecated.
-    @available(*, deprecated, message: "Use configure(with:queueId:visitorContext:) with Optional<VisitorContext> instead.")
+    @available(*, unavailable, message: "Use configure(with:queueId:visitorContext:) with Optional<VisitorContext> instead.")
     public func configure(
         with configuration: Configuration,
         queueId: String,


### PR DESCRIPTION
Glia's policy is to keep deprecated methods in use for additional 6 months. This PR makes older methods unavailable. This PR also covers 1319 and 1348 tickets

MOB-1319 and MOB-1348