### PR TITLE
Make old configure method unavailable

### DIFF
--- a/GliaWidgets/Public/Glia/Glia.Deprecated.swift
+++ b/GliaWidgets/Public/Glia/Glia.Deprecated.swift
@@ -2,7 +2,7 @@ import SalemoveSDK
 
 extension Glia {
     /// Deprecated.
-    @available(*, deprecated, message: "Use configure(with:queueId:uiConfig:assetsBuilder:completion:) instead.")
+    @available(*, unavailable, message: "Use configure(with:queueId:uiConfig:assetsBuilder:completion:) instead.")
     public func configure(
         with configuration: Configuration,
         queueId: String,
@@ -14,20 +14,6 @@ extension Glia {
             queueId: queueId,
             uiConfig: nil,
             completion: completion
-        )
-    }
-
-    /// Deprecated.
-    @available(*, unavailable, message: "Use configure(with:queueId:visitorContext:) with Optional<VisitorContext> instead.")
-    public func configure(
-        with configuration: Configuration,
-        queueId: String,
-        visitorContext: VisitorContext
-    ) throws {
-        try self.configure(
-            with: configuration,
-            queueId: queueId,
-            visitorContext: Optional(visitorContext)
         )
     }
 


### PR DESCRIPTION
This PR makes the old configure method unavailable and since an even older one called the first one, it was removed entirely. In addition, app token was removed from authorization methods, because it has been deprecated for more than 12 months.

MOB-1912