### PR TITLE
Introduce new `clearVisitorSession` method

### DIFF
--- a/GliaWidgets/Public/Glia/Glia.Deprecated.swift
+++ b/GliaWidgets/Public/Glia/Glia.Deprecated.swift
@@ -70,4 +70,23 @@ extension Glia {
             sceneProvider: sceneProvider
         )
     }
+
+    /// Deprecated, use `clearVisitorSession(_:)` instead.
+    @available(
+        *,
+         deprecated,
+         message: "Use clearVisitorSession(_:) instead."
+    )
+    public func clearVisitorSession() {
+        if environment.coreSdk.getCurrentEngagement() != nil {
+            print("⚠️ Don't call `clearVisitorSession` during active engagement. Otherwise, it might break the engagement interaction.")
+        }
+        environment.coreSdk.clearSession()
+    }
+
+    /// Deprecated, use ``callVisualizer.showVisitorCodeViewController`` instead.
+    @available(*, deprecated, message: "Deprecated, use ``CallVisualizer.showVisitorCodeViewController`` instead.")
+    public func requestVisitorCode(completion: @escaping (Result<VisitorCode, Swift.Error>) -> Void) {
+        _ = environment.coreSdk.requestVisitorCode(completion)
+    }
 }

--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -157,8 +157,19 @@ public class Glia {
     }
 
     /// Clear visitor session
-    public func clearVisitorSession() {
+    ///
+    /// - Parameter completion: Completion handler.
+    ///
+    /// - Important: Note, that in case of ongoing engagement, `clearVisitorSession` must be called after ending engagement,
+    /// because `GliaError.clearingVisitorSessionDuringEngagementIsNotAllowed` will occur otherwise.
+    ///
+    public func clearVisitorSession(_ completion: @escaping (Result<Void, Error>) -> Void) {
+        guard environment.coreSdk.getCurrentEngagement() == nil else {
+            completion(.failure(GliaError.clearingVisitorSessionDuringEngagementIsNotAllowed))
+            return
+        }
         environment.coreSdk.clearSession()
+        completion(.success(()))
     }
 
     /// Fetch current Visitor's information.
@@ -245,12 +256,6 @@ public class Glia {
             success: { completion(.success(())) },
             failure: { completion(.failure($0)) }
         )
-    }
-
-    /// Deprecated, use ``callVisualizer.showVisitorCodeViewController`` instead.
-    @available(*, deprecated, message: "Deprecated, use ``CallVisualizer.showVisitorCodeViewController`` instead.")
-    public func requestVisitorCode(completion: @escaping (Result<VisitorCode, Swift.Error>) -> Void) {
-        _ = environment.coreSdk.requestVisitorCode(completion)
     }
 }
 

--- a/GliaWidgets/Public/GliaError.swift
+++ b/GliaWidgets/Public/GliaError.swift
@@ -5,4 +5,5 @@ public enum GliaError: Error {
     case sdkIsNotConfigured
     case callVisualizerEngagementExists
     case configuringDuringEngagementIsNotAllowed
+    case clearingVisitorSessionDuringEngagementIsNotAllowed
 }

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -234,4 +234,21 @@ final class GliaTests: XCTestCase {
             XCTAssertEqual(error as? GliaError, GliaError.configuringDuringEngagementIsNotAllowed)
         }
     }
+
+    func testClearVisitorSessionThrowsErrorDuringActiveEngagement() throws {
+        var environment = Glia.Environment.failing
+        environment.coreSdk.getCurrentEngagement = { .mock() }
+        let sdk = Glia(environment: environment)
+
+        var resultingError: Error?
+        sdk.clearVisitorSession { result in
+            guard case let .failure(error) = result else {
+                fail("`clearVisitorSession` should fail when ongoing engegament exists.")
+                return
+            }
+            resultingError = error
+        }
+
+        XCTAssertEqual(resultingError as? GliaError, GliaError.clearingVisitorSessionDuringEngagementIsNotAllowed)
+    }
 }

--- a/TestingApp/ViewController/ViewController.swift
+++ b/TestingApp/ViewController/ViewController.swift
@@ -100,7 +100,10 @@ class ViewController: UIViewController {
     }
 
     @IBAction private func clearSessionTapped() {
-        Glia.sharedInstance.clearVisitorSession()
+        Glia.sharedInstance.clearVisitorSession { [weak self] result in
+            guard case let .failure(error) = result else { return }
+            self?.alert(message: "The operation couldn't be completed. '\(error)'.")
+        }
     }
 
     @IBAction private func configureSDKTapped() {
@@ -510,6 +513,8 @@ extension ViewController {
             self.alert(message: error.reason)
         } catch let error as ConfigurationError {
             self.alert(message: "Configuration error: '\(error)'.")
+        } catch let error as GliaError {
+            self.alert(message: "The operation couldn't be completed. '\(error)'.")
         } catch {
             self.alert(message: error.localizedDescription)
         }


### PR DESCRIPTION
New`clearVisitorSession(_:)` method was added to provide the ability to throw the error to integrator in case when they try to clear visitor session during active engagement.

MOB-2136