### PR TITLE
Fix thumbnail generating

### DIFF
--- a/GliaWidgets/Sources/QuickLookBased/QuickLookBased.Live.swift
+++ b/GliaWidgets/Sources/QuickLookBased/QuickLookBased.Live.swift
@@ -23,7 +23,7 @@ extension QuickLookBased.ThumbnailGenerator {
         let request = QLThumbnailGenerator.Request(
             fileAt: fileURL.standardizedFileURL,
             size: newSize,
-            scale: scale,
+            scale: 1,
             representationTypes: .thumbnail
         )
         generateBestRepresentation(request) { thumbnail, error in


### PR DESCRIPTION
Previously there was passed incorrect scale value, because few lines above we already took the scale into account when calculated image size. This commit fixes it.

 MOB-2249