### PR TITLE
Fix copping UnifiedUI json file into the testing app bundle

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -3619,7 +3619,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "find -L ${SRCROOT}/TestingApp \\\n    -type f \\\n    -name \"*.json\" \\\n    | xargs -t -I {} \\\n    cp {} ${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/\n";
+			shellScript = "mkdir -p ${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/UnifiedUI/\nfind -L ${SRCROOT}/TestingApp/UnifiedUI \\\n    -type f \\\n    -name \"*.json\" \\\n    | xargs -t -I {} \\\n    cp {} ${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/UnifiedUI\n";
 		};
 		9A1BD2C2282932F500089691 /* Write SnapshotTests/Changes.diff */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/TestingApp/ViewController/ViewController.swift
+++ b/TestingApp/ViewController/ViewController.swift
@@ -285,7 +285,7 @@ extension ViewController {
     }
 
     private func jsonNames() -> [String] {
-        let paths = Bundle.main.paths(forResourcesOfType: "json", inDirectory: nil)
+        let paths = Bundle.main.paths(forResourcesOfType: "json", inDirectory: "UnifiedUI")
         return paths
             .compactMap(URL.init(string:))
             .compactMap {


### PR DESCRIPTION
Currently shell script from build phase copies all json files into root app bundle directory. This commit extends script, which now create separate folder.
Recently something was changed that Contents.json started to appear in app bundle, which affected Acceptance tests.

MOB-2254