### PR TITLE
PoC for theme remote configuration tests

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -485,6 +485,8 @@
 		AFC40C1C29965F0F001B4C53 /* SecureConversations.ChatWithTranscriptModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFC40C1B29965F0F001B4C53 /* SecureConversations.ChatWithTranscriptModel.swift */; };
 		AFCF8A5A2A02A97100B7ABB3 /* ChatItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCF8A592A02A97100B7ABB3 /* ChatItemTests.swift */; };
 		AFCF8A5C2A02AB3000B7ABB3 /* OutgoingMessage.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCF8A5B2A02AB3000B7ABB3 /* OutgoingMessage.Mock.swift */; };
+		AFE9893D2A279C63004B5524 /* ThemeRemoteConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE9893C2A279C63004B5524 /* ThemeRemoteConfigurationTests.swift */; };
+		AFE989412A28652F004B5524 /* unified_sample.json in Resources */ = {isa = PBXBuildFile; fileRef = AFE989402A28652F004B5524 /* unified_sample.json */; };
 		AFEF5C6F29928DB0005C3D8D /* SecureConversations.FileUploadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFEF5C6E29928DB0005C3D8D /* SecureConversations.FileUploadView.swift */; };
 		AFEF5C7129929601005C3D8D /* SecureConversations.FilePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFEF5C7029929601005C3D8D /* SecureConversations.FilePreviewView.swift */; };
 		AFEF5C7429929A8D005C3D8D /* SecureConversations.FileUploadListViewModel.Environment.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFEF5C7329929A8D005C3D8D /* SecureConversations.FileUploadListViewModel.Environment.Failing.swift */; };
@@ -1116,6 +1118,8 @@
 		AFC40C1B29965F0F001B4C53 /* SecureConversations.ChatWithTranscriptModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.ChatWithTranscriptModel.swift; sourceTree = "<group>"; };
 		AFCF8A592A02A97100B7ABB3 /* ChatItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatItemTests.swift; sourceTree = "<group>"; };
 		AFCF8A5B2A02AB3000B7ABB3 /* OutgoingMessage.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutgoingMessage.Mock.swift; sourceTree = "<group>"; };
+		AFE9893C2A279C63004B5524 /* ThemeRemoteConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeRemoteConfigurationTests.swift; sourceTree = "<group>"; };
+		AFE989402A28652F004B5524 /* unified_sample.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = unified_sample.json; sourceTree = "<group>"; };
 		AFEF5C6E29928DB0005C3D8D /* SecureConversations.FileUploadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FileUploadView.swift; sourceTree = "<group>"; };
 		AFEF5C7029929601005C3D8D /* SecureConversations.FilePreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FilePreviewView.swift; sourceTree = "<group>"; };
 		AFEF5C7329929A8D005C3D8D /* SecureConversations.FileUploadListViewModel.Environment.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FileUploadListViewModel.Environment.Failing.swift; sourceTree = "<group>"; };
@@ -2906,6 +2910,7 @@
 		9A1992CE27D61F5400161AAE /* SnapshotTests */ = {
 			isa = PBXGroup;
 			children = (
+				AFE989402A28652F004B5524 /* unified_sample.json */,
 				846E822728996A5C008EFBF0 /* AlertViewControllerTests.swift */,
 				9AB3401227F71D5D006E0FE2 /* BubbleViewVoiceOverTests.swift */,
 				9AE9E4B427E0EE2E00BFE239 /* CallViewControllerVoiceOverTests.swift */,
@@ -2918,6 +2923,7 @@
 				8458769E2823FD18007AC3DF /* SurveyViewControllerVoiceOverTests.swift */,
 				C07FA04D29B0E41A00E9FB7F /* VideoCallViewControllerTests.swift */,
 				C07FA04E29B0E41A00E9FB7F /* VisitorCodeViewControllerTests.swift */,
+				AFE9893C2A279C63004B5524 /* ThemeRemoteConfigurationTests.swift */,
 			);
 			path = SnapshotTests;
 			sourceTree = "<group>";
@@ -3476,6 +3482,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AFE989412A28652F004B5524 /* unified_sample.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4254,6 +4261,7 @@
 				846E822828996A5C008EFBF0 /* AlertViewControllerTests.swift in Sources */,
 				75CF8D9129C3A85C00CB1524 /* SecureConversationsWelcomeScreenTests.swift in Sources */,
 				9AE9E4B527E0EE2E00BFE239 /* CallViewControllerVoiceOverTests.swift in Sources */,
+				AFE9893D2A279C63004B5524 /* ThemeRemoteConfigurationTests.swift in Sources */,
 				C07FA05029B0E41A00E9FB7F /* VideoCallViewControllerTests.swift in Sources */,
 				9AB3401327F71D5D006E0FE2 /* BubbleViewVoiceOverTests.swift in Sources */,
 				9A1992D827D61F8100161AAE /* ChatViewControllerVoiceOverTests.swift in Sources */,

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
@@ -31,7 +31,7 @@ extension ChatViewController {
     }
 
     // MARK: - Messages from Chat Storage
-    static func mockHistoryMessagesScreen() -> ChatViewController {
+    static func mockHistoryMessagesScreen(theme: Theme? = nil) -> ChatViewController {
         var chatViewModelEnv = ChatViewModel.Environment.mock
         var fileManager = FoundationBased.FileManager.mock
         fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
@@ -192,7 +192,10 @@ extension ChatViewController {
         var factoryEnv = ViewFactory.Environment.mock
         factoryEnv.data.dataWithContentsOfFileUrl = { _ in UIImage.mock.pngData() ?? Data() }
         factoryEnv.imageViewCache.getImageForKey = { _ in  .mock }
-        let viewFactory = ViewFactory.mock(environment: factoryEnv)
+        let viewFactory = ViewFactory.mock(
+            theme: theme ?? .mock(),
+            environment: factoryEnv
+        )
         return .mock(chatViewModel: chatViewModel, viewFactory: viewFactory)
     }
 

--- a/SnapshotTests/ThemeRemoteConfigurationTests.swift
+++ b/SnapshotTests/ThemeRemoteConfigurationTests.swift
@@ -1,0 +1,34 @@
+@testable import GliaWidgets
+import XCTest
+import SnapshotTesting
+
+final class ThemeRemoteConfigurationTests: SnapshotTestCase {
+    func test_themeForMessagesFromHistory() throws {
+        let url = try XCTUnwrap(
+            Bundle(for: Self.self)
+                .url(
+                    forResource: "unified_sample.json",
+                    withExtension: nil
+                )
+        )
+
+        let jsonData = try Data(contentsOf: url)
+        let config = try JSONDecoder().decode(
+            RemoteConfiguration.self,
+            from: .init(jsonData)
+        )
+
+        let theme = Theme(
+            uiConfig: config,
+            assetsBuilder: .standard
+        )
+
+        let viewController = ChatViewController.mockHistoryMessagesScreen(theme: theme)
+        viewController.view.frame = UIScreen.main.bounds
+        assertSnapshot(
+            matching: viewController,
+            as: .image,
+            named: nameForDevice()
+        )
+    }
+}

--- a/SnapshotTests/unified_sample.json
+++ b/SnapshotTests/unified_sample.json
@@ -1,0 +1,3662 @@
+{
+  "alert": {
+    "backgroundColor": {
+      "type": "fill",
+      "value": ["#ffd100"]
+    },
+    "buttonAxis": "vertical",
+    "closeButtonColor": {
+      "type": "fill",
+      "value": ["#000000"]
+    },
+    "message": {
+      "alignment": "leading",
+      "background": {
+        "type": "fill",
+        "value": ["#FF0000"]
+      },
+      "font": {
+        "size": 14,
+        "style": "regular"
+      },
+      "foreground": {
+        "type": "fill",
+        "value": ["#000000"]
+      }
+    },
+    "negativeButton": {
+      "background": {
+        "border": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "borderWidth": 0,
+        "color": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "cornerRadius": 8
+      },
+      "shadow": {
+        "color": {
+          "type": "fill",
+          "value": ["FF0000"]
+        },
+        "offset": 0,
+        "opacity": 1,
+        "radius": 8
+      },
+      "text": {
+        "alignment": "center",
+        "background": {
+          "type": "fill",
+          "value": ["FF0000"]
+        },
+        "font": {
+          "size": 16,
+          "style": "regular"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#000000"]
+        }
+      },
+      "tintColor": {
+        "type": "fill",
+        "value": ["#ffd100"]
+      }
+    },
+    "positiveButton": {
+      "background": {
+        "border": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "borderWidth": 0,
+        "color": {
+          "type": "fill",
+          "value": ["#04728c"]
+        },
+        "cornerRadius": 8
+      },
+      "shadow": {
+        "color": {
+          "type": "fill",
+          "value": ["FF0000"]
+        },
+        "offset": 0,
+        "opacity": 1,
+        "radius": 8
+      },
+      "text": {
+        "alignment": "center",
+        "background": {
+          "type": "fill",
+          "value": ["FF0000"]
+        },
+        "font": {
+          "size": 16,
+          "style": "regular"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        }
+      },
+      "tintColor": {
+        "type": "fill",
+        "value": ["#FFFFFF"]
+      }
+    },
+    "title": {
+      "alignment": "center",
+      "background": {
+        "type": "fill",
+        "value": ["#FFFFFF"]
+      },
+      "font": {
+        "size": 24,
+        "style": "regular"
+      },
+      "foreground": {
+        "type": "fill",
+        "value": ["#000000"]
+      }
+    },
+    "titleImageColor": {
+      "type": "fill",
+      "value": ["#04728c"]
+    }
+  },
+  "bubble": {
+    "badge": {
+      "background": {
+        "border": {
+          "type": "fill",
+          "value": ["#fdd42b"]
+        },
+        "borderWidth": 1,
+        "color": {
+          "type": "fill",
+          "value": ["#04728c"]
+        }
+      },
+      "font": {
+        "size": 12,
+        "style": "bold"
+      },
+      "fontColor": {
+        "type": "fill",
+        "value": ["#fdd42b"]
+      }
+    },
+    "onHoldOverlay": {
+      "backgroundColor": {
+        "type": "fill",
+        "value": ["#000000"]
+      },
+      "tintColor": {
+        "type": "fill",
+        "value": ["#ffd100"]
+      }
+    },
+    "userImage": {
+      "imageBackgroundColor": {
+        "type": "fill",
+        "value": ["#04728c"]
+      },
+      "placeholderBackgroundColor": {
+        "type": "fill",
+        "value": ["#04728c"]
+      },
+      "placeholderColor": {
+        "type": "fill",
+        "value": ["#fdd42b"]
+      }
+    }
+  },
+  "callScreen": {
+    "background": {
+      "border": {
+        "type": "fill",
+        "value": ["FF0000"]
+      },
+      "borderWidth": 2,
+      "color": {
+        "type": "fill",
+        "value": ["#3A3A3A"]
+      },
+      "cornerRadius": 8
+    },
+    "bottomText": {
+      "alignment": "center",
+      "background": {
+        "type": "fill",
+        "value": ["#FFFFFF"]
+      },
+      "font": {
+        "size": 12,
+        "style": "regular"
+      },
+      "foreground": {
+        "type": "fill",
+        "value": ["#FFFFFF"]
+      }
+    },
+    "buttonBar": {
+      "badge": {
+        "background": {
+          "border": {
+            "type": "fill",
+            "value": ["#fdd42b"]
+          },
+          "borderWidth": 1,
+          "color": {
+            "type": "fill",
+            "value": ["#fdd42b"]
+          }
+        },
+        "font": {
+          "size": 12,
+          "style": "bold"
+        },
+        "fontColor": {
+          "type": "fill",
+          "value": ["#04728c"]
+        }
+      },
+      "chatButton": {
+        "active": {
+          "background": {
+            "type": "fill",
+            "value": ["#04728c"]
+          },
+          "imageColor": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "title": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "font": {
+              "size": 12,
+              "style": "regular"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            }
+          }
+        },
+        "inactive": {
+          "background": {
+            "type": "fill",
+            "value": ["#000000"]
+          },
+          "imageColor": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "title": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "font": {
+              "size": 12,
+              "style": "regular"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            }
+          }
+        },
+        "selected": {
+          "background": {
+            "type": "fill",
+            "value": ["#000000"]
+          },
+          "imageColor": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "title": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "font": {
+              "size": 12,
+              "style": "regular"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            }
+          }
+        }
+      },
+      "minimizeButton": {
+        "active": {
+          "background": {
+            "type": "fill",
+            "value": ["#04728c"]
+          },
+          "imageColor": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "title": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "font": {
+              "size": 12,
+              "style": "regular"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            }
+          }
+        },
+        "inactive": {
+          "background": {
+            "type": "fill",
+            "value": ["#000000"]
+          },
+          "imageColor": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "title": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "font": {
+              "size": 12,
+              "style": "regular"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            }
+          }
+        },
+        "selected": {
+          "background": {
+            "type": "fill",
+            "value": ["#000000"]
+          },
+          "imageColor": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "title": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "font": {
+              "size": 12,
+              "style": "regular"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            }
+          }
+        }
+      },
+      "muteButton": {
+        "active": {
+          "background": {
+            "type": "fill",
+            "value": ["#04728c"]
+          },
+          "imageColor": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "title": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "font": {
+              "size": 12,
+              "style": "regular"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            }
+          }
+        },
+        "inactive": {
+          "background": {
+            "type": "fill",
+            "value": ["#000000"]
+          },
+          "imageColor": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "title": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "font": {
+              "size": 12,
+              "style": "regular"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            }
+          }
+        },
+        "selected": {
+          "background": {
+            "type": "fill",
+            "value": ["#000000"]
+          },
+          "imageColor": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "title": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "font": {
+              "size": 12,
+              "style": "regular"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            }
+          }
+        }
+      },
+      "speakerButton": {
+        "active": {
+          "background": {
+            "type": "fill",
+            "value": ["#04728c"]
+          },
+          "imageColor": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "title": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "font": {
+              "size": 12,
+              "style": "regular"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            }
+          }
+        },
+        "inactive": {
+          "background": {
+            "type": "fill",
+            "value": ["#000000"]
+          },
+          "imageColor": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "title": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "font": {
+              "size": 12,
+              "style": "regular"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            }
+          }
+        },
+        "selected": {
+          "background": {
+            "type": "fill",
+            "value": ["#000000"]
+          },
+          "imageColor": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "title": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "font": {
+              "size": 12,
+              "style": "regular"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            }
+          }
+        }
+      },
+      "videoButton": {
+        "active": {
+          "background": {
+            "type": "fill",
+            "value": ["#04728c"]
+          },
+          "imageColor": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "title": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "font": {
+              "size": 12,
+              "style": "regular"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            }
+          }
+        },
+        "inactive": {
+          "background": {
+            "type": "fill",
+            "value": ["#000000"]
+          },
+          "imageColor": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "title": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "font": {
+              "size": 12,
+              "style": "regular"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            }
+          }
+        },
+        "selected": {
+          "background": {
+            "type": "fill",
+            "value": ["#000000"]
+          },
+          "imageColor": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "title": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "font": {
+              "size": 12,
+              "style": "regular"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            }
+          }
+        }
+      }
+    },
+    "operator": {
+      "alignment": "center",
+      "background": {
+        "type": "fill",
+        "value": ["#FFFFFF"]
+      },
+      "font": {
+        "size": 24,
+        "style": "regular"
+      },
+      "foreground": {
+        "type": "fill",
+        "value": ["#FFFFFF"]
+      }
+    },
+    "connect": {
+      "connected": {
+        "title": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 24,
+            "style": "bold"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        },
+        "description": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 18,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        }
+      },
+      "connecting": {
+        "title": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 24,
+            "style": "bold"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        },
+        "description": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 18,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        }
+      },
+      "onHold": {
+        "title": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 24,
+            "style": "bold"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#8E8E93"]
+          }
+        },
+        "description": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 18,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#8E8E93"]
+          }
+        }
+      },
+      "operator": {
+        "image": {
+          "placeholderColor": {
+            "type": "fill",
+            "value": ["#04728c"]
+          },
+          "placeholderBackgroundColor": {
+            "type": "fill",
+            "value": ["#f9d12b"]
+          },
+          "imageBackgroundColor": {
+            "type": "fill",
+            "value": ["#f9d12b"]
+          }
+        },
+        "animationColor": {
+          "type": "fill",
+          "value": ["#f9d12b"]
+        },
+        "onHoldOverlay": {
+          "backgroundColor": {
+            "type": "fill",
+            "value": ["#000000"]
+          },
+          "tintColor": {
+            "type": "fill",
+            "value": ["#f9d12b"]
+          }
+        }
+      },
+      "queue": {
+        "title": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 24,
+            "style": "bold"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        },
+        "description": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 18,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        }
+      },
+      "transferring": {
+        "title": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 24,
+            "style": "bold"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        },
+        "description": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 18,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        }
+      }
+    },
+    "duration": {
+      "alignment": "center",
+      "background": {
+        "type": "fill",
+        "value": ["#FFFFFF"]
+      },
+      "font": {
+        "size": 16,
+        "style": "regular"
+      },
+      "foreground": {
+        "type": "fill",
+        "value": ["#FFFFFF"]
+      }
+    },
+    "header": {
+      "backButton": {
+        "background": {
+          "border": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "borderWidth": 2,
+          "color": {
+            "type": "fill",
+            "value": ["#000000"]
+          },
+          "cornerRadius": 8
+        },
+        "shadow": {
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "offset": 0,
+          "opacity": 1,
+          "radius": 5
+        },
+        "text": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 16,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#000000"]
+          }
+        },
+        "tintColor": {
+          "type": "fill",
+          "value": ["#000000"]
+        }
+      },
+      "background": {
+        "border": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "borderWidth": 2,
+        "color": {
+          "type": "fill",
+          "value": ["#f9d12b"]
+        },
+        "cornerRadius": 8
+      },
+      "closeButton": {
+        "background": {
+          "border": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "borderWidth": 2,
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "cornerRadius": 8
+        },
+        "shadow": {
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "offset": 0,
+          "opacity": 1,
+          "radius": 5
+        },
+        "text": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 16,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        },
+        "tintColor": {
+          "type": "fill",
+          "value": ["#000000"]
+        }
+      },
+      "endButton": {
+        "background": {
+          "border": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "borderWidth": 0,
+          "color": {
+            "type": "fill",
+            "value": ["#04728c"]
+          },
+          "cornerRadius": 8
+        },
+        "shadow": {
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "offset": 0,
+          "opacity": 1,
+          "radius": 5
+        },
+        "text": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 16,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        },
+        "tintColor": {
+          "type": "fill",
+          "value": ["#3e95a6"]
+        }
+      },
+      "endScreenSharingButton": {
+        "background": {
+          "border": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "borderWidth": 2,
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "cornerRadius": 8
+        },
+        "shadow": {
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "offset": 0,
+          "opacity": 1,
+          "radius": 5
+        },
+        "text": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 16,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        },
+        "tintColor": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        }
+      },
+      "text": {
+        "alignment": "center",
+        "background": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "font": {
+          "size": 20,
+          "style": "regular"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#000000"]
+        }
+      }
+    },
+    "topText": {
+      "alignment": "center",
+      "background": {
+        "type": "fill",
+        "value": ["#FFFFFF"]
+      },
+      "font": {
+        "size": 16,
+        "style": "regular"
+      },
+      "foreground": {
+        "type": "fill",
+        "value": ["#FFFFFF"]
+      }
+    }
+  },
+  "chatScreen": {
+    "attachmentSourceList": {
+      "items": [
+        {
+          "type": "photoLibrary",
+          "text": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "font": {
+              "size": 18,
+              "style": "bold"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#04728c"]
+            }
+          },
+          "tintColor": {
+            "type": "fill",
+            "value": ["#04728c"]
+          }
+        },
+        {
+          "type": "takePhoto",
+          "text": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "font": {
+              "size": 18,
+              "style": "bold"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#04728c"]
+            }
+          },
+          "tintColor": {
+            "type": "fill",
+            "value": ["#04728c"]
+          }
+        },
+        {
+          "type": "browse",
+          "text": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "font": {
+              "size": 18,
+              "style": "bold"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#04728c"]
+            }
+          },
+          "tintColor": {
+            "type": "fill",
+            "value": ["#04728c"]
+          }
+        }
+      ],
+      "separator": {
+        "type": "fill",
+        "value": ["#04728c"]
+      },
+      "background": {
+        "type": "fill",
+        "value": ["#FAFAFA"]
+      }
+    },
+    "audioUpgrade": {
+      "background": {
+        "border": {
+          "type": "fill",
+          "value": ["#04728c"]
+        },
+        "color": {
+          "type": "fill",
+          "value": ["#88fdd42b"]
+        },
+        "cornerRadius": 8,
+        "borderWidth": 1
+      },
+      "description": {
+        "alignment": "center",
+        "background": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "font": {
+          "size": 16,
+          "style": "regular"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#111111"]
+        }
+      },
+      "iconColor": {
+        "type": "fill",
+        "value": ["#04728c"]
+      },
+      "text": {
+        "alignment": "center",
+        "background": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "font": {
+          "size": 16,
+          "style": "regular"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        }
+      }
+    },
+    "background": {
+      "border": {
+        "type": "fill",
+        "value": ["#FFFFFF"]
+      },
+      "borderWidth": 2,
+      "color": {
+        "type": "fill",
+        "value": ["#FFFFFF"]
+      },
+      "cornerRadius": 16
+    },
+    "bubble": {
+      "badge": {
+        "background": {
+          "border": {
+            "type": "fill",
+            "value": ["#fdd42b"]
+          },
+          "borderWidth": 1,
+          "color": {
+            "type": "fill",
+            "value": ["#04728c"]
+          }
+        },
+        "font": {
+          "size": 12,
+          "style": "bold"
+        },
+        "fontColor": {
+          "type": "fill",
+          "value": ["#fdd42b"]
+        }
+      },
+      "onHoldOverlay": {
+        "backgroundColor": {
+          "type": "fill",
+          "value": ["#000000"]
+        },
+        "tintColor": {
+          "type": "fill",
+          "value": ["#ffd100"]
+        }
+      },
+      "userImage": {
+        "imageBackgroundColor": {
+          "type": "fill",
+          "value": ["#04728c"]
+        },
+        "placeholderBackgroundColor": {
+          "type": "fill",
+          "value": ["#04728c"]
+        },
+        "placeholderColor": {
+          "type": "fill",
+          "value": ["#fdd42b"]
+        }
+      }
+    },
+    "connect": {
+      "connected": {
+        "title": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 24,
+            "style": "bold"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#8E8E93"]
+          }
+        },
+        "description": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 18,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#8E8E93"]
+          }
+        }
+      },
+      "connecting": {
+        "title": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 24,
+            "style": "bold"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#8E8E93"]
+          }
+        },
+        "description": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 18,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#8E8E93"]
+          }
+        }
+      },
+      "onHold": {
+        "title": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 24,
+            "style": "bold"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#8E8E93"]
+          }
+        },
+        "description": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 18,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#8E8E93"]
+          }
+        }
+      },
+      "operator": {
+        "image": {
+          "placeholderColor": {
+            "type": "fill",
+            "value": ["#f9d12b"]
+          },
+          "placeholderBackgroundColor": {
+            "type": "fill",
+            "value": ["#04728c"]
+          },
+          "imageBackgroundColor": {
+            "type": "fill",
+            "value": ["#04728c"]
+          }
+        },
+        "animationColor": {
+          "type": "fill",
+          "value": ["#04728c"]
+        },
+        "onHoldOverlay": {
+          "backgroundColor": {
+            "type": "fill",
+            "value": ["#000000"]
+          },
+          "tintColor": {
+            "type": "fill",
+            "value": ["#f9d12b"]
+          }
+        }
+      },
+      "queue": {
+        "title": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 24,
+            "style": "bold"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#8E8E93"]
+          }
+        },
+        "description": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 18,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#8E8E93"]
+          }
+        }
+      },
+      "transferring": {
+        "title": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 24,
+            "style": "bold"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#8E8E93"]
+          }
+        },
+        "description": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 18,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#8E8E93"]
+          }
+        }
+      }
+    },
+    "header": {
+      "backButton": {
+        "background": {
+          "border": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "borderWidth": 2,
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "cornerRadius": 8
+        },
+        "shadow": {
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "offset": 0,
+          "opacity": 1,
+          "radius": 5
+        },
+        "text": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 16,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        },
+        "tintColor": {
+          "type": "fill",
+          "value": ["#000000"]
+        }
+      },
+      "background": {
+        "border": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "borderWidth": 2,
+        "color": {
+          "type": "fill",
+          "value": ["#fdd42b"]
+        },
+        "cornerRadius": 8
+      },
+      "closeButton": {
+        "background": {
+          "border": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "borderWidth": 2,
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "cornerRadius": 8
+        },
+        "shadow": {
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "offset": 0,
+          "opacity": 1,
+          "radius": 5
+        },
+        "text": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 24,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        },
+        "tintColor": {
+          "type": "fill",
+          "value": ["#000000"]
+        }
+      },
+      "endButton": {
+        "background": {
+          "border": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "borderWidth": 0,
+          "color": {
+            "type": "fill",
+            "value": ["#04728c"]
+          },
+          "cornerRadius": 8
+        },
+        "shadow": {
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "offset": 0,
+          "opacity": 1,
+          "radius": 5
+        },
+        "text": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 16,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        },
+        "tintColor": {
+          "type": "fill",
+          "value": ["#2596be"]
+        }
+      },
+      "endScreenSharingButton": {
+        "background": {
+          "border": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "borderWidth": 2,
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "cornerRadius": 8
+        },
+        "shadow": {
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "offset": 0,
+          "opacity": 1,
+          "radius": 5
+        },
+        "text": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 16,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        },
+        "tintColor": {
+          "type": "fill",
+          "value": ["#2596be"]
+        }
+      },
+      "text": {
+        "alignment": "center",
+        "background": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "font": {
+          "size": 24,
+          "style": "bold"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#000000"]
+        }
+      }
+    },
+    "input": {
+      "background": {
+        "border": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "borderWidth": 2,
+        "color": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "cornerRadius": 8
+      },
+      "fileUploadBar": {
+        "error": {
+          "info": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "font": {
+              "size": 18,
+              "style": "bold"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            }
+          },
+          "text": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "font": {
+              "size": 18,
+              "style": "bold"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            }
+          }
+        },
+        "errorProgress": {
+          "type": "fill",
+          "value": ["#ffff99"]
+        },
+        "filePreview": {
+          "text": {
+            "font": {
+              "size": 18,
+              "style": "bold"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#66ff99"]
+            }
+          },
+          "errorIcon": {
+            "type": "fill",
+            "value": ["#ff0000"]
+          },
+          "background": {
+            "color": {
+              "type": "fill",
+              "value": ["#ff00ff"]
+            },
+            "cornerRadius": 0,
+            "borderWidth": 0,
+            "border": {
+              "type": "fill",
+              "value": ["#0099ff"]
+            }
+          },
+          "errorBackground": {
+            "color": {
+              "type": "fill",
+              "value": ["#0099ff"]
+            },
+            "cornerRadius": 0,
+            "borderWidth": 0,
+            "border": {
+              "type": "fill",
+              "value": ["#ff00ff"]
+            }
+          }
+        },
+        "progress": {
+          "type": "fill",
+          "value": ["#006666"]
+        },
+        "progressBackground": {
+          "type": "fill",
+          "value": ["#00ffff"]
+        },
+        "removeButton": {
+          "type": "fill",
+          "value": ["#bf8040"]
+        },
+        "uploading": {
+          "info": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "font": {
+              "size": 18,
+              "style": "bold"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            }
+          },
+          "text": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "font": {
+              "size": 18,
+              "style": "bold"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            }
+          }
+        },
+        "uploaded": {
+          "info": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "font": {
+              "size": 18,
+              "style": "bold"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            }
+          },
+          "text": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "font": {
+              "size": 18,
+              "style": "bold"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            }
+          }
+        }
+      },
+      "mediaButton": {
+        "background": {
+          "border": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "borderWidth": 2,
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "cornerRadius": 8
+        },
+        "shadow": {
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "offset": 0,
+          "opacity": 1,
+          "radius": 5
+        },
+        "text": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 12,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        },
+        "tintColor": {
+          "type": "fill",
+          "value": ["#2596be"]
+        }
+      },
+      "placeholder": {
+        "alignment": "center",
+        "font": {
+          "size": 18,
+          "style": "bold"
+        },
+        "background": {
+          "type": "fill",
+          "value": ["#8E8E93"]
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#8E8E93"]
+        }
+      },
+      "sendButton": {
+        "background": {
+          "border": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "borderWidth": 2,
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "cornerRadius": 0
+        },
+        "shadow": {
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "offset": 0,
+          "opacity": 1,
+          "radius": 5
+        },
+        "text": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 16,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        },
+        "tintColor": {
+          "type": "fill",
+          "value": ["#04728c"]
+        }
+      },
+      "separator": {
+        "type": "fill",
+        "value": ["#8E8E93"]
+      },
+      "text": {
+        "alignment": "center",
+        "background": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "font": {
+          "size": 18,
+          "style": "bold"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#000000"]
+        }
+      }
+    },
+    "operatorMessage": {
+      "background": {
+        "border": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "borderWidth": 2,
+        "color": {
+          "type": "fill",
+          "value": ["#04728c"]
+        },
+        "cornerRadius": 10
+      },
+      "status": {
+        "alignment": "center",
+        "background": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "font": {
+          "size": 16,
+          "style": "regular"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        }
+      },
+      "text": {
+        "alignment": "center",
+        "background": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "font": {
+          "size": 16,
+          "style": "regular"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        }
+      },
+      "userImage": {
+        "placeholderColor": {
+          "type": "fill",
+          "value": ["#8E8E93"]
+        },
+        "placeholderBackgroundColor": {
+          "type": "fill",
+          "value": ["#8E8E93"]
+        },
+        "imageBackgroundColor": {
+          "type": "fill",
+          "value": ["#8E8E93"]
+        }
+      }
+    },
+    "responseCard": {
+      "background": {
+        "border": {
+          "type": "fill",
+          "value": ["#04728c"]
+        },
+        "color": {
+          "type": "fill",
+          "value": ["#8878e1e1"]
+        },
+        "cornerRadius": 8,
+        "borderWidth": 1
+      },
+      "option": {
+        "normal": {
+          "background": {
+            "border": {
+              "type": "fill",
+              "value": ["#04728c"]
+            },
+            "borderWidth": 1,
+            "color": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "cornerRadius": 8
+          },
+          "shadow": {
+            "color": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "offset": 0,
+            "opacity": 1,
+            "radius": 8
+          },
+          "text": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["FF0000"]
+            },
+            "font": {
+              "size": 16,
+              "style": "regular"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#000000"]
+            }
+          },
+          "tintColor": {
+            "type": "fill",
+            "value": ["#ffd100"]
+          }
+        },
+        "selected": {
+          "background": {
+            "border": {
+              "type": "fill",
+              "value": ["#04728c"]
+            },
+            "borderWidth": 1,
+            "color": {
+              "type": "fill",
+              "value": ["#04728c"]
+            },
+            "cornerRadius": 8
+          },
+          "shadow": {
+            "color": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "offset": 0,
+            "opacity": 1,
+            "radius": 8
+          },
+          "text": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["FF0000"]
+            },
+            "font": {
+              "size": 16,
+              "style": "regular"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            }
+          },
+          "tintColor": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        },
+        "disabled": {
+          "background": {
+            "border": {
+              "type": "fill",
+              "value": ["#66000000"]
+            },
+            "borderWidth": 1,
+            "color": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "cornerRadius": 8
+          },
+          "shadow": {
+            "color": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "offset": 0,
+            "opacity": 1,
+            "radius": 8
+          },
+          "text": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["FF0000"]
+            },
+            "font": {
+              "size": 16,
+              "style": "regular"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#66000000"]
+            }
+          },
+          "tintColor": {
+            "type": "fill",
+            "value": ["#ffd100"]
+          }
+        }
+      },
+      "text": {
+        "alignment": "leading",
+        "background": {
+          "type": "fill",
+          "value": ["8E8E93"]
+        },
+        "font": {
+          "size": 16,
+          "style": "bold"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#88000000"]
+        }
+      },
+      "userImage": {
+        "placeholderColor": {
+          "type": "fill",
+          "value": ["#8E8E93"]
+        },
+        "placeholderBackgroundColor": {
+          "type": "fill",
+          "value": ["#8E8E93"]
+        },
+        "imageBackgroundColor": {
+          "type": "fill",
+          "value": ["#8E8E93"]
+        }
+      }
+    },
+    "typingIndicator": {
+      "type": "fill",
+      "value": ["#04728c"]
+    },
+    "unreadIndicator": {
+      "backgroundColor": {
+        "type": "fill",
+        "value": ["#04728c"]
+      },
+      "bubble": {
+        "badge": {
+          "background": {
+            "border": {
+              "type": "fill",
+              "value": ["#fdd42b"]
+            },
+            "borderWidth": 1,
+            "color": {
+              "type": "fill",
+              "value": ["#04728c"]
+            }
+          },
+          "font": {
+            "size": 12,
+            "style": "bold"
+          },
+          "fontColor": {
+            "type": "fill",
+            "value": ["#fdd42b"]
+          }
+        },
+        "onHoldOverlay": {
+          "backgroundColor": {
+            "type": "fill",
+            "value": ["#000000"]
+          },
+          "tintColor": {
+            "type": "fill",
+            "value": ["#ffd100"]
+          }
+        },
+        "userImage": {
+          "imageBackgroundColor": {
+            "type": "fill",
+            "value": ["#04728c"]
+          },
+          "placeholderBackgroundColor": {
+            "type": "fill",
+            "value": ["#04728c"]
+          },
+          "placeholderColor": {
+            "type": "fill",
+            "value": ["#fdd42b"]
+          }
+        }
+      }
+    },
+    "videoUpgrade": {
+      "background": {
+        "border": {
+          "type": "fill",
+          "value": ["#04728c"]
+        },
+        "color": {
+          "type": "fill",
+          "value": ["#88fdd42b"]
+        },
+        "cornerRadius": 8,
+        "borderWidth": 1
+      },
+      "description": {
+        "alignment": "center",
+        "background": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "font": {
+          "size": 16,
+          "style": "regular"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#111111"]
+        }
+      },
+      "iconColor": {
+        "type": "fill",
+        "value": ["#04728c"]
+      },
+      "text": {
+        "alignment": "center",
+        "background": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "font": {
+          "size": 16,
+          "style": "regular"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        }
+      }
+    },
+    "visitorMessage": {
+      "background": {
+        "border": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "borderWidth": 2,
+        "color": {
+          "type": "fill",
+          "value": ["#e7e7e7"]
+        },
+        "cornerRadius": 10
+      },
+      "status": {
+        "alignment": "center",
+        "background": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "font": {
+          "size": 16,
+          "style": "regular"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        }
+      },
+      "text": {
+        "alignment": "center",
+        "background": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "font": {
+          "size": 16,
+          "style": "regular"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#000000"]
+        }
+      },
+      "userImage": {
+        "placeholderColor": {
+          "type": "fill",
+          "value": ["#8E8E93"]
+        },
+        "placeholderBackgroundColor": {
+          "type": "fill",
+          "value": ["#8E8E93"]
+        },
+        "imageBackgroundColor": {
+          "type": "fill",
+          "value": ["#8E8E93"]
+        }
+      }
+    },
+    "newMessagesDividerColor": {
+      "type": "fill",
+      "value": ["#f9d12b"]
+    },
+    "newMessagesDividerText" : {
+      "font": {
+        "size": 16,
+        "style": "regular"
+      },
+      "foreground": {
+        "type": "fill",
+        "value": ["#FFFF00"]
+      }
+    }
+  },
+  "surveyScreen": {
+    "layer": {
+      "border": {
+        "type": "fill",
+        "value": ["#FFFFFF"]
+      },
+      "borderWidth": 2,
+      "color": {
+        "type": "fill",
+        "value": ["#f9d12b"]
+      },
+      "cornerRadius": 16
+    },
+    "title": {
+      "alignment": "center",
+      "background": {
+        "type": "fill",
+        "value": ["#FFFF00"]
+      },
+      "font": {
+        "size": 24,
+        "style": "bold"
+      },
+      "foreground": {
+        "type": "fill",
+        "value": ["#000000"]
+      }
+    },
+    "submitButton": {
+      "background": {
+        "border": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "borderWidth": 2,
+        "color": {
+          "type": "fill",
+          "value": ["#3e95a6"]
+        },
+        "cornerRadius": 8
+      },
+      "shadow": {
+        "color": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "offset": 0,
+        "opacity": 1,
+        "radius": 0
+      },
+      "text": {
+        "alignment": "center",
+        "background": {
+          "type": "fill",
+          "value": ["#f0d12b"]
+        },
+        "font": {
+          "size": 16,
+          "style": "regular"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        }
+      },
+      "tintColor": {
+        "type": "fill",
+        "value": ["#FFFFFF"]
+      }
+    },
+    "cancelButton": {
+      "background": {
+        "border": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "borderWidth": 2,
+        "color": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "cornerRadius": 8
+      },
+      "shadow": {
+        "color": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "offset": 0,
+        "opacity": 1,
+        "radius": 0
+      },
+      "text": {
+        "alignment": "center",
+        "background": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "font": {
+          "size": 16,
+          "style": "regular"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#000000"]
+        }
+      },
+      "tintColor": {
+        "type": "fill",
+        "value": ["#FFFFFF"]
+      }
+    },
+    "singleQuestion": {
+      "option": {
+        "alignment": "center",
+        "background": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "font": {
+          "size": 16,
+          "style": "regular"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#000000"]
+        }
+      },
+      "tintColor": {
+        "type": "fill",
+        "value": ["#3e95a6"]
+      },
+      "title": {
+        "alignment": "center",
+        "background": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "font": {
+          "size": 20,
+          "style": "regular"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#000000"]
+        }
+      }
+    },
+    "booleanQuestion": {
+      "optionButton": {
+        "font": {
+          "size": 12,
+          "style": "regular"
+        },
+        "highlightedLayer": {
+          "border": {
+            "type": "fill",
+            "value": ["#00FF00"]
+          },
+          "borderWidth": 4,
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "cornerRadius": 8
+        },
+        "highlightedText": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 12,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        },
+        "normalLayer": {
+          "border": {
+            "type": "fill",
+            "value": ["#000000"]
+          },
+          "borderWidth": 1,
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "cornerRadius": 8
+        },
+        "normalText": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 16,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#000000"]
+          }
+        },
+        "selectedLayer": {
+          "border": {
+            "type": "fill",
+            "value": ["#00FF00"]
+          },
+          "borderWidth": 0,
+          "color": {
+            "type": "fill",
+            "value": ["#3e95a6"]
+          },
+          "cornerRadius": 8
+        },
+        "selectedText": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 16,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        }
+      },
+      "title": {
+        "alignment": "center",
+        "background": {
+          "type": "fill",
+          "value": ["#000000"]
+        },
+        "font": {
+          "size": 20,
+          "style": "regular"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#000000"]
+        }
+      }
+    },
+    "scaleQuestion": {
+      "optionButton": {
+        "font": {
+          "size": 12,
+          "style": "regular"
+        },
+        "highlightedLayer": {
+          "border": {
+            "type": "fill",
+            "value": ["#00FF00"]
+          },
+          "borderWidth": 4,
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "cornerRadius": 8
+        },
+        "highlightedText": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 12,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        },
+        "normalLayer": {
+          "border": {
+            "type": "fill",
+            "value": ["#000000"]
+          },
+          "borderWidth": 1,
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "cornerRadius": 8
+        },
+        "normalText": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 16,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#000000"]
+          }
+        },
+        "selectedLayer": {
+          "border": {
+            "type": "fill",
+            "value": ["#00FF00"]
+          },
+          "borderWidth": 0,
+          "color": {
+            "type": "fill",
+            "value": ["#3e95a6"]
+          },
+          "cornerRadius": 8
+        },
+        "selectedText": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 16,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        }
+      },
+      "title": {
+        "alignment": "center",
+        "background": {
+          "type": "fill",
+          "value": ["#000000"]
+        },
+        "font": {
+          "size": 20,
+          "style": "regular"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#000000"]
+        }
+      }
+    },
+    "inputQuestion": {
+      "background": {
+        "border": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "borderWidth": 4,
+        "color": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "cornerRadius": 16
+      },
+      "option": {
+        "font": {
+          "size": 12,
+          "style": "regular"
+        },
+        "highlightedLayer": {
+          "border": {
+            "type": "fill",
+            "value": ["#00FF00"]
+          },
+          "borderWidth": 4,
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "cornerRadius": 8
+        },
+        "highlightedText": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 12,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        },
+        "normalLayer": {
+          "border": {
+            "type": "fill",
+            "value": ["#000000"]
+          },
+          "borderWidth": 1,
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "cornerRadius": 8
+        },
+        "normalText": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 16,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#000000"]
+          }
+        },
+        "selectedLayer": {
+          "border": {
+            "type": "fill",
+            "value": ["#00FF00"]
+          },
+          "borderWidth": 0,
+          "color": {
+            "type": "fill",
+            "value": ["#3e95a6"]
+          },
+          "cornerRadius": 8
+        },
+        "selectedText": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 16,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        }
+      },
+      "text": {
+        "alignment": "center",
+        "background": {
+          "type": "fill",
+          "value": ["#000000"]
+        },
+        "font": {
+          "size": 16,
+          "style": "regular"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#000000"]
+        }
+      },
+      "title": {
+        "alignment": "center",
+        "background": {
+          "type": "fill",
+          "value": ["#000000"]
+        },
+        "font": {
+          "size": 20,
+          "style": "regular"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#000000"]
+        }
+      }
+    }
+  },
+  "callVisualizer": {
+    "screenSharing": {
+      "header": {
+        "backButton": {
+          "background": {
+            "border": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "borderWidth": 2,
+            "color": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "cornerRadius": 8
+          },
+          "shadow": {
+            "color": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "offset": 0,
+            "opacity": 1,
+            "radius": 5
+          },
+          "text": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "font": {
+              "size": 16,
+              "style": "regular"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            }
+          },
+          "tintColor": {
+            "type": "fill",
+            "value": ["#000000"]
+          }
+        },
+        "background": {
+          "border": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "borderWidth": 2,
+          "color": {
+            "type": "fill",
+            "value": ["#fdd42b"]
+          },
+          "cornerRadius": 8
+        },
+        "closeButton": {
+          "background": {
+            "border": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "borderWidth": 2,
+            "color": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "cornerRadius": 8
+          },
+          "shadow": {
+            "color": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "offset": 0,
+            "opacity": 1,
+            "radius": 5
+          },
+          "text": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "font": {
+              "size": 24,
+              "style": "regular"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            }
+          },
+          "tintColor": {
+            "type": "fill",
+            "value": ["#000000"]
+          }
+        },
+        "endButton": {
+          "background": {
+            "border": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "borderWidth": 0,
+            "color": {
+              "type": "fill",
+              "value": ["#04728c"]
+            },
+            "cornerRadius": 8
+          },
+          "shadow": {
+            "color": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "offset": 0,
+            "opacity": 1,
+            "radius": 5
+          },
+          "text": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "font": {
+              "size": 16,
+              "style": "regular"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            }
+          },
+          "tintColor": {
+            "type": "fill",
+            "value": ["#2596be"]
+          }
+        },
+        "endScreenSharingButton": {
+          "background": {
+            "border": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "borderWidth": 2,
+            "color": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "cornerRadius": 8
+          },
+          "shadow": {
+            "color": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "offset": 0,
+            "opacity": 1,
+            "radius": 5
+          },
+          "text": {
+            "alignment": "center",
+            "background": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            },
+            "font": {
+              "size": 16,
+              "style": "regular"
+            },
+            "foreground": {
+              "type": "fill",
+              "value": ["#FFFFFF"]
+            }
+          },
+          "tintColor": {
+            "type": "fill",
+            "value": ["#2596be"]
+          }
+        },
+        "text": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 24,
+            "style": "bold"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#000000"]
+          }
+        }
+      },
+      "message": {
+        "alignment": "leading",
+        "background": {
+          "type": "fill",
+          "value": ["#FF0000"]
+        },
+        "font": {
+          "size": 20,
+          "style": "regular"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#000000"]
+        }
+      },
+      "endButton": {
+        "background": {
+          "border": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "borderWidth": 0,
+          "color": {
+            "type": "fill",
+            "value": ["#04728c"]
+          },
+          "cornerRadius": 8
+        },
+        "shadow": {
+          "color": {
+            "type": "fill",
+            "value": ["FF0000"]
+          },
+          "offset": 0,
+          "opacity": 1,
+          "radius": 8
+        },
+        "text": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["FF0000"]
+          },
+          "font": {
+            "size": 16,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        },
+        "tintColor": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        }
+      },
+      "background": {
+        "border": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "borderWidth": 0,
+        "color": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "cornerRadius": 0
+      }
+    },
+    "visitorCode": {
+      "actionButton": {
+        "background": {
+          "border": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "borderWidth": 0,
+          "color": {
+            "type": "fill",
+            "value": ["#04728c"]
+          },
+          "cornerRadius": 8
+        },
+        "shadow": {
+          "color": {
+            "type": "fill",
+            "value": ["FF0000"]
+          },
+          "offset": 0,
+          "opacity": 1,
+          "radius": 8
+        },
+        "text": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["FF0000"]
+          },
+          "font": {
+            "size": 16,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        },
+        "tintColor": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        }
+      },
+      "background": {
+        "border": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "borderWidth": 0,
+        "color": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "cornerRadius": 30
+      },
+      "closeButtonColor": {
+        "type": "fill",
+        "value": ["#000000"]
+      },
+      "numberSlotBackground": {
+        "border": {
+          "type": "fill",
+          "value": ["#F3F3F3"]
+        },
+        "borderWidth": 1,
+        "color": {
+          "type": "fill",
+          "value": ["#ffd100"]
+        },
+        "cornerRadius": 8
+      },
+      "numberSlotText": {
+        "font": {
+          "size": 40,
+          "style": "regular"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#000000"]
+        }
+      },
+      "loadingProgressColor": {
+        "type": "fill",
+        "value": ["#fdd42b"]
+      },
+      "title": {
+        "alignment": "center",
+        "background": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "font": {
+          "size": 20,
+          "style": "regular"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#000000"]
+        }
+      }
+    }
+  },
+  "secureConversationsConfirmationScreen": {
+    "header": {
+      "backButton": {
+        "background": {
+          "border": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "borderWidth": 2,
+          "color": {
+            "type": "fill",
+            "value": ["#000000"]
+          },
+          "cornerRadius": 8
+        },
+        "shadow": {
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "offset": 0,
+          "opacity": 1,
+          "radius": 5
+        },
+        "text": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 16,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#000000"]
+          }
+        },
+        "tintColor": {
+          "type": "fill",
+          "value": ["#000000"]
+        }
+      },
+      "background": {
+        "border": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "borderWidth": 2,
+        "color": {
+          "type": "fill",
+          "value": ["#f9d12b"]
+        },
+        "cornerRadius": 8
+      },
+      "closeButton": {
+        "background": {
+          "border": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "borderWidth": 2,
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "cornerRadius": 8
+        },
+        "shadow": {
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "offset": 0,
+          "opacity": 1,
+          "radius": 5
+        },
+        "text": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 16,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        },
+        "tintColor": {
+          "type": "fill",
+          "value": ["#000000"]
+        }
+      },
+      "endButton": {
+        "background": {
+          "border": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "borderWidth": 0,
+          "color": {
+            "type": "fill",
+            "value": ["#04728c"]
+          },
+          "cornerRadius": 8
+        },
+        "shadow": {
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "offset": 0,
+          "opacity": 1,
+          "radius": 5
+        },
+        "text": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 16,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        },
+        "tintColor": {
+          "type": "fill",
+          "value": ["#3e95a6"]
+        }
+      },
+      "endScreenSharingButton": {
+        "background": {
+          "border": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "borderWidth": 2,
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "cornerRadius": 8
+        },
+        "shadow": {
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "offset": 0,
+          "opacity": 1,
+          "radius": 5
+        },
+        "text": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 16,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        },
+        "tintColor": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        }
+      },
+      "text": {
+        "alignment": "center",
+        "background": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "font": {
+          "size": 20,
+          "style": "regular"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#000000"]
+        }
+      }
+    },
+    "background": { "type": "fill", "value": ["#FFFFFF"] },
+    "iconColor": {
+      "type": "fill",
+      "value": ["#f9d12b"]
+    },
+    "title": {
+      "font": { "style": "bold", "size": 22 },
+      "foreground": { "type": "fill", "value": ["#3B3B40"] }
+    },
+    "subtitle": {
+      "font": { "style": "regular", "size": 18 },
+      "foreground": { "type": "fill", "value": ["#3B3B40"] }
+    },
+    "checkMessagesButton": {
+      "background": { "color": { "type": "fill", "value": ["#f9d12b"] } },
+      "text": { "foreground": { "type": "fill", "value": ["#FFFFFF"] } }
+    }
+  },
+  "secureConversationsWelcomeScreen": {
+    "activityIndicatorColor": { "type": "fill", "value": ["#f9d12b"] },
+    "enabledSendButton": {
+      "text": { "foreground": { "type": "fill", "value": ["#FFFFFF"] } },
+      "background": { "color": { "type": "fill", "value": ["#f9d12b"] } }
+    },
+    "messageWarningIconColor": { "type": "fill", "value": ["#FB8074"] },
+    "filePickerButtonDisabled": { "type": "fill", "value": ["#f9d12b"] },
+    "disabledSendButton": {
+      "text": { "foreground": { "type": "fill", "value": ["#FFFFFF"] } },
+      "background": { "color": { "type": "fill", "value": ["#cfcaca"] } }
+    },
+    "welcomeSubtitle": {
+      "foreground": { "type": "fill", "value": ["#3B3B40"] }
+    },
+    "titleImage": { "type": "fill", "value": ["#f9d12b"] },
+    "header": {
+      "backButton": {
+        "background": {
+          "border": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "borderWidth": 2,
+          "color": {
+            "type": "fill",
+            "value": ["#000000"]
+          },
+          "cornerRadius": 8
+        },
+        "shadow": {
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "offset": 0,
+          "opacity": 1,
+          "radius": 5
+        },
+        "text": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 16,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#000000"]
+          }
+        },
+        "tintColor": {
+          "type": "fill",
+          "value": ["#000000"]
+        }
+      },
+      "background": {
+        "border": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "borderWidth": 2,
+        "color": {
+          "type": "fill",
+          "value": ["#f9d12b"]
+        },
+        "cornerRadius": 8
+      },
+      "closeButton": {
+        "background": {
+          "border": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "borderWidth": 2,
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "cornerRadius": 8
+        },
+        "shadow": {
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "offset": 0,
+          "opacity": 1,
+          "radius": 5
+        },
+        "text": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 16,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        },
+        "tintColor": {
+          "type": "fill",
+          "value": ["#000000"]
+        }
+      },
+      "endButton": {
+        "background": {
+          "border": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "borderWidth": 0,
+          "color": {
+            "type": "fill",
+            "value": ["#04728c"]
+          },
+          "cornerRadius": 8
+        },
+        "shadow": {
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "offset": 0,
+          "opacity": 1,
+          "radius": 5
+        },
+        "text": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 16,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        },
+        "tintColor": {
+          "type": "fill",
+          "value": ["#3e95a6"]
+        }
+      },
+      "endScreenSharingButton": {
+        "background": {
+          "border": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "borderWidth": 2,
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "cornerRadius": 8
+        },
+        "shadow": {
+          "color": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "offset": 0,
+          "opacity": 1,
+          "radius": 5
+        },
+        "text": {
+          "alignment": "center",
+          "background": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          },
+          "font": {
+            "size": 16,
+            "style": "regular"
+          },
+          "foreground": {
+            "type": "fill",
+            "value": ["#FFFFFF"]
+          }
+        },
+        "tintColor": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        }
+      },
+      "text": {
+        "alignment": "center",
+        "background": {
+          "type": "fill",
+          "value": ["#FFFFFF"]
+        },
+        "font": {
+          "size": 20,
+          "style": "regular"
+        },
+        "foreground": {
+          "type": "fill",
+          "value": ["#000000"]
+        }
+      }
+    },
+    "messageWarning": {
+      "foreground": { "type": "fill", "value": ["#FB8074"] }
+    },
+    "messageInputNormal": {
+      "text": {
+        "foreground": { "type": "fill", "value": ["#3B3B40"] }
+      },
+      "background": {
+        "color": { "type": "fill", "value": ["#FFFFFF"] },
+        "border": { "type": "fill", "value": ["#CFCACA"] }
+      }
+    },
+    "messageInputActive": {
+      "text": {
+        "foreground": { "type": "fill", "value": ["#3B3B40"] }
+      },
+      "background": {
+        "color": { "type": "fill", "value": ["#FFFFFF"] },
+        "border": { "type": "fill", "value": ["#F9D12B"] }
+      }
+    },
+    "messageInputDisabled": {
+      "text": {
+        "foreground": { "type": "fill", "value": ["#4D4D53"] }
+      },
+      "background": {
+        "color": { "type": "fill", "value": ["#CFCACA"] },
+        "border": { "type": "fill", "value": ["#4D4D53"] }
+      }
+    },
+    "messageInputError": {
+      "text": {
+        "foreground": { "type": "fill", "value": ["#3B3B40"] }
+      },
+      "background": {
+        "color": { "type": "fill", "value": ["#FFFFFF"] },
+        "border": { "type": "fill", "value": ["#FB8074"] }
+      }
+    },
+    "messageInputHint": {
+      "foreground": { "type": "fill", "value": ["#CFCACA"] }
+    },
+    "loadingSendButton": {
+      "text": { "foreground": { "type": "fill", "value": ["#FFFFFF"] } },
+      "tintColor": { "type": "fill", "value": ["#f9d12b"] }
+    },
+    "messageTitle": { "foreground": { "type": "fill", "value": ["#3B3B40"] } },
+    "checkMessagesButton": {
+      "foreground": { "type": "fill", "value": ["#3B3B40"] }
+    },
+    "filePickerButton": { "type": "fill", "value": ["#f9d12b"] },
+    "background": { "type": "fill", "value": ["#FFFFFF"] },
+    "welcomeTitle": {
+      "font": { "style": "bold", "size": 22 },
+      "foreground": { "type": "fill", "value": ["#3B3B40"] }
+    }
+  }
+}


### PR DESCRIPTION
Provide proof of concept of how theme remote configuration can be tested using snapshot images. The goal of this PR is serve as example how we can ensure that changes in unified customisation can be backed up by tests. If something like this can be achieved for Android, we can use this approach to cover both platforms.

MOB-2010

<img src="https://github.com/salemove/ios-sdk-widgets/assets/3148347/79b274e0-fa18-42fd-bb54-f0f779eb11a8" width="428" height="926">
<img src="https://github.com/salemove/ios-sdk-widgets/assets/3148347/ef225be3-54b2-4228-bc41-9f59a2ac2d0f" width="428" height="926">
<img src="https://github.com/salemove/ios-sdk-widgets/assets/3148347/f93afdea-c0b2-4622-b816-6d652fd07d8e" width="428" height="926">
