### PR TITLE
Remove 'api.' prefix for beta environment due to changes in Core SDK

### DIFF
--- a/GliaWidgets.podspec
+++ b/GliaWidgets.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   }
   s.exclude_files         = ['GliaWidgets/Window/**']
 
-  s.dependency 'GliaCoreSDK', '1.0.2'
+  s.dependency 'GliaCoreSDK', '1.0.3'
 end

--- a/GliaWidgets/Public/Environment.swift
+++ b/GliaWidgets/Public/Environment.swift
@@ -19,7 +19,7 @@ public enum Environment {
             return .eu
         case .beta:
             // swiftlint:disable force_unwrapping
-            return .custom(URL(string: "https://api.beta.salemove.com/")!)
+            return .custom(URL(string: "https://beta.salemove.com/")!)
             // swiftlint:enable force_unwrapping
         case .custom(let url):
             return .custom(url)

--- a/Package.swift
+++ b/Package.swift
@@ -35,8 +35,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "GliaCoreSDK",
-            url: "https://github.com/salemove/ios-bundle/releases/download/1.0.2/GliaCoreSDK.xcframework.zip",
-            checksum: "4d997e74bb975db723b7d93a26f2fb3611f735f809a825aa2e89e5226cc602d4"
+            url: "https://github.com/salemove/ios-bundle/releases/download/1.0.3/GliaCoreSDK.xcframework.zip",
+            checksum: "267140b0bb4b71c7755c5a530e6f9afc3392d431449b8e3361def7b8de2ee6e2"
         ),
         .binaryTarget(
             name: "GliaWidgetsXcf",

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
     - AccessibilitySnapshot/Core
     - SnapshotTesting (~> 1.0)
   - GliaCoreDependency (1.2)
-  - GliaCoreSDK (1.0.2):
+  - GliaCoreSDK (1.0.3):
     - GliaCoreDependency (= 1.2)
     - TwilioVoice (= 6.3.1)
     - WebRTC-lib (= 96.0.0)
@@ -37,7 +37,7 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   AccessibilitySnapshot: a91e4a69f870188b51f43863d9fc7269d07cdd93
   GliaCoreDependency: 87b3897f0d85321ecf77f1faa829211ad527e54d
-  GliaCoreSDK: e4e3a4c758651dcc5f8a978488b247e486728704
+  GliaCoreSDK: 08b8e50f47aed46ce3f52b4a668f57b671be75ec
   PureLayout: 5fb5e5429519627d60d079ccb1eaa7265ce7cf88
   SnapshotTesting: 6141c48b6aa76ead61431ca665c14ab9a066c53b
   SwiftLint: 13280e21cdda6786ad908dc6e416afe5acd1fcb7

--- a/templates/GliaWidgets.podspec
+++ b/templates/GliaWidgets.podspec
@@ -19,4 +19,4 @@ Pod::Spec.new do |s|
   }
   s.exclude_files         = ['GliaWidgets/Window/**']
 
-  s.dependency 'GliaCoreSDK', '1.0.2'
+  s.dependency 'GliaCoreSDK', '1.0.3'


### PR DESCRIPTION
'api.' prefix is added by Core SDK, so changes introduced here are to remove this prefix. Note that this PR awaits Core SDK release (1.0.3 or higher).

Bumping CoreSDK version also was done in this PR to prevent issues with Acceptance tests.

MOB-2328