### PR TITLE
Fixed subsequent media upgrade alerts

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -339,6 +339,11 @@
 		845E2F98283FC9A900C04D56 /* Theme.Survey.OptionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845E2F97283FC9A900C04D56 /* Theme.Survey.OptionButton.swift */; };
 		845E2F9B283FCA9000C04D56 /* Theme.Survey.Checkbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845E2F9A283FCA9000C04D56 /* Theme.Survey.Checkbox.swift */; };
 		845E2F9D283FCB1400C04D56 /* Theme.Survey.Checkbox.Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845E2F9C283FCB1400C04D56 /* Theme.Survey.Checkbox.Accessibility.swift */; };
+		8464297A2A44937600943BD6 /* AlertViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846429792A44937600943BD6 /* AlertViewControllerTests.swift */; };
+		8464297D2A459E7D00943BD6 /* UIViewController+Replaceble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8464297C2A459E7D00943BD6 /* UIViewController+Replaceble.swift */; };
+		846429802A45A1F200943BD6 /* OfferPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8464297F2A45A1F200943BD6 /* OfferPresenter.swift */; };
+		846429832A45DA7500943BD6 /* AlertViewController+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846429822A45DA7500943BD6 /* AlertViewController+Mock.swift */; };
+		846429862A45DB4100943BD6 /* AlertViewController.Kind+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846429852A45DB4100943BD6 /* AlertViewController.Kind+Mock.swift */; };
 		846A5C3429CB3A130049B29F /* ScreenShareHandler.Implementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846A5C3329CB3A130049B29F /* ScreenShareHandler.Implementation.swift */; };
 		846A5C3629CB3E270049B29F /* ScreenShareHandler.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846A5C3529CB3E270049B29F /* ScreenShareHandler.Mock.swift */; };
 		846A5C3929D18D400049B29F /* ScreenShareHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846A5C3829D18D400049B29F /* ScreenShareHandlerTests.swift */; };
@@ -968,6 +973,11 @@
 		845E2F97283FC9A900C04D56 /* Theme.Survey.OptionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.Survey.OptionButton.swift; sourceTree = "<group>"; };
 		845E2F9A283FCA9000C04D56 /* Theme.Survey.Checkbox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.Survey.Checkbox.swift; sourceTree = "<group>"; };
 		845E2F9C283FCB1400C04D56 /* Theme.Survey.Checkbox.Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.Survey.Checkbox.Accessibility.swift; sourceTree = "<group>"; };
+		846429792A44937600943BD6 /* AlertViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertViewControllerTests.swift; sourceTree = "<group>"; };
+		8464297C2A459E7D00943BD6 /* UIViewController+Replaceble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Replaceble.swift"; sourceTree = "<group>"; };
+		8464297F2A45A1F200943BD6 /* OfferPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfferPresenter.swift; sourceTree = "<group>"; };
+		846429822A45DA7500943BD6 /* AlertViewController+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AlertViewController+Mock.swift"; sourceTree = "<group>"; };
+		846429852A45DB4100943BD6 /* AlertViewController.Kind+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AlertViewController.Kind+Mock.swift"; sourceTree = "<group>"; };
 		846A5C3329CB3A130049B29F /* ScreenShareHandler.Implementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenShareHandler.Implementation.swift; sourceTree = "<group>"; };
 		846A5C3529CB3E270049B29F /* ScreenShareHandler.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenShareHandler.Mock.swift; sourceTree = "<group>"; };
 		846A5C3829D18D400049B29F /* ScreenShareHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenShareHandlerTests.swift; sourceTree = "<group>"; };
@@ -2080,6 +2090,8 @@
 		1A63B2EF257A3EF100508478 /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				8464297E2A45A1D900943BD6 /* OfferPresenter */,
+				8464297B2A459E3500943BD6 /* Replaceble */,
 				1A5892AF2608C66300E183CC /* QuickLook */,
 				C47901AD25ED2E59007EE195 /* ScreenShare */,
 				1A2DA72425EF891300032611 /* FilePicker */,
@@ -2394,6 +2406,7 @@
 		7512A57827BF9FB800319DF1 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				846429812A45DA5900943BD6 /* AlertViewController */,
 				846A5C4329F6BEB60049B29F /* Glia */,
 				7512A57627BE8A6700319DF1 /* InteractorTests.swift */,
 				AF29811429E6D76A0005BD55 /* FileDownloadTests.swift */,
@@ -2850,6 +2863,40 @@
 				845A28FB28AFF092008558EA /* URLScheme.swift */,
 			);
 			path = URLScheme;
+			sourceTree = "<group>";
+		};
+		8464297B2A459E3500943BD6 /* Replaceble */ = {
+			isa = PBXGroup;
+			children = (
+				8464297C2A459E7D00943BD6 /* UIViewController+Replaceble.swift */,
+			);
+			path = Replaceble;
+			sourceTree = "<group>";
+		};
+		8464297E2A45A1D900943BD6 /* OfferPresenter */ = {
+			isa = PBXGroup;
+			children = (
+				8464297F2A45A1F200943BD6 /* OfferPresenter.swift */,
+			);
+			path = OfferPresenter;
+			sourceTree = "<group>";
+		};
+		846429812A45DA5900943BD6 /* AlertViewController */ = {
+			isa = PBXGroup;
+			children = (
+				846429842A45DB1A00943BD6 /* Mocks */,
+				846429792A44937600943BD6 /* AlertViewControllerTests.swift */,
+			);
+			path = AlertViewController;
+			sourceTree = "<group>";
+		};
+		846429842A45DB1A00943BD6 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				846429822A45DA7500943BD6 /* AlertViewController+Mock.swift */,
+				846429852A45DB4100943BD6 /* AlertViewController.Kind+Mock.swift */,
+			);
+			path = Mocks;
 			sourceTree = "<group>";
 		};
 		846A5C3729D18D220049B29F /* ScreenShareHandler */ = {
@@ -3716,6 +3763,7 @@
 				C0D2F07C29A4E47200803B47 /* ConnectOperatorView.Mock.swift in Sources */,
 				C08D776028F583D7000461E5 /* Array+Extensions.swift in Sources */,
 				9AE9E4B727E1E30500BFE239 /* MockHelpers.swift in Sources */,
+				8464297D2A459E7D00943BD6 /* UIViewController+Replaceble.swift in Sources */,
 				1A2DA72625EF892600032611 /* FilePickerController.swift in Sources */,
 				1ABD6C9625B6F46700D56EFA /* AlertViewController+SingleMediaUpgrade.swift in Sources */,
 				9AB3401527F724BC006E0FE2 /* CallStyle.Accessibility.swift in Sources */,
@@ -3743,6 +3791,7 @@
 				1A60B01D2567FCAD00E53F53 /* ButtonProperties.swift in Sources */,
 				1AC7A7482582237500567FF8 /* GliaViewController.swift in Sources */,
 				75AF8D0427DBF07D009EEE2C /* Survey.ScaleQuestionView.swift in Sources */,
+				846429802A45A1F200943BD6 /* OfferPresenter.swift in Sources */,
 				1A4AF5D325AEF543002CD0F4 /* AlertViewController+Confirmation.swift in Sources */,
 				755D187B29A6A7180009F5E8 /* WelcomeStyle+TitleImageStyle.swift in Sources */,
 				1AFB1E7825F8B26800CA460D /* ChatTextContentStyle.swift in Sources */,
@@ -4189,6 +4238,7 @@
 				3142696A29FFB712003DF62E /* Interactor.Failing.swift in Sources */,
 				9A8130C427D9099F00220BBD /* FileDownload.Environment.Failing.swift in Sources */,
 				AF29811029E06E830005BD55 /* Availability.Environment.Failing.swift in Sources */,
+				8464297A2A44937600943BD6 /* AlertViewControllerTests.swift in Sources */,
 				AFCF8A5A2A02A97100B7ABB3 /* ChatItemTests.swift in Sources */,
 				7512A5A727C3926500319DF1 /* GliaTests.swift in Sources */,
 				31D286AD2A00DD2C009192A6 /* SecureConversations.ConfirmationViewModelTests.swift in Sources */,
@@ -4217,12 +4267,14 @@
 				9A1992E727D66C7400161AAE /* UIKitBased.Failing.swift in Sources */,
 				846A5C3929D18D400049B29F /* ScreenShareHandlerTests.swift in Sources */,
 				9AE05CB62805D2CB00871321 /* Interactor.Environment.Failing.swift in Sources */,
+				846429862A45DB4100943BD6 /* AlertViewController.Kind+Mock.swift in Sources */,
 				AF29811229E42F3C0005BD55 /* AvailabilityTests.swift in Sources */,
 				9AE05CB32805C9D900871321 /* ChatViewModel.Environment.Failing.swift in Sources */,
 				AFEF5C7429929A8D005C3D8D /* SecureConversations.FileUploadListViewModel.Environment.Failing.swift in Sources */,
 				9A3E1D9D27BA7741005634EB /* FoundationBased.Failing.swift in Sources */,
 				9A3E1D8427B67F1B005634EB /* Helper.swift in Sources */,
 				9A8130C627D90B3800220BBD /* FileSystemStorage.Failing.swift in Sources */,
+				846429832A45DA7500943BD6 /* AlertViewController+Mock.swift in Sources */,
 				846A5C4529F6BEFA0049B29F /* GliaTests+StartEngagement.swift in Sources */,
 				7512A57A27BF9FCD00319DF1 /* ChatViewModelTests.swift in Sources */,
 			);

--- a/GliaWidgets/Sources/ViewController/Call/CallViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Call/CallViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class CallViewController: EngagementViewController, MediaUpgradePresenter {
+final class CallViewController: EngagementViewController {
     private let viewModel: CallViewModel
     private let environment: Environment
     private var proximityManager: ProximityManager?

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
@@ -1,8 +1,7 @@
 import MobileCoreServices
 import UIKit
 
-class ChatViewController: EngagementViewController, MediaUpgradePresenter,
-    PopoverPresenter, ScreenShareOfferPresenter {
+final class ChatViewController: EngagementViewController, PopoverPresenter {
     private var viewModel: SecureConversations.ChatWithTranscriptModel {
         didSet {
             renderProps()

--- a/GliaWidgets/Sources/ViewController/Common/Alert/AlertPresenter.swift
+++ b/GliaWidgets/Sources/ViewController/Common/Alert/AlertPresenter.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-protocol AlertPresenter where Self: UIViewController {
+protocol AlertPresenter: DismissalAndPresentationController where Self: UIViewController {
     var viewFactory: ViewFactory { get }
 
     func presentAlert(
@@ -43,7 +43,7 @@ extension AlertPresenter {
             ),
             viewFactory: viewFactory
         )
-        present(alert, animated: true, completion: nil)
+        replacePresentedOfferIfPossible(with: alert)
     }
 
     func presentAlertAsView(
@@ -83,7 +83,7 @@ extension AlertPresenter {
             ),
             viewFactory: viewFactory
         )
-        present(alert, animated: true, completion: nil)
+        replacePresentedOfferIfPossible(with: alert)
     }
 
     func presentSingleActionAlert(
@@ -99,7 +99,7 @@ extension AlertPresenter {
             ),
             viewFactory: viewFactory
         )
-        present(alert, animated: true, completion: nil)
+        replacePresentedOfferIfPossible(with: alert)
     }
 
     func presentSettingsAlert(

--- a/GliaWidgets/Sources/ViewController/Common/Alert/AlertViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Common/Alert/AlertViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class AlertViewController: UIViewController {
+class AlertViewController: UIViewController, Replaceable {
     enum Kind {
         case message(
             MessageAlertConfiguration,
@@ -27,9 +27,28 @@ class AlertViewController: UIViewController {
             accepted: () -> Void,
             declined: () -> Void
         )
+
+        /// Indicating presentation priority of an alert.
+        /// Based on comparing values we can decide whether an alert can be replaced with another alert.
+        fileprivate var presentationPriority: PresentationPriority {
+            switch self {
+            case .singleAction:
+                return .highest
+            case .confirmation:
+                return .high
+            case .message, .singleMediaUpgrade, .screenShareOffer:
+                return .regular
+            }
+        }
     }
 
     let viewFactory: ViewFactory
+
+    /// Indicating presentation priority of an alert.
+    /// Based on comparing values we can decide whether an alert can be replaced with another alert.
+    var presentationPriority: PresentationPriority {
+        kind.presentationPriority
+    }
 
     private let kind: Kind
     private var alertView: AlertView?

--- a/GliaWidgets/Sources/ViewController/Common/MediaUpgrade/MediaUpgradePresenter.swift
+++ b/GliaWidgets/Sources/ViewController/Common/MediaUpgrade/MediaUpgradePresenter.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-protocol MediaUpgradePresenter where Self: UIViewController {
+protocol MediaUpgradePresenter: DismissalAndPresentationController where Self: UIViewController {
     var viewFactory: ViewFactory { get }
 
     func offerMediaUpgrade(
@@ -10,18 +10,20 @@ protocol MediaUpgradePresenter where Self: UIViewController {
     )
 }
 
-extension AlertPresenter {
+extension MediaUpgradePresenter {
     func offerMediaUpgrade(
         with conf: SingleMediaUpgradeAlertConfiguration,
         accepted: @escaping () -> Void,
         declined: @escaping () -> Void
     ) {
         let alert = AlertViewController(
-            kind: .singleMediaUpgrade(conf,
-                                      accepted: accepted,
-                                      declined: declined),
-            viewFactory: viewFactory
+            kind: .singleMediaUpgrade(
+                conf,
+                accepted: accepted,
+                declined: declined
+            ),
+            viewFactory: self.viewFactory
         )
-        present(alert, animated: true, completion: nil)
+        replacePresentedOfferIfPossible(with: alert)
     }
 }

--- a/GliaWidgets/Sources/ViewController/Common/OfferPresenter/OfferPresenter.swift
+++ b/GliaWidgets/Sources/ViewController/Common/OfferPresenter/OfferPresenter.swift
@@ -1,0 +1,20 @@
+import UIKit
+
+protocol DismissalAndPresentationController where Self: UIViewController {
+    func replacePresentedOfferIfPossible(with offer: Replaceable)
+}
+
+extension DismissalAndPresentationController {
+    func replacePresentedOfferIfPossible(with offer: Replaceable) {
+        let completion = { [unowned self] in
+            self.present(offer, animated: true)
+        }
+        guard let presented = self.presentedViewController as? Replaceable else {
+            completion()
+            return
+        }
+        if presented.isReplaceable(with: offer) {
+            presented.dismiss(animated: true, completion: completion)
+        }
+    }
+}

--- a/GliaWidgets/Sources/ViewController/Common/Popover/PopoverViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Common/Popover/PopoverViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-final class PopoverViewController: UIViewController {
+final class PopoverViewController: UIViewController, Replaceable {
     private let contentView: UIView
     private let sourceView: UIView
     private let contentInsets: UIEdgeInsets

--- a/GliaWidgets/Sources/ViewController/Common/Replaceble/UIViewController+Replaceble.swift
+++ b/GliaWidgets/Sources/ViewController/Common/Replaceble/UIViewController+Replaceble.swift
@@ -1,0 +1,25 @@
+import UIKit
+
+/// Indicating presentation priority of an alert.
+/// Based on comparing values we can decide whether an alert can be replaced with another alert.
+enum PresentationPriority: Int {
+    /// Applicable for `message`, `singleMediaUpgrade` and `screenShareOffer` cases
+    case regular
+    /// Applicable for `confirmation` case
+    case high
+    /// Applicable for `singleAction` case
+    case highest
+}
+
+protocol Replaceable where Self: UIViewController {
+    var presentationPriority: PresentationPriority { get }
+    func isReplaceable(with replaceable: Replaceable) -> Bool
+}
+
+extension Replaceable {
+    var presentationPriority: PresentationPriority { .regular }
+
+    func isReplaceable(with replaceable: Replaceable) -> Bool {
+        presentationPriority.rawValue <= replaceable.presentationPriority.rawValue
+    }
+}

--- a/GliaWidgets/Sources/ViewController/Common/ScreenShare/ScreenShareOfferPresenter.swift
+++ b/GliaWidgets/Sources/ViewController/Common/ScreenShare/ScreenShareOfferPresenter.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-protocol ScreenShareOfferPresenter where Self: UIViewController {
+protocol ScreenShareOfferPresenter: DismissalAndPresentationController where Self: UIViewController {
     var viewFactory: ViewFactory { get }
 
     func offerScreenShare(
@@ -10,7 +10,7 @@ protocol ScreenShareOfferPresenter where Self: UIViewController {
     )
 }
 
-extension AlertPresenter {
+extension ScreenShareOfferPresenter {
     func offerScreenShare(
         with conf: ScreenShareOfferAlertConfiguration,
         accepted: @escaping () -> Void,
@@ -18,8 +18,8 @@ extension AlertPresenter {
     ) {
         let alert = AlertViewController(
             kind: .screenShareOffer(conf, accepted: accepted, declined: declined),
-            viewFactory: viewFactory
+            viewFactory: self.viewFactory
         )
-        present(alert, animated: true, completion: nil)
+        replacePresentedOfferIfPossible(with: alert)
     }
 }

--- a/GliaWidgets/Sources/ViewController/EngagementViewController.swift
+++ b/GliaWidgets/Sources/ViewController/EngagementViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class EngagementViewController: UIViewController, AlertPresenter {
+class EngagementViewController: UIViewController, AlertPresenter, MediaUpgradePresenter, ScreenShareOfferPresenter {
     let viewFactory: ViewFactory
     private var viewModel: CommonEngagementModel
 

--- a/GliaWidgetsTests/Sources/AlertViewController/AlertViewControllerTests.swift
+++ b/GliaWidgetsTests/Sources/AlertViewController/AlertViewControllerTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import GliaWidgets
+
+final class AlertViewControllerTests: XCTestCase {
+    func test_isSingleActionReplaceable() {
+        /// `lhs` is a `AlertKind` which we want to test whether it can be replaced
+        /// `rhs` is an array of tuples which contains `AlertKind` to compare with `lhs` and
+        /// a `Bool` value is indicating whether lhs `AlertKind` can be replaced with rhs `AlertKind`
+        let data: [(lhs: AlertKind, rhs: [(AlertKind, Bool)])] = [
+            (.message, [(.message, true),
+                        (.singleAction, true),
+                        (.singleMediaUpgrade, true),
+                        (.screenShareOffer, true),
+                        (.confirmation, true)]),
+            (.singleAction, [(.message, false),
+                             (.singleAction, true),
+                             (.singleMediaUpgrade, false),
+                             (.screenShareOffer, false),
+                             (.confirmation, false)]),
+            (.singleMediaUpgrade, [(.message, true),
+                                   (.singleAction, true),
+                                   (.singleMediaUpgrade, true),
+                                   (.screenShareOffer, true),
+                                   (.confirmation, true)]),
+            (.screenShareOffer, [(.message, true),
+                                 (.singleAction, true),
+                                 (.singleMediaUpgrade, true),
+                                 (.screenShareOffer, true),
+                                 (.confirmation, true)]),
+            (.confirmation, [(.message, false),
+                             (.singleAction, true),
+                             (.singleMediaUpgrade, false),
+                             (.screenShareOffer, false),
+                             (.confirmation, true)])
+        ]
+
+        func test(
+            replaceable: Replaceable,
+            data: (kind: AlertKind, isReplaceable: Bool)
+        ) {
+            let alert = AlertViewController.mock(kind: data.kind)
+            XCTAssertEqual(replaceable.isReplaceable(with: alert), data.isReplaceable)
+        }
+
+        data.forEach { item in
+            let alert = AlertViewController.mock(kind: item.lhs)
+            item.rhs.forEach {
+                test(replaceable: alert, data: $0)
+            }
+        }
+    }
+}

--- a/GliaWidgetsTests/Sources/AlertViewController/Mocks/AlertViewController+Mock.swift
+++ b/GliaWidgetsTests/Sources/AlertViewController/Mocks/AlertViewController+Mock.swift
@@ -1,0 +1,24 @@
+import UIKit
+@testable import GliaWidgets
+
+extension AlertViewController {
+    static func mock(
+        kind: Kind,
+        viewFactory: ViewFactory = .mock()
+    ) -> AlertViewController {
+        AlertViewController(
+            kind: kind,
+            viewFactory: viewFactory
+        )
+    }
+
+    static func mock(
+        kind: AlertKind,
+        viewFactory: ViewFactory = .mock()
+    ) -> AlertViewController {
+        .mock(
+            kind: .mock(kind: kind),
+            viewFactory: viewFactory
+        )
+    }
+}

--- a/GliaWidgetsTests/Sources/AlertViewController/Mocks/AlertViewController.Kind+Mock.swift
+++ b/GliaWidgetsTests/Sources/AlertViewController/Mocks/AlertViewController.Kind+Mock.swift
@@ -1,0 +1,23 @@
+import Foundation
+@testable import GliaWidgets
+
+enum AlertKind {
+    case message, singleAction, singleMediaUpgrade, screenShareOffer, confirmation
+}
+
+extension AlertViewController.Kind {
+    static func mock(kind: AlertKind) -> Self {
+        switch kind {
+        case .message:
+            return .message(.mock(), accessibilityIdentifier: nil, dismissed: nil)
+        case .singleAction:
+            return .singleAction(.mock(), accessibilityIdentifier: "", actionTapped: {})
+        case .singleMediaUpgrade:
+            return .singleMediaUpgrade(.mock(), accepted: {}, declined: {})
+        case .screenShareOffer:
+            return .screenShareOffer(.mock(), accepted: {}, declined: {})
+        case .confirmation:
+            return .confirmation(.mock(), accessibilityIdentifier: "", confirmed: {})
+        }
+    }
+}


### PR DESCRIPTION
Before:
- if operator requests more than one media upgrade in a row, we show only the first one and skip further. As a result, even if visitor presses “Accept” button, the SDK sends response for outdated request, so nothing happens on operator side, but it causes the issue on SDK side. 
- If PopoverViewController is presented, no alerts could be presented, even alert about ending engagement (only if no survey).
- If any AlertViewController is presented, end engagement `singleAction` alert could not be presented, as result, SDK doesn't close an engagement (only if no survey)

Now: 
- `PresentationPriority` is introduced, which we can rely on when decide whether already presented alert should be replaced with incoming one.
- Media upgrade alerts along with screen sharing request can be replaced with another one if operator re-requests it.
- PopoverViewController will be dismissed when any media request comes.
- When visitor presses "End" engagement button, or presses stop screen sharing button, so appropriate confirmation alert is shown and operator requests any media upgrade, this media upgrade alert is skipped, because "user-initiated" alert has `high` priority.
- (only if no survey for the queue) When operator end engagement and PopoverViewController or any media upgrade alert or "user-initiated" alert is presented, it will be dismissed and end engagement `singleAction` alert will be presented.

MOB-2264