### PR TITLE
Fix CI changelog generation

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -63,6 +63,7 @@ workflows:
     - activate-ssh-key@4: {}
     - git-clone@8:
         inputs:
+        - clone_depth: "-1"
         - fetch_tags: "yes"
     - cache-pull@2: {}
     - cocoapods-install@2: {}
@@ -72,18 +73,6 @@ workflows:
     - git-tag@1:
         inputs:
         - tag: $NEW_VERSION
-    - script@1:
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            # fail if any commands fails
-            set -e
-            # make pipelines' return status equal the last command to exit with a non-zero status, or zero if all commands exit successfully
-            set -o pipefail
-            # debug log
-            set -x
-
-            git fetch --tags
     - generate-changelog@0: {}
     - github-release@0:
         inputs:


### PR DESCRIPTION
Changelog has been generating incorrectly because the git clone step by default only load commits with depth=1 as a result only the last commit information is available in CI.
Also removed the script that fetched git tags since that now also should work correctly during the git clone step.

MOB-1913