### PR TITLE
Extend TestingApp with UI for visitor info update in acceptance tests

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -466,7 +466,12 @@
 		AF29811029E06E830005BD55 /* Availability.Environment.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF29810F29E06E830005BD55 /* Availability.Environment.Failing.swift */; };
 		AF29811229E42F3C0005BD55 /* AvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF29811129E42F3C0005BD55 /* AvailabilityTests.swift */; };
 		AF29811529E6D76A0005BD55 /* FileDownloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF29811429E6D76A0005BD55 /* FileDownloadTests.swift */; };
+		AF35DFEF2A507B4C0038BCA7 /* VisitorInfoViewController.HeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF35DFEE2A507B4C0038BCA7 /* VisitorInfoViewController.HeaderView.swift */; };
+		AF35DFF12A507CA70038BCA7 /* VisitorInfoViewController.Cells.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF35DFF02A507CA70038BCA7 /* VisitorInfoViewController.Cells.swift */; };
+		AF35DFF32A507D3E0038BCA7 /* UIView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF35DFF22A507D3E0038BCA7 /* UIView+Extensions.swift */; };
 		AF39330B29B2A6A00008B60D /* ChatViewModel.SecureConverstaions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF39330A29B2A6A00008B60D /* ChatViewModel.SecureConverstaions.swift */; };
+		AF3BD1DD2A41D09100A7713E /* VisitorInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3BD1DC2A41D09100A7713E /* VisitorInfoViewController.swift */; };
+		AF3BD1DF2A42026D00A7713E /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3BD1DE2A42026D00A7713E /* Command.swift */; };
 		AF3D520B2983235C00AD8E69 /* FileUploader.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D520A2983235C00AD8E69 /* FileUploader.Mock.swift */; };
 		AF3D520D2983B3DD00AD8E69 /* FileUploader.Environment.Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D520C2983B3DD00AD8E69 /* FileUploader.Environment.Interface.swift */; };
 		AF3D520F2983BC5600AD8E69 /* FileUploader.Environment.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D520E2983BC5600AD8E69 /* FileUploader.Environment.Mock.swift */; };
@@ -491,6 +496,7 @@
 		AFC40C1C29965F0F001B4C53 /* SecureConversations.ChatWithTranscriptModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFC40C1B29965F0F001B4C53 /* SecureConversations.ChatWithTranscriptModel.swift */; };
 		AFCF8A5A2A02A97100B7ABB3 /* ChatItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCF8A592A02A97100B7ABB3 /* ChatItemTests.swift */; };
 		AFCF8A5C2A02AB3000B7ABB3 /* OutgoingMessage.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCF8A5B2A02AB3000B7ABB3 /* OutgoingMessage.Mock.swift */; };
+		AFD3C52C2A472B7500BC37A9 /* VisitorInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFD3C52B2A472B7500BC37A9 /* VisitorInfoModel.swift */; };
 		AFEF5C6F29928DB0005C3D8D /* SecureConversations.FileUploadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFEF5C6E29928DB0005C3D8D /* SecureConversations.FileUploadView.swift */; };
 		AFEF5C7129929601005C3D8D /* SecureConversations.FilePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFEF5C7029929601005C3D8D /* SecureConversations.FilePreviewView.swift */; };
 		AFEF5C7429929A8D005C3D8D /* SecureConversations.FileUploadListViewModel.Environment.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFEF5C7329929A8D005C3D8D /* SecureConversations.FileUploadListViewModel.Environment.Failing.swift */; };
@@ -1103,7 +1109,12 @@
 		AF29810F29E06E830005BD55 /* Availability.Environment.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Availability.Environment.Failing.swift; sourceTree = "<group>"; };
 		AF29811129E42F3C0005BD55 /* AvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailabilityTests.swift; sourceTree = "<group>"; };
 		AF29811429E6D76A0005BD55 /* FileDownloadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDownloadTests.swift; sourceTree = "<group>"; };
+		AF35DFEE2A507B4C0038BCA7 /* VisitorInfoViewController.HeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitorInfoViewController.HeaderView.swift; sourceTree = "<group>"; };
+		AF35DFF02A507CA70038BCA7 /* VisitorInfoViewController.Cells.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitorInfoViewController.Cells.swift; sourceTree = "<group>"; };
+		AF35DFF22A507D3E0038BCA7 /* UIView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extensions.swift"; sourceTree = "<group>"; };
 		AF39330A29B2A6A00008B60D /* ChatViewModel.SecureConverstaions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.SecureConverstaions.swift; sourceTree = "<group>"; };
+		AF3BD1DC2A41D09100A7713E /* VisitorInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitorInfoViewController.swift; sourceTree = "<group>"; };
+		AF3BD1DE2A42026D00A7713E /* Command.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
 		AF3D520A2983235C00AD8E69 /* FileUploader.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploader.Mock.swift; sourceTree = "<group>"; };
 		AF3D520C2983B3DD00AD8E69 /* FileUploader.Environment.Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploader.Environment.Interface.swift; sourceTree = "<group>"; };
 		AF3D520E2983BC5600AD8E69 /* FileUploader.Environment.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploader.Environment.Mock.swift; sourceTree = "<group>"; };
@@ -1128,6 +1139,7 @@
 		AFC40C1B29965F0F001B4C53 /* SecureConversations.ChatWithTranscriptModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.ChatWithTranscriptModel.swift; sourceTree = "<group>"; };
 		AFCF8A592A02A97100B7ABB3 /* ChatItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatItemTests.swift; sourceTree = "<group>"; };
 		AFCF8A5B2A02AB3000B7ABB3 /* OutgoingMessage.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutgoingMessage.Mock.swift; sourceTree = "<group>"; };
+		AFD3C52B2A472B7500BC37A9 /* VisitorInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitorInfoModel.swift; sourceTree = "<group>"; };
 		AFEF5C6E29928DB0005C3D8D /* SecureConversations.FileUploadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FileUploadView.swift; sourceTree = "<group>"; };
 		AFEF5C7029929601005C3D8D /* SecureConversations.FilePreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FilePreviewView.swift; sourceTree = "<group>"; };
 		AFEF5C7329929A8D005C3D8D /* SecureConversations.FileUploadListViewModel.Environment.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FileUploadListViewModel.Environment.Failing.swift; sourceTree = "<group>"; };
@@ -1493,12 +1505,14 @@
 		1A205D7925655CEC003AA3CD /* TestingApp */ = {
 			isa = PBXGroup;
 			children = (
+				AFD3C52A2A472B1C00BC37A9 /* VisitorInfo */,
 				C0D2F05E299F93EC00803B47 /* Playbook */,
 				84265E6C29914DAA00D65842 /* ViewController */,
 				C46B2463262F05BE001245A1 /* TestingApp.entitlements */,
 				1A60AFF32567CDFB00E53F53 /* Settings */,
 				1A4AD3D4256FE7DA00468BFB /* Extensions */,
 				1A205D7A25655CEC003AA3CD /* AppDelegate.swift */,
+				AF3BD1DE2A42026D00A7713E /* Command.swift */,
 				1A205D8525655CEE003AA3CD /* LaunchScreen.storyboard */,
 				756979C42A1E5E3C002ED254 /* Assets.xcassets */,
 				1A205D8825655CEE003AA3CD /* Info.plist */,
@@ -1632,6 +1646,7 @@
 			isa = PBXGroup;
 			children = (
 				1A4AD3D5256FE7F800468BFB /* UIColor+Extensions.swift */,
+				AF35DFF22A507D3E0038BCA7 /* UIView+Extensions.swift */,
 				AF11F30628BE6F0C002ACEB4 /* UIAlertController+Extensions.swift */,
 				754313CE2870E64600C9C1C6 /* Configuration.Extensions.swift */,
 			);
@@ -3046,6 +3061,17 @@
 			path = Factory;
 			sourceTree = "<group>";
 		};
+		AFD3C52A2A472B1C00BC37A9 /* VisitorInfo */ = {
+			isa = PBXGroup;
+			children = (
+				AF3BD1DC2A41D09100A7713E /* VisitorInfoViewController.swift */,
+				AF35DFF02A507CA70038BCA7 /* VisitorInfoViewController.Cells.swift */,
+				AF35DFEE2A507B4C0038BCA7 /* VisitorInfoViewController.HeaderView.swift */,
+				AFD3C52B2A472B7500BC37A9 /* VisitorInfoModel.swift */,
+			);
+			path = VisitorInfo;
+			sourceTree = "<group>";
+		};
 		AFEF5C6D29928376005C3D8D /* FileUploadListView */ = {
 			isa = PBXGroup;
 			children = (
@@ -4286,16 +4312,22 @@
 			files = (
 				1A4AD3D9256FE9D300468BFB /* SettingsTextCell.swift in Sources */,
 				1A4AD3DC256FF67200468BFB /* SettingsFontCell.swift in Sources */,
+				AF35DFEF2A507B4C0038BCA7 /* VisitorInfoViewController.HeaderView.swift in Sources */,
 				1A205D7F25655CEC003AA3CD /* ViewController.swift in Sources */,
+				AFD3C52C2A472B7500BC37A9 /* VisitorInfoModel.swift in Sources */,
 				1A4AD3D6256FE7F800468BFB /* UIColor+Extensions.swift in Sources */,
 				AF11F30728BE6F0C002ACEB4 /* UIAlertController+Extensions.swift in Sources */,
+				AF3BD1DF2A42026D00A7713E /* Command.swift in Sources */,
 				754313CD2870B1C400C9C1C6 /* UserDefaultsStored.swift in Sources */,
 				1A205D7B25655CEC003AA3CD /* AppDelegate.swift in Sources */,
+				AF35DFF32A507D3E0038BCA7 /* UIView+Extensions.swift in Sources */,
 				C0D2F060299F93EC00803B47 /* PlaybookViewController.swift in Sources */,
 				754313CB2870A65400C9C1C6 /* SettingsViewController.Props.swift in Sources */,
 				7543141828806AEB00C9C1C6 /* EnvironmentSettingsTextCell.swift in Sources */,
 				84265E6E29914DDA00D65842 /* ViewController+CallVisualizer.swift in Sources */,
 				754313CF2870E64600C9C1C6 /* Configuration.Extensions.swift in Sources */,
+				AF35DFF12A507CA70038BCA7 /* VisitorInfoViewController.Cells.swift in Sources */,
+				AF3BD1DD2A41D09100A7713E /* VisitorInfoViewController.swift in Sources */,
 				1A4AD3D1256E92F300468BFB /* SettingsColorCell.swift in Sources */,
 				1A4AD3CE256E8F5500468BFB /* SettingsCell.swift in Sources */,
 				6B2BFCE2274297F100B68506 /* SettingsSwitchCell.swift in Sources */,

--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeView.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeView.swift
@@ -127,8 +127,8 @@ extension SecureConversations {
         let environment: Environemnt
 
         // Since some of the reusable views require style
-        // to be passed during initializtion, we have to
-        // provide `Props` also during initializtion, because
+        // to be passed during initialization, we have to
+        // provide `Props` also during initialization, because
         // it is single source of data (including styles)
         // for the data-driven view.
         init(props: Props, environment: Environemnt) {

--- a/TestingApp/Command.swift
+++ b/TestingApp/Command.swift
@@ -1,0 +1,70 @@
+/// Developer-friendly wrapper around a closure.
+/// It makes debugging easier by providing callee information.
+/// Note: since closure does not conform to `Equatable`, it will
+/// also be ignored in `Equatable` and `Hashable` implementations
+/// of `Command`.
+///
+/// Example of declaration and execution:
+/// ```
+/// let validateEmail = Command<String> { email in /* email validation goes here */ }
+/// validateEmail("email@example.test")
+/// ```
+struct Command<T>: Hashable {
+    let tag: String
+    let file: String
+    let function: String
+    let line: UInt
+    let closure: (T) -> Void
+
+    init(
+        tag: String = "",
+        file: StaticString = #file,
+        function: StaticString = #function,
+        line: UInt = #line,
+        closure: @escaping (T) -> Void
+    ) {
+        self.tag = tag
+        self.file = "\(file)"
+        self.function = "\(function)"
+        self.line = line
+        self.closure = closure
+    }
+
+    func execute(with value: T) {
+        closure(value)
+    }
+
+    func callAsFunction(_ value: T) {
+        execute(with: value)
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.tag == rhs.tag &&
+        lhs.file == rhs.file &&
+        lhs.function == rhs.function &&
+        lhs.line == rhs.line
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(tag)
+        hasher.combine(file)
+        hasher.combine(function)
+        hasher.combine(line)
+    }
+
+    /// Command with empty closure.
+    static var nop: Self { Self(tag: "nop", closure: { _ in }) }
+}
+
+/// A shorthand for Command for closure with zero parameters.
+typealias Cmd = Command<Void>
+
+extension Cmd {
+    func execute() where T == Void {
+        self.execute(with: ())
+    }
+
+    func callAsFunction() {
+        execute()
+    }
+}

--- a/TestingApp/Extensions/UIView+Extensions.swift
+++ b/TestingApp/Extensions/UIView+Extensions.swift
@@ -1,0 +1,43 @@
+import UIKit
+
+extension UIView {
+    /// Checks if current view is firstResponder, if not check the same
+    /// for every subview. This is handy when we need to know if keyboard
+    /// is presented at the moment by the view or its subviews.
+    /// - Returns: `true` if view or subviews has `isFirstResponder` set to `true`.
+    func isKeyboardPresented() -> Bool {
+        Self.hasResponder(self)
+    }
+
+    private static func hasResponder(_ view: UIView) -> Bool {
+        if view.isFirstResponder {
+            return true
+        }
+        for subview in view.subviews {
+            if hasResponder(subview) {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    /// Search for superview in view hierarchy using predicate closure.
+    /// This is useful when we need to get access from cell to table view for
+    /// example.
+    /// - Parameter predicate: Closure that receives view, as parameter,
+    /// to be inspected by the predicate. `superview` traversal is stopped when there's no `superview`
+    /// or if `superview` matches predicate.
+    /// - Returns: View that matches predicate or nil otherwise.
+    func superview(by predicate: (UIView) -> Bool) -> UIView? {
+        if let superview {
+            if predicate(superview) {
+                return superview
+            } else {
+                return superview.superview(by: predicate)
+            }
+        }
+
+        return nil
+    }
+}

--- a/TestingApp/Main.storyboard
+++ b/TestingApp/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -21,7 +21,7 @@
                                 <rect key="frame" x="0.0" y="48" width="414" height="814"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="A3Y-Xf-Ufg">
-                                        <rect key="frame" x="0.0" y="16" width="414" height="782.5"/>
+                                        <rect key="frame" x="0.0" y="16" width="414" height="827.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Configuration" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4l1-DH-Wkd">
                                                 <rect key="frame" x="155.5" y="0.0" width="103.5" height="20.5"/>
@@ -165,14 +165,23 @@
                                                     <action selector="endEngagementTapped" destination="Y6W-OH-hqX" eventType="touchUpInside" id="HY1-eg-X4F"/>
                                                 </connections>
                                             </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tYL-hF-sF1">
+                                                <rect key="frame" x="152" y="421.5" width="110" height="30"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                                <state key="normal" title="Show vistor info"/>
+                                                <connections>
+                                                    <action selector="showUpdateVisitorInfo" destination="Y6W-OH-hqX" eventType="touchUpInside" id="bQD-DE-a1m"/>
+                                                </connections>
+                                            </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="UI customization" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E1e-uA-HuC">
-                                                <rect key="frame" x="143.5" y="421.5" width="127.5" height="20.5"/>
+                                                <rect key="frame" x="143.5" y="466.5" width="127.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ezc-iY-PbB">
-                                                <rect key="frame" x="141" y="457" width="132" height="30"/>
+                                                <rect key="frame" x="141" y="502" width="132" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_endEngagement_button"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="Nef-0j-qW7"/>
@@ -183,13 +192,13 @@
                                                 </connections>
                                             </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VisitorCode" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tI8-TQ-jWA">
-                                                <rect key="frame" x="162.5" y="502" width="89" height="20.5"/>
+                                                <rect key="frame" x="162.5" y="547" width="89" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="1gR-qB-lno">
-                                                <rect key="frame" x="90.5" y="537.5" width="233" height="30"/>
+                                                <rect key="frame" x="90.5" y="582.5" width="233" height="30"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YnU-rR-gCc">
                                                         <rect key="frame" x="0.0" y="0.0" width="88" height="30"/>
@@ -218,7 +227,7 @@
                                                 </subviews>
                                             </stackView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7mi-et-ybT">
-                                                <rect key="frame" x="0.0" y="582.5" width="414" height="200"/>
+                                                <rect key="frame" x="0.0" y="627.5" width="414" height="200"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="200" id="GaG-7F-RUb"/>

--- a/TestingApp/ViewController/ViewController.swift
+++ b/TestingApp/ViewController/ViewController.swift
@@ -18,6 +18,14 @@ class ViewController: UIViewController {
     @UserDefaultsStored(key: "features", defaultValue: Features.all, coder: .rawRepresentable())
     private var features: Features
 
+    let visitorInfoModel = VisitorInfoModel(
+        environment: .init(
+            fetchVisitorInfo: GliaCore.sharedInstance.fetchVisitorInfo,
+            updateVisitorInfo: GliaCore.sharedInstance.updateVisitorInfo,
+            uuid: UUID.init
+        )
+    )
+
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Glia UI testing"

--- a/TestingApp/VisitorInfo/VisitorInfoModel.swift
+++ b/TestingApp/VisitorInfo/VisitorInfoModel.swift
@@ -1,0 +1,464 @@
+import Combine
+import GliaWidgets
+import GliaCoreSDK
+
+final class VisitorInfoModel {
+    typealias Props = VisitorInfoViewController.Props
+    typealias Section = Props.Section
+    typealias InfoField = Props.InfoField
+    typealias KeyValuePair = Props.KeyValuePair
+    typealias CustomAttributesUpdateMethod = Props.InfoField.CustomAttributesUpdateMethod
+    typealias NotesUpdateMethod = InfoField.NotesUpdateMethod
+    typealias HeaderViewProps = HeaderView.Props
+    typealias HeaderButton = HeaderViewProps.ActionButton
+    typealias Segment = HeaderView.Props.Segment
+    typealias Delegate = (DelegateEvent) -> Void
+    typealias UpdateButton = Props.UpdateButton
+
+    // Stores visitor fields to be sent for update.
+    var visitorInfoUpdate = VisitorInfoUpdate() {
+        didSet {
+            requestPropsRendered()
+        }
+    }
+
+    var previousVisitorInfoUpdate: VisitorInfoUpdate = VisitorInfoUpdate() {
+        didSet {
+            requestPropsRendered()
+        }
+    }
+
+    // Keeps track of *fetch* visitor info request state.
+    var fetchInfoRequestState: RequestState<GliaCore.VisitorInfo>? {
+        didSet {
+            requestPropsRendered()
+        }
+    }
+    // Keeps track of *update* visitor info request state.
+    var updateInfoRequestState: RequestState<Bool>? {
+        didSet {
+            requestPropsRendered()
+        }
+    }
+    // Keeps attributes ordered, to
+    // have consistent text field order,
+    // since `customAttributes` is represented
+    // by `Dictionary` which does not have ordered keys.
+    var attributeIDs: [UUID] = []
+    // Keeps attributes identifiable,
+    // and lookup-able by identifier.
+    var attributes: [UUID: (id: UUID, key: String, value: String)] = [:] {
+        didSet {
+            var rawCustomAttributes: [String: String] = self.visitorInfoUpdate.customAttributes ?? [:]
+
+            for (_, attribute) in attributes {
+                rawCustomAttributes[attribute.key] = attribute.value
+            }
+
+            self.visitorInfoUpdate.customAttributes = rawCustomAttributes
+        }
+    }
+
+    var noteUpdateMethod: VisitorInfoUpdate.NoteUpdateMethod = .replace {
+        didSet {
+            self.visitorInfoUpdate.noteUpdateMethod = noteUpdateMethod
+        }
+    }
+
+    var customAttributesUpdateMethod: VisitorInfoUpdate.CustomAttributesUpdateMethod = .replace {
+        didSet {
+            self.visitorInfoUpdate.customAttributesUpdateMethod = customAttributesUpdateMethod
+        }
+    }
+
+    var delegate: Delegate?
+
+    let environment: Environment
+
+    init(environment: Environment) {
+        self.environment = environment
+    }
+
+    func loadVisitorInfo() {
+        self.fetchInfoRequestState = .inFlight
+        environment.fetchVisitorInfo { [weak self] result in
+            guard let self else { return }
+            // Attributes needs to be ordered in some way,
+            // that is why we need to keep their IDs in order.
+            // We remove information about order every time
+            // visitor info is fetched.
+            self.attributeIDs.removeAll(keepingCapacity: true)
+            self.attributes.removeAll(keepingCapacity: true)
+
+            self.fetchInfoRequestState = .result(result)
+            switch result {
+            case let .success(fetchedVisitorInfo):
+                let visitorInfoUpdate = VisitorInfoUpdate(
+                    name: fetchedVisitorInfo.name ?? "",
+                    email: fetchedVisitorInfo.email ?? "",
+                    phone: fetchedVisitorInfo.phone ?? "",
+                    note: fetchedVisitorInfo.note ?? "",
+                    // Update method for note is not present in visitor info,
+                    // so we use locally stored one.
+                    noteUpdateMethod: self.noteUpdateMethod,
+                    // External id is not available in fetched info,
+                    // so we do not show it in UI.
+                    externalID: nil,
+                    customAttributes: fetchedVisitorInfo.customAttributes,
+                    // Update method for custom attributes is not present in visitor info,
+                    // so we use locally stored one.
+                    customAttributesUpdateMethod: self.customAttributesUpdateMethod
+                )
+
+                // Sort custom attribute keys to have them oredered.
+                let keys = (fetchedVisitorInfo.customAttributes ?? [:]).keys.sorted(by: <)
+                for key in keys {
+                    guard let value = fetchedVisitorInfo.customAttributes?[key] else { continue }
+                    let id = self.environment.uuid()
+                    self.attributeIDs.append(id)
+                    self.attributes[id] = (id: id, key: key, value: value)
+                }
+
+                self.previousVisitorInfoUpdate = visitorInfoUpdate
+                self.visitorInfoUpdate = visitorInfoUpdate
+            case let .failure(error):
+                print("Error", error)
+            }
+        }
+    }
+
+    func updateVisitorInfo() {
+        self.updateInfoRequestState = .inFlight
+        self.environment.updateVisitorInfo(self.visitorInfoUpdate) { [weak self] result in
+            guard let self else { return }
+            self.updateInfoRequestState = nil
+            switch result {
+            case .success:
+                self.previousVisitorInfoUpdate = self.visitorInfoUpdate
+            case let .failure(error):
+                print(error)
+            }
+        }
+    }
+
+    func props() -> Props {
+        let nameField = InfoField.name(
+            label: "Name:",
+            value: self.visitorInfoUpdate.name ?? "",
+            update: .init { [weak self] in self?.visitorInfoUpdate.name = $0 }
+        )
+
+        let emailField = InfoField.email(
+            label: "Email:",
+            value: self.visitorInfoUpdate.email ?? "",
+            update: .init { [weak self] in
+                self?.visitorInfoUpdate.email = $0
+            }
+        )
+
+        let phoneField = InfoField.phoneNumber(
+            label: "Phone:",
+            value: self.visitorInfoUpdate.phone ?? "",
+            update: .init { [weak self] in self?.visitorInfoUpdate.phone = $0 }
+        )
+
+        let fieldsHeader = HeaderViewProps(headerTitle: "Fields")
+
+        let fieldsSection = Section.fields(
+            title: fieldsHeader,
+            fields: [
+                nameField,
+                emailField,
+                phoneField
+            ]
+        )
+
+        let noteField = InfoField.notes(
+            placeholder: "Enter notes",
+            text: self.visitorInfoUpdate.note ?? "",
+            update: .init { [weak self] text in
+                self?.visitorInfoUpdate.note = text
+            }
+        )
+
+        let appendNoteSegment = Segment(
+            title: NotesUpdateMethod.append.label(),
+            select: Cmd { [weak self] in
+                self?.noteUpdateMethod = .append
+            }
+        )
+        let replaceNoteSegment = Segment(
+            title: NotesUpdateMethod.replace.label(),
+            select: Cmd { [weak self] in
+                self?.noteUpdateMethod = .replace
+            }
+        )
+
+        let noteSelectedSegment: Segment
+
+        switch self.noteUpdateMethod {
+        case .append:
+            noteSelectedSegment = appendNoteSegment
+        case .replace:
+            noteSelectedSegment = replaceNoteSegment
+        @unknown default:
+            noteSelectedSegment = replaceNoteSegment
+        }
+
+        let noteHeader = HeaderViewProps(
+            headerTitle: "Notes",
+            segments: [
+                appendNoteSegment,
+                replaceNoteSegment
+            ],
+            selectedSegment: noteSelectedSegment,
+            segmentAccessibilityIdentifierPrefix: "visitor_info_notes_method_"
+        )
+
+        let noteSection = Section.notes(
+            title: noteHeader,
+            notes: noteField
+        )
+
+        let mergeAttributesSegment = Segment(
+            title: CustomAttributesUpdateMethod.merge.label(),
+            select: Cmd { [weak self] in
+                self?.customAttributesUpdateMethod = .merge
+            }
+        )
+        let replaceAttributesSegment = Segment(
+            title: CustomAttributesUpdateMethod.replace.label(),
+            select: Cmd { [weak self] in
+                self?.customAttributesUpdateMethod = .replace
+            }
+        )
+
+        let attributesSelectedSegment: Segment
+
+        switch self.customAttributesUpdateMethod {
+        case .replace:
+            attributesSelectedSegment = replaceAttributesSegment
+        case .merge:
+            attributesSelectedSegment = mergeAttributesSegment
+        @unknown default:
+            attributesSelectedSegment = replaceAttributesSegment
+        }
+
+        let addAttributeButton = HeaderButton(
+            title: "+",
+            tap: Cmd { [weak self] in
+                guard let self else { return }
+                
+                let keys: Set = Set(self.attributes.values.map(\.key))
+
+                var nextAttributeKeyCounter = 0
+                var key: String { "key\(nextAttributeKeyCounter)" }
+
+                while keys.contains(key) {
+                    nextAttributeKeyCounter += 1
+                }
+
+                let id = self.environment.uuid()
+
+                let pair = KeyValuePair(
+                    key: key,
+                    keyUpdate: Command { [weak self] key in
+                        self?.attributes[id]?.key = key
+                    },
+                    value: "",
+                    valueUpdate: Command { [weak self] value in
+                        self?.attributes[id]?.value = value
+                    },
+                    remove: Cmd {
+                        self.attributes.removeValue(forKey: id)
+                        self.attributeIDs.removeAll(where: { $0 == id })
+                    },
+                    keyFieldAccIdentifier: "visitor_info_custom_attribute_key_input_\(self.attributeIDs.count)",
+                    valueFieldAccIdentifier: "visitor_info_custom_attribute_value_input_\(self.attributeIDs.count)"
+                )
+
+                self.attributeIDs.append(id)
+                self.attributes[id] = (id: id, key: pair.key, value: pair.value)
+            },
+            accIdentifier: "visitor_info_add_custom_attribute_button"
+        )
+        let attributesHeader = HeaderViewProps(
+            title: "Custom attributes",
+            segments: [
+                mergeAttributesSegment,
+                replaceAttributesSegment
+            ],
+            selectedSegment: attributesSelectedSegment,
+            actionButton: addAttributeButton,
+            segmentAccessibilityIdentifierPrefix: "visitor_info_custom_attribute_method_"
+        )
+        let customAttributesSection = Section.customAttributes(
+            title: attributesHeader,
+            attributes: zip(self.attributeIDs, 0...).compactMap { id, idx in
+                guard let attribute = self.attributes[id] else {
+                    return nil
+                }
+
+                let remove = Cmd { [weak self] in
+                    self?.attributeIDs.removeAll { $0 == id }
+                    self?.attributes[id] = nil
+                    self?.visitorInfoUpdate.customAttributes?[attribute.key] = nil
+                }
+
+                let keyUpdate = Command<String> { [weak self] key in
+                    var attribute = attribute
+                    attribute.key = key
+                    self?.attributes[attribute.id] = attribute
+                }
+
+                let valueUpdate = Command<String> { [weak self] value in
+                    var attribute = attribute
+                    attribute.value = value
+                    self?.attributes[attribute.id] = attribute
+                }
+
+                return .customAttributes(
+                    KeyValuePair(
+                        key: attribute.key,
+                        keyUpdate: keyUpdate,
+                        value: attribute.value,
+                        valueUpdate: valueUpdate,
+                        remove: remove,
+                        keyFieldAccIdentifier: "visitor_info_custom_attribute_key_input_\(idx)",
+                        valueFieldAccIdentifier: "visitor_info_custom_attribute_value_input_\(idx)"
+                    )
+                )
+            }
+        )
+
+        let pulledToRefresh = Cmd { [weak self] in
+            self?.loadVisitorInfo()
+        }
+
+        let cancelTap = Cmd { [weak self] in
+            self?.delegate?(.cancel)
+        }
+
+        let updateTap = Cmd { [weak self] in
+            self?.updateVisitorInfo()
+        }
+
+        let hasChanges: Bool = !Self.diffBetweenVisitorInfoUpdates(
+            updateA: self.visitorInfoUpdate,
+            updateB: self.previousVisitorInfoUpdate
+        ).isEmpty
+
+        let updateButton: UpdateButton
+        switch self.updateInfoRequestState {
+        case .none, .result:
+            updateButton = .normal(updateTap, isEnabled: hasChanges)
+        case .inFlight:
+            updateButton = .loading
+        }
+
+        let props = Props(
+            title: "Visitor Info",
+            sections: [
+                fieldsSection,
+                noteSection,
+                customAttributesSection
+            ],
+            pulledToRefresh: pulledToRefresh,
+            showsRefreshing: self.fetchInfoRequestState == .inFlight,
+            cancelTap: cancelTap,
+            updateButton: updateButton
+        )
+
+        return props
+    }
+
+    func requestPropsRendered() {
+        self.delegate?(.renderProps(self.props()))
+    }
+
+    fileprivate enum DiffField {
+        case name, email, phone, note, noteUpdateMethod, customAttributesUpdateMethod
+        case customAttributes(lhs: [String: String], rhs: [String: String])
+    }
+
+    fileprivate static func diffBetweenVisitorInfoUpdates(
+        updateA: VisitorInfoUpdate,
+        updateB: VisitorInfoUpdate
+    ) -> [DiffField] {
+        var fields: [DiffField] = []
+
+        if updateA.name ?? "" != updateB.name ?? "" {
+            fields.append(.name)
+        }
+
+        if updateA.email ?? "" != updateB.email ?? "" {
+            fields.append(.email)
+        }
+
+        if updateA.phone ?? "" != updateB.phone ?? "" {
+            fields.append(.phone)
+        }
+
+        if updateA.note ?? "" != updateB.note ?? "" {
+            fields.append(.note)
+        }
+
+        if updateA.customAttributes ?? [:] != updateB.customAttributes ?? [:] {
+            fields.append(
+                .customAttributes(
+                    lhs: updateA.customAttributes ?? [:],
+                    rhs: updateB.customAttributes ?? [:]
+                )
+            )
+        }
+
+        if updateA.customAttributesUpdateMethod != updateB.customAttributesUpdateMethod {
+            fields.append(.customAttributesUpdateMethod)
+        }
+
+        if updateA.noteUpdateMethod != updateB.noteUpdateMethod {
+            fields.append(.noteUpdateMethod)
+        }
+
+        return fields
+    }
+}
+
+extension VisitorInfoModel {
+    struct Environment {
+        let fetchVisitorInfo: (@escaping (Result<GliaCore.VisitorInfo, Error>) -> Void) -> Void
+        let updateVisitorInfo: (VisitorInfoUpdate, @escaping (Result<Bool, Error>) -> Void) -> Void
+        let uuid: () -> UUID
+    }
+}
+
+extension VisitorInfoModel {
+    enum RequestState<Value: Equatable> {
+        case inFlight
+        case result(Result<Value, Error>)
+    }
+}
+
+extension VisitorInfoModel.RequestState: Equatable {
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case(.inFlight, .inFlight):
+            return true
+        case (.result, .inFlight), (.inFlight, .result):
+            return false
+        case let (.result(.success(lhsInfo)), .result(.success(rhsInfo))):
+            return lhsInfo == rhsInfo
+        case let (.result(.failure(lhsError)), .result(.failure(rhsError))):
+            return lhsError as NSError == rhsError as NSError
+        case (.result(.failure), .result(.success)), (.result(.success), .result(.failure)):
+            return false
+        }
+    }
+}
+
+extension VisitorInfoModel {
+    enum DelegateEvent {
+        case cancel
+        case renderProps(VisitorInfoViewController.Props)
+    }
+}

--- a/TestingApp/VisitorInfo/VisitorInfoViewController.Cells.swift
+++ b/TestingApp/VisitorInfo/VisitorInfoViewController.Cells.swift
@@ -1,0 +1,369 @@
+import UIKit
+
+final class NotesCell: UITableViewCell {
+    static var identifier: String { "\(Self.self)" }
+
+    var props: Props = Props(placeholder: "", text: "", textChanged: .nop, textViewAccIdentifier: "") {
+        didSet {
+            renderProps()
+        }
+    }
+
+    private lazy var textView = UITextView()
+    private lazy var placeholderLabel = UILabel()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setup()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    private func setup() {
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.isScrollEnabled = false
+        textView.delegate = self
+        contentView.addSubview(textView)
+
+        placeholderLabel.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(placeholderLabel)
+        placeholderLabel.textColor = .lightGray
+
+        let margins = 10.0
+
+        NSLayoutConstraint.activate([
+            textView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: margins),
+            textView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -margins),
+            textView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: margins),
+            textView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -margins),
+            placeholderLabel.leadingAnchor.constraint(equalTo: textView.leadingAnchor),
+            placeholderLabel.trailingAnchor.constraint(equalTo: textView.trailingAnchor),
+            placeholderLabel.topAnchor.constraint(equalTo: textView.topAnchor),
+            placeholderLabel.bottomAnchor.constraint(equalTo: textView.bottomAnchor)
+        ])
+    }
+
+    private func renderProps() {
+        if !textView.isFirstResponder {
+            textView.text = props.text
+        }
+        placeholderLabel.text = props.placeholder
+        placeholderLabel.isHidden = !props.text.isEmpty || textView.isFirstResponder
+        textView.accessibilityIdentifier = props.textViewAccIdentifier
+    }
+}
+
+extension NotesCell: UITextViewDelegate {
+    func textViewDidChange(_ textView: UITextView) {
+        props.textChanged(textView.text)
+    }
+
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        placeholderLabel.isHidden = textView.isFirstResponder
+    }
+
+    func textViewDidEndEditing(_ textView: UITextView) {
+        placeholderLabel.isHidden = !props.text.isEmpty || textView.isFirstResponder
+    }
+}
+
+extension NotesCell {
+    struct Props: Equatable {
+        let placeholder: String
+        let text: String
+        let textChanged: Command<String>
+        let textViewAccIdentifier: String
+    }
+}
+
+final class CustomAttributeCell: UITableViewCell {
+    static var identifier: String { "\(Self.self)" }
+
+    var props = Props(
+        keyText: "",
+        keyUpdate: .nop,
+        valueText: "",
+        valueUpdate: .nop,
+        remove: .nop,
+        keyTextFieldAccIdentifier: "",
+        valueTextFieldAccIdentifier: ""
+    ) {
+        didSet {
+            renderProps()
+        }
+    }
+
+    private lazy var keyTextField = UITextField()
+    private lazy var valueTextField = UITextField()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setup()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    private func setup() {
+        let margins = 10.0
+        let stackView = UIStackView()
+        stackView.distribution = .fillEqually
+        stackView.alignment = .fill
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(stackView)
+
+        keyTextField.borderStyle = .roundedRect
+        stackView.addArrangedSubview(keyTextField)
+        keyTextField.addTarget(self, action: #selector(handleTextChanged(textField:)), for: .editingChanged)
+
+        valueTextField.borderStyle = .roundedRect
+        valueTextField.addTarget(self, action: #selector(handleTextChanged(textField:)), for: .editingChanged)
+
+        stackView.addArrangedSubview(valueTextField)
+        stackView.spacing = margins
+
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: margins),
+            stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -margins),
+            stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: margins),
+            stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -margins)
+        ])
+    }
+
+    private func renderProps() {
+        keyTextField.placeholder = "Key"
+        keyTextField.accessibilityIdentifier = props.keyTextFieldAccIdentifier
+        valueTextField.placeholder = "Value"
+        valueTextField.accessibilityIdentifier = props.valueTextFieldAccIdentifier
+        if !keyTextField.isFirstResponder {
+            keyTextField.text = props.keyText
+        }
+
+        if !valueTextField.isFirstResponder {
+            valueTextField.text = props.valueText
+        }
+    }
+
+    @objc private func handleTextChanged(textField: UITextField) {
+        switch textField {
+        case self.keyTextField:
+            self.props.keyUpdate(textField.text ?? "")
+        case self.valueTextField:
+            self.props.valueUpdate(textField.text ?? "")
+        default:
+            break
+        }
+    }
+}
+
+extension CustomAttributeCell {
+    struct Props: Equatable {
+        let keyText: String
+        let keyUpdate: Command<String>
+        let valueText: String
+        let valueUpdate: Command<String>
+        let remove: Cmd
+        let keyTextFieldAccIdentifier: String
+        let valueTextFieldAccIdentifier: String
+    }
+}
+
+enum CellType {
+    case infoField(InfoFieldCell)
+    case notes(NotesCell)
+    case customAttribute(CustomAttributeCell)
+}
+
+extension CellType {
+    init?(_ cell: UITableViewCell) {
+        switch cell {
+        case let cell as InfoFieldCell:
+            self = .infoField(cell)
+        case let cell as NotesCell:
+            self = .notes(cell)
+        case let cell as CustomAttributeCell:
+            self = .customAttribute(cell)
+        default:
+            return nil
+        }
+    }
+
+    static func renderCell(_ cellType: CellType, infoField: VisitorInfoViewController.Props.InfoField) {
+        switch infoField {
+        case let .name(label, value, update):
+            switch cellType {
+            case let .infoField(infoFieldCell):
+                infoFieldCell.props = .init(
+                    label: label,
+                    value: value,
+                    change: update,
+                    keyboardType: .default,
+                    textFieldAccIdentifier: "visitor_info_name_input")
+            case .customAttribute, .notes:
+                // We do not use attributes, notes cells for name.
+                break
+            }
+        case let .email(label, value, update):
+            switch cellType {
+            case let .infoField(infoFieldCell):
+                infoFieldCell.props = .init(
+                    label: label,
+                    value: value,
+                    change: update,
+                    keyboardType: .emailAddress,
+                    textFieldAccIdentifier: "visitor_info_email_input"
+                )
+            case .customAttribute, .notes:
+                // We do not use attributes, notes cells for email.
+                break
+            }
+        case let .phoneNumber(label, value, update):
+            switch cellType {
+            case let .infoField(infoFieldCell):
+                infoFieldCell.props = .init(
+                    label: label,
+                    value: value,
+                    change: update,
+                    keyboardType: .phonePad,
+                    textFieldAccIdentifier: "visitor_info_phone_input"
+                )
+            case .customAttribute, .notes:
+                // We do not use attributes, notes cells for phone number.
+                break
+            }
+        case let .notes(placeholder, text, update):
+            switch cellType {
+            case let .notes(notesCell):
+                notesCell.props = .init(
+                    placeholder: placeholder,
+                    text: text,
+                    textChanged: update,
+                    textViewAccIdentifier: "visitor_info_note_input"
+                )
+            case .customAttribute, .infoField:
+                // We do not use attributes, infoField cells for notes.
+                break
+            }
+        case let .customAttributes(pair):
+            switch cellType {
+            case let .customAttribute(customAttributeCell):
+                customAttributeCell.props = .init(
+                    keyText: pair.key,
+                    keyUpdate: pair.keyUpdate,
+                    valueText: pair.value,
+                    valueUpdate: pair.valueUpdate,
+                    remove: pair.remove,
+                    keyTextFieldAccIdentifier: pair.keyFieldAccIdentifier,
+                    valueTextFieldAccIdentifier: pair.valueFieldAccIdentifier
+                )
+            case .infoField, .notes:
+                break
+            }
+        }
+    }
+
+    static func dequeueCell(
+        for infoField: VisitorInfoViewController.Props.InfoField,
+        from tableView: UITableView,
+        at indexPath: IndexPath
+    ) -> CellType? {
+        switch infoField {
+        case .name, .email, .phoneNumber:
+            return (tableView.dequeueReusableCell(withIdentifier: InfoFieldCell.identifier) as? InfoFieldCell)
+                .map(CellType.infoField)
+        case .notes:
+            return (tableView.dequeueReusableCell(withIdentifier: NotesCell.identifier) as? NotesCell)
+                .map(CellType.notes)
+        case .customAttributes:
+            return (tableView.dequeueReusableCell(withIdentifier: CustomAttributeCell.identifier) as? CustomAttributeCell)
+                .map(CellType.customAttribute)
+        }
+    }
+
+    func cell() -> UITableViewCell {
+        switch self {
+        case let .infoField(cell):
+            return cell
+        case let .notes(cell):
+            return cell
+        case let .customAttribute(cell):
+            return cell
+        }
+    }
+}
+
+final class InfoFieldCell: UITableViewCell {
+    static var identifier: String { "\(Self.self)" }
+
+    private lazy var textField = UITextField()
+    private lazy var titleLabel = UILabel()
+
+    var props = Props(
+        label: "",
+        value: "",
+        change: .nop,
+        keyboardType: .default,
+        textFieldAccIdentifier: ""
+    ) {
+        didSet {
+            updateProps()
+        }
+    }
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setup()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    private func setup() {
+        textField.borderStyle = .roundedRect
+        textField.addTarget(self, action: #selector(handleTextChanged(textField:)), for: .editingChanged)
+
+        let margins = 10.0
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(stackView)
+        stackView.alignment = .leading
+        stackView.distribution = .fill
+        stackView.axis = .horizontal
+        stackView.addArrangedSubview(titleLabel)
+        stackView.addArrangedSubview(textField)
+        stackView.isLayoutMarginsRelativeArrangement = true
+        stackView.layoutMargins = .init(top: margins, left: margins, bottom: margins, right: margins)
+        stackView.spacing = margins
+        NSLayoutConstraint.activate([
+            titleLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+        ])
+    }
+
+    func updateProps() {
+        titleLabel.text = props.label
+        textField.keyboardType = props.keyboardType
+        if !textField.isFirstResponder {
+            textField.text = props.value
+        }
+        textField.accessibilityIdentifier = props.textFieldAccIdentifier
+    }
+
+    @objc func handleTextChanged(textField: UITextField) {
+        props.change(textField.text ?? "")
+    }
+}
+
+extension InfoFieldCell {
+    struct Props {
+        let label: String
+        let value: String
+        let change: Command<String>
+        let keyboardType: UIKeyboardType
+        let textFieldAccIdentifier: String
+    }
+}

--- a/TestingApp/VisitorInfo/VisitorInfoViewController.HeaderView.swift
+++ b/TestingApp/VisitorInfo/VisitorInfoViewController.HeaderView.swift
@@ -1,0 +1,171 @@
+import UIKit
+
+final class HeaderView: UITableViewHeaderFooterView {
+    static var identifier: String { "\(Self.self)" }
+    static var height: CGFloat { UITableView.automaticDimension }
+
+    private lazy var titleLabel = UILabel()
+    private lazy var segmentedControl = UISegmentedControl()
+    private lazy var actionButton = UIButton(type: .system)
+
+    var props = Props(title: "", segments: [], selectedSegment: nil, actionButton: nil, segmentAccessibilityIdentifierPrefix: "") {
+        didSet {
+            guard props != oldValue else { return }
+            renderProps()
+        }
+    }
+
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+        setup()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    private func setup() {
+        let margins = 10.0
+
+        contentView.addSubview(titleLabel)
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.font = .systemFont(ofSize: 18, weight: .semibold)
+
+        let stackView = UIStackView()
+        stackView.spacing = margins
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(stackView)
+
+        stackView.addArrangedSubview(segmentedControl)
+        segmentedControl.addTarget(
+            self,
+            action: #selector(handleSegmentedControlSelect),
+            for: .valueChanged
+        )
+
+        stackView.addArrangedSubview(actionButton)
+        actionButton.addTarget(
+            self,
+            action: #selector(handleActionButtonTap),
+            for: .touchUpInside
+        )
+        actionButton.titleLabel?.textAlignment = .center
+        actionButton.titleLabel?.font = .monospacedSystemFont(ofSize: 30, weight: .heavy)
+
+        NSLayoutConstraint.activate([
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: margins),
+            titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -margins),
+            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: margins),
+            titleLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -margins),
+            stackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -margins),
+        ])
+    }
+
+    func renderProps() {
+        titleLabel.text = props.title
+        renderedSegments = .init(segments: props.segments, selectedSegment: props.selectedSegment)
+        actionButton.isHidden = props.actionButton == nil
+        actionButton.accessibilityIdentifier = props.actionButton?.accIdentifier
+        if let title = props.actionButton?.title {
+            actionButton.setTitle(title, for: .normal)
+        }
+    }
+
+    private var renderedSegments: RenderedSegments = .init(segments: [], selectedSegment: nil) {
+        didSet {
+            guard renderedSegments != oldValue else { return }
+            var selectedIdx: Int?
+
+            // Render list of segments if needed.
+            if renderedSegments.segments != oldValue.segments {
+                segmentedControl.removeAllSegments()
+                for (segment, idx) in zip(renderedSegments.segments, 0...) {
+                    segmentedControl.insertSegment(withTitle: segment.title, at: idx, animated: false)
+                    if renderedSegments.selectedSegment == segment {
+                        selectedIdx = idx
+                    }
+                }
+
+            // Render segment selection if needed, to preserve uninterrupted animation.
+            } else if renderedSegments.selectedSegment != oldValue.selectedSegment {
+                for (segment, idx) in zip(renderedSegments.segments, 0...) {
+                    if renderedSegments.selectedSegment == segment {
+                        selectedIdx = idx
+                    }
+                }
+            }
+
+            if let selectedIdx, segmentedControl.selectedSegmentIndex != selectedIdx {
+                segmentedControl.selectedSegmentIndex = selectedIdx
+                // Segments of UISegmentedControl are private, so there's no direct way to access them
+                // to assign accessibility identifier, so we need to use workaround for that.
+                var idx = 0
+                for view in segmentedControl.subviews where "\(type(of: view))".lowercased().hasSuffix("segment") {
+                    view.accessibilityIdentifier = "\(props.segmentAccessibilityIdentifierPrefix)\(idx)"
+                    idx += 1
+                }
+            }
+
+            segmentedControl.isHidden = renderedSegments.segments.isEmpty
+        }
+    }
+
+    @objc
+    private func handleActionButtonTap() {
+        // Dismiss keyboard if something is being edited
+        // when new attribute is added, to prevent
+        // `tableView.begin/endUpdates` crash.
+        if let tableView = self.superview(by: { $0 is UITableView }), tableView.isKeyboardPresented() {
+            tableView.endEditing(true)
+        } else {
+            props.actionButton?.tap()
+        }
+
+    }
+
+    @objc
+    private func handleSegmentedControlSelect(_ control: UISegmentedControl) {
+        props.segments[control.selectedSegmentIndex].select()
+    }
+}
+
+extension HeaderView {
+    struct Props: Equatable {
+        struct Segment: Equatable {
+            let title: String
+            let select: Cmd
+        }
+
+        struct ActionButton: Equatable {
+            let title: String
+            let tap: Cmd
+            let accIdentifier: String
+        }
+
+        let title: String
+        let segments: [Segment]
+        let selectedSegment: Segment?
+        let actionButton: ActionButton?
+        let segmentAccessibilityIdentifierPrefix: String
+    }
+
+    struct RenderedSegments: Equatable {
+        let segments: [Props.Segment]
+        let selectedSegment: Props.Segment?
+    }
+}
+
+extension HeaderView.Props {
+    init(headerTitle: String,
+         segments: [HeaderView.Props.Segment] = [],
+         selectedSegment: HeaderView.Props.Segment? = nil,
+         actionButton: HeaderView.Props.ActionButton? = nil,
+         segmentAccessibilityIdentifierPrefix: String = ""
+    ) {
+        self.title = headerTitle
+        self.segments = segments
+        self.selectedSegment = selectedSegment
+        self.actionButton = actionButton
+        self.segmentAccessibilityIdentifierPrefix = segmentAccessibilityIdentifierPrefix
+    }
+}

--- a/TestingApp/VisitorInfo/VisitorInfoViewController.swift
+++ b/TestingApp/VisitorInfo/VisitorInfoViewController.swift
@@ -1,0 +1,438 @@
+import UIKit
+import GliaWidgets
+import GliaCoreSDK
+
+extension ViewController {
+    @IBAction func showUpdateVisitorInfo() {
+        let controller = VisitorInfoViewController()
+        let navController = UINavigationController(rootViewController: controller)
+        navController.modalPresentationStyle = .fullScreen
+
+        self.present(navController, animated: true) { [weak self] in
+            self?.visitorInfoModel.loadVisitorInfo()
+        }
+
+        visitorInfoModel.delegate = { [weak navController, weak controller] delegateAction in
+            switch delegateAction {
+            case .cancel:
+                navController?.presentingViewController?.dismiss(animated: true)
+            case let .renderProps(props):
+                controller?.props = props
+            }
+        }
+    }
+}
+
+final class VisitorInfoViewController: UIViewController {
+    private lazy var tableView = UITableView()
+    private var tableViewBottomConstraint: NSLayoutConstraint?
+    private lazy var activityIndicator = UIActivityIndicatorView(style: .medium)
+    private lazy var refreshControl = UIRefreshControl()
+    private lazy var cancelBarButtonItem = UIBarButtonItem(
+        barButtonSystemItem: .close,
+        target: self,
+        action: #selector(handleCancelTap)
+    )
+    private lazy var updateBarButtonItem = UIBarButtonItem(
+        barButtonSystemItem: .save,
+        target: self,
+        action: #selector(handleUpdateTap)
+    )
+    private lazy var loadingBarButtonItem: UIBarButtonItem = {
+        let activityIndicator = UIActivityIndicatorView(style: .medium)
+        activityIndicator.startAnimating()
+        let barButtonItem = UIBarButtonItem(customView: activityIndicator)
+        return barButtonItem
+    }()
+
+    var props = Props(
+        title: "",
+        sections: [],
+        pulledToRefresh: .nop,
+        showsRefreshing: false,
+        cancelTap: .nop,
+        updateButton: .loading
+    ) {
+        didSet {
+            updateProps()
+        }
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupTableView()
+        setupCancelButton()
+        subscribeToNotification(UIResponder.keyboardWillShowNotification, selector: #selector(keyboardWillShow))
+        subscribeToNotification(UIResponder.keyboardWillHideNotification, selector: #selector(keyboardWillHide))
+    }
+
+    private func setupTableView() {
+        view.addSubview(tableView)
+        refreshControl.addTarget(self, action: #selector(handlePullToRefresh), for: .valueChanged)
+
+        tableView.refreshControl = refreshControl
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableViewBottomConstraint = tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+
+        NSLayoutConstraint.activate(
+            [
+                tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+                tableView.topAnchor.constraint(equalTo: view.topAnchor),
+                tableViewBottomConstraint
+            ].compactMap { $0 }
+        )
+        tableView.register(InfoFieldCell.self, forCellReuseIdentifier: InfoFieldCell.identifier)
+        tableView.register(NotesCell.self, forCellReuseIdentifier: NotesCell.identifier)
+        tableView.register(CustomAttributeCell.self, forCellReuseIdentifier: CustomAttributeCell.identifier)
+        tableView.register(HeaderView.self, forHeaderFooterViewReuseIdentifier: HeaderView.identifier)
+        tableView.dataSource = self
+        tableView.delegate = self
+    }
+
+    func setupCancelButton() {
+        self.navigationItem.leftBarButtonItem = cancelBarButtonItem
+    }
+
+    func updateProps() {
+        title = props.title
+        let visibleCells = tableView.visibleCells
+        var hasResponder = false
+        // We should skip reloading cells with responder, to avoid
+        // keyboard being dismissed because of cell reuse.
+        // Instead we find cell that has 'firstResponder'
+        // and render it directly.
+        for cell in visibleCells where cell.isKeyboardPresented() {
+            hasResponder = true
+            guard let indexPath = tableView.indexPath(for: cell) else { break }
+            switch props.sections[indexPath.section] {
+            case let .fields(_, fields):
+                if let cellType = CellType(cell) {
+                    CellType.renderCell(cellType, infoField: fields[indexPath.row])
+                }
+            case let .notes(_, note):
+                if let cellType = CellType(cell) {
+                    CellType.renderCell(cellType, infoField: note)
+                    // We need to ask table view to recompute cell,
+                    // to adjust its height to the height requested
+                    // by text view if needed.
+                    // This can crash if changes have been done
+                    // to table view in parallel to these method calls,
+                    // so maybe additional checks may be necessary.
+                    tableView.beginUpdates()
+                    tableView.endUpdates()
+                }
+            case let .customAttributes(_, attributes):
+                if let cellType = CellType(cell) {
+                    CellType.renderCell(cellType, infoField: attributes[indexPath.row])
+                }
+            }
+        }
+        // If cells do not contain 'firstResponder' views,
+        // we just reload visible cells, to let them be rendered
+        // during cell reuse phase.
+        if !hasResponder {
+            tableView.reloadData()
+        }
+
+        self.renderedShowsRefreshing = props.showsRefreshing
+        self.renderedUpdateButton = props.updateButton
+    }
+
+    @objc func handlePullToRefresh() {
+        if tableView.isKeyboardPresented() {
+            tableView.endEditing(true)
+        }
+        props.pulledToRefresh()
+    }
+
+    @objc func handleCancelTap() {
+        props.cancelTap()
+    }
+
+    @objc func handleUpdateTap() {
+        guard !tableView.isKeyboardPresented() else {
+            tableView.endEditing(true)
+            return
+        }
+        Props.UIUpdateButton(props.updateButton).tap?()
+    }
+
+    private var renderedShowsRefreshing: Bool = false {
+        didSet {
+            guard oldValue != renderedShowsRefreshing else { return }
+            if renderedShowsRefreshing {
+                if !self.refreshControl.isRefreshing {
+                    self.refreshControl.beginRefreshing()
+                }
+            } else {
+                if self.refreshControl.isRefreshing {
+                    self.refreshControl.endRefreshing()
+                }
+            }
+        }
+    }
+
+    private var renderedUpdateButton: Props.UpdateButton = .loading {
+        didSet {
+            guard oldValue != renderedUpdateButton else { return }
+            switch self.renderedUpdateButton {
+            case let .normal(_, isEnabled):
+                self.navigationItem.rightBarButtonItem = self.updateBarButtonItem
+                self.updateBarButtonItem.isEnabled = isEnabled
+            case .loading:
+                self.navigationItem.rightBarButtonItem = self.loadingBarButtonItem
+            }
+
+        }
+    }
+}
+
+extension VisitorInfoViewController {
+    func subscribeToNotification(_ notification: NSNotification.Name, selector: Selector) {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: selector,
+            name: notification,
+            object: nil
+        )
+    }
+
+    @objc
+    func keyboardWillHide(notification: NSNotification) {
+        if let userInfo = notification.userInfo,
+            let durationValue = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] {
+            tableViewBottomConstraint?.constant = 0
+            let duration = (durationValue as AnyObject).doubleValue ?? 0.3
+            UIView.animate(withDuration: duration) {
+                self.view.layoutIfNeeded()
+            }
+        }
+    }
+
+    @objc
+    func keyboardWillShow(notification: NSNotification) {
+        if let userInfo = notification.userInfo,
+            let endValue = userInfo[UIResponder.keyboardFrameEndUserInfoKey],
+            let durationValue = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] {
+            let endRect = self.view.convert((endValue as AnyObject).cgRectValue, from: self.view.window)
+            tableViewBottomConstraint?.constant = -endRect.height
+            let duration = (durationValue as AnyObject).doubleValue ?? 0.3
+            UIView.animate(withDuration: duration) {
+                self.view.layoutIfNeeded()
+            }
+            if let responderView = tableView.visibleCells.first(where: { $0.isKeyboardPresented() }) {
+                tableView.scrollRectToVisible(responderView.frame, animated: true)
+            }
+        }
+    }
+}
+
+extension VisitorInfoViewController {
+    struct Props: Equatable {
+        let title: String
+        let sections: [Section]
+        let pulledToRefresh: Cmd
+        let showsRefreshing: Bool
+        let cancelTap: Cmd
+        let updateButton: UpdateButton
+    }
+}
+
+extension VisitorInfoViewController.Props {
+    struct UIUpdateButton {
+        let tap: Cmd?
+
+        init(_ updateButton: UpdateButton) {
+            switch updateButton {
+            case let .normal(tap, _):
+                self.tap = tap
+            case .loading:
+                tap = nil
+            }
+        }
+    }
+}
+
+
+extension VisitorInfoViewController.Props {
+    typealias KeyValuePair = InfoField.CustomAttributesUpdateMethod.KeyValuePair
+
+    enum InfoField: Hashable {
+        case name(label: String, value: String, update: Command<String>)
+        case email(label: String, value: String, update: Command<String>)
+        case phoneNumber(label: String, value: String, update: Command<String>)
+        case notes(placeholder: String, text: String, update: Command<String>)
+        case customAttributes(KeyValuePair)
+    }
+
+    enum Section: Equatable {
+        case fields(title: HeaderView.Props, fields: [InfoField])
+        case notes(title: HeaderView.Props, notes: InfoField)
+        case customAttributes(title: HeaderView.Props, attributes: [InfoField])
+    }
+
+    enum UpdateButton: Equatable {
+        case normal(Cmd, isEnabled: Bool)
+        case loading
+    }
+}
+
+extension VisitorInfoViewController.Props.InfoField {
+    var isRemovable: Bool {
+        switch self {
+        case .customAttributes:
+            return true
+        case .email, .name, .phoneNumber, .notes:
+            return false
+        }
+    }
+}
+
+extension VisitorInfoViewController.Props.InfoField {
+    enum NotesUpdateMethod: Hashable {
+        case replace
+        case append
+    }
+
+    enum CustomAttributesUpdateMethod: Hashable {
+        case replace
+        case merge
+    }
+}
+
+extension VisitorInfoViewController.Props.InfoField.NotesUpdateMethod {
+    func label() -> String {
+        switch self {
+        case .append:
+            return "Append"
+        case .replace:
+            return "Replace"
+        }
+    }
+}
+
+extension VisitorInfoViewController.Props.InfoField.CustomAttributesUpdateMethod {
+    struct KeyValuePair: Hashable {
+        let key: String
+        let keyUpdate: Command<String>
+        let value: String
+        let valueUpdate: Command<String>
+        let remove: Cmd
+        let keyFieldAccIdentifier: String
+        let valueFieldAccIdentifier: String
+    }
+}
+
+extension VisitorInfoViewController.Props.InfoField.CustomAttributesUpdateMethod {
+    func label() -> String {
+        switch self {
+        case .replace:
+            return "Replace"
+        case .merge:
+            return "Merge"
+        }
+    }
+}
+
+extension VisitorInfoViewController: UITableViewDataSource {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        props.sections.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        switch props.sections[section] {
+        case let .fields(_, items):
+            return items.count
+        case .notes:
+            return 1
+        case let .customAttributes(_, attributes):
+            return attributes.count
+        }
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        switch props.sections[indexPath.section] {
+        case let .fields(_, fields):
+            let field = fields[indexPath.row]
+            if let cell = CellType.dequeueCell(for: field, from: tableView, at: indexPath) {
+                CellType.renderCell(cell, infoField: field)
+                return cell.cell()
+            } else {
+                return UITableViewCell()
+            }
+        case let .notes(_, note):
+            if let cell = CellType.dequeueCell(for: note, from: tableView, at: indexPath) {
+                CellType.renderCell(cell, infoField: note)
+                return cell.cell()
+            } else {
+                return UITableViewCell()
+            }
+        case let .customAttributes(_, attributes):
+            let attribute = attributes[indexPath.row]
+            if let cell = CellType.dequeueCell(for: attribute, from: tableView, at: indexPath) {
+                CellType.renderCell(cell, infoField: attribute)
+                return cell.cell()
+            } else {
+                return UITableViewCell()
+            }
+        }   
+    }
+}
+
+extension VisitorInfoViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let header = tableView
+            .dequeueReusableHeaderFooterView(withIdentifier: HeaderView.identifier) as? HeaderView
+
+        switch props.sections[section] {
+        case let .fields(headerProps, _):
+            header?.props = headerProps
+
+        case let .notes(notesProps, _):
+            header?.props = notesProps
+        case let .customAttributes(headerProps, _):
+            header?.props = headerProps
+        }
+
+        return header
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        HeaderView.height
+    }
+
+    func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
+        false
+    }
+
+    func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
+        switch self.props.sections[indexPath.section] {
+        case let .customAttributes(_, attributes):
+            let isRemovable = attributes[indexPath.row].isRemovable
+
+            if isRemovable && tableView.isKeyboardPresented() {
+                tableView.endEditing(true)
+                return .none
+            }
+
+            return isRemovable ? .delete : .none
+        case .fields, .notes:
+            return .none
+        }
+    }
+
+    func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+        switch self.props.sections[indexPath.section] {
+        case let .customAttributes(_, attributes):
+            switch attributes[indexPath.row] {
+            case let .customAttributes(pair):
+                pair.remove()
+            case .email, .name, .notes, .phoneNumber:
+                break
+            }
+        case .fields, .notes:
+            break
+        }
+    }
+}


### PR DESCRIPTION
Add UI that allows testing visitor info loading and updating visitor info in acceptance tests. At the moment error handling is not taken into account.

MOB-2339

<img src="https://github.com/salemove/ios-sdk-widgets/assets/3148347/0bb0961b-225d-4b4e-b2bf-a1593150e62a" width="428" height="926">

