### PR TITLE
Add possibility to update Core SDK version in widgets

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -164,6 +164,18 @@ workflows:
     steps:
     - activate-ssh-key@4: {}
     - git-clone@8: {}
+    - script@1:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # make pipelines' return status equal the last command to exit with a non-zero status, or zero if all commands exit successfully
+            set -o pipefail
+            # debug log
+            set -x
+
+            git checkout development
     - cocoapods-install@2:
         inputs:
         - command: update

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -24,10 +24,6 @@ platform :ios do
       base: 'development',
       team_reviewers: ["tm-mobile-ios"]
     )
-
-    sh("cp ../templates/GliaWidgets.podspec ../GliaWidgets.podspec")
-    sh("sed -i '' 's/\${WIDGETS_SDK_VERSION_SEMVER}/#{new_version}/' ../GliaWidgets.podspec")
-    
   end
 
   desc "Increments versions in Xcode projects and Podspec file "\
@@ -50,6 +46,9 @@ platform :ios do
       version: new_version
     )
 
+    sh("cp ../templates/GliaWidgets.podspec ../GliaWidgets.podspec")
+    sh("sed -i '' 's/\${WIDGETS_SDK_VERSION_SEMVER}/#{new_version}/' ../GliaWidgets.podspec")
+
     new_version
   end
 
@@ -70,6 +69,10 @@ platform :ios do
   desc "Creates a pull request in the repository with whatever changes have been made. "\
     "Used in tandem with Bitrise to update dependencies."
   lane :create_pr_for_dependencies_update do |options|
+    version = options[:version]
+    checksum = options[:checksum]
+    update_core_sdk_version(core_sdk_version: version, core_sdk_checksum: checksum)
+
     branch_name = 'dependencies-update'
     message = "Update dependencies declared in `Podfile`"
 
@@ -81,5 +84,24 @@ platform :ios do
       base: 'development',
       team_reviewers: ["tm-mobile-ios"]
     )
+  end
+
+  desc "Creates a pull request in the repository with updates to Core SDK version. "
+  lane :update_core_sdk_version do |options|
+    project_version = get_version_number(xcodeproj: 'GliaWidgets.xcodeproj', target: 'GliaWidgets')
+
+    core_sdk_version = options[:core_sdk_version]
+    UI.user_error!("No Core SDK version specified") unless !core_sdk_version.nil?
+
+    core_sdk_checksum = options[:core_sdk_checksum]
+    UI.user_error!("No Core SDK checksum specified") unless !core_sdk_checksum.nil?
+
+    sh("cp ../templates/GliaWidgets.podspec ../GliaWidgets.podspec")
+    sh("sed -i '' \"s/.*GliaCoreSDK.*/  s.dependency 'GliaCoreSDK', '#{core_sdk_version}'/g\" ../GliaWidgets.podspec")
+    sh("sed -i '' \"s/.*  s.version.*/  s.version               = '#{project_version}'/g\" ../GliaWidgets.podspec")
+
+    sh("cp ../templates/Package.swift ../Package.swift")
+    sh("sed -i '' 's/\${CORE_SDK_VERSION}/#{core_sdk_version}/' ../Package.swift")
+    sh("sed -i '' 's/\${CORE_SDK_CHECKSUM}/#{core_sdk_checksum}/' ../Package.swift")
   end
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -45,6 +45,14 @@ fastlane increment_project_version type:patch - increments 0.0.X
 
 Creates a pull request in the repository with whatever changes have been made. Used in tandem with Bitrise to update dependencies.
 
+### ios update_core_sdk_version
+
+```sh
+[bundle exec] fastlane ios update_core_sdk_version
+```
+
+Creates a pull request in the repository with updates to Core SDK version. 
+
 ----
 
 This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.

--- a/templates/GliaWidgets.podspec
+++ b/templates/GliaWidgets.podspec
@@ -13,9 +13,9 @@ Pod::Spec.new do |s|
   s.source_files          = 'GliaWidgets/**/*.swift'
   s.swift_version         = '5.3'
 
-  s.resources             = ['GliaWidgets/Resources/*.{xcassets}', 'GliaWidgets/Resources/**/*.{strings}', 'GliaWidgets/Resources/Font/*.{ttf}']
+  s.resources             = ['GliaWidgets/Resources/*.{xcassets}', 'GliaWidgets/Resources/**/*.{strings}']
   s.resource_bundle       = {
-    'GliaWidgets' => ['GliaWidgets/Resources/*.{xcassets}', 'GliaWidgets/Resources/**/*.{strings}', 'GliaWidgets/Resources/Font/*.{ttf}']
+    'GliaWidgets' => ['GliaWidgets/Resources/*.{xcassets}', 'GliaWidgets/Resources/**/*.{strings}']
   }
   s.exclude_files         = ['GliaWidgets/Window/**']
 

--- a/templates/Package.swift
+++ b/templates/Package.swift
@@ -1,0 +1,79 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "GliaWidgets",
+    defaultLocalization: .init(stringLiteral: "en"),
+    platforms: [
+        .iOS(.v13)
+    ],
+    products: [
+        .library(
+            name: "GliaWidgets",
+            targets: ["GliaWidgetsSDK"]
+        ),
+        .library(
+            name: "GliaWidgets-xcframework",
+            targets: ["GliaWidgetsSDK-xcframework"]
+        )
+    ],
+    targets: [
+        .binaryTarget(
+            name: "GliaCoreDependency",
+            url: "https://github.com/salemove/ios-bundle/releases/download/0.35.0/GliaCoreDependency.xcframework.zip",
+            checksum: "8e1746da612dad8a130fd872b3058511121b7c6f29e3b0351ecbbffa96971489"
+        ),
+        .binaryTarget(
+            name: "TwilioVoice",
+            url: "https://github.com/salemove/ios-bundle/releases/download/0.33.0/TwilioVoice.xcframework.zip",
+            checksum: "34288e0876a8840fa51d3813046cf1f40a5939079bea23ace5afe6e752f12f9e"
+        ),
+        .binaryTarget(
+            name: "WebRTC",
+            url: "https://github.com/salemove/ios-bundle/releases/download/0.33.0/WebRTC.xcframework.zip",
+            checksum: "f76e410f608d96989ba0312e099697703a37b4414f8f46bb9e30c3d9b4291a52"
+        ),
+        .binaryTarget(
+            name: "GliaCoreSDK",
+            url: "https://github.com/salemove/ios-bundle/releases/download/${CORE_SDK_VERSION}/GliaCoreSDK.xcframework.zip",
+            checksum: "${CORE_SDK_CHECKSUM}"
+        ),
+        .binaryTarget(
+            name: "GliaWidgetsXcf",
+            url: "https://github.com/salemove/ios-sdk-widgets/releases/download/2.0.1/GliaWidgetsXcf.xcframework.zip",
+            checksum: "26f6e0bc6e32f4223f635d8de8aa4877338aed7a323f2127a05980f347ac1f9a"
+        ),
+        .target(
+            name: "GliaWidgets",
+            path: "GliaWidgets",
+            exclude: [
+                "Cartfile.resolved",
+                "Cartfile",
+                "Info.plist"
+            ],
+            resources: [
+                .process("Resources")
+            ]
+        ),
+        .target(
+            name: "GliaWidgetsSDK",
+            dependencies: [
+                "GliaCoreSDK",
+                "GliaCoreDependency",
+                "TwilioVoice",
+                "WebRTC",
+                "GliaWidgets"
+            ]
+        ),
+        .target(
+            name: "GliaWidgetsSDK-xcframework",
+            dependencies: [
+                "GliaCoreSDK",
+                "GliaWidgetsXcf",
+                "GliaCoreDependency",
+                "TwilioVoice",
+                "WebRTC"
+            ]
+        )
+    ]
+)


### PR DESCRIPTION
When ios-bundle executes a post release workflow, Bitrise will update the version in the Podfile and the checksum, getting the parameters sent from ios-bundle. This will also automatically checkout the development branch.

MOB-1792