### PR TITLE
Text entry field remains active when interacting with chat

### DIFF
--- a/GliaWidgets/Sources/View/Chat/ChatView.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatView.swift
@@ -312,8 +312,6 @@ extension ChatView {
         )
 
         tapGesture.cancelsTouchesInView = false
-
-        tableView.addGestureRecognizer(tapGesture)
     }
 
     @objc

--- a/GliaWidgets/Sources/View/Chat/Entry/ChatMessageEntryView.swift
+++ b/GliaWidgets/Sources/View/Chat/Entry/ChatMessageEntryView.swift
@@ -17,11 +17,6 @@ class ChatMessageEntryView: BaseView {
 
     var isChoiceCardModeEnabled: Bool {
         didSet {
-            isEnabled = !isChoiceCardModeEnabled
-            if isChoiceCardModeEnabled {
-                textView.resignFirstResponder()
-            }
-
             updatePickMediaButtonVisibility(mediaPickerButtonVisibility)
             updatePlaceholderText()
         }


### PR DESCRIPTION
Previously in the presence of customCard (or now GVA) the text entry field was disabled and couldn't be used until user had made a choice. Now this has been removed and text entry field stays active during custom cards / GVA and even when user has pressed 'send'

MOB-2332