### PR TITLE
Fix hidden end screen sharing button

### DIFF
--- a/GliaWidgets/Sources/CallVisualizer/VideoCall/ViewModel/VideoCallViewModel.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VideoCall/ViewModel/VideoCallViewModel.swift
@@ -104,7 +104,7 @@ extension CallVisualizer {
             title = L10n.Call.Video.title
             callDuration = ""
             topLabelHidden = false
-            endScreenShareButtonHidden = true
+            endScreenShareButtonHidden = environment.screenShareHandler.status().value == .stopped
             statusStyle = style.connect.connecting
 
             self.call.kind.addObserver(self) { [weak self] kind, _ in
@@ -456,12 +456,6 @@ private extension CallVisualizer.VideoCallViewModel {
     }
 
     func showConnected() {
-        switch environment.screenShareHandler.status().value {
-        case .started:
-            endScreenShareButtonHidden = false
-        case .stopped:
-            break
-        }
         let engagedOperator = environment.engagedOperator()
         setConnectViewState(.connected(name: engagedOperator?.firstName, imageUrl: engagedOperator?.picture?.url), animated: true)
         connectOperatorSize = .init(size: .large, animated: true)

--- a/GliaWidgetsTests/CallVisualizer/VideoCall/VideoCallTests.swift
+++ b/GliaWidgetsTests/CallVisualizer/VideoCall/VideoCallTests.swift
@@ -66,4 +66,31 @@ final class VideoCallTests: XCTestCase {
         headerProps.backButton?.tap()
         XCTAssertEqual(wasExecuted, true)
     }
+
+    func test_endScreenSharingIsVisible() {
+        let viewModel = mockViewModel(with: .started)
+        let props = viewModel.makeProps()
+
+        XCTAssertFalse(props.videoCallViewProps.endScreenShareButtonHidden)
+    }
+
+    func test_endScreenSharingIsHidden() {
+        let viewModel = mockViewModel(with: .stopped)
+        let props = viewModel.makeProps()
+
+        XCTAssertTrue(props.videoCallViewProps.endScreenShareButtonHidden)
+    }
+}
+
+private extension VideoCallTests {
+    func mockViewModel(
+        with screenSharingStatus: ScreenSharingStatus
+    ) -> CallVisualizer.VideoCallViewModel {
+        var screenShareHandlerMock = ScreenShareHandler.mock
+        screenShareHandlerMock.status = { .init(with: screenSharingStatus) }
+        var environment = CallVisualizer.VideoCallViewModel.Environment.mock
+        environment.screenShareHandler = screenShareHandlerMock
+
+        return .mock(environment: environment)
+    }
 }


### PR DESCRIPTION
Previously, if one-way video is accepted by visitor during screen sharing session, end screen sharing button is hidden on Call screen. This commit fixes it.

MOB-2452