### PR TITLE
Handle HTML text in GVA messages

### DIFF
--- a/GliaWidgets/Sources/View/Chat/ChatView.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatView.swift
@@ -845,7 +845,7 @@ extension ChatView {
             )
         )
         view.appendContent(
-            .text(
+            .attributedText(
                 text.content,
                 accessibility: Self.operatorAccessibilityMessage(
                     for: message,

--- a/GliaWidgets/Sources/View/Chat/Message/ChatMessageView.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/ChatMessageView.swift
@@ -56,6 +56,18 @@ class ChatMessageView: BaseView {
                 accessibilityProperties: accProperties
             )
             appendContentViews(contentViews, animated: animated)
+        case let .attributedText(text, accProperties):
+            let contentView = ChatTextContentView(
+                with: style.text,
+                contentAlignment: contentAlignment
+            )
+            contentView.attributedText = text
+            contentView.linkTapped = { [weak self] in self?.linkTapped?($0) }
+            contentView.accessibilityProperties = .init(
+                label: accProperties.label,
+                value: accProperties.value
+            )
+            appendContentView(contentView, animated: animated)
         default:
             break
         }

--- a/GliaWidgets/Sources/View/Chat/Message/Content/ChatMessageContent.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/Content/ChatMessageContent.swift
@@ -5,6 +5,7 @@ enum ChatMessageContent {
     case files([LocalFile], accessibility: ChatFileContentView.AccessibilityProperties)
     case downloads([FileDownload], accessibility: ChatFileContentView.AccessibilityProperties)
     case choiceCard(ChoiceCard)
+    case attributedText(NSAttributedString, accessibility: TextAccessibilityProperties)
 
     struct TextAccessibilityProperties {
         let label: String

--- a/GliaWidgets/Sources/View/Chat/Message/Content/Text/ChatTextContentView.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/Content/Text/ChatTextContentView.swift
@@ -6,6 +6,11 @@ class ChatTextContentView: BaseView {
         set { setText(newValue) }
     }
 
+    var attributedText: NSAttributedString? {
+        get { return textView.attributedText }
+        set { return setAttributedText(newValue) }
+    }
+
     var accessibilityProperties: AccessibilityProperties {
         get {
             .init(
@@ -89,18 +94,51 @@ class ChatTextContentView: BaseView {
     }
 
     private func setText(_ text: String?) {
-        if text == nil || text?.isEmpty == true {
+        guard let text, !text.isEmpty else {
             textView.removeFromSuperview()
-        } else {
-            if textView.superview == nil {
-                contentView.addSubview(textView)
-                textView.translatesAutoresizingMaskIntoConstraints = false
-                var constraints = [NSLayoutConstraint](); defer { constraints.activate() }
-                constraints += textView.layoutInSuperview(insets: kTextInsets)
-            }
-            textView.text = text
+            return
         }
+
+        if textView.superview == nil {
+            contentView.addSubview(textView)
+            textView.translatesAutoresizingMaskIntoConstraints = false
+            var constraints = [NSLayoutConstraint](); defer { constraints.activate() }
+            constraints += textView.layoutInSuperview(insets: kTextInsets)
+        }
+        textView.text = text
+
         textView.accessibilityIdentifier = text
+    }
+
+    private func setAttributedText(_ text: NSAttributedString?) {
+        guard let text, !text.string.isEmpty else {
+            textView.removeFromSuperview()
+            return
+        }
+
+        if textView.superview == nil {
+            contentView.addSubview(textView)
+            textView.translatesAutoresizingMaskIntoConstraints = false
+            var constraints = [NSLayoutConstraint](); defer { constraints.activate() }
+            constraints += textView.layoutInSuperview(insets: kTextInsets)
+        }
+
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: style.textFont,
+            .foregroundColor: style.textColor
+        ]
+
+        let attributedText = NSMutableAttributedString(attributedString: text)
+        attributedText.addAttributes(
+            attributes,
+            range: NSRange(
+                location: 0,
+                length: attributedText.length
+            )
+        )
+
+        textView.attributedText = attributedText
+        textView.accessibilityIdentifier = text.string
     }
 }
 


### PR DESCRIPTION
This PR allows the HTML to be rendered in GVA messages. The conversion of string to attributed string happens in decoding for performance and proper layout reasons.