### PR TITLE
Unsupported broadcast events alert action

### DIFF
--- a/GliaWidgets/L10n.swift
+++ b/GliaWidgets/L10n.swift
@@ -10,6 +10,8 @@ import Foundation
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
 public enum L10n {
+  /// This action is not currently supported on mobile
+  public static let gvaNotSupported = L10n.tr("Localizable", "gva_not_supported", fallback: "This action is not currently supported on mobile")
   /// Operator
   public static let `operator` = L10n.tr("Localizable", "operator", fallback: "Operator")
   /// Powered by

--- a/GliaWidgets/Resources/en.lproj/Localizable.strings
+++ b/GliaWidgets/Resources/en.lproj/Localizable.strings
@@ -263,3 +263,5 @@
 "callVisualizer.screenSharing.accessibility.messageHint" = "Message label";
 "callVisualizer.screenSharing.accessibility.buttonLabel" = "End screen sharing";
 "callVisualizer.screenSharing.accessibility.buttonHint" = "Ends screen sharing";
+
+"gva_not_supported" = "This action is not currently supported on mobile";

--- a/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.Mock.swift
+++ b/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.Mock.swift
@@ -19,7 +19,8 @@ extension AlertConfiguration {
             unexpectedError: .mock(),
             apiError: .mock(),
             unavailableMessageCenter: .mock(),
-            unavailableMessageCenterForBeingUnauthenticated: .mock()
+            unavailableMessageCenterForBeingUnauthenticated: .mock(),
+            unsupportedGvaBroadcastError: .mock()
         )
     }
 }

--- a/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.swift
+++ b/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.swift
@@ -51,6 +51,9 @@ public struct AlertConfiguration {
     /// Configuration of the unavailable message center error alert due to unautheticated visitor.
     public var unavailableMessageCenterForBeingUnauthenticated: MessageAlertConfiguration
 
+    /// Configuration of the unsupported GVA broadcast events error alert.
+    public var unsupportedGvaBroadcastError: MessageAlertConfiguration
+
     ///
     /// - Parameters:
     ///   - leaveQueue: Configuration of the queue leaving confirmation alert.
@@ -70,6 +73,7 @@ public struct AlertConfiguration {
     ///   - apiError: Configuration of the API error alert.
     ///   - unavailableMessageCenter: Configuration of the unavailable message center error alert.
     ///   - unavailableMessageCenterForBeingUnauthenticated: Configuration of the unavailable message center error alert due to unautheticated visitor.
+    ///   - unsupportedGvaBroadcastError: Configuration of the unsupported GVA broadcast events error alert.
     ///
     public init(
         leaveQueue: ConfirmationAlertConfiguration,
@@ -88,7 +92,8 @@ public struct AlertConfiguration {
         unexpectedError: MessageAlertConfiguration,
         apiError: MessageAlertConfiguration,
         unavailableMessageCenter: MessageAlertConfiguration,
-        unavailableMessageCenterForBeingUnauthenticated: MessageAlertConfiguration
+        unavailableMessageCenterForBeingUnauthenticated: MessageAlertConfiguration,
+        unsupportedGvaBroadcastError: MessageAlertConfiguration
     ) {
         self.leaveQueue = leaveQueue
         self.endEngagement = endEngagement
@@ -107,5 +112,6 @@ public struct AlertConfiguration {
         self.apiError = apiError
         self.unavailableMessageCenter = unavailableMessageCenter
         self.unavailableMessageCenterForBeingUnauthenticated = unavailableMessageCenterForBeingUnauthenticated
+        self.unsupportedGvaBroadcastError = unsupportedGvaBroadcastError
     }
 }

--- a/GliaWidgets/Sources/Theme/Theme+AlertConfiguration.swift
+++ b/GliaWidgets/Sources/Theme/Theme+AlertConfiguration.swift
@@ -130,6 +130,11 @@ extension Theme {
             shouldShowCloseButton: false
         )
 
+        let unsupportedGvaBroadcastError = MessageAlertConfiguration(
+            title: L10n.gvaNotSupported,
+            message: nil
+        )
+
         return AlertConfiguration(
             leaveQueue: leaveQueue,
             endEngagement: endEngagement,
@@ -147,7 +152,8 @@ extension Theme {
             unexpectedError: unexpected,
             apiError: api,
             unavailableMessageCenter: unavailableMessageCenter,
-            unavailableMessageCenterForBeingUnauthenticated: unavailableMessageCenterForBeingUnauthenticated
+            unavailableMessageCenterForBeingUnauthenticated: unavailableMessageCenterForBeingUnauthenticated,
+            unsupportedGvaBroadcastError: unsupportedGvaBroadcastError
         )
     }
 }

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+GVA.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+GVA.swift
@@ -8,10 +8,15 @@ private extension String {
 
 extension ChatViewModel {
     func gvaOptionAction(for option: GvaOption) -> Cmd {
+        // If `option.destinationPdBroadcastEvent` is specified,
+        // this is broadcast event button, which is not supported
+        // on mobile. So an alert should be shown.
         // If option contains `url`, then it's URL Button,
         // otherwise it's Postback Button and option should be sent
         // to the server as `SingleChoiceOption`
-        if let urlString = option.url,
+        if option.destinationPdBroadcastEvent != nil {
+            return broadcastEventButtonAction()
+        } else if let urlString = option.url,
            let url = URL(string: urlString) {
             return urlButtonAction(url: url, urlTarget: option.urlTarget)
         } else {
@@ -75,6 +80,16 @@ private extension ChatViewModel {
                     )
                 }
             }
+        }
+    }
+
+    func broadcastEventButtonAction() -> Cmd {
+        .init { [weak self] in
+            guard let self = self else { return }
+            self.showAlert(
+                with: self.alertConfiguration.unsupportedGvaBroadcastError,
+                dismissed: nil
+            )
         }
     }
 }

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Gva.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Gva.swift
@@ -56,12 +56,27 @@ extension ChatViewModelTests {
 
         XCTAssertEqual(calls, [.sendOption("text", "value")])
     }
+
+    func test_broadcastEventAction() {
+        let option = GvaOption.mock(text: "text", destinationPdBroadcastEvent: "mock")
+        var calls: [Call] = []
+        viewModel = .mock(environment: .mock)
+        viewModel.engagementAction = { action in
+            guard case .showAlert = action else { return }
+            calls.append(.showAlert)
+        }
+
+        viewModel.gvaOptionAction(for: option)()
+
+        XCTAssertEqual(calls, [.showAlert])
+    }
 }
 
 private extension ChatViewModelTests {
     enum Call: Equatable {
         case openUrl(String?)
         case sendOption(String?, String?)
+        case showAlert
 
         static func == (lhs: Call, rhs: Call) -> Bool {
             switch (lhs, rhs) {
@@ -69,6 +84,8 @@ private extension ChatViewModelTests {
                 return lhsUrl == rhsUrl
             case let (.sendOption(lhsText, lhsValue), .sendOption(rhsText, rhsValue)):
                 return lhsText == rhsText && lhsValue == rhsValue
+            case (.showAlert, .showAlert):
+                return true
             default:
                 return false
             }


### PR DESCRIPTION
Since mobile does not supported broadcast events, we need to show alert by pressing corresponding GVA message

snake-cased "gva_not_supported" localization key was defined in the ticket

MOB-2388