### PR TITLE
Introduce snapshot tests for dynamic type font

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -468,6 +468,17 @@
 		9AE9E4B527E0EE2E00BFE239 /* CallViewControllerVoiceOverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE9E4B427E0EE2E00BFE239 /* CallViewControllerVoiceOverTests.swift */; };
 		9AE9E4B727E1E30500BFE239 /* MockHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE9E4B627E1E30500BFE239 /* MockHelpers.swift */; };
 		AD57658B6D7BB11749113284 /* Pods_SnapshotTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9131A19E516E338E979C0C43 /* Pods_SnapshotTests.framework */; };
+		AF03A7AF2A6E7DC40081887D /* AlertViewControllerDynamicTypeFontTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF03A7AE2A6E7DC40081887D /* AlertViewControllerDynamicTypeFontTests.swift */; };
+		AF03A7B12A6E96870081887D /* BubbleViewDynamicTypeFontTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF03A7B02A6E96870081887D /* BubbleViewDynamicTypeFontTests.swift */; };
+		AF03A7B32A6EA5490081887D /* CallViewControllerDynamicTypeFontTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF03A7B22A6EA5490081887D /* CallViewControllerDynamicTypeFontTests.swift */; };
+		AF03A7B52A6EAA950081887D /* ChatCallUpgradeViewDynamicTypeFontTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF03A7B42A6EAA950081887D /* ChatCallUpgradeViewDynamicTypeFontTests.swift */; };
+		AF03A7B72A6EAFBA0081887D /* ChatViewControllerDynamicTypeFontTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF03A7B62A6EAFBA0081887D /* ChatViewControllerDynamicTypeFontTests.swift */; };
+		AF03A7B92A6ED1240081887D /* ScreenShareViewControllerDynamicTypeFontTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF03A7B82A6ED1240081887D /* ScreenShareViewControllerDynamicTypeFontTests.swift */; };
+		AF03A7BB2A6ED73E0081887D /* SecureConversationsWelcomeScreenDynamicTypeFontTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF03A7BA2A6ED73E0081887D /* SecureConversationsWelcomeScreenDynamicTypeFontTests.swift */; };
+		AF03A7BD2A6EDACF0081887D /* SecureConversationsConfirmationScreenDynamicTypeFontTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF03A7BC2A6EDACF0081887D /* SecureConversationsConfirmationScreenDynamicTypeFontTests.swift */; };
+		AF03A7BF2A6EDCBF0081887D /* SurveyViewControllerDynamicTypeFontTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF03A7BE2A6EDCBF0081887D /* SurveyViewControllerDynamicTypeFontTests.swift */; };
+		AF03A7C12A6EDE190081887D /* VideoCallViewControllerDynamicTypeFontTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF03A7C02A6EDE190081887D /* VideoCallViewControllerDynamicTypeFontTests.swift */; };
+		AF03A7C32A6EDF490081887D /* VisitorCodeViewControllerDynamicTypeFontTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF03A7C22A6EDF490081887D /* VisitorCodeViewControllerDynamicTypeFontTests.swift */; };
 		AF0D26D629705FDF00816CCB /* SecureConversations.ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0D26D529705FDE00816CCB /* SecureConversations.ActivityIndicator.swift */; };
 		AF0D26D82971912A00816CCB /* SecureConversations.SendMessageButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0D26D72971912A00816CCB /* SecureConversations.SendMessageButton.swift */; };
 		AF10ED8B29B7A4C000E85309 /* ChatViewModel+ChoiceCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF10ED8A29B7A4C000E85309 /* ChatViewModel+ChoiceCards.swift */; };
@@ -1144,6 +1155,17 @@
 		9AE9E4B427E0EE2E00BFE239 /* CallViewControllerVoiceOverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallViewControllerVoiceOverTests.swift; sourceTree = "<group>"; };
 		9AE9E4B627E1E30500BFE239 /* MockHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHelpers.swift; sourceTree = "<group>"; };
 		AB58EB188E5FABE4A07F2ACD /* Pods-GliaWidgets.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GliaWidgets.release.xcconfig"; path = "Target Support Files/Pods-GliaWidgets/Pods-GliaWidgets.release.xcconfig"; sourceTree = "<group>"; };
+		AF03A7AE2A6E7DC40081887D /* AlertViewControllerDynamicTypeFontTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertViewControllerDynamicTypeFontTests.swift; sourceTree = "<group>"; };
+		AF03A7B02A6E96870081887D /* BubbleViewDynamicTypeFontTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BubbleViewDynamicTypeFontTests.swift; sourceTree = "<group>"; };
+		AF03A7B22A6EA5490081887D /* CallViewControllerDynamicTypeFontTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallViewControllerDynamicTypeFontTests.swift; sourceTree = "<group>"; };
+		AF03A7B42A6EAA950081887D /* ChatCallUpgradeViewDynamicTypeFontTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatCallUpgradeViewDynamicTypeFontTests.swift; sourceTree = "<group>"; };
+		AF03A7B62A6EAFBA0081887D /* ChatViewControllerDynamicTypeFontTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewControllerDynamicTypeFontTests.swift; sourceTree = "<group>"; };
+		AF03A7B82A6ED1240081887D /* ScreenShareViewControllerDynamicTypeFontTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenShareViewControllerDynamicTypeFontTests.swift; sourceTree = "<group>"; };
+		AF03A7BA2A6ED73E0081887D /* SecureConversationsWelcomeScreenDynamicTypeFontTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversationsWelcomeScreenDynamicTypeFontTests.swift; sourceTree = "<group>"; };
+		AF03A7BC2A6EDACF0081887D /* SecureConversationsConfirmationScreenDynamicTypeFontTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversationsConfirmationScreenDynamicTypeFontTests.swift; sourceTree = "<group>"; };
+		AF03A7BE2A6EDCBF0081887D /* SurveyViewControllerDynamicTypeFontTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyViewControllerDynamicTypeFontTests.swift; sourceTree = "<group>"; };
+		AF03A7C02A6EDE190081887D /* VideoCallViewControllerDynamicTypeFontTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCallViewControllerDynamicTypeFontTests.swift; sourceTree = "<group>"; };
+		AF03A7C22A6EDF490081887D /* VisitorCodeViewControllerDynamicTypeFontTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitorCodeViewControllerDynamicTypeFontTests.swift; sourceTree = "<group>"; };
 		AF0D26D529705FDE00816CCB /* SecureConversations.ActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.ActivityIndicator.swift; sourceTree = "<group>"; };
 		AF0D26D72971912A00816CCB /* SecureConversations.SendMessageButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.SendMessageButton.swift; sourceTree = "<group>"; };
 		AF10ED8A29B7A4C000E85309 /* ChatViewModel+ChoiceCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatViewModel+ChoiceCards.swift"; sourceTree = "<group>"; };
@@ -3099,27 +3121,38 @@
 			children = (
 				846E822728996A5C008EFBF0 /* AlertViewControllerTests.swift */,
 				AF22C8842A6154780004BF3C /* AlertViewControllerLayoutTests.swift */,
+				AF03A7AE2A6E7DC40081887D /* AlertViewControllerDynamicTypeFontTests.swift */,
 				9AB3401227F71D5D006E0FE2 /* BubbleViewVoiceOverTests.swift */,
 				AF22C8862A6182AF0004BF3C /* BubbleViewLayoutTests.swift */,
+				AF03A7B02A6E96870081887D /* BubbleViewDynamicTypeFontTests.swift */,
 				9AE9E4B427E0EE2E00BFE239 /* CallViewControllerVoiceOverTests.swift */,
 				AF22C8882A6184C50004BF3C /* CallViewControllerLayoutTests.swift */,
+				AF03A7B22A6EA5490081887D /* CallViewControllerDynamicTypeFontTests.swift */,
 				9AB3402828002422006E0FE2 /* ChatCallUpgradeViewVoiceOverTests.swift */,
 				AF22C88A2A6186A20004BF3C /* ChatCallUpgradeViewLayoutTests.swift */,
+				AF03A7B42A6EAA950081887D /* ChatCallUpgradeViewDynamicTypeFontTests.swift */,
 				9A1992D627D61F8100161AAE /* ChatViewControllerVoiceOverTests.swift */,
 				AF22C88C2A6188EF0004BF3C /* ChatViewControllerLayoutTests.swift */,
+				AF03A7B62A6EAFBA0081887D /* ChatViewControllerDynamicTypeFontTests.swift */,
 				C07FA04C29B0E41A00E9FB7F /* ScreenShareViewControllerTests.swift */,
 				AF22C88E2A618B9D0004BF3C /* ScreenShareViewControllerLayoutTests.swift */,
+				AF03A7B82A6ED1240081887D /* ScreenShareViewControllerDynamicTypeFontTests.swift */,
 				75CF8D9029C3A85C00CB1524 /* SecureConversationsWelcomeScreenTests.swift */,
 				AF22C8902A6198FF0004BF3C /* SecureConversationsWelcomeScreenLayoutTests.swift */,
+				AF03A7BA2A6ED73E0081887D /* SecureConversationsWelcomeScreenDynamicTypeFontTests.swift */,
 				75CF8DAC29C8F2B500CB1524 /* SecureConversationsConfirmationScreenTests.swift */,
 				AF22C8922A619F5C0004BF3C /* SecureConversationsConfirmationScreenLayoutTests.swift */,
+				AF03A7BC2A6EDACF0081887D /* SecureConversationsConfirmationScreenDynamicTypeFontTests.swift */,
 				9A1992D727D61F8100161AAE /* SnapshotTestCase.swift */,
 				8458769E2823FD18007AC3DF /* SurveyViewControllerVoiceOverTests.swift */,
 				AF22C8942A61A6B80004BF3C /* SurveyViewControllerLayoutTests.swift */,
+				AF03A7BE2A6EDCBF0081887D /* SurveyViewControllerDynamicTypeFontTests.swift */,
 				C07FA04D29B0E41A00E9FB7F /* VideoCallViewControllerTests.swift */,
 				AF22C8962A61A9BF0004BF3C /* VideoCallViewControllerLayoutTests.swift */,
+				AF03A7C02A6EDE190081887D /* VideoCallViewControllerDynamicTypeFontTests.swift */,
 				C07FA04E29B0E41A00E9FB7F /* VisitorCodeViewControllerTests.swift */,
 				AF22C8982A61AE930004BF3C /* VisitorCodeViewControllerLayoutTests.swift */,
+				AF03A7C22A6EDF490081887D /* VisitorCodeViewControllerDynamicTypeFontTests.swift */,
 			);
 			path = SnapshotTests;
 			sourceTree = "<group>";
@@ -4538,16 +4571,24 @@
 			buildActionMask = 2147483647;
 			files = (
 				846E822828996A5C008EFBF0 /* AlertViewControllerTests.swift in Sources */,
+				AF03A7BB2A6ED73E0081887D /* SecureConversationsWelcomeScreenDynamicTypeFontTests.swift in Sources */,
 				75CF8D9129C3A85C00CB1524 /* SecureConversationsWelcomeScreenTests.swift in Sources */,
 				AF22C8972A61A9BF0004BF3C /* VideoCallViewControllerLayoutTests.swift in Sources */,
+				AF03A7BD2A6EDACF0081887D /* SecureConversationsConfirmationScreenDynamicTypeFontTests.swift in Sources */,
+				AF03A7B92A6ED1240081887D /* ScreenShareViewControllerDynamicTypeFontTests.swift in Sources */,
 				9AE9E4B527E0EE2E00BFE239 /* CallViewControllerVoiceOverTests.swift in Sources */,
+				AF03A7BF2A6EDCBF0081887D /* SurveyViewControllerDynamicTypeFontTests.swift in Sources */,
 				AF22C8852A6154780004BF3C /* AlertViewControllerLayoutTests.swift in Sources */,
 				AF22C8872A6182AF0004BF3C /* BubbleViewLayoutTests.swift in Sources */,
+				AF03A7C12A6EDE190081887D /* VideoCallViewControllerDynamicTypeFontTests.swift in Sources */,
 				C07FA05029B0E41A00E9FB7F /* VideoCallViewControllerTests.swift in Sources */,
 				AF22C88D2A6188EF0004BF3C /* ChatViewControllerLayoutTests.swift in Sources */,
+				AF03A7B12A6E96870081887D /* BubbleViewDynamicTypeFontTests.swift in Sources */,
+				AF03A7AF2A6E7DC40081887D /* AlertViewControllerDynamicTypeFontTests.swift in Sources */,
 				AF22C8992A61AE930004BF3C /* VisitorCodeViewControllerLayoutTests.swift in Sources */,
 				9AB3401327F71D5D006E0FE2 /* BubbleViewVoiceOverTests.swift in Sources */,
 				AF22C8932A619F5C0004BF3C /* SecureConversationsConfirmationScreenLayoutTests.swift in Sources */,
+				AF03A7B32A6EA5490081887D /* CallViewControllerDynamicTypeFontTests.swift in Sources */,
 				9A1992D827D61F8100161AAE /* ChatViewControllerVoiceOverTests.swift in Sources */,
 				AF22C8892A6184C50004BF3C /* CallViewControllerLayoutTests.swift in Sources */,
 				8458769F2823FD18007AC3DF /* SurveyViewControllerVoiceOverTests.swift in Sources */,
@@ -4557,9 +4598,12 @@
 				C07FA04F29B0E41A00E9FB7F /* ScreenShareViewControllerTests.swift in Sources */,
 				AF22C8952A61A6B80004BF3C /* SurveyViewControllerLayoutTests.swift in Sources */,
 				9A1992D927D61F8100161AAE /* SnapshotTestCase.swift in Sources */,
+				AF03A7B52A6EAA950081887D /* ChatCallUpgradeViewDynamicTypeFontTests.swift in Sources */,
+				AF03A7C32A6EDF490081887D /* VisitorCodeViewControllerDynamicTypeFontTests.swift in Sources */,
 				AF22C88F2A618B9D0004BF3C /* ScreenShareViewControllerLayoutTests.swift in Sources */,
 				AF22C8912A6198FF0004BF3C /* SecureConversationsWelcomeScreenLayoutTests.swift in Sources */,
 				AF22C88B2A6186A20004BF3C /* ChatCallUpgradeViewLayoutTests.swift in Sources */,
+				AF03A7B72A6EAFBA0081887D /* ChatViewControllerDynamicTypeFontTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SnapshotTests/AlertViewControllerDynamicTypeFontTests.swift
+++ b/SnapshotTests/AlertViewControllerDynamicTypeFontTests.swift
@@ -1,0 +1,67 @@
+import AccessibilitySnapshot
+@testable import GliaWidgets
+import SnapshotTesting
+import XCTest
+
+final class AlertViewControllerDynamicTypeFontTests: SnapshotTestCase {
+    func test_screenSharingOffer_extra3Large() {
+        let alert = alert(ofKind: .screenShareOffer(
+            .mock(),
+            accepted: {},
+            declined: {}
+        ))
+        assertSnapshot(
+            matching: alert,
+            as: .extra3LargeFontStrategy,
+            named: nameForDevice()
+        )
+    }
+
+    func test_mediaUpgradeOffer_extra3Large() {
+        let alert = alert(ofKind: .singleMediaUpgrade(
+            .mock(),
+            accepted: {},
+            declined: {}
+        ))
+        assertSnapshot(
+            matching: alert,
+            as: .extra3LargeFontStrategy,
+            named: nameForDevice()
+        )
+    }
+
+    func test_messageAlert_extra3Large() {
+        let alert = alert(ofKind: .message(
+            .mock(),
+            accessibilityIdentifier: nil,
+            dismissed: {}
+        ))
+        assertSnapshot(
+            matching: alert,
+            as: .extra3LargeFontStrategy,
+            named: nameForDevice()
+        )
+    }
+
+    func test_singleAction_extra3Large() {
+        let alert = alert(ofKind: .singleAction(
+            .mock(),
+            accessibilityIdentifier: "mocked-accessibility-identifier",
+            actionTapped: {}
+        ))
+        assertSnapshot(
+            matching: alert,
+            as: .extra3LargeFontStrategy,
+            named: nameForDevice()
+        )
+    }
+
+    private func alert(ofKind kind: AlertViewController.Kind) -> AlertViewController {
+        let viewController = AlertViewController(
+            kind: kind,
+            viewFactory: .mock()
+        )
+        viewController.view.frame = UIScreen.main.bounds
+        return viewController
+    }
+}

--- a/SnapshotTests/BubbleViewDynamicTypeFontTests.swift
+++ b/SnapshotTests/BubbleViewDynamicTypeFontTests.swift
@@ -1,0 +1,16 @@
+import AccessibilitySnapshot
+@testable import GliaWidgets
+import SnapshotTesting
+import XCTest
+
+final class BubbleViewDynamicTypeFontTests: SnapshotTestCase {
+    func test_bubble_extra3Large() {
+        let bubble = ViewFactory.mock().makeBubbleView()
+        bubble.frame = .init(origin: .zero, size: .init(width: 50, height: 50))
+        // If shadow will cause failing test locally or on CI, we should disable it.
+        assertSnapshot(
+            matching: bubble,
+            as: .extra3LargeFontStrategy
+        )
+    }
+}

--- a/SnapshotTests/CallViewControllerDynamicTypeFontTests.swift
+++ b/SnapshotTests/CallViewControllerDynamicTypeFontTests.swift
@@ -1,0 +1,65 @@
+@testable import GliaWidgets
+import SnapshotTesting
+import XCTest
+
+final class CallViewControllerDynamicTypeFontTests: SnapshotTestCase {
+    func test_audioCallQueueState_extra3Large() throws {
+        let viewController = try CallViewController.mockAudioCallQueueState()
+        viewController.view.frame = UIScreen.main.bounds
+        assertSnapshot(
+            matching: viewController,
+            as: .extra3LargeFontStrategy,
+            named: nameForDevice()
+        )
+    }
+
+    func test_audioCallConnectingState_extra3Large() throws {
+        let viewController = try CallViewController.mockAudioCallConnectingState()
+        viewController.view.frame = UIScreen.main.bounds
+        assertSnapshot(
+            matching: viewController,
+            as: .extra3LargeFontStrategy,
+            named: nameForDevice()
+        )
+    }
+
+    func test_audioCallConnectedState_extra3Large() throws {
+        let viewController = try CallViewController.mockAudioCallConnectedState()
+        viewController.view.frame = UIScreen.main.bounds
+        assertSnapshot(
+            matching: viewController,
+            as: .extra3LargeFontStrategy,
+            named: nameForDevice()
+        )
+    }
+
+    func test_mockVideoCallConnectingState_extra3Large() throws {
+        let viewController = try CallViewController.mockVideoCallConnectingState()
+        viewController.view.frame = UIScreen.main.bounds
+        assertSnapshot(
+            matching: viewController,
+            as: .extra3LargeFontStrategy,
+            named: nameForDevice()
+        )
+    }
+
+    func test_mockVideoCallQueueState_extra3Large() throws {
+        let viewController = try CallViewController.mockVideoCallQueueState()
+        viewController.view.frame = UIScreen.main.bounds
+        assertSnapshot(
+            matching: viewController,
+            as: .extra3LargeFontStrategy,
+            named: nameForDevice()
+        )
+    }
+
+    func test_mockVideoCallConnectedState_extra3Large() throws {
+        let viewController = try CallViewController.mockVideoCallConnectedState()
+        viewController.view.frame = UIScreen.main.bounds
+        assertSnapshot(
+            matching: viewController,
+            as: .extra3LargeFontStrategy,
+            named: nameForDevice()
+        )
+    }
+}

--- a/SnapshotTests/ChatCallUpgradeViewDynamicTypeFontTests.swift
+++ b/SnapshotTests/ChatCallUpgradeViewDynamicTypeFontTests.swift
@@ -1,0 +1,23 @@
+@testable import GliaWidgets
+import SnapshotTesting
+import XCTest
+
+final class ChatCallUpgradeViewDynamicTypeFontTests: SnapshotTestCase {
+    func test_chatCallUpgradeViewToAudio_extra3Large() {
+        let upgradeView = ChatCallUpgradeView(with: Theme.mock().chat.audioUpgrade, duration: .init(with: .zero))
+        upgradeView.frame = .init(origin: .zero, size: .init(width: 300, height: 120))
+        assertSnapshot(
+            matching: upgradeView,
+            as: .extra3LargeFontStrategy
+        )
+    }
+
+    func test_chatCallUpgradeViewToVideo_extra3Large() {
+        let upgradeView = ChatCallUpgradeView(with: Theme.mock().chat.videoUpgrade, duration: .init(with: .zero))
+        upgradeView.frame = .init(origin: .zero, size: .init(width: 300, height: 120))
+        assertSnapshot(
+            matching: upgradeView,
+            as: .extra3LargeFontStrategy
+        )
+    }
+}

--- a/SnapshotTests/ChatViewControllerDynamicTypeFontTests.swift
+++ b/SnapshotTests/ChatViewControllerDynamicTypeFontTests.swift
@@ -1,0 +1,55 @@
+@testable import GliaWidgets
+import SnapshotTesting
+import XCTest
+
+final class ChatViewControllerDynamicTypeFontTests: SnapshotTestCase {
+    func test_messagesFromHistory_extra3Large() {
+        let viewController = ChatViewController.mockHistoryMessagesScreen()
+        viewController.view.frame = UIScreen.main.bounds
+        assertSnapshot(
+            matching: viewController,
+            as: .extra3LargeFontStrategy,
+            named: nameForDevice()
+        )
+    }
+
+    func test_visitorUploadedFileStates_extra3Large() throws {
+        let viewController = try ChatViewController.mockVisitorFileUploadStates()
+        viewController.view.frame = UIScreen.main.bounds
+        assertSnapshot(
+            matching: viewController,
+            as: .extra3LargeFontStrategy,
+            named: nameForDevice()
+        )
+    }
+
+    func test_choiceCard_extra3Large() throws {
+        let viewController = try ChatViewController.mockChoiceCard()
+        viewController.view.frame = UIScreen.main.bounds
+        assertSnapshot(
+            matching: viewController,
+            as: .extra3LargeFontStrategy,
+            named: nameForDevice()
+        )
+    }
+
+    func test_visitorFileDownloadStates_extra3Large() throws {
+        var chatMessages: [ChatMessage] = []
+        let viewController = try ChatViewController.mockVisitorFileDownloadStates { messages in
+            chatMessages = messages
+        }
+        viewController.view.frame = UIScreen.main.bounds
+        viewController.view.setNeedsLayout()
+        viewController.view.layoutIfNeeded()
+        XCTAssertEqual(chatMessages.count, 4)
+        chatMessages[0].downloads[0].state.value = .none
+        chatMessages[1].downloads[0].state.value = .downloading(progress: .init(with: 0.5))
+        chatMessages[2].downloads[0].state.value = .downloaded(.mock())
+        chatMessages[3].downloads[0].state.value = .error(.deleted)
+        assertSnapshot(
+            matching: viewController,
+            as: .extra3LargeFontStrategy,
+            named: self.nameForDevice()
+        )
+    }
+}

--- a/SnapshotTests/ScreenShareViewControllerDynamicTypeFontTests.swift
+++ b/SnapshotTests/ScreenShareViewControllerDynamicTypeFontTests.swift
@@ -1,0 +1,28 @@
+@testable import GliaWidgets
+import SnapshotTesting
+import XCTest
+
+// swiftlint:disable type_name
+final class ScreenShareViewControllerDynamicTypeFontTests: SnapshotTestCase {
+    func testScreenShareViewController_extra3Large() {
+        let props: CallVisualizer.ScreenSharingViewController.Props = .init(
+            screenSharingViewProps: .init(
+                style: .mock(),
+                header: .mock(
+                    title: L10n.CallVisualizer.ScreenSharing.title,
+                    backButton: .init(style: .mock(image: Asset.back.image))
+                ),
+                endScreenSharing: .mock()
+            )
+        )
+        let screenShareViewController = CallVisualizer.ScreenSharingViewController(props: props)
+        screenShareViewController.view.frame = UIScreen.main.bounds
+
+        assertSnapshot(
+            matching: screenShareViewController,
+            as: .extra3LargeFontStrategy,
+            named: nameForDevice()
+        )
+    }
+}
+// swiftlint:enable type_name

--- a/SnapshotTests/SecureConversationsConfirmationScreenDynamicTypeFontTests.swift
+++ b/SnapshotTests/SecureConversationsConfirmationScreenDynamicTypeFontTests.swift
@@ -1,0 +1,48 @@
+@testable import GliaWidgets
+import SnapshotTesting
+import XCTest
+
+// swiftlint:disable type_name
+final class SecureConversationsConfirmationScreenDynamicTypeFontTests: SnapshotTestCase {
+    let theme = Theme.mock()
+
+    func test_confirmationView_extra3Large() {
+        let props = Self.makeConfirmationProps(style: theme.secureConversationsConfirmation)
+        let viewController = SecureConversations.ConfirmationViewController(
+            viewModel: .init(environment: .init(confirmationStyle: theme.defaultSecureConversationsConfirmationStyle)),
+            viewFactory: .mock(theme: theme, messageRenderer: nil, environment: .mock),
+            props: props
+        )
+        viewController.view.frame = UIScreen.main.bounds
+
+        assertSnapshot(
+            matching: viewController.view,
+            as: .extra3LargeFontStrategy,
+            named: self.nameForDevice()
+        )
+    }
+
+    // MARK: - Helpers
+
+    static func headerProps() -> Header.Props {
+        .mock(
+            title: "Secure Conversations",
+            backButton: .init(style: .mock(image: Asset.back.image)),
+            closeButton: .init(style: .mock(image: Asset.close.image))
+        )
+    }
+
+    static func makeConfirmationProps(
+        headerProps: Header.Props = headerProps(),
+        style: SecureConversations.ConfirmationStyle
+    ) -> SecureConversations.ConfirmationViewController.Props {
+        .init(
+            confirmationViewProps: .init(
+                style: style,
+                header: headerProps,
+                checkMessageButtonTap: .nop
+            )
+        )
+    }
+}
+// swiftlint:enable type_name

--- a/SnapshotTests/SecureConversationsWelcomeScreenDynamicTypeFontTests.swift
+++ b/SnapshotTests/SecureConversationsWelcomeScreenDynamicTypeFontTests.swift
@@ -1,0 +1,125 @@
+@testable import GliaWidgets
+import SnapshotTesting
+import XCTest
+
+// swiftlint:disable type_name
+final class SecureConversationsWelcomeScreenDynamicTypeFontTests: SnapshotTestCase {
+    let theme = Theme.mock()
+
+    func test_welcomeView_extra3Large() {
+        let props = Self.makeWelcomeProps(
+            theme: theme.secureConversationsWelcome,
+            uploads: []
+        )
+        let viewController = SecureConversations.WelcomeViewController(
+            viewFactory: .mock(theme: theme, messageRenderer: nil, environment: .mock),
+            props: .welcome(props),
+            environment: .init(gcd: .live, uiScreen: .mock, notificationCenter: .mock)
+        )
+        viewController.view.frame = UIScreen.main.bounds
+
+        assertSnapshot(
+            matching: viewController.view,
+            as: .extra3LargeFontStrategy,
+            named: self.nameForDevice()
+        )
+    }
+
+    func test_welcomeWithAttachments_extra3Large() {
+        let props = Self.makeWelcomeProps(
+            theme: theme.secureConversationsWelcome,
+            uploads: [
+                uploadedFileProps(),
+                failedFileUploadProps()
+            ]
+        )
+        let viewController = SecureConversations.WelcomeViewController(
+            viewFactory: .mock(theme: theme, messageRenderer: nil, environment: .mock),
+            props: .welcome(props),
+            environment: .init(gcd: .live, uiScreen: .mock, notificationCenter: .mock)
+        )
+        viewController.view.frame = UIScreen.main.bounds
+
+        assertSnapshot(
+            matching: viewController.view,
+            as: .extra3LargeFontStrategy,
+            named: self.nameForDevice()
+        )
+    }
+
+    func test_welcomeViewController_withValidationError_extra3Large() {
+        let props = Self.makeWelcomeProps(theme: theme.secureConversationsWelcome, warningMessage: "This is warning message")
+        let viewController = SecureConversations.WelcomeViewController(
+            viewFactory: .mock(theme: theme, messageRenderer: nil, environment: .mock),
+            props: .welcome(props),
+            environment: .init(gcd: .live, uiScreen: .mock, notificationCenter: .mock)
+        )
+        viewController.view.frame = UIScreen.main.bounds
+
+        assertSnapshot(
+            matching: viewController.view,
+            as: .extra3LargeFontStrategy,
+            named: self.nameForDevice()
+        )
+    }
+
+    // MARK: - Helpers
+
+    func uploadedFileProps() -> SecureConversations.FileUploadView.Props {
+        .init(
+            id: "id-a",
+            style: .messageCenter(theme.secureConversationsWelcome.attachmentListStyle.item),
+            state: .uploaded(.init(localFile: .mock())),
+            removeTapped: .nop
+        )
+    }
+
+    func failedFileUploadProps() -> SecureConversations.FileUploadView.Props {
+        .init(
+            id: "id-b",
+            style: .messageCenter(theme.secureConversationsWelcome.attachmentListStyle.item),
+            state: .error(.network),
+            removeTapped: .nop
+        )
+    }
+
+    static func headerProps() -> Header.Props {
+        .mock(
+            title: "Secure Conversations",
+            backButton: .init(style: .mock(image: Asset.back.image)),
+            closeButton: .init(style: .mock(image: Asset.close.image))
+        )
+    }
+
+    static func makeWelcomeProps(
+        theme: SecureConversations.WelcomeStyle,
+        headerProps: Header.Props = headerProps(),
+        uploads: [SecureConversations.FileUploadView.Props] = [],
+        warningMessage: String = ""
+    ) -> SecureConversations.WelcomeView.Props {
+        .init(
+            style: theme,
+            checkMessageButtonTap: .nop,
+            filePickerButton: .init(isEnabled: true, tap: .nop),
+            sendMessageButton: .active(.nop),
+            messageTextViewProps: .active(
+                .init(
+                    style: theme.messageTextViewStyle,
+                    text: "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
+                    textChanged: .nop,
+                    activeChanged: .nop
+                )
+            ),
+            warningMessage: .init(text: warningMessage, animated: false),
+            fileUploadListProps: .init(
+                maxUnscrollableViews: 3,
+                style: .chat(.mock),
+                uploads: .init(uploads),
+                isScrollingEnabled: true
+            ),
+            headerProps: headerProps,
+            isUiHidden: false
+        )
+    }
+}
+// swiftlint:enable type_name

--- a/SnapshotTests/SnapshotTestCase.swift
+++ b/SnapshotTests/SnapshotTestCase.swift
@@ -167,3 +167,25 @@ extension Snapshotting where Value == UIViewController, Format == UIImage {
             }
     }
 }
+
+extension Snapshotting where Value == UIViewController, Format == UIImage {
+    /// Strategy for making image references with largest dynamic font type for UIViewController.
+    static var extra3LargeFontStrategy: Self {
+        Self.image(
+            traits: UITraitCollection(
+                preferredContentSizeCategory: .accessibilityExtraExtraExtraLarge
+            )
+        )
+    }
+}
+
+extension Snapshotting where Value == UIView, Format == UIImage {
+    /// Strategy for making image references with largest dynamic font type for UIView.
+    static var extra3LargeFontStrategy: Self {
+        Self.image(
+            traits: UITraitCollection(
+                preferredContentSizeCategory: .accessibilityExtraExtraExtraLarge
+            )
+        )
+    }
+}

--- a/SnapshotTests/SurveyViewControllerDynamicTypeFontTests.swift
+++ b/SnapshotTests/SurveyViewControllerDynamicTypeFontTests.swift
@@ -1,0 +1,35 @@
+@testable import GliaWidgets
+import SnapshotTesting
+import XCTest
+
+final class SurveyViewControllerDynamicTypeFontTests: SnapshotTestCase {
+    func test_emptySurvey_extra3Large() {
+        let viewController = Survey.ViewController(viewFactory: .mock(), environment: .init(notificationCenter: .mock), props: .emptyPropsMock())
+        viewController.view.frame = UIScreen.main.bounds
+        assertSnapshot(
+            matching: viewController,
+            as: .extra3LargeFontStrategy,
+            named: nameForDevice()
+        )
+    }
+
+    func test_filledSurvey_extra3Large() {
+        let viewController = Survey.ViewController(viewFactory: .mock(), environment: .init(notificationCenter: .mock), props: .filledPropsMock())
+        viewController.view.frame = UIScreen.main.bounds
+        assertSnapshot(
+            matching: viewController,
+            as: .extra3LargeFontStrategy,
+            named: nameForDevice()
+        )
+    }
+
+    func test_emptySurveyErrorState_extra3Large() {
+        let viewController = Survey.ViewController(viewFactory: .mock(), environment: .init(notificationCenter: .mock), props: .errorPropsMock())
+        viewController.view.frame = UIScreen.main.bounds
+        assertSnapshot(
+            matching: viewController,
+            as: .extra3LargeFontStrategy,
+            named: nameForDevice()
+        )
+    }
+}

--- a/SnapshotTests/VideoCallViewControllerDynamicTypeFontTests.swift
+++ b/SnapshotTests/VideoCallViewControllerDynamicTypeFontTests.swift
@@ -1,0 +1,61 @@
+@testable import GliaWidgets
+import SnapshotTesting
+import XCTest
+
+// swiftlint:disable type_name
+final class VideoCallViewControllerDynamicTypeFontTests: SnapshotTestCase {
+    func testVideoCallViewController_extra3Large() {
+        let videoCallViewProps: CallVisualizer.VideoCallView.Props = .mock(
+            buttonBarProps: .mock(
+                style: .mock(
+                    chatButton: .mock(),
+                    videButton: .mock(
+                        inactive: .activeMock(
+                            image: Asset.callVideoActive.image,
+                            title: L10n.Call.Buttons.Video.title,
+                            accessibility: .init(label: L10n.Call.Accessibility.Buttons.Video.Active.label)
+                        )
+                    ),
+                    muteButton: .mock(
+                        inactive: .inactiveMock(
+                            image: Asset.callMuteInactive.image,
+                            title: L10n.Call.Buttons.Mute.Inactive.title,
+                            accessibility: .init(label: L10n.Call.Accessibility.Buttons.Mute.Inactive.label)
+                        )
+                    ),
+                    speakerButton: .mock(
+                        inactive: .inactiveMock(
+                            image: Asset.callSpeakerInactive.image,
+                            title: L10n.Call.Buttons.Speaker.title,
+                            accessibility: .init(label: L10n.Call.Accessibility.Buttons.Speaker.Inactive.label)
+                        )
+                    ),
+                    minimizeButton: .mock(
+                        inactive: .inactiveMock(
+                            image: Asset.callMiminize.image,
+                            title: L10n.Call.Buttons.Minimize.title,
+                            accessibility: .init(label: L10n.Call.Accessibility.Buttons.Minimize.Inactive.label)
+                        )
+                    ),
+                    badge: .mock()
+                )
+            ),
+            headerProps: .mock(
+                title: "Video",
+                effect: .blur,
+                backButton: .init(style: .mock(image: Asset.back.image))
+            )
+        )
+        let props: CallVisualizer.VideoCallViewController.Props = .init(videoCallViewProps: videoCallViewProps)
+
+        let videoCallViewController: CallVisualizer.VideoCallViewController = .mock(props: props)
+        videoCallViewController.view.frame = UIScreen.main.bounds
+
+        assertSnapshot(
+            matching: videoCallViewController,
+            as: .extra3LargeFontStrategy,
+            named: nameForDevice()
+        )
+    }
+}
+// swiftlint:enable type_name

--- a/SnapshotTests/VisitorCodeViewControllerDynamicTypeFontTests.swift
+++ b/SnapshotTests/VisitorCodeViewControllerDynamicTypeFontTests.swift
@@ -1,0 +1,108 @@
+@testable import GliaWidgets
+import SnapshotTesting
+import XCTest
+
+// swiftlint:disable type_name
+final class VisitorCodeViewControllerDynamicTypeFontTests: SnapshotTestCase {
+    func testVisitorCodeAlertWhenLoading() {
+        let props: CallVisualizer.VisitorCodeViewController.Props = .init(
+            visitorCodeViewProps: .init(
+                viewType: .alert(closeButtonTap: .nop),
+                viewState: .loading
+            )
+        )
+        let visitorCodeViewController = CallVisualizer.VisitorCodeViewController(props: props)
+        visitorCodeViewController.view.frame = UIScreen.main.bounds
+
+        assertSnapshot(
+            matching: visitorCodeViewController,
+            as: .extra3LargeFontStrategy,
+            named: nameForDevice()
+        )
+    }
+
+    func testVisitorCodeAlertWhenError() {
+        let props: CallVisualizer.VisitorCodeViewController.Props = .init(
+            visitorCodeViewProps: .init(
+                viewType: .alert(closeButtonTap: .nop),
+                viewState: .error(refreshTap: .nop)
+            )
+        )
+        let visitorCodeViewController = CallVisualizer.VisitorCodeViewController(props: props)
+        visitorCodeViewController.view.frame = UIScreen.main.bounds
+
+        assertSnapshot(
+            matching: visitorCodeViewController,
+            as: .extra3LargeFontStrategy,
+            named: nameForDevice()
+        )
+    }
+
+    func testVisitorCodeAlertWhenSuccess() {
+        let props: CallVisualizer.VisitorCodeViewController.Props = .init(
+            visitorCodeViewProps: .init(
+                viewType: .alert(closeButtonTap: .nop),
+                viewState: .success(visitorCode: "12345")
+            )
+        )
+        let visitorCodeViewController = CallVisualizer.VisitorCodeViewController(props: props)
+        visitorCodeViewController.view.frame = UIScreen.main.bounds
+
+        assertSnapshot(
+            matching: visitorCodeViewController,
+            as: .extra3LargeFontStrategy,
+            named: nameForDevice()
+        )
+    }
+
+    func testVisitorCodeEmbeddedWhenLoading() {
+        let props: CallVisualizer.VisitorCodeViewController.Props = .init(
+            visitorCodeViewProps: .init(
+                viewType: .embedded,
+                viewState: .loading
+            )
+        )
+        let visitorCodeViewController = CallVisualizer.VisitorCodeViewController(props: props)
+        visitorCodeViewController.view.frame = UIScreen.main.bounds
+
+        assertSnapshot(
+            matching: visitorCodeViewController,
+            as: .extra3LargeFontStrategy,
+            named: nameForDevice()
+        )
+    }
+
+    func testVisitorCodeEmbeddedWhenError() {
+        let props: CallVisualizer.VisitorCodeViewController.Props = .init(
+            visitorCodeViewProps: .init(
+                viewType: .embedded,
+                viewState: .error(refreshTap: .nop)
+            )
+        )
+        let visitorCodeViewController = CallVisualizer.VisitorCodeViewController(props: props)
+        visitorCodeViewController.view.frame = UIScreen.main.bounds
+
+        assertSnapshot(
+            matching: visitorCodeViewController,
+            as: .extra3LargeFontStrategy,
+            named: nameForDevice()
+        )
+    }
+    func testVisitorCodeEmbeddedWhenSuccess() {
+        let props: CallVisualizer.VisitorCodeViewController.Props = .init(
+            visitorCodeViewProps: .init(
+                viewType: .embedded,
+                viewState: .success(visitorCode: "12345")
+            )
+        )
+        let visitorCodeViewController = CallVisualizer.VisitorCodeViewController(props: props)
+        visitorCodeViewController.view.frame = UIScreen.main.bounds
+
+        assertSnapshot(
+            matching: visitorCodeViewController,
+            as: .extra3LargeFontStrategy,
+            named: nameForDevice()
+        )
+    }
+}
+// swiftlint:enable type_name


### PR DESCRIPTION
Add initial snapshot tests for dynamic type fonts. Note that these tests reveal that some UI does not take into account dynamic font type, so appropriate tickets are to be created.

MOB-2476