### PR TITLE
Fix custom cards handling

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -227,6 +227,8 @@
 		7552DFA62A683A2C0093519B /* Layout+UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B7BD7D2A39D5430060794D /* Layout+UIView.swift */; };
 		7552DFA72A683A2C0093519B /* NSLayoutConstraint+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75940957298D386F008B173A /* NSLayoutConstraint+Extensions.swift */; };
 		7552DFA82A683A2C0093519B /* UIStackView.Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75940956298D386F008B173A /* UIStackView.Extensions.swift */; };
+		7552DFB12A6FB7DF0093519B /* ChatMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7552DFB02A6FB7DF0093519B /* ChatMessageTests.swift */; };
+		7552DFB42A6FBC7F0093519B /* CoreSdk.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7552DFB32A6FBC7F0093519B /* CoreSdk.swift */; };
 		755D186529A6A4E20009F5E8 /* WelcomeStyle+TitleStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755D186429A6A4E20009F5E8 /* WelcomeStyle+TitleStyle.swift */; };
 		755D186729A6A4FA0009F5E8 /* WelcomeStyle+SubtitleStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755D186629A6A4FA0009F5E8 /* WelcomeStyle+SubtitleStyle.swift */; };
 		755D186929A6A5270009F5E8 /* WelcomeStyle+CheckMessagesButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755D186829A6A5270009F5E8 /* WelcomeStyle+CheckMessagesButtonStyle.swift */; };
@@ -896,6 +898,8 @@
 		754313CE2870E64600C9C1C6 /* Configuration.Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.Extensions.swift; sourceTree = "<group>"; };
 		7543141728806AEB00C9C1C6 /* EnvironmentSettingsTextCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentSettingsTextCell.swift; sourceTree = "<group>"; };
 		754CC61427E27C42005676E9 /* Survey.Checkbox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Survey.Checkbox.swift; sourceTree = "<group>"; };
+		7552DFB02A6FB7DF0093519B /* ChatMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageTests.swift; sourceTree = "<group>"; };
+		7552DFB32A6FBC7F0093519B /* CoreSdk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSdk.swift; sourceTree = "<group>"; };
 		755D186429A6A4E20009F5E8 /* WelcomeStyle+TitleStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WelcomeStyle+TitleStyle.swift"; sourceTree = "<group>"; };
 		755D186629A6A4FA0009F5E8 /* WelcomeStyle+SubtitleStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WelcomeStyle+SubtitleStyle.swift"; sourceTree = "<group>"; };
 		755D186829A6A5270009F5E8 /* WelcomeStyle+CheckMessagesButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WelcomeStyle+CheckMessagesButtonStyle.swift"; sourceTree = "<group>"; };
@@ -1551,6 +1555,8 @@
 		1A205D6525655CB2003AA3CD /* GliaWidgetsTests */ = {
 			isa = PBXGroup;
 			children = (
+				7552DFB22A6FBC6E0093519B /* CoreSdk */,
+				7552DFAF2A6FB37E0093519B /* ChatMessage */,
 				846A5C3729D18D220049B29F /* ScreenShareHandler */,
 				AFEF5C7229929A73005C3D8D /* SecureConversations */,
 				C096B408297EBCEB00F0C552 /* CallVisualizer */,
@@ -2518,6 +2524,22 @@
 				C03A8048292BC8DB00DDECA6 /* CallViewControllerTests.swift */,
 			);
 			path = Sources;
+			sourceTree = "<group>";
+		};
+		7552DFAF2A6FB37E0093519B /* ChatMessage */ = {
+			isa = PBXGroup;
+			children = (
+				7552DFB02A6FB7DF0093519B /* ChatMessageTests.swift */,
+			);
+			path = ChatMessage;
+			sourceTree = "<group>";
+		};
+		7552DFB22A6FBC6E0093519B /* CoreSdk */ = {
+			isa = PBXGroup;
+			children = (
+				7552DFB32A6FBC7F0093519B /* CoreSdk.swift */,
+			);
+			path = CoreSdk;
 			sourceTree = "<group>";
 		};
 		755D186329A6A4B10009F5E8 /* WelcomeStyle */ = {
@@ -4441,6 +4463,7 @@
 				84681A982A61853300DD7406 /* GvaOption.Mock.swift in Sources */,
 				AF6AB34B2989517100003645 /* FileUploader.Failing.swift in Sources */,
 				EB03B00E27FFF6DD0058F6B1 /* CallViewTests.swift in Sources */,
+				7552DFB42A6FBC7F0093519B /* CoreSdk.swift in Sources */,
 				3197F7AD29E6A5C8008EE9F7 /* SecureConversations.FileUploadListView.Mock.swift in Sources */,
 				AF29810929E045CE0005BD55 /* TranscriptModelTests.swift in Sources */,
 				7512A57727BE8A6700319DF1 /* InteractorTests.swift in Sources */,
@@ -4488,6 +4511,7 @@
 				846429862A45DB4100943BD6 /* AlertViewController.Kind+Mock.swift in Sources */,
 				AF29811229E42F3C0005BD55 /* AvailabilityTests.swift in Sources */,
 				9AE05CB32805C9D900871321 /* ChatViewModel.Environment.Failing.swift in Sources */,
+				7552DFB12A6FB7DF0093519B /* ChatMessageTests.swift in Sources */,
 				AFEF5C7429929A8D005C3D8D /* SecureConversations.FileUploadListViewModel.Environment.Failing.swift in Sources */,
 				9A3E1D9D27BA7741005634EB /* FoundationBased.Failing.swift in Sources */,
 				9A3E1D8427B67F1B005634EB /* Helper.swift in Sources */,

--- a/GliaWidgets/Sources/ViewModel/Chat/Data/ChatMessage.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/Data/ChatMessage.swift
@@ -52,14 +52,10 @@ class ChatMessage: Codable {
         }
 
         if attachment?.type == .singleChoice {
-            return .choiceCard
+            return metadata != nil ? .customCard : .choiceCard
         }
 
-        if metadata == nil {
-            return .none
-        }
-
-        return .customCard
+        return .none
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -127,7 +123,8 @@ class ChatMessage: Codable {
         sender: ChatMessageSender,
         content: String,
         attachment: ChatAttachment?,
-        downloads: [FileDownload]
+        downloads: [FileDownload],
+        metadata: MessageMetadata? = nil
     ) {
         self.id = id
         self.queueID = queueID
@@ -136,5 +133,6 @@ class ChatMessage: Codable {
         self.content = content
         self.attachment = attachment
         self.downloads = downloads
+        self.metadata = metadata
     }
 }

--- a/GliaWidgetsTests/ChatMessage/ChatMessageTests.swift
+++ b/GliaWidgetsTests/ChatMessage/ChatMessageTests.swift
@@ -1,0 +1,50 @@
+import GliaCoreSDK
+import XCTest
+
+@testable import GliaWidgets
+
+final class ChatMessageTests: XCTestCase {
+
+    func testCardType__singleChoiceWithoutMetadata() throws {
+        let msg = ChatMessage.mock(
+            attachment: .mock(type: .singleChoice, files: nil, imageUrl: nil, options: nil),
+            metadata: nil
+        )
+        XCTAssertEqual(msg.cardType, .choiceCard)
+    }
+
+    func testCardType__singleChoiceWithMetadata() throws {
+        let metadataDecodingContainer = try CoreSdkMessageMetadataContainer(
+            jsonData: "{\"html\": \"Hello\"}".data(using: .utf8)!
+        ).container
+        let msg = ChatMessage.mock(
+            attachment: .mock(type: .singleChoice, files: nil, imageUrl: nil, options: nil),
+            metadata: MessageMetadata(container: metadataDecodingContainer)
+        )
+        XCTAssertEqual(msg.cardType, .customCard)
+    }
+}
+
+extension ChatMessage {
+    static func mock(
+        id: String = "mocked-message-id",
+        queueId: String? = "queue-id",
+        operator: ChatOperator? = .init(name: "XCTest Operator", pictureUrl: nil),
+        sender: ChatMessageSender = .`operator`,
+        content: String = "Hello unit test!",
+        attachment: ChatAttachment? = nil,
+        downloads: [FileDownload] = [],
+        metadata: MessageMetadata? = nil
+    ) -> ChatMessage {
+        ChatMessage(
+            id: id,
+            queueID: queueId,
+            operator: `operator`,
+            sender: sender,
+            content: content,
+            attachment: attachment,
+            downloads: downloads,
+            metadata: metadata
+        )
+    }
+}

--- a/GliaWidgetsTests/CoreSdk/CoreSdk.swift
+++ b/GliaWidgetsTests/CoreSdk/CoreSdk.swift
@@ -1,0 +1,24 @@
+import Foundation
+import GliaCoreSDK
+
+/// Defines wrapper structure for getting decoding container.
+/// This container can be used when message metadata is needed in
+/// tests.
+struct CoreSdkMessageMetadataContainer: Decodable {
+    let container: KeyedDecodingContainer<GliaCoreSDK.Message.Metadata.CodingKeys>
+
+    init(from decoder: Decoder) throws {
+        self.container = try decoder.container(keyedBy: GliaCoreSDK.Message.Metadata.CodingKeys.self)
+    }
+
+    /// Creates instance with decoding container inside.
+    /// This initializer can be used for created mocked Metadata with passing
+    /// json-data inside of this initializer.
+    /// NB! Empty 'jsonData' will lead to decoding error.
+    init(
+        jsonData: Data,
+        jsonDecoder: JSONDecoder = .init()
+    ) throws {
+        self = try jsonDecoder.decode(CoreSdkMessageMetadataContainer.self, from: jsonData)
+    }
+}


### PR DESCRIPTION
SDK differentiate custom card and response card based on metadata property. 
If the type is single choice card and metadata is nil, SDK should draw a message as a response card.
If the type is single choice card and metadata is not nil, SDK should pass metadata to renderer and render custom card.

MOB-2342