### PR TITLE
Fix bubble view alignment in dedicated window.

### DIFF
--- a/GliaWidgets/Sources/Component/Bubble/BubbleWindow.swift
+++ b/GliaWidgets/Sources/Component/Bubble/BubbleWindow.swift
@@ -99,7 +99,14 @@ private class BubbleViewController: UIViewController {
         view.addSubview(bubbleView)
         bubbleView.translatesAutoresizingMaskIntoConstraints = false
         var constraints = [NSLayoutConstraint](); defer { constraints.activate() }
-        constraints += bubbleView.layoutInSuperview(insets: UIEdgeInsets(top: edgeInset, left: edgeInset, bottom: -edgeInset, right: -edgeInset))
+        constraints += bubbleView.layoutInSuperview(
+            insets: UIEdgeInsets(
+                top: edgeInset,
+                left: edgeInset,
+                bottom: edgeInset,
+                right: edgeInset
+            )
+        )
     }
 }
 


### PR DESCRIPTION
Address improper alignment of bubble view in bubble window after PureLayout removal. Snapshot test is to be added in separate PR.

MOB-2348

#### Before fix
<img src="https://github.com/salemove/ios-sdk-widgets/assets/3148347/11187d2e-101c-4952-861b-8dba8230fba7" width="428" height="926">

#### After fix
<img src="https://github.com/salemove/ios-sdk-widgets/assets/3148347/304702b5-4e30-44ea-b3c8-871bf551be2f" width="428" height="926">

