### PR TITLE
Fix system messages layout

### DIFF
--- a/GliaWidgets/Sources/View/Chat/Message/SystemMessageView.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/SystemMessageView.swift
@@ -28,10 +28,12 @@ final class SystemMessageView: ChatMessageView {
     private func layout() {
         addSubview(contentViews)
 
-        var constraints = [NSLayoutConstraint](); defer { constraints.activate() }
-        constraints += contentViews.layoutInSuperview(edges: .vertical, insets: kInsets)
-        constraints += contentViews.layoutInSuperview(edges: .top, insets: kInsets)
-        constraints += contentViews.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: kInsets.right)
+        NSLayoutConstraint.activate([
+            contentViews.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: kInsets.left),
+            contentViews.trailingAnchor.constraint(lessThanOrEqualTo: self.trailingAnchor, constant: -kInsets.right),
+            contentViews.topAnchor.constraint(equalTo: self.topAnchor, constant: kInsets.top),
+            contentViews.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -kInsets.bottom)
+        ])
     }
 }
 


### PR DESCRIPTION
Address layout inconsistency of system messages after `PureLayout` removal.

MOB-2480

**Before fix:**
<img src="https://github.com/salemove/ios-sdk-widgets/assets/3148347/96adb142-e7b1-4ba6-b2ee-49a404cd55b9" width="428" height="926">

**After fix:**
<img src="https://github.com/salemove/ios-sdk-widgets/assets/3148347/29092cf7-93ab-47e0-82f4-20222095e080" width="428" height="926">