### PR TITLE
Add missing acc. identifiers and custom segmented control

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -518,6 +518,7 @@
 		AF6AB34B2989517100003645 /* FileUploader.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6AB34A2989517100003645 /* FileUploader.Failing.swift */; };
 		AF6AB34D298A9F2500003645 /* SecureConversations.FileUploadListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6AB34C298A9F2500003645 /* SecureConversations.FileUploadListViewModel.swift */; };
 		AF6AB34F298AA02400003645 /* SecureConversations.FileUploadListViewModel.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6AB34E298AA02400003645 /* SecureConversations.FileUploadListViewModel.Environment.swift */; };
+		AF75601C2A78146600871E36 /* CustomSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF75601B2A78146500871E36 /* CustomSegmentedControl.swift */; };
 		AF755FDA2A71583900871E36 /* BubbleWindowLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF755FD92A71583900871E36 /* BubbleWindowLayoutTests.swift */; };
 		AF9DB22E2890571A00A0C442 /* RootCoordinator.Environment.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9DB22D2890571A00A0C442 /* RootCoordinator.Environment.Failing.swift */; };
 		AF9DB23128905A1D00A0C442 /* ViewFactory.Environment.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9DB23028905A1D00A0C442 /* ViewFactory.Environment.Failing.swift */; };
@@ -1208,6 +1209,7 @@
 		AF6AB34A2989517100003645 /* FileUploader.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploader.Failing.swift; sourceTree = "<group>"; };
 		AF6AB34C298A9F2500003645 /* SecureConversations.FileUploadListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FileUploadListViewModel.swift; sourceTree = "<group>"; };
 		AF6AB34E298AA02400003645 /* SecureConversations.FileUploadListViewModel.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FileUploadListViewModel.Environment.swift; sourceTree = "<group>"; };
+		AF75601B2A78146500871E36 /* CustomSegmentedControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomSegmentedControl.swift; sourceTree = "<group>"; };
 		AF755FD92A71583900871E36 /* BubbleWindowLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BubbleWindowLayoutTests.swift; sourceTree = "<group>"; };
 		AF9DB22D2890571A00A0C442 /* RootCoordinator.Environment.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootCoordinator.Environment.Failing.swift; sourceTree = "<group>"; };
 		AF9DB23028905A1D00A0C442 /* ViewFactory.Environment.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewFactory.Environment.Failing.swift; sourceTree = "<group>"; };
@@ -3261,6 +3263,7 @@
 		AFD3C52A2A472B1C00BC37A9 /* VisitorInfo */ = {
 			isa = PBXGroup;
 			children = (
+				AF75601B2A78146500871E36 /* CustomSegmentedControl.swift */,
 				AF3BD1DC2A41D09100A7713E /* VisitorInfoViewController.swift */,
 				AF35DFF02A507CA70038BCA7 /* VisitorInfoViewController.Cells.swift */,
 				AF35DFEE2A507B4C0038BCA7 /* VisitorInfoViewController.HeaderView.swift */,
@@ -4570,6 +4573,7 @@
 				7552DFA52A683A2C0093519B /* Makeable.swift in Sources */,
 				1A205D7F25655CEC003AA3CD /* ViewController.swift in Sources */,
 				AFD3C52C2A472B7500BC37A9 /* VisitorInfoModel.swift in Sources */,
+				AF75601C2A78146600871E36 /* CustomSegmentedControl.swift in Sources */,
 				1A4AD3D6256FE7F800468BFB /* UIColor+Extensions.swift in Sources */,
 				AF11F30728BE6F0C002ACEB4 /* UIAlertController+Extensions.swift in Sources */,
 				7552DFA82A683A2C0093519B /* UIStackView.Extensions.swift in Sources */,

--- a/TestingApp/Main.storyboard
+++ b/TestingApp/Main.storyboard
@@ -167,6 +167,7 @@
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tYL-hF-sF1">
                                                 <rect key="frame" x="152" y="421.5" width="110" height="30"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="main_visitorInfo_button"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                 <state key="normal" title="Show vistor info"/>

--- a/TestingApp/VisitorInfo/CustomSegmentedControl.swift
+++ b/TestingApp/VisitorInfo/CustomSegmentedControl.swift
@@ -1,0 +1,171 @@
+import UIKit
+
+protocol CustomSegmentedControlDelegate: AnyObject {
+    func segmentedControl(_ segmentedControl: CustomSegmentedControl, didSelectSegmentAt index: Int)
+}
+
+class CustomSegmentedControl: UIControl {
+    weak var delegate: CustomSegmentedControlDelegate?
+
+    private var buttons = [UIButton]()
+    private (set) var selectedSegmentIndex = 0
+
+    var segments: [String] = [] {
+        didSet {
+            setupSegments()
+        }
+    }
+
+    var textColor: UIColor = .gray {
+        didSet {
+            updateButtonAppearance()
+        }
+    }
+
+    var selectedTextColor: UIColor = .label {
+        didSet {
+            updateButtonAppearance()
+        }
+    }
+
+    var segmentSpacing: CGFloat = 8 {
+        didSet {
+            stackView.spacing = segmentSpacing
+            invalidateIntrinsicContentSize()
+        }
+    }
+
+    var cornerRadius: CGFloat = 8 {
+        didSet {
+            layer.cornerRadius = cornerRadius
+        }
+    }
+
+    var borderWidth: CGFloat = 1 {
+        didSet {
+            layer.borderWidth = borderWidth
+        }
+    }
+
+    var borderColor: UIColor = .gray {
+        didSet {
+            layer.borderColor = borderColor.cgColor
+        }
+    }
+
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.distribution = .fillEqually
+        stackView.spacing = segmentSpacing
+        stackView.isLayoutMarginsRelativeArrangement = true
+        stackView.layoutMargins = .init(top: 0, left: 10, bottom: 0, right: 10)
+        return stackView
+    }()
+
+    // MARK: - Initialization
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        setupView()
+    }
+
+    // MARK: - View setup
+
+    private func setupView() {
+        layer.cornerRadius = cornerRadius
+        layer.borderWidth = borderWidth
+        layer.borderColor = borderColor.cgColor
+        backgroundColor = .clear
+
+        addSubview(stackView)
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+
+        setupSegments()
+    }
+
+    private func setupSegments() {
+        // Remove previous buttons
+        buttons.forEach { $0.removeFromSuperview() }
+        buttons.removeAll(keepingCapacity: true)
+
+        // Create and add buttons for each segment
+        for title in segments {
+            let button = UIButton(type: .custom)
+            button.setTitle(title, for: .normal)
+            button.addTarget(self, action: #selector(segmentTapped(_:)), for: .touchUpInside)
+            buttons.append(button)
+            stackView.addArrangedSubview(button)
+        }
+
+        // Update UI appearance
+        updateButtonAppearance()
+    }
+
+    private func updateButtonAppearance() {
+        for (index, button) in zip(0..., buttons) {
+            button.tintColor = .clear
+            button.setTitleColor(
+                index == selectedSegmentIndex ? selectedTextColor : textColor,
+                for: .normal
+            )
+            let fontSize = UIFont.systemFontSize - 2
+
+            button.titleLabel?.font = index == selectedSegmentIndex ? .boldSystemFont(ofSize: fontSize) :
+                .systemFont(ofSize: fontSize)
+        }
+    }
+
+    // MARK: - Segment Handling
+
+    @objc private func segmentTapped(_ sender: UIButton) {
+        guard let index = buttons.firstIndex(of: sender) else { return }
+        setSelectedSegment(index, sendActions: true)
+    }
+
+    private func setSelectedSegment(_ index: Int, sendActions: Bool) {
+        if selectedSegmentIndex != index {
+            selectedSegmentIndex = index
+            updateButtonAppearance()
+            if sendActions {
+                self.sendActions(for: .valueChanged)
+                delegate?.segmentedControl(self, didSelectSegmentAt: index)
+            }
+        }
+    }
+
+    // MARK: - Public API
+
+    func setSelectedSegmentIndex(_ index: Int, sendActions: Bool) {
+        guard segments.indices.contains(index) else { return }
+        setSelectedSegment(index, sendActions: sendActions)
+    }
+
+    func setTitle(_ title: String, forSegmentAt index: Int) {
+        guard segments.indices.contains(index) else { return }
+        segments[index] = title
+        buttons[index].setTitle(title, for: .normal)
+        invalidateIntrinsicContentSize()
+    }
+
+    func titleForSegment(at index: Int) -> String? {
+        guard segments.indices.contains(index) else { return nil }
+        return segments[index]
+    }
+
+    func setAccessibilityIdentifier(_ identifier: String, at index: Int) {
+        guard segments.indices.contains(index) else { return }
+        stackView.arrangedSubviews[index].accessibilityIdentifier = identifier
+    }
+}

--- a/TestingApp/VisitorInfo/VisitorInfoModel.swift
+++ b/TestingApp/VisitorInfo/VisitorInfoModel.swift
@@ -14,6 +14,7 @@ final class VisitorInfoModel {
     typealias Segment = HeaderView.Props.Segment
     typealias Delegate = (DelegateEvent) -> Void
     typealias UpdateButton = Props.UpdateButton
+    typealias CancelButton = Props.CancelButton
 
     // Stores visitor fields to be sent for update.
     var visitorInfoUpdate = VisitorInfoUpdate() {
@@ -351,10 +352,19 @@ final class VisitorInfoModel {
         let updateButton: UpdateButton
         switch self.updateInfoRequestState {
         case .none, .result:
-            updateButton = .normal(updateTap, isEnabled: hasChanges)
+            updateButton = .normal(
+                updateTap,
+                isEnabled: hasChanges,
+                accIdentifier: "visitor_info_save_button"
+            )
         case .inFlight:
             updateButton = .loading
         }
+
+        let cancelButton = CancelButton(
+            tap: cancelTap,
+            accIdentifier: "visitor_info_cancel_button"
+        )
 
         let props = Props(
             title: "Visitor Info",
@@ -365,7 +375,7 @@ final class VisitorInfoModel {
             ],
             pulledToRefresh: pulledToRefresh,
             showsRefreshing: self.fetchInfoRequestState == .inFlight,
-            cancelTap: cancelTap,
+            cancelButton: cancelButton,
             updateButton: updateButton
         )
 

--- a/TestingApp/VisitorInfo/VisitorInfoViewController.swift
+++ b/TestingApp/VisitorInfo/VisitorInfoViewController.swift
@@ -50,7 +50,7 @@ final class VisitorInfoViewController: UIViewController {
         sections: [],
         pulledToRefresh: .nop,
         showsRefreshing: false,
-        cancelTap: .nop,
+        cancelButton: .init(tap: .nop, accIdentifier: ""),
         updateButton: .loading
     ) {
         didSet {
@@ -135,6 +135,7 @@ final class VisitorInfoViewController: UIViewController {
             tableView.reloadData()
         }
 
+        self.cancelBarButtonItem.accessibilityIdentifier = props.cancelButton.accIdentifier
         self.renderedShowsRefreshing = props.showsRefreshing
         self.renderedUpdateButton = props.updateButton
     }
@@ -147,7 +148,7 @@ final class VisitorInfoViewController: UIViewController {
     }
 
     @objc func handleCancelTap() {
-        props.cancelTap()
+        props.cancelButton.tap()
     }
 
     @objc func handleUpdateTap() {
@@ -177,9 +178,10 @@ final class VisitorInfoViewController: UIViewController {
         didSet {
             guard oldValue != renderedUpdateButton else { return }
             switch self.renderedUpdateButton {
-            case let .normal(_, isEnabled):
+            case let .normal(_, isEnabled, accIdentifier):
                 self.navigationItem.rightBarButtonItem = self.updateBarButtonItem
                 self.updateBarButtonItem.isEnabled = isEnabled
+                self.updateBarButtonItem.accessibilityIdentifier = accIdentifier
             case .loading:
                 self.navigationItem.rightBarButtonItem = self.loadingBarButtonItem
             }
@@ -234,7 +236,7 @@ extension VisitorInfoViewController {
         let sections: [Section]
         let pulledToRefresh: Cmd
         let showsRefreshing: Bool
-        let cancelTap: Cmd
+        let cancelButton: CancelButton
         let updateButton: UpdateButton
     }
 }
@@ -245,15 +247,19 @@ extension VisitorInfoViewController.Props {
 
         init(_ updateButton: UpdateButton) {
             switch updateButton {
-            case let .normal(tap, _):
+            case let .normal(tap, _, _):
                 self.tap = tap
             case .loading:
                 tap = nil
             }
         }
     }
-}
 
+    struct CancelButton: Equatable {
+        let tap: Cmd
+        let accIdentifier: String
+    }
+}
 
 extension VisitorInfoViewController.Props {
     typealias KeyValuePair = InfoField.CustomAttributesUpdateMethod.KeyValuePair
@@ -273,7 +279,7 @@ extension VisitorInfoViewController.Props {
     }
 
     enum UpdateButton: Equatable {
-        case normal(Cmd, isEnabled: Bool)
+        case normal(Cmd, isEnabled: Bool, accIdentifier: String)
         case loading
     }
 }
@@ -376,7 +382,7 @@ extension VisitorInfoViewController: UITableViewDataSource {
             } else {
                 return UITableViewCell()
             }
-        }   
+        }
     }
 }
 


### PR DESCRIPTION
Add more accessibility identifiers and replace regular UISegmentedControl with custom implementation to overcome Voice Over (screen reader) issue, where views order is broken, if such control is used in section header.

MOB-1100