### PR TITLE
Add translation layer from new strings to old string

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -196,6 +196,7 @@
 		3197F7B829F7C318008EE9F7 /* SecureConversations.CommonEngagementModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3197F7B729F7C318008EE9F7 /* SecureConversations.CommonEngagementModel.swift */; };
 		31D286AD2A00DD2C009192A6 /* SecureConversations.ConfirmationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D286AC2A00DD2C009192A6 /* SecureConversations.ConfirmationViewModelTests.swift */; };
 		31D286AF2A00DE2B009192A6 /* SecureConversations.ConfirmationViewModel.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D286AE2A00DE2B009192A6 /* SecureConversations.ConfirmationViewModel.Mock.swift */; };
+		31D3AAEE2A77ED53004451CF /* L10n+BackwardsCompatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D3AAED2A77ED53004451CF /* L10n+BackwardsCompatibility.swift */; };
 		31DB0C01287C2EFC00FB288E /* StaticValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31DB0C00287C2EFC00FB288E /* StaticValues.swift */; };
 		31DD41652A57105400F92612 /* SecureConversations.TranscriptModel.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31DD41642A57105400F92612 /* SecureConversations.TranscriptModel.Environment.swift */; };
 		6B2BFCE2274297F100B68506 /* SettingsSwitchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B2BFCE1274297F100B68506 /* SettingsSwitchCell.swift */; };
@@ -518,8 +519,8 @@
 		AF6AB34B2989517100003645 /* FileUploader.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6AB34A2989517100003645 /* FileUploader.Failing.swift */; };
 		AF6AB34D298A9F2500003645 /* SecureConversations.FileUploadListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6AB34C298A9F2500003645 /* SecureConversations.FileUploadListViewModel.swift */; };
 		AF6AB34F298AA02400003645 /* SecureConversations.FileUploadListViewModel.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6AB34E298AA02400003645 /* SecureConversations.FileUploadListViewModel.Environment.swift */; };
-		AF75601C2A78146600871E36 /* CustomSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF75601B2A78146500871E36 /* CustomSegmentedControl.swift */; };
 		AF755FDA2A71583900871E36 /* BubbleWindowLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF755FD92A71583900871E36 /* BubbleWindowLayoutTests.swift */; };
+		AF75601C2A78146600871E36 /* CustomSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF75601B2A78146500871E36 /* CustomSegmentedControl.swift */; };
 		AF9DB22E2890571A00A0C442 /* RootCoordinator.Environment.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9DB22D2890571A00A0C442 /* RootCoordinator.Environment.Failing.swift */; };
 		AF9DB23128905A1D00A0C442 /* ViewFactory.Environment.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9DB23028905A1D00A0C442 /* ViewFactory.Environment.Failing.swift */; };
 		AFA2FDEC28907D7C00428E6D /* EngagementCoordinator.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA2FDEB28907D7C00428E6D /* EngagementCoordinator.Environment.swift */; };
@@ -888,6 +889,7 @@
 		3197F7B729F7C318008EE9F7 /* SecureConversations.CommonEngagementModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.CommonEngagementModel.swift; sourceTree = "<group>"; };
 		31D286AC2A00DD2C009192A6 /* SecureConversations.ConfirmationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.ConfirmationViewModelTests.swift; sourceTree = "<group>"; };
 		31D286AE2A00DE2B009192A6 /* SecureConversations.ConfirmationViewModel.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.ConfirmationViewModel.Mock.swift; sourceTree = "<group>"; };
+		31D3AAED2A77ED53004451CF /* L10n+BackwardsCompatibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "L10n+BackwardsCompatibility.swift"; sourceTree = "<group>"; };
 		31DB0C00287C2EFC00FB288E /* StaticValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticValues.swift; sourceTree = "<group>"; };
 		31DD41642A57105400F92612 /* SecureConversations.TranscriptModel.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.TranscriptModel.Environment.swift; sourceTree = "<group>"; };
 		6304CD1CAD1108C78C7B11BF /* Pods-GliaWidgetsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GliaWidgetsTests.release.xcconfig"; path = "Target Support Files/Pods-GliaWidgetsTests/Pods-GliaWidgetsTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -1209,8 +1211,8 @@
 		AF6AB34A2989517100003645 /* FileUploader.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploader.Failing.swift; sourceTree = "<group>"; };
 		AF6AB34C298A9F2500003645 /* SecureConversations.FileUploadListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FileUploadListViewModel.swift; sourceTree = "<group>"; };
 		AF6AB34E298AA02400003645 /* SecureConversations.FileUploadListViewModel.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FileUploadListViewModel.Environment.swift; sourceTree = "<group>"; };
-		AF75601B2A78146500871E36 /* CustomSegmentedControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomSegmentedControl.swift; sourceTree = "<group>"; };
 		AF755FD92A71583900871E36 /* BubbleWindowLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BubbleWindowLayoutTests.swift; sourceTree = "<group>"; };
+		AF75601B2A78146500871E36 /* CustomSegmentedControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomSegmentedControl.swift; sourceTree = "<group>"; };
 		AF9DB22D2890571A00A0C442 /* RootCoordinator.Environment.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootCoordinator.Environment.Failing.swift; sourceTree = "<group>"; };
 		AF9DB23028905A1D00A0C442 /* ViewFactory.Environment.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewFactory.Environment.Failing.swift; sourceTree = "<group>"; };
 		AFA2FDEB28907D7C00428E6D /* EngagementCoordinator.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngagementCoordinator.Environment.swift; sourceTree = "<group>"; };
@@ -1912,6 +1914,7 @@
 			children = (
 				1A60AFA225667EA300E53F53 /* Assets.xcassets */,
 				1A60AFAC2566806000E53F53 /* Localizable.strings */,
+				31D3AAED2A77ED53004451CF /* L10n+BackwardsCompatibility.swift */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -4144,6 +4147,7 @@
 				1A4674A725E905AC0078FA1C /* AttachmentSourceListView.swift in Sources */,
 				75B7BD792A39D12B0060794D /* Button.swift in Sources */,
 				9A19926C27D3BA8700161AAE /* ViewFactory.Mock.swift in Sources */,
+				31D3AAEE2A77ED53004451CF /* L10n+BackwardsCompatibility.swift in Sources */,
 				1A60B02D256BF7FF00E53F53 /* OperatorChatMessageView.swift in Sources */,
 				C43C12F92694B14900C37E1B /* GliaPresenter.swift in Sources */,
 				1A0452F025DBE268000DA0C1 /* MessageButtonStyle.swift in Sources */,

--- a/GliaWidgets/L10n.swift
+++ b/GliaWidgets/L10n.swift
@@ -118,8 +118,8 @@ public enum L10n {
       /// Operators are no longer available.
       /// Please try again later.
       public static let message = L10n.tr("Localizable", "alert.operatorsUnavailable.message", fallback: "Operators are no longer available.\nPlease try again later.")
-      /// We’re sorry
-      public static let title = L10n.tr("Localizable", "alert.operatorsUnavailable.title", fallback: "We’re sorry")
+      /// We're sorry
+      public static let title = L10n.tr("Localizable", "alert.operatorsUnavailable.title", fallback: "We're sorry")
     }
     public enum ScreenSharing {
       public enum Start {
@@ -332,8 +332,8 @@ public enum L10n {
         public enum Avatar {
           /// Displays operator avatar or placeholder.
           public static let hint = L10n.tr("Localizable", "call.accessibility.operator.avatar.hint", fallback: "Displays operator avatar or placeholder.")
-          /// Avatar
-          public static let label = L10n.tr("Localizable", "call.accessibility.operator.avatar.label", fallback: "Avatar")
+          /// Operator Avatar
+          public static let label = L10n.tr("Localizable", "call.accessibility.operator.avatar.label", fallback: "Operator Avatar")
         }
       }
       public enum OperatorName {
@@ -430,9 +430,8 @@ public enum L10n {
   }
   public enum CallVisualizer {
     public enum ScreenSharing {
-      /// Your Screen
-      /// is Being Shared
-      public static let message = L10n.tr("Localizable", "callVisualizer.screenSharing.message", fallback: "Your Screen\nis Being Shared")
+      /// Your Screen is Being Shared
+      public static let message = L10n.tr("Localizable", "callVisualizer.screenSharing.message", fallback: "Your Screen is Being Shared")
       /// Screen Sharing
       public static let title = L10n.tr("Localizable", "callVisualizer.screenSharing.title", fallback: "Screen Sharing")
       public enum Accessibility {
@@ -468,8 +467,8 @@ public enum L10n {
         public static let refresh = L10n.tr("Localizable", "callVisualizer.visitorCode.action.refresh", fallback: "Refresh")
       }
       public enum Title {
-        /// Could not show visitor code. Please try refreshing.
-        public static let error = L10n.tr("Localizable", "callVisualizer.visitorCode.title.error", fallback: "Could not show visitor code. Please try refreshing.")
+        /// Could not load the visitor code. Please try refreshing.
+        public static let error = L10n.tr("Localizable", "callVisualizer.visitorCode.title.error", fallback: "Could not load the visitor code. Please try refreshing.")
         /// Your Visitor Code
         public static let standard = L10n.tr("Localizable", "callVisualizer.visitorCode.title.standard", fallback: "Your Visitor Code")
       }
@@ -672,6 +671,16 @@ public enum L10n {
       /// End
       public static let title = L10n.tr("Localizable", "chat.endButton.title", fallback: "End")
     }
+    public enum File {
+      public enum Upload {
+        /// Checking safety of the file…
+        public static let scanning = L10n.tr("Localizable", "chat.file.upload.scanning", fallback: "Checking safety of the file…")
+      }
+    }
+    public enum Input {
+      /// Send
+      public static let send = L10n.tr("Localizable", "chat.input.send", fallback: "Send")
+    }
     public enum Message {
       /// Tap on the answer above
       public static let choiceCardPlaceholder = L10n.tr("Localizable", "chat.message.choiceCardPlaceholder", fallback: "Tap on the answer above")
@@ -698,6 +707,10 @@ public enum L10n {
       /// New Messages
       public static let unreadMessageDividerTitle = L10n.tr("Localizable", "chat.secureTranscript.unreadMessageDividerTitle", fallback: "New Messages")
     }
+    public enum Status {
+      /// Operator typing
+      public static let typing = L10n.tr("Localizable", "chat.status.typing", fallback: "Operator typing")
+    }
     public enum Upgrade {
       public enum Audio {
         /// Upgraded to Audio Call
@@ -716,18 +729,68 @@ public enum L10n {
       /// Uploading file…
       public static let uploading = L10n.tr("Localizable", "chat.upload.uploading", fallback: "Uploading file…")
       public enum Error {
-        /// File size over 25mb limit!
-        public static let fileTooBig = L10n.tr("Localizable", "chat.upload.error.fileTooBig", fallback: "File size over 25mb limit!")
+        /// File size over 25MB limit!
+        public static let fileTooBig = L10n.tr("Localizable", "chat.upload.error.fileTooBig", fallback: "File size over 25MB limit!")
         /// Failed to upload.
         public static let generic = L10n.tr("Localizable", "chat.upload.error.generic", fallback: "Failed to upload.")
         /// Network error.
         public static let network = L10n.tr("Localizable", "chat.upload.error.network", fallback: "Network error.")
-        /// Failed to check the safety of the file.
-        public static let safetyCheckFailed = L10n.tr("Localizable", "chat.upload.error.safetyCheckFailed", fallback: "Failed to check the safety of the file.")
+        /// Failed to confirm the safety of the file.
+        public static let safetyCheckFailed = L10n.tr("Localizable", "chat.upload.error.safetyCheckFailed", fallback: "Failed to confirm the safety of the file.")
         /// Invalid file type!
         public static let unsupportedFileType = L10n.tr("Localizable", "chat.upload.error.unsupportedFileType", fallback: "Invalid file type!")
       }
     }
+  }
+  public enum Error {
+    /// Something went wrong
+    public static let general = L10n.tr("Localizable", "error.general", fallback: "Something went wrong")
+    /// Internal error
+    public static let `internal` = L10n.tr("Localizable", "error.internal", fallback: "Internal error")
+  }
+  public enum General {
+    /// Accept
+    public static let accept = L10n.tr("Localizable", "general.accept", fallback: "Accept")
+    /// Back
+    public static let back = L10n.tr("Localizable", "general.back", fallback: "Back")
+    /// Browse
+    public static let browse = L10n.tr("Localizable", "general.browse", fallback: "Browse")
+    /// Cancel
+    public static let cancel = L10n.tr("Localizable", "general.cancel", fallback: "Cancel")
+    /// Close
+    public static let close = L10n.tr("Localizable", "general.close", fallback: "Close")
+    /// Comment
+    public static let comment = L10n.tr("Localizable", "general.comment", fallback: "Comment")
+    /// CompanyName
+    public static let companyName = L10n.tr("Localizable", "general.company_name", fallback: "CompanyName")
+    /// Decline
+    public static let decline = L10n.tr("Localizable", "general.decline", fallback: "Decline")
+    /// Download
+    public static let download = L10n.tr("Localizable", "general.download", fallback: "Download")
+    /// End
+    public static let end = L10n.tr("Localizable", "general.end", fallback: "End")
+    /// Message
+    public static let message = L10n.tr("Localizable", "general.message", fallback: "Message")
+    /// No
+    public static let no = L10n.tr("Localizable", "general.no", fallback: "No")
+    /// Ok
+    public static let ok = L10n.tr("Localizable", "general.ok", fallback: "Ok")
+    /// Open
+    public static let `open` = L10n.tr("Localizable", "general.open", fallback: "Open")
+    /// Powered by Glia
+    public static let poweredBy = L10n.tr("Localizable", "general.powered_by", fallback: "Powered by Glia")
+    /// Retry
+    public static let retry = L10n.tr("Localizable", "general.retry", fallback: "Retry")
+    /// Selected
+    public static let selected = L10n.tr("Localizable", "general.selected", fallback: "Selected")
+    /// Submit
+    public static let submit = L10n.tr("Localizable", "general.submit", fallback: "Submit")
+    /// Thank you!
+    public static let thankYou = L10n.tr("Localizable", "general.thank_you", fallback: "Thank you!")
+    /// Yes
+    public static let yes = L10n.tr("Localizable", "general.yes", fallback: "Yes")
+    /// You
+    public static let you = L10n.tr("Localizable", "general.you", fallback: "You")
   }
   public enum MessageCenter {
     public enum Confirmation {
@@ -735,9 +798,8 @@ public enum L10n {
       public static let checkMessages = L10n.tr("Localizable", "messageCenter.confirmation.checkMessages", fallback: "Check messages")
       /// Messaging
       public static let header = L10n.tr("Localizable", "messageCenter.confirmation.header", fallback: "Messaging")
-      /// Your message has been sent.
-      /// We will get back to you within 48 hours.
-      public static let subtitle = L10n.tr("Localizable", "messageCenter.confirmation.subtitle", fallback: "Your message has been sent.\nWe will get back to you within 48 hours.")
+      /// Your message has been sent. We will get back to you within 48 hours.
+      public static let subtitle = L10n.tr("Localizable", "messageCenter.confirmation.subtitle", fallback: "Your message has been sent. We will get back to you within 48 hours.")
       /// Thank you!
       public static let title = L10n.tr("Localizable", "messageCenter.confirmation.title", fallback: "Thank you!")
       public enum Accessibility {
@@ -752,8 +814,8 @@ public enum L10n {
       public static let checkMessages = L10n.tr("Localizable", "messageCenter.welcome.checkMessages", fallback: "Check messages")
       /// Messaging
       public static let header = L10n.tr("Localizable", "messageCenter.welcome.header", fallback: "Messaging")
-      /// The message cannot exceed {textLength} characters.
-      public static let messageLengthWarning = L10n.tr("Localizable", "messageCenter.welcome.messageLengthWarning", fallback: "The message cannot exceed {textLength} characters.")
+      /// The message cannot exceed 10000 characters.
+      public static let messageLengthWarning = L10n.tr("Localizable", "messageCenter.welcome.messageLengthWarning", fallback: "The message cannot exceed 10000 characters.")
       /// Enter your message
       public static let messageTextViewActive = L10n.tr("Localizable", "messageCenter.welcome.messageTextViewActive", fallback: "Enter your message")
       /// Enter your message
@@ -787,6 +849,20 @@ public enum L10n {
         public static let sendLabel = L10n.tr("Localizable", "messageCenter.welcome.accessibility.sendLabel", fallback: "Send")
       }
     }
+  }
+  public enum Screensharing {
+    public enum VisitorScreen {
+      public enum Disclaimer {
+        /// Depending on your selection, your entire screen might be shared with the operator, not just the application window.
+        public static let info = L10n.tr("Localizable", "screensharing.visitor_screen.disclaimer.info", fallback: "Depending on your selection, your entire screen might be shared with the operator, not just the application window.")
+      }
+    }
+  }
+  public enum SendMessage {
+    /// Send message
+    public static let send = L10n.tr("Localizable", "send_message.send", fallback: "Send message")
+    /// Sending…
+    public static let sending = L10n.tr("Localizable", "send_message.sending", fallback: "Sending…")
   }
   public enum Survey {
     public enum Accessibility {
@@ -870,5 +946,3 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
-
-// swiftlint:enable all

--- a/GliaWidgets/Resources/L10n+BackwardsCompatibility.swift
+++ b/GliaWidgets/Resources/L10n+BackwardsCompatibility.swift
@@ -1,0 +1,364 @@
+import Foundation
+
+extension L10n.Call {
+    static let onHold = L10n.Call.OnHold.topText
+
+    struct Bubble {
+        struct Accessibility {
+            static let hint = L10n.Call.Accessibility.Bubble.hint
+            static let label = L10n.Call.Accessibility.Bubble.label
+        }
+    }
+
+    struct Button {
+        static let mute = L10n.Call.Buttons.Mute.Inactive.title
+        static let speaker = L10n.Call.Buttons.Speaker.title
+        static let unmute = L10n.Call.Buttons.Mute.Active.title
+    }
+
+    struct Header {
+        struct CloseButton {
+            struct Accessibility {
+                static let hint = L10n.Call.Accessibility.Header.BackButton.hint
+            }
+        }
+    }
+
+    struct OperatorName {
+        struct Accessibility {
+            static let hint = L10n.Call.Accessibility.OperatorName.hint
+        }
+    }
+}
+
+extension L10n.Call.Buttons.Chat {
+    struct BadgeValue {
+        struct MultipleItems {
+            struct Accessibility {
+                static let label = L10n.Call.Accessibility.Buttons.Chat.BadgeValue.multipleItems
+            }
+        }
+
+        struct SingleItem {
+            struct Accessibility {
+                static let label = L10n.Call.Accessibility.Buttons.Chat.BadgeValue.singleItem
+            }
+        }
+    }
+}
+
+extension L10n.Call.Connect {
+    struct FirstText {
+        struct Accessibility {
+            static let hint = L10n.Call.Accessibility.Connect.Queue.FirstText.hint
+        }
+    }
+
+    struct SecondText {
+        struct Accessibility {
+            static let hint = L10n.Call.Accessibility.Connect.Queue.SecondText.hint
+        }
+    }
+}
+
+extension L10n.Call.Operator {
+    struct Avatar {
+        struct Accessibility {
+            static let label = L10n.Call.Accessibility.Operator.Avatar.label
+            static let hint = L10n.Call.Accessibility.Operator.Avatar.hint
+        }
+    }
+}
+
+extension L10n.Call.Video {
+    struct Operator {
+        struct Accessiblity {
+            static let label = L10n.Call.Accessibility.Video.Operator.label
+        }
+    }
+
+    struct Visitor {
+        struct Accessibility {
+            static let label = L10n.Call.Accessibility.Video.Visitor.label
+        }
+    }
+}
+
+extension L10n.CallVisualizer.ScreenSharing {
+    struct Message {
+        struct Accessibility {
+            static let hint = L10n.CallVisualizer.ScreenSharing.Accessibility.messageHint
+        }
+    }
+}
+
+extension L10n.CallVisualizer.VisitorCode {
+    static let title = L10n.CallVisualizer.VisitorCode.Title.standard
+
+    struct Close {
+        struct Accessibility {
+            static let hint = L10n.CallVisualizer.VisitorCode.Accessibility.closeHint
+            static let label = L10n.CallVisualizer.VisitorCode.Accessibility.closeLabel
+        }
+    }
+
+    struct Refresh {
+        struct Accessibility {
+            static let hint = L10n.CallVisualizer.VisitorCode.Accessibility.refreshHint
+            static let label = L10n.CallVisualizer.VisitorCode.Accessibility.refreshLabel
+        }
+    }
+}
+
+extension L10n.CallVisualizer.VisitorCode.Title {
+    struct Accessibility {
+        static let label = L10n.CallVisualizer.VisitorCode.Accessibility.titleHint
+    }
+}
+
+extension L10n.Chat {
+    static let attachFiles = L10n.Chat.Accessibility.PickMedia.PickAttachmentButton.label
+    static let operatorJoined = L10n.Chat.Connect.Connected.secondText
+    static let unreadMessageDivider = L10n.Chat.SecureTranscript.unreadMessageDividerTitle
+
+    struct Attachment {
+        static let photoLibrary = L10n.Chat.PickMedia.photo
+        static let takePhoto = L10n.Chat.PickMedia.takePhoto
+
+        struct Upload {
+            static let unsupportedFile = L10n.Chat.Upload.Error.unsupportedFileType
+        }
+    }
+
+    struct Operator {
+        struct Avatar {
+            struct Accessibility {
+                static let label = L10n.Chat.Accessibility.Operator.Avatar.label
+            }
+        }
+
+        struct Name {
+            struct Accessibility {
+                static let label = L10n.Chat.Accessibility.Connect.Queue.FirstText.hint
+            }
+        }
+    }
+}
+
+extension L10n.Chat.File {
+    static let infectedError = L10n.Chat.Upload.Error.safetyCheckFailed
+    static let tooLargeError = L10n.Chat.Upload.Error.fileTooBig
+}
+
+extension L10n.Chat.File.Upload {
+    static let failed = L10n.Chat.Upload.Error.generic
+    static let inProgress = L10n.Chat.Upload.uploading
+    static let success = L10n.Chat.Upload.uploaded
+}
+
+extension L10n.Chat.Input {
+    static let placeholder = L10n.Chat.Message.enterMessagePlaceholder
+}
+
+extension L10n.Chat.Upload {
+    struct Remove {
+        struct Accessibility {
+            static let label = L10n.Chat.Accessibility.Upload.RemoveUpload.label
+        }
+    }
+}
+
+extension L10n.Chat.Message {
+    struct Unread {
+        struct Accessibility {
+            static let label = L10n.Chat.Accessibility.Message.UnreadMessagesIndicator.label
+        }
+    }
+}
+
+extension L10n {
+    struct Engagement {
+        static let defaultOperatorName = L10n.operator
+        static let minimizeVideoButton = L10n.Call.Buttons.Minimize.title
+        static let offerUpgrade = L10n.Alert.MediaUpgrade.title
+
+        struct Connect {
+            static let placeholder = L10n.Call.Connect.Queue.secondText
+            static let with = L10n.Call.Connect.Connecting.firstText
+        }
+
+        struct End {
+            static let message = L10n.Alert.EndEngagement.message
+
+            struct Confirmation {
+                static let header = L10n.Alert.EndEngagement.title
+            }
+        }
+
+        struct Ended {
+            static let header = L10n.Alert.OperatorEndedEngagement.title
+            static let message = L10n.Alert.OperatorEndedEngagement.message
+        }
+
+        struct QueueClosed {
+            static let header = L10n.Alert.OperatorsUnavailable.title
+            static let message = L10n.Alert.OperatorsUnavailable.message
+        }
+
+        struct QueueLeave {
+            static let header = L10n.Alert.LeaveQueue.title
+            static let message = L10n.Alert.LeaveQueue.message
+        }
+
+        struct QueueReconnectionFailed {
+            static let tryAgain = L10n.Alert.Unexpected.message
+        }
+
+        struct QueueTransferring {
+            static let message = L10n.Chat.Connect.Transferring.firstText
+        }
+
+        struct QueueWait {
+            static let message = L10n.Call.bottomText
+        }
+
+        struct SecureMessaging {
+            static let title = L10n.MessageCenter.Welcome.header
+        }
+    }
+
+    struct Media {
+        struct Audio {
+            static let name = L10n.Call.Audio.title
+        }
+
+        struct Phone {
+            static let name = L10n.Alert.MediaUpgrade.Phone.title
+        }
+
+        struct Text {
+            static let name = L10n.Chat.title
+        }
+
+        struct Video {
+            static let name = L10n.Call.Video.title
+        }
+    }
+}
+
+extension L10n.MessageCenter {
+    static let checkMessages = L10n.MessageCenter.Welcome.checkMessages
+    static let header = L10n.MessageCenter.Welcome.header
+
+    struct NotAuthenticated {
+        static let message = L10n.Alert.UnavailableMessageCenter.notAuthenticatedMessage
+    }
+
+    struct Unavailable {
+        static let message = L10n.Alert.UnavailableMessageCenter.message
+        static let title = L10n.Alert.UnavailableMessageCenter.title
+    }
+}
+
+extension L10n.MessageCenter.Welcome {
+    struct CheckMessages {
+        struct Accessibility {
+            static let hint = L10n.MessageCenter.Welcome.Accessibility.checkMessagesHint
+        }
+    }
+
+    struct FilePicker {
+        struct Acccessibility {
+            static let hint = L10n.MessageCenter.Welcome.Accessibility.filePickerHint
+            static let label = L10n.MessageCenter.Welcome.Accessibility.filePickerLabel
+        }
+    }
+
+    struct MessageTextView {
+        static let placeholder = L10n.MessageCenter.Welcome.messageTextViewNormal
+    }
+
+    struct Send {
+        struct Accessibility {
+            static let hint = L10n.MessageCenter.Welcome.Accessibility.sendHint
+        }
+    }
+}
+extension L10n.MessageCenter.Confirmation {
+    struct CheckMessages {
+        struct Accessibility {
+            static let hint = L10n.MessageCenter.Welcome.Accessibility.checkMessagesHint
+            static let label = L10n.MessageCenter.Welcome.Accessibility.checkMessagesLabel
+        }
+    }
+}
+
+extension L10n {
+    struct ScreenSharing {
+        struct VisitorScreen {
+            static let end = L10n.CallVisualizer.ScreenSharing.Button.title
+        }
+    }
+}
+
+extension L10n.Survey.Question {
+    struct OptionButton {
+        struct Selected {
+            struct Accessibility {
+                static let label = L10n.Survey.Accessibility.Question.OptionButton.Selected.label
+            }
+        }
+
+        struct Unselected {
+            struct Accessibility {
+                static let label = L10n.Survey.Accessibility.Question.OptionButton.Unselected.label
+            }
+        }
+    }
+
+    struct TextField {
+        struct Accessibility {
+            static let hint = L10n.Survey.Accessibility.Question.TextField.hint
+        }
+    }
+}
+
+extension L10n.Survey.Question.Title {
+    struct Accessibility {
+        static let label = L10n.Survey.Accessibility.Question.Title.value
+    }
+}
+
+extension L10n.Survey {
+    struct Validation {
+        struct Title {
+            struct Accessibility {
+                static let label = L10n.Survey.Accessibility.Validation.Title.label
+            }
+        }
+    }
+}
+
+extension L10n {
+    struct Upgrade {
+        struct Audio {
+            static let title = L10n.Alert.AudioUpgrade.title
+        }
+
+        struct Video {
+            struct OneWay {
+                static let title = L10n.Alert.VideoUpgrade.OneWay.title
+            }
+
+            struct TwoWay {
+                static let title = L10n.Alert.VideoUpgrade.TwoWay.title
+            }
+        }
+    }
+}
+
+extension L10n {
+    struct VisitorCode {
+        static let failed = L10n.CallVisualizer.VisitorCode.Title.error
+    }
+}

--- a/GliaWidgets/Resources/en.lproj/Localizable.strings
+++ b/GliaWidgets/Resources/en.lproj/Localizable.strings
@@ -26,7 +26,7 @@
 "alert.operatorEndedEngagement.title" = "Engagement Ended";
 "alert.operatorEndedEngagement.message" = "This engagement has ended.\nThank you!";
 
-"alert.operatorsUnavailable.title" = "We’re sorry";
+"alert.operatorsUnavailable.title" = "We're sorry";
 "alert.operatorsUnavailable.message" = "Operators are no longer available.\nPlease try again later.";
 
 "alert.unexpected.title" = "We're sorry, there has been an unexpected error.";
@@ -85,9 +85,10 @@
 "chat.upload.uploading" = "Uploading file…";
 "chat.upload.uploaded" = "Ready to send";
 "chat.upload.failed" = "Uploading failed";
-"chat.upload.error.fileTooBig" = "File size over 25mb limit!";
+"chat.upload.error.fileTooBig" = "File size over 25MB limit!";
 "chat.upload.error.unsupportedFileType" = "Invalid file type!";
-"chat.upload.error.safetyCheckFailed" = "Failed to check the safety of the file.";
+"chat.upload.error.safetyCheckFailed" = "Failed to confirm the safety of the file.";
+"chat.file.upload.scanning" = "Checking safety of the file…";
 "chat.upload.error.network" = "Network error.";
 "chat.upload.error.generic" = "Failed to upload.";
 "chat.download.download" = "Download";
@@ -174,7 +175,7 @@
 "call.accessibility.callDuration.hint" = "Displays call duration.";
 "call.accessibility.video.operator.label" = "Operator's Video";
 "call.accessibility.video.visitor.label" = "Your Video";
-"call.accessibility.operator.avatar.label" = "Avatar";
+"call.accessibility.operator.avatar.label" = "Operator Avatar";
 "call.accessibility.operator.avatar.hint" = "Displays operator avatar or placeholder.";
 "call.accessibility.connect.queue.firstText.hint" = "Displays operator name.";
 "call.accessibility.connect.queue.secondText.hint" = "Displays call duration.";
@@ -223,7 +224,7 @@
 "survey.accessibility.question.optionButton.unselected.label" = "Unselected: {buttonTitle}";
 "survey.accessibility.validation.title.label" = "Please provide an answer for question above";
 
-"messageCenter.welcome.messageLengthWarning" = "The message cannot exceed {textLength} characters.";
+"messageCenter.welcome.messageLengthWarning" = "The message cannot exceed 10000 characters.";
 "messageCenter.welcome.header" = "Messaging";
 "messageCenter.welcome.title" = "Welcome to Message Center";
 "messageCenter.welcome.subtitle" = "Send a message and we’ll get back to you within 48 hours";
@@ -243,13 +244,13 @@
 "messageCenter.welcome.accessibility.sendHint" = "Sends a secure message.";
 "messageCenter.confirmation.header" = "Messaging";
 "messageCenter.confirmation.title" = "Thank you!";
-"messageCenter.confirmation.subtitle" = "Your message has been sent.\nWe will get back to you within 48 hours.";
+"messageCenter.confirmation.subtitle" = "Your message has been sent. We will get back to you within 48 hours.";
 "messageCenter.confirmation.checkMessages" = "Check messages";
 "messageCenter.confirmation.accessibility.checkMessagesLabel" = "Check messages";
 "messageCenter.confirmation.accessibility.checkMessagesHint" = "Navigates you to the chat transcript.";
 
 "callVisualizer.visitorCode.title.standard" = "Your Visitor Code";
-"callVisualizer.visitorCode.title.error" = "Could not show visitor code. Please try refreshing.";
+"callVisualizer.visitorCode.title.error" = "Could not load the visitor code. Please try refreshing.";
 "callVisualizer.visitorCode.action.refresh" = "Refresh";
 "callVisualizer.visitorCode.action.close" = "Close";
 "callVisualizer.visitorCode.accessibility.titleHint" = "Your five-digit visitor code is";
@@ -258,10 +259,40 @@
 "callVisualizer.visitorCode.accessibility.closeLabel" = "Close Button";
 "callVisualizer.visitorCode.accessibility.closeHint" = "Closes visitor code";
 "callVisualizer.screenSharing.title" = "Screen Sharing";
-"callVisualizer.screenSharing.message" = "Your Screen\nis Being Shared";
+"callVisualizer.screenSharing.message" = "Your Screen is Being Shared";
 "callVisualizer.screenSharing.button.title" = "End Screen Sharing";
 "callVisualizer.screenSharing.accessibility.messageHint" = "Message label";
 "callVisualizer.screenSharing.accessibility.buttonLabel" = "End screen sharing";
 "callVisualizer.screenSharing.accessibility.buttonHint" = "Ends screen sharing";
 
 "gva_not_supported" = "This action is not currently supported on mobile";
+"chat.input.send" = "Send";
+"chat.status.typing" = "Operator typing";
+"error.general" = "Something went wrong";
+"error.internal" = "Internal error";
+
+"general.accept" = "Accept";
+"general.back" = "Back";
+"general.browse" = "Browse";
+"general.cancel" = "Cancel";
+"general.close" = "Close";
+"general.comment" = "Comment";
+"general.company_name" = "CompanyName";
+"general.decline" = "Decline";
+"general.download" = "Download";
+"general.end" = "End";
+"general.message" = "Message";
+"general.no" = "No";
+"general.ok" = "Ok";
+"general.open" = "Open";
+"general.powered_by" = "Powered by Glia";
+"general.retry" = "Retry";
+"general.selected" = "Selected";
+"general.submit" = "Submit";
+"general.thank_you" = "Thank you!";
+"general.yes" = "Yes";
+"general.you" = "You";
+
+"screensharing.visitor_screen.disclaimer.info" = "Depending on your selection, your entire screen might be shared with the operator, not just the application window.";
+"send_message.send" = "Send message";
+"send_message.sending" = "Sending…";


### PR DESCRIPTION
In the new list of strings unified between iOS and Android, there are some strings that have changed their name. However, the string itself is the same. Thus, there's a layer that converts between these new strings and the old strings. These aren't used anywhere yet. However, subsequent pull requests will put them to use. The idea is to have those old strings deprecated and only use the new ones, and then delete this layer in a year, just keeping the new ones in use.

Also some strings were changed already if the change was really small and new strings that didn't have an equivalent before were added.

MOB-2492