### PR TITLE
Make `webRenderer` as default message renderer

### DIFF
--- a/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
+++ b/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
@@ -80,7 +80,6 @@ extension Glia {
         sceneProvider: SceneProvider? = nil
     ) throws {
         let completion = { [weak self] in
-            self?.setChatMessageRenderer(messageRenderer: .webRenderer)
             try self?.startEngagement(
                 engagementKind: engagementKind,
                 theme: theme,

--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -87,7 +87,7 @@ public class Glia {
     var rootCoordinator: EngagementCoordinator?
     var interactor: Interactor?
     var environment: Environment
-    var messageRenderer: MessageRenderer?
+    var messageRenderer: MessageRenderer? = .webRenderer
     var uiConfig: RemoteConfiguration?
     var assetsBuilder: RemoteConfiguration.AssetsBuilder = .standard
 
@@ -152,7 +152,7 @@ public class Glia {
     ///
     /// - Parameter messageRenderer: Custom message renderer.
     ///
-    public func setChatMessageRenderer(messageRenderer: MessageRenderer) {
+    public func setChatMessageRenderer(messageRenderer: MessageRenderer?) {
         self.messageRenderer = messageRenderer
     }
 

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -112,12 +112,11 @@ final class GliaTests: XCTestCase {
 
     func test__messageRenderer() throws {
         let sdk = Glia(environment: .failing)
-        XCTAssertNil(sdk.messageRenderer)
-
-        let messageRendererMock = MessageRenderer.mock
-        sdk.setChatMessageRenderer(messageRenderer: messageRendererMock)
-
         XCTAssertNotNil(sdk.messageRenderer)
+
+        sdk.setChatMessageRenderer(messageRenderer: nil)
+
+        XCTAssertNil(sdk.messageRenderer)
     }
 
     func testOnEventWhenCallVisualizerEngagementStarts() throws {


### PR DESCRIPTION
Based on Custom Response Card requirements `webRenderer` was set as default message renderer
Also added optionality for `setChatMessageRenderer` method param 
Also removed setting `webRenderer` in `Glia.start` method

MOB-2511