### PR TITLE
Cover GVA Quick Replies with snapshot tests

### DIFF
--- a/GliaWidgets/Sources/View/Chat/GVA/QuickReply/QuickReplyView.swift
+++ b/GliaWidgets/Sources/View/Chat/GVA/QuickReply/QuickReplyView.swift
@@ -1,14 +1,14 @@
 import UIKit
 
 final class QuickReplyView: BaseView {
-    var props: Props = .hidden {
+    var props: Props {
         didSet {
             renderProps()
         }
     }
 
     let style: GvaQuickReplyButtonStyle
-    private lazy var collectionView: SelfSizingCollectionView = {
+    lazy var collectionView: SelfSizingCollectionView = {
         let layout = LeftAlignedCollectionViewFlowLayout()
         layout.estimatedItemSize = UICollectionViewFlowLayout.automaticSize
         layout.minimumLineSpacing = 0
@@ -21,9 +21,11 @@ final class QuickReplyView: BaseView {
     }()
     private var collectionViewHeightConstraint: NSLayoutConstraint?
 
-    init(style: GvaQuickReplyButtonStyle) {
+    init(style: GvaQuickReplyButtonStyle, props: Props = .hidden) {
         self.style = style
+        self.props = props
         super.init()
+        renderProps()
     }
 
     @available(*, unavailable)

--- a/SnapshotTests/ChatViewControllerLayoutTests.swift
+++ b/SnapshotTests/ChatViewControllerLayoutTests.swift
@@ -53,6 +53,26 @@ class ChatViewControllerLayoutTests: SnapshotTestCase {
         )
     }
 
+    func test_gvaQuickReply() throws {
+        let theme = Theme()
+        let props: QuickReplyView.Props = .shown([
+            .init(title: "First Button", action: .nop),
+            .init(title: "Second Button", action: .nop),
+            .init(title: "Third Button", action: .nop)
+        ])
+        let view: QuickReplyView = .init(
+            style: theme.chat.gliaVirtualAssistant.quickReplyButton,
+            props: props
+        )
+        view.frame = .init(origin: .zero, size: .init(width: 350, height: 200))
+        view.collectionView.heightAnchor.constraint(equalToConstant: 200).isActive = true
+        assertSnapshot(
+            matching: view,
+            as: .image,
+            named: self.nameForDevice()
+        )
+    }
+
     func test_visitorFileDownloadStates() throws {
         var chatMessages: [ChatMessage] = []
         let viewController = try ChatViewController.mockVisitorFileDownloadStates { messages in

--- a/SnapshotTests/ChatViewControllerVoiceOverTests.swift
+++ b/SnapshotTests/ChatViewControllerVoiceOverTests.swift
@@ -73,4 +73,24 @@ class ChatViewControllerVoiceOverTests: SnapshotTestCase {
             named: nameForDevice()
         )
     }
+
+    func test_gvaQuickReply() throws {
+        let theme = Theme()
+        let props: QuickReplyView.Props = .shown([
+            .init(title: "First Button", action: .nop),
+            .init(title: "Second Button", action: .nop),
+            .init(title: "Third Button", action: .nop)
+        ])
+        let view: QuickReplyView = .init(
+            style: theme.chat.gliaVirtualAssistant.quickReplyButton,
+            props: props
+        )
+        view.frame = .init(origin: .zero, size: .init(width: 350, height: 200))
+        view.collectionView.heightAnchor.constraint(equalToConstant: 200).isActive = true
+        assertSnapshot(
+            matching: view,
+            as: .accessibilityImage(precision: Self.possiblePrecision),
+            named: self.nameForDevice()
+        )
+    }
 }


### PR DESCRIPTION
Due to the nature of quick replies container, it was not possible to snapshot test the entire screen with quickreplies' container present. However the container itself is testable and this PR covers 2/3 tests for it.

MOB-2521