### PR TITLE
Fix SwiftLint warnings

### DIFF
--- a/GliaWidgets/L10n.swift
+++ b/GliaWidgets/L10n.swift
@@ -946,3 +946,5 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+
+// swiftlint:enable all

--- a/GliaWidgets/Sources/ViewModel/Chat/Data/Gva.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/Data/Gva.swift
@@ -117,10 +117,11 @@ private extension Data {
     }
 
     func containsHtml(_ string: String) -> Bool {
-        if let _ = string.range(of: "<[^>]+>", options: .regularExpression) {
-            return true
+        if string.range(of: "<[^>]+>", options: .regularExpression) == nil {
+            return false
         }
-        return false
+
+        return true
     }
 
     var htmlToString: String { htmlToAttributedString?.string ?? "" }


### PR DESCRIPTION
There were a couple of warnings about preferring `== nil` notation and a disable all that didn't re-enable all rules in the localization file.