### PR TITLE
Update background usage in SurveyStyle.InputQuestion schema

### DIFF
--- a/GliaWidgets/Sources/Theme/Survey/Theme.Survey.InputQuestion.swift
+++ b/GliaWidgets/Sources/Theme/Survey/Theme.Survey.InputQuestion.swift
@@ -7,8 +7,6 @@ public extension Theme.SurveyStyle {
         public var title: Theme.Text
         /// OptionButton style.
         public var option: OptionButton
-        /// Background style.
-        public var background: Theme.Layer
         /// Text style.
         public var text: Theme.Text
         /// Validation error style.
@@ -62,12 +60,6 @@ public extension Theme.SurveyStyle {
                     textStyle: .caption1,
                     accessibility: .init(isFontScalingEnabled: true)
                 ),
-                background: Theme.Layer(
-                    background: .fill(color: color.background),
-                    borderColor: color.baseNormal.cgColor,
-                    borderWidth: 1,
-                    cornerRadius: 5
-                ),
                 text: .init(
                     color: color.baseDark.hex,
                     font: font.subtitle,
@@ -91,7 +83,6 @@ public extension Theme.SurveyStyle {
                 configuration: configuration?.text,
                 assetsBuilder: assetsBuilder
             )
-            background.apply(configuration: configuration?.background)
             option.apply(
                 configuration: configuration?.option,
                 assetsBuilder: assetsBuilder

--- a/GliaWidgets/Sources/ViewController/Survey/Components/InputQuestionView/Survey.InputQuestionView.swift
+++ b/GliaWidgets/Sources/ViewController/Survey/Components/InputQuestionView/Survey.InputQuestionView.swift
@@ -79,7 +79,7 @@ extension Survey {
             textView.layer.borderWidth = props.showValidationError ?
                 style.option.highlightedLayer.borderWidth :
                 style.option.normalLayer.borderWidth
-            if let backgroundColor = style.background.background {
+            if let backgroundColor = style.option.normalLayer.background {
                 switch backgroundColor {
                 case .fill(let color):
                     textView.backgroundColor = color


### PR DESCRIPTION
InputQuestion doesn't need to have separate background property and should inherit the background from option's normal state.

MOB-1946