### PR TITLE
Remove outdated visitor info keys

### DIFF
--- a/TestingApp/VisitorInfo/VisitorInfoModel.swift
+++ b/TestingApp/VisitorInfo/VisitorInfoModel.swift
@@ -52,6 +52,12 @@ final class VisitorInfoModel {
         didSet {
             var rawCustomAttributes: [String: String] = self.visitorInfoUpdate.customAttributes ?? [:]
 
+            // Remove outdated key-values.
+            for (_, attribute) in oldValue {
+                rawCustomAttributes[attribute.key] = nil
+            }
+
+            // Set relevant key-values.
             for (_, attribute) in attributes {
                 rawCustomAttributes[attribute.key] = attribute.value
             }


### PR DESCRIPTION
Address issue where changing existing key name of custom attributes resulted in old key name still being kept.

MOB-1100