### PR TITLE
Discard duplicate messages delivered by sockets

### DIFF
--- a/GliaWidgets/Sources/ViewModel/Chat/Data/ChatMessage.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/Data/ChatMessage.swift
@@ -25,7 +25,8 @@ enum ChatMessageSender: Int, Codable {
 }
 
 class ChatMessage: Codable {
-    let id: String
+    typealias MessageId = String
+    let id: MessageId
     var queueID: String?
     let `operator`: ChatOperator?
     let sender: ChatMessageSender


### PR DESCRIPTION
When messages from history are loaded, same messages delivered from sockets are to be discarded to avoid duplicates.

MOB-2542