### PR TITLE
Fix missing operator image after reusing GvaGalleryListView

### DIFF
--- a/GliaWidgets/Sources/View/Chat/ChatView.GvaGallery.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatView.GvaGallery.swift
@@ -22,6 +22,7 @@ extension ChatView {
             style: style.gliaVirtualAssistant.galleryList
         )
         view.showsOperatorImage = showsImage
+        view.setOperatorImage(fromUrl: imageUrl, animated: false)
         return .gvaGallery(view, height)
     }
 

--- a/GliaWidgets/Sources/View/Chat/GVA/Gallery/GalleryList/GvaGalleryListView.swift
+++ b/GliaWidgets/Sources/View/Chat/GVA/Gallery/GalleryList/GvaGalleryListView.swift
@@ -18,7 +18,7 @@ final class GvaGalleryListView: BaseView {
     }
 
     let sectionInsets = UIEdgeInsets(top: 8, left: 44, bottom: 8, right: 16)
-    private let operatorImageInsets = UIEdgeInsets(top: 0, left: 8, bottom: 16, right: 0)
+    private let operatorImageInsets = UIEdgeInsets(top: 0, left: 8, bottom: 8, right: 0)
     private let environment: Environment
 
     private lazy var operatorImageView = UserImageView(


### PR DESCRIPTION
Previously operator image rendered properly only for the first render of GvaGalleryListView. After scrolling away and back operator image is disappeared. This commit fixes it.

MOB-2537