### PR TITLE
Gallery Card not rendered correctly when image url is invalid

### DIFF
--- a/GliaWidgets/Sources/View/Chat/ChatView.GvaGallery.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatView.GvaGallery.swift
@@ -49,7 +49,7 @@ extension ChatView {
                 )
             } ?? []
             var image: GvaGalleryCardView.Props.Image?
-            if let url = card.imageUrl {
+            if let urlString = card.imageUrl, let url = URL(string: urlString) {
                 image = GvaGalleryCardView.Props.Image(
                     url: url,
                     environment: .init(

--- a/GliaWidgets/Sources/ViewModel/Chat/Data/Gva.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/Data/Gva.swift
@@ -54,7 +54,7 @@ struct GvaGallery: Decodable, Equatable {
 struct GvaGalleryCard: Decodable, Equatable {
     let title: String
     let subtitle: String?
-    let imageUrl: URL?
+    let imageUrl: String?
     let options: [GvaOption]?
 }
 


### PR DESCRIPTION
It could happen that a GVA gallery card image URL is not a valid URL. This PR allows the gallery card to be rendered regardless, compared to the current implementation where gallery card decoding fails.

MOB-2560