### PR TITLE
Update strings to ensure successful snapshot tests

### DIFF
--- a/GliaWidgets/L10n.swift
+++ b/GliaWidgets/L10n.swift
@@ -167,8 +167,8 @@ public enum L10n {
     }
   }
   public enum Call {
-    /// You can continue browsing and we’ll connect you automatically.
-    public static let bottomText = L10n.tr("Deprecated", "call.bottomText", fallback: "You can continue browsing and we’ll connect you automatically.")
+    /// You can continue browsing and we will connect you automatically.
+    public static let bottomText = L10n.tr("Deprecated", "call.bottomText", fallback: "You can continue browsing and we will connect you automatically.")
     /// (By default your video will be off)
     public static let topText = L10n.tr("Deprecated", "call.topText", fallback: "(By default your video will be off)")
     public enum Accessibility {
@@ -401,8 +401,8 @@ public enum L10n {
       public enum Queue {
         /// CompanyName
         public static let firstText = L10n.tr("Deprecated", "call.connect.queue.firstText", fallback: "CompanyName")
-        /// We're here to help!
-        public static let secondText = L10n.tr("Deprecated", "call.connect.queue.secondText", fallback: "We're here to help!")
+        /// We are here to help!
+        public static let secondText = L10n.tr("Deprecated", "call.connect.queue.secondText", fallback: "We are here to help!")
       }
       public enum Transferring {
         /// Transferring
@@ -645,8 +645,8 @@ public enum L10n {
       public enum Queue {
         /// CompanyName
         public static let firstText = L10n.tr("Deprecated", "chat.connect.queue.firstText", fallback: "CompanyName")
-        /// We're here to help!
-        public static let secondText = L10n.tr("Deprecated", "chat.connect.queue.secondText", fallback: "We're here to help!")
+        /// We are here to help!
+        public static let secondText = L10n.tr("Deprecated", "chat.connect.queue.secondText", fallback: "We are here to help!")
       }
       public enum Transferring {
         /// Transferring
@@ -869,8 +869,8 @@ public enum L10n {
     }
     public enum Question {
       public enum Title {
-        ///  *
-        public static let asterisk = L10n.tr("Deprecated", "survey.question.title.asterisk", fallback: " *")
+        /// *
+        public static let asterisk = L10n.tr("Deprecated", "survey.question.title.asterisk", fallback: "*")
       }
     }
   }

--- a/GliaWidgets/Resources/en.lproj/Deprecated.strings
+++ b/GliaWidgets/Resources/en.lproj/Deprecated.strings
@@ -67,7 +67,7 @@
 "chat.title" = "Chat";
 "chat.endButton.title" = "End";
 "chat.connect.queue.firstText" = "CompanyName";
-"chat.connect.queue.secondText" = "We're here to help!";
+"chat.connect.queue.secondText" = "We are here to help!";
 "chat.connect.connecting.firstText" = "Connecting with {operatorName}";
 "chat.connect.connecting.secondText" = "";
 "chat.connect.connected.firstText" = "{operatorName}";
@@ -143,7 +143,7 @@
 "call.video.title" = "Video";
 "call.endButton.title" = "End";
 "call.connect.queue.firstText" = "CompanyName";
-"call.connect.queue.secondText" = "We're here to help!";
+"call.connect.queue.secondText" = "We are here to help!";
 "call.connect.connecting.firstText" = "Connecting with {operatorName}";
 "call.connect.connecting.secondText" = "";
 "call.connect.connected.firstText" = "{operatorName}";
@@ -151,7 +151,7 @@
 "call.connect.transferring.firstText" = "Transferring";
 "call.operator.name" = "{operatorName}";
 "call.topText" = "(By default your video will be off)";
-"call.bottomText" = "You can continue browsing and we’ll connect you automatically.";
+"call.bottomText" = "You can continue browsing and we will connect you automatically.";
 "call.buttons.chat.title" = "Chat";
 "call.buttons.video.title" = "Video";
 "call.buttons.mute.inactive.title" = "Mute";
@@ -214,7 +214,7 @@
 "survey.action.yes" = "Yes";
 "survey.action.no" = "No";
 "survey.action.validationError" = "Please provide an answer.";
-"survey.question.title.asterisk" = " *";
+"survey.question.title.asterisk" = "*";
 
 "survey.accessibility.footer.cancelButton.label" = "Cancel";
 "survey.accessibility.footer.submitButton.label" = "Submit";


### PR DESCRIPTION
Three strings have changed:

* "we are" instead of "we're".
* Asterisk has the space removed.
* "we will" instead of "we'll"

The changes in which the longer version is used were done because Android doesn't like quotes on strings, so they had to use escaping or something like that, but iOS doesn't have that issue, however we would still need to have escaped strings. Thus we have just removed all quotes. The asterisk space was removed because it is viewing logic, so it shouldn't be in the string.

MOB-2538