### PR TITLE
Postback button actions caching

### DIFF
--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -223,7 +223,10 @@ class ChatViewModel: EngagementViewModel, ViewModel {
             fetchSiteConfigurations()
 
             pendingMessages.forEach { [weak self] outgoingMessage in
-                self?.interactor.send(outgoingMessage.content, attachment: nil) { [weak self] message in
+                self?.interactor.send(
+                    outgoingMessage.content,
+                    attachment: outgoingMessage.attachment
+                ) { [weak self] message in
                     guard let self = self else { return }
 
                     self.replace(
@@ -501,7 +504,7 @@ extension ChatViewModel {
         messageText = ""
     }
 
-    private func handle(pendingMessage: OutgoingMessage) {
+    func handle(pendingMessage: OutgoingMessage) {
         switch interactor.state {
         case .engaged: return
         case .enqueueing, .enqueued, .ended, .none:

--- a/GliaWidgets/Sources/ViewModel/Chat/Data/OutgoingMessage.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/Data/OutgoingMessage.swift
@@ -1,23 +1,28 @@
 import Foundation
+import GliaCoreSDK
 
 class OutgoingMessage: Equatable {
     let id: String
     let content: String
     let files: [LocalFile]
+    let attachment: Attachment?
 
     init(
         id: String = UUID().uuidString,
         content: String,
-        files: [LocalFile] = []
+        files: [LocalFile] = [],
+        attachment: Attachment? = nil
     ) {
         self.id = id
         self.content = content
         self.files = files
+        self.attachment = attachment
     }
 
     static func == (lhs: OutgoingMessage, rhs: OutgoingMessage) -> Bool {
         lhs.id == rhs.id &&
         lhs.content == rhs.content &&
-        lhs.files == rhs.files
+        lhs.files == rhs.files &&
+        lhs.attachment == rhs.attachment
     }
 }

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Gva.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Gva.swift
@@ -50,11 +50,35 @@ extension ChatViewModelTests {
         env.sendSelectedOptionValue = { option, _ in
             calls.append(.sendOption(option.text, option.value))
         }
-        viewModel = .mock(environment: env)
+        let interactorMock = Interactor.mock()
+        interactorMock.state = .engaged(nil)
+        viewModel = .mock(interactor: interactorMock, environment: env)
 
         viewModel.gvaOptionAction(for: option)()
 
         XCTAssertEqual(calls, [.sendOption("text", "value")])
+    }
+
+    func test_gvaPostbackButtonActionTriggersStartEngagement() {
+        let option = GvaOption.mock(text: "text", value: "value")
+        var calls: [Call] = []
+        var env = ChatViewModel.Environment.mock
+        // To ensure `open` is not called in case of URL Button
+        env.uiApplication.open = { url in
+            calls.append(.openUrl(url.absoluteString))
+        }
+        // To ensure `sendSelectedOptionValue` is not called in case of Postback Button
+        env.sendSelectedOptionValue = { option, _ in
+            calls.append(.sendOption(option.text, option.value))
+        }
+        let interactorMock = Interactor.mock()
+        interactorMock.state = .none
+        viewModel = .mock(interactor: interactorMock, environment: env)
+
+        viewModel.gvaOptionAction(for: option)()
+
+        XCTAssertEqual(calls, [])
+        XCTAssertEqual(interactorMock.state, .enqueueing)
     }
 
     func test_broadcastEventAction() {


### PR DESCRIPTION
Caching mechanism for postback actions was added similar to caching pending messages for authenticated visitor. Now if authenticated visitor press postback button in chat transcript, chat engagement will be initiated and all postback actions will be sent, when engagement is established.

[MOB-2573](https://glia.atlassian.net/browse/MOB-2573)

[MOB-2573]: https://glia.atlassian.net/browse/MOB-2573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ