### PR TITLE
Capitalize accessibility identifier for back button

### DIFF
--- a/GliaWidgets/L10n.swift
+++ b/GliaWidgets/L10n.swift
@@ -544,8 +544,8 @@ public enum L10n {
         public enum BackButton {
           ///
           public static let hint = L10n.tr("Deprecated", "chat.accessibility.header.backButton.hint", fallback: "")
-          /// back
-          public static let label = L10n.tr("Deprecated", "chat.accessibility.header.backButton.label", fallback: "back")
+          /// Back
+          public static let label = L10n.tr("Deprecated", "chat.accessibility.header.backButton.label", fallback: "Back")
         }
         public enum CloseButton {
           ///

--- a/GliaWidgets/Resources/en.lproj/Deprecated.strings
+++ b/GliaWidgets/Resources/en.lproj/Deprecated.strings
@@ -117,7 +117,7 @@
 "chat.accessibility.message.choiceCard.buttonState.normal" = "";
 "chat.accessibility.message.choiceCard.buttonState.selected" = "Selected";
 "chat.accessibility.message.choiceCard.buttonState.disabled" = "Disabled";
-"chat.accessibility.header.backButton.label" = "back";
+"chat.accessibility.header.backButton.label" = "Back";
 "chat.accessibility.header.backButton.hint" = "";
 "chat.accessibility.header.endButton.label" = "End";
 "chat.accessibility.header.closeButton.label" = "Close";


### PR DESCRIPTION
Before, the accessibility label was "back". Now it is "Back". This is done to make unification of strings easier, as I don't want to have both strings to say the same thing. Also, all other accessibility labels start with a capital letter.

Done in tandem with the snapshot test fix[1].

MOB-2538

[1]: https://github.com/salemove/ios-widgets-snapshots/pull/37