### PR TITLE
Show Quick Replies for visitor when the QR message is the latest message in history

### DIFF
--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -390,6 +390,11 @@ extension ChatViewModel {
                     fromHistory: self.environment.loadChatMessagesFromHistory()
                 )
             }
+            if let item = items.last, case .gvaQuickReply(_, let button, _, _) = item.kind {
+                let props = button.options.map { self.quickReplyOption($0) }
+                self.action?(.quickReplyPropsUpdated(.shown(props)))
+            }
+
             self.historySection.set(items)
             self.action?(.refreshSection(self.historySection.index))
             self.action?(.scrollToBottom(animated: false))


### PR DESCRIPTION
This PR allows Quick Reply buttons to be displayed from history if quick reply button is the last message. This works for regular and authenticated vistor. The same implementation will be added to Secure Conversations in a subsequent PR because of a blocking issue.

MOB-2580