### PR TITLE
Replace old strings in remaining views

### DIFF
--- a/GliaWidgets/Localization.swift
+++ b/GliaWidgets/Localization.swift
@@ -219,8 +219,8 @@ internal enum Localization {
       internal enum Upload {
         /// Uploading failed
         internal static let failed = Localization.tr("Localizable", "chat.file.upload.failed", fallback: "Uploading failed")
-        /// Network error.
-        internal static let genericError = Localization.tr("Localizable", "chat.file.upload.generic_error", fallback: "Network error.")
+        /// Failed to upload.
+        internal static let genericError = Localization.tr("Localizable", "chat.file.upload.generic_error", fallback: "Failed to upload.")
         /// Uploading file…
         internal static let inProgress = Localization.tr("Localizable", "chat.file.upload.in_progress", fallback: "Uploading file…")
         /// Network error.

--- a/GliaWidgets/Resources/en.lproj/Localizable.strings
+++ b/GliaWidgets/Resources/en.lproj/Localizable.strings
@@ -116,7 +116,7 @@
 "chat.file.upload.scanning" = "Checking safety of the file…";
 "chat.file.upload.success" = "Ready to send";
 "chat.file.upload.network_error" = "Network error.";
-"chat.file.upload.generic_error" = "Network error.";
+"chat.file.upload.generic_error" = "Failed to upload.";
 "chat.input.placeholder" = "Enter Message";
 "chat.input.send" = "Send";
 "chat.message.unread.accessibility.label" = "Unread messages";

--- a/GliaWidgets/SecureConversations/Confirmation/Theme+SecureConversationsConfirmation.swift
+++ b/GliaWidgets/SecureConversations/Confirmation/Theme+SecureConversationsConfirmation.swift
@@ -4,41 +4,39 @@ extension Theme {
     /// Default style for confirmation screen in secure conversation. Be aware it depends on
     /// `self.colors` (ThemeColor).
     var defaultSecureConversationsConfirmationStyle: SecureConversations.ConfirmationStyle {
-        typealias Confirmation = L10n.MessageCenter.Confirmation
-
         let chatStyle = chatStyle
         var header = chatStyle.header
         header.backButton = nil
 
         let titleStyle = SecureConversations.ConfirmationStyle.TitleStyle(
-            text: Confirmation.title,
+            text: Localization.General.thankYou,
             font: font.header3,
             color: color.baseDark,
             accessibility: .init(isFontScalingEnabled: true)
         )
 
         let subtitleStyle = SecureConversations.ConfirmationStyle.SubtitleStyle(
-            text: Confirmation.subtitle,
+            text: Localization.MessageCenter.Confirmation.subtitle,
             font: font.bodyText,
             color: color.baseDark,
             accessibility: .init(isFontScalingEnabled: true)
         )
 
         let checkMessagesButtonStyle = SecureConversations.ConfirmationStyle.CheckMessagesButtonStyle(
-            title: Confirmation.checkMessages,
+            title: Localization.MessageCenter.checkMessages,
             font: font.bodyText,
             textColor: color.baseLight,
             backgroundColor: color.primary,
             accessibility: .init(
                 isFontScalingEnabled: true,
-                label: Confirmation.Accessibility.checkMessagesLabel,
-                hint: Confirmation.Accessibility.checkMessagesHint
+                label: Localization.MessageCenter.Confirmation.CheckMessages.Accessibility.label,
+                hint: Localization.MessageCenter.Confirmation.CheckMessages.Accessibility.hint
             )
         )
 
         return .init(
             header: header,
-            headerTitle: Confirmation.header,
+            headerTitle: Localization.MessageCenter.header,
             confirmationImage: Asset.mcEnvelope.image,
             confirmationImageTint: color.primary,
             titleStyle: titleStyle,

--- a/GliaWidgets/SecureConversations/Welcome/Theme+SecureConversationsWelcome.swift
+++ b/GliaWidgets/SecureConversations/Welcome/Theme+SecureConversationsWelcome.swift
@@ -9,7 +9,7 @@ extension Theme {
         header.backButton = nil
 
         let welcomeTitleStyle = SecureConversations.WelcomeStyle.TitleStyle(
-            text: Welcome.title,
+            text: Localization.MessageCenter.Welcome.title,
             font: font.header3,
             textStyle: .title3,
             color: .black,
@@ -17,7 +17,7 @@ extension Theme {
         )
 
         let welcomeSubtitleStyle = SecureConversations.WelcomeStyle.SubtitleStyle(
-            text: Welcome.subtitle,
+            text: Localization.MessageCenter.Welcome.subtitle,
             font: font.subtitle,
             textStyle: .footnote,
             color: .black,
@@ -32,12 +32,12 @@ extension Theme {
             accessibility: .init(
                 isFontScalingEnabled: true,
                 label: Localization.MessageCenter.checkMessages,
-                hint: Welcome.CheckMessages.Accessibility.hint
+                hint: Localization.MessageCenter.Welcome.CheckMessages.Accessibility.hint
             )
         )
 
         let messageTitleStyle = SecureConversations.WelcomeStyle.MessageTitleStyle(
-            title: Welcome.messageTitle,
+            title: Localization.MessageCenter.Welcome.messageTitle,
             font: font.mediumSubtitle1,
             textStyle: .subheadline,
             color: .black,
@@ -45,7 +45,7 @@ extension Theme {
         )
 
         let messageTextViewNormalStyle = SecureConversations.WelcomeStyle.MessageTextViewNormalStyle(
-            placeholderText: Welcome.MessageTextView.placeholder,
+            placeholderText: Localization.MessageCenter.Welcome.MessageTextView.placeholder,
             placeholderFont: font.bodyText,
             placeholderColor: color.baseNormal,
             textFont: font.bodyText,
@@ -59,7 +59,7 @@ extension Theme {
         )
 
         let messageTextViewActiveStyle = SecureConversations.WelcomeStyle.MessageTextViewActiveStyle(
-            placeholderText: Welcome.MessageTextView.placeholder,
+            placeholderText: Localization.MessageCenter.Welcome.MessageTextView.placeholder,
             placeholderFont: font.bodyText,
             placeholderColor: color.baseNormal,
             textFont: font.bodyText,
@@ -73,7 +73,7 @@ extension Theme {
         )
 
         let messageTextViewDisabledStyle = SecureConversations.WelcomeStyle.MessageTextViewDisabledStyle(
-            placeholderText: Welcome.MessageTextView.placeholder,
+            placeholderText: Localization.MessageCenter.Welcome.MessageTextView.placeholder,
             placeholderFont: font.bodyText,
             placeholderColor: color.baseNormal,
             textFont: font.bodyText,
@@ -104,7 +104,7 @@ extension Theme {
             accessibility: .init(
                 isFontScalingEnabled: true,
                 label: Localization.Chat.Input.send,
-                hint: Welcome.Send.Accessibility.hint
+                hint: Localization.MessageCenter.Welcome.Send.Accessibility.hint
             )
         )
 
@@ -120,7 +120,7 @@ extension Theme {
             accessibility: .init(
                 isFontScalingEnabled: true,
                 label: Localization.Chat.Input.send,
-                hint: Welcome.Send.Accessibility.hint
+                hint: Localization.MessageCenter.Welcome.Send.Accessibility.hint
             )
         )
 
@@ -137,7 +137,7 @@ extension Theme {
             accessibility: .init(
                 isFontScalingEnabled: true,
                 label: Localization.Chat.Input.send,
-                hint: Welcome.Send.Accessibility.hint
+                hint: Localization.MessageCenter.Welcome.Send.Accessibility.hint
             )
         )
 
@@ -152,7 +152,7 @@ extension Theme {
             textFont: .systemFont(ofSize: 12.0),
             textStyle: .caption1,
             iconColor: color.systemNegative,
-            messageLengthLimitText: L10n.MessageCenter.Welcome.messageLengthWarning,
+            messageLengthLimitText: Localization.MessageCenter.Welcome.messageLengthWarning,
             accessibility: .init(isFontScalingEnabled: true)
         )
 
@@ -161,8 +161,8 @@ extension Theme {
             disabledColor: .lightGray,
             accessibility: .init(
                 isFontScalingEnabled: true,
-                accessibilityLabel: Welcome.FilePicker.Accessibility.label,
-                accessibilityHint: Welcome.FilePicker.Accessibility.hint
+                accessibilityLabel: Localization.MessageCenter.Welcome.FilePicker.Accessibility.label,
+                accessibilityHint: Localization.MessageCenter.Welcome.FilePicker.Accessibility.hint
             )
         )
 
@@ -172,11 +172,6 @@ extension Theme {
         )
 
         var uploadListStyle: MessageCenterFileUploadListStyle {
-            // TODO: Introduce dedicated localization for Secure conversations upload list instaed of using Chat's one.
-            // MOB-1831
-            typealias Upload = L10n.Chat.Upload
-            typealias Accessibility = L10n.Chat.Accessibility.Upload
-
             let filePreview = FilePreviewStyle(
                 fileFont: font.subtitle,
                 fileColor: color.baseLight,
@@ -187,30 +182,30 @@ extension Theme {
                 accessibility: .init(isFontScalingEnabled: true)
             )
             let uploading = FileUploadStateStyle(
-                text: Upload.uploading,
+                text: Localization.Chat.File.Upload.inProgress,
                 font: font.mediumSubtitle2,
                 textColor: color.baseDark,
                 infoFont: font.caption,
                 infoColor: color.baseNormal
             )
             let uploaded = FileUploadStateStyle(
-                text: Upload.uploaded,
+                text: Localization.Chat.File.Upload.success,
                 font: font.mediumSubtitle2,
                 textColor: color.baseDark,
                 infoFont: font.caption,
                 infoColor: color.baseNormal
             )
             let error = FileUploadErrorStateStyle(
-                text: Upload.failed,
+                text: Localization.Chat.File.Upload.failed,
                 font: font.mediumSubtitle2,
                 textColor: color.baseDark,
                 infoFont: font.caption,
                 infoColor: color.systemNegative,
-                infoFileTooBig: Upload.Error.fileTooBig,
-                infoUnsupportedFileType: Upload.Error.unsupportedFileType,
-                infoSafetyCheckFailed: Upload.Error.safetyCheckFailed,
-                infoNetworkError: Upload.Error.network,
-                infoGenericError: Upload.Error.generic
+                infoFileTooBig: Localization.Chat.File.tooLargeError,
+                infoUnsupportedFileType: Localization.Chat.Attachment.Upload.unsupportedFile,
+                infoSafetyCheckFailed: Localization.Chat.File.infectedError,
+                infoNetworkError: Localization.Chat.File.Upload.networkError,
+                infoGenericError: Localization.Chat.File.Upload.genericError
             )
             let upload = MessageCenterFileUploadStyle(
                 filePreview: filePreview,
@@ -224,9 +219,9 @@ extension Theme {
                 removeButtonColor: color.baseNormal,
                 backgroundColor: .commonGray,
                 accessibility: .init(
-                    removeButtonAccessibilityLabel: Accessibility.RemoveUpload.label,
-                    progressPercentValue: Accessibility.Progress.percentValue,
-                    fileNameWithProgressValue: Accessibility.Progress.fileNameWithProgressValue,
+                    removeButtonAccessibilityLabel: Localization.Chat.Upload.Remove.Accessibility.label,
+                    progressPercentValue: L10n.Chat.Accessibility.Upload.Progress.percentValue,
+                    fileNameWithProgressValue: L10n.Chat.Accessibility.Upload.Progress.fileNameWithProgressValue,
                     isFontScalingEnabled: true
                 )
             )
@@ -237,15 +232,13 @@ extension Theme {
         // TODO: Introduce dedicated localization for Secure conversations upload list instaed of using Chat's one.
         // MOB-1831
         var pickMediaStyle: AttachmentSourceListStyle {
-           typealias Chat = L10n.Chat.PickMedia
-
            let itemFont = font.bodyText
            let itemFontColor = color.baseDark
            let itemIconColor = color.baseDark
 
            let pickPhoto = AttachmentSourceItemStyle(
                kind: .photoLibrary,
-               title: Chat.photo,
+               title: Localization.Chat.Attachment.photoLibrary,
                titleFont: itemFont,
                titleColor: itemFontColor,
                icon: Asset.photoLibraryIcon.image,
@@ -254,7 +247,7 @@ extension Theme {
            )
            let takePhoto = AttachmentSourceItemStyle(
                kind: .takePhoto,
-               title: Chat.takePhoto,
+               title: Localization.Chat.Attachment.takePhoto,
                titleFont: itemFont,
                titleColor: itemFontColor,
                icon: Asset.cameraIcon.image,
@@ -263,7 +256,7 @@ extension Theme {
            )
            let browse = AttachmentSourceItemStyle(
                kind: .browse,
-               title: Chat.browse,
+               title: Localization.General.browse,
                titleFont: itemFont,
                titleColor: itemFontColor,
                icon: Asset.browseIcon.image,

--- a/GliaWidgets/Sources/CallVisualizer/VideoCall/ViewModel/VideoCallViewModel.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VideoCall/ViewModel/VideoCallViewModel.swift
@@ -101,7 +101,7 @@ extension CallVisualizer {
             videoButtonState = .active
             videoButtonEnabled = true
             minimizeButtonEnabled = true
-            title = L10n.Call.Video.title
+            title = Localization.Media.Video.name
             callDuration = ""
             topLabelHidden = false
             endScreenShareButtonHidden = environment.screenShareHandler.status().value == .stopped
@@ -505,7 +505,7 @@ private extension CallVisualizer.VideoCallViewModel {
             default:
                 topLabelHidden = true
             }
-            title = L10n.Call.Video.title
+            title = Localization.Media.Video.name
         }
         updateButtons()
     }

--- a/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeView.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeView.swift
@@ -75,8 +75,8 @@ extension CallVisualizer {
         let refreshButton = UIButton().make { button in
             button.accessibilityIdentifier = "visitor_code_refresh_button"
             button.accessibilityTraits = .button
-            button.accessibilityLabel = L10n.CallVisualizer.VisitorCode.Accessibility.refreshLabel
-            button.accessibilityHint = L10n.CallVisualizer.VisitorCode.Accessibility.refreshHint
+            button.accessibilityLabel = Localization.CallVisualizer.VisitorCode.Refresh.Accessibility.label
+            button.accessibilityHint = Localization.CallVisualizer.VisitorCode.Refresh.Accessibility.hint
         }
         let spinnerView = UIImageView().make { imageView in
             imageView.image = Asset.spinner.image.withRenderingMode(.alwaysTemplate)
@@ -102,8 +102,8 @@ extension CallVisualizer {
         ).make { button in
             button.accessibilityIdentifier = "visitor_code_alert_close_button"
             button.accessibilityTraits = .button
-            button.accessibilityLabel = L10n.CallVisualizer.VisitorCode.Accessibility.closeLabel
-            button.accessibilityHint = L10n.CallVisualizer.VisitorCode.Accessibility.closeHint
+            button.accessibilityLabel = Localization.CallVisualizer.VisitorCode.Close.Accessibility.label
+            button.accessibilityHint = Localization.CallVisualizer.VisitorCode.Close.Accessibility.hint
         }
 
         lazy var poweredBy: PoweredBy = PoweredBy(style: props.style.poweredBy)
@@ -266,15 +266,15 @@ extension CallVisualizer.VisitorCodeView {
         switch props.viewState {
         case .success(visitorCode: let code):
             renderedVisitorCode = code
-            titleLabel.text = L10n.CallVisualizer.VisitorCode.Title.standard
+            titleLabel.text = Localization.CallVisualizer.VisitorCode.title
             renderVisitorCode()
-            titleLabel.accessibilityHint = L10n.CallVisualizer.VisitorCode.Accessibility.titleHint
+            titleLabel.accessibilityHint = Localization.CallVisualizer.VisitorCode.Title.Accessibility.hint
         case .error:
-            titleLabel.text = L10n.CallVisualizer.VisitorCode.Title.error
+            titleLabel.text = Localization.VisitorCode.failed
             renderError()
             titleLabel.accessibilityHint = nil
         case .loading:
-            titleLabel.text = L10n.CallVisualizer.VisitorCode.Title.standard
+            titleLabel.text = Localization.CallVisualizer.VisitorCode.title
             renderSpinner()
         }
         setFontScalingEnabled(

--- a/GliaWidgets/Sources/Theme/Survey/Theme+Survey.swift
+++ b/GliaWidgets/Sources/Theme/Survey/Theme+Survey.swift
@@ -2,7 +2,6 @@ import Foundation
 import UIKit
 
 extension Theme {
-
     public struct SurveyStyle {
         /// Layer style.
         public var layer: Layer
@@ -53,7 +52,6 @@ extension Theme.SurveyStyle {
         font: ThemeFont,
         alertStyle: AlertStyle
     ) -> Self {
-
         let font = ThemeFontStyle.default.font
 
         return .init(
@@ -71,14 +69,14 @@ extension Theme.SurveyStyle {
             submitButton: .init(
                 actionButtonStyle: alertStyle.positiveAction,
                 accessibility: .init(
-                    label: L10n.Survey.Accessibility.Footer.SubmitButton.label,
+                    label: Localization.General.submit,
                     isFontScalingEnabled: true
                 )
             ),
             cancellButton: .init(
                 actionButtonStyle: alertStyle.negativeAction,
                 accessibility: .init(
-                    label: L10n.Survey.Accessibility.Footer.CancelButton.label,
+                    label: Localization.General.cancel,
                     isFontScalingEnabled: true
                 )
             ),

--- a/GliaWidgets/Sources/Theme/Theme+ScreenSharing.swift
+++ b/GliaWidgets/Sources/Theme/Theme+ScreenSharing.swift
@@ -3,19 +3,19 @@ import UIKit
 extension Theme {
     var screenSharingStyle: ScreenSharingViewStyle {
         return ScreenSharingViewStyle(
-            title: L10n.CallVisualizer.ScreenSharing.title,
+            title: Localization.CallVisualizer.ScreenSharing.title,
             header: chat.header,
-            messageText: L10n.CallVisualizer.ScreenSharing.message,
+            messageText: Localization.CallVisualizer.ScreenSharing.message,
             messageTextFont: font.header2,
             messageTextColor: color.baseDark,
             buttonStyle: .init(
-                title: L10n.CallVisualizer.ScreenSharing.Button.title,
+                title: Localization.ScreenSharing.VisitorScreen.end,
                 titleFont: font.buttonLabel,
                 titleColor: color.baseLight,
                 backgroundColor: .fill(color: color.systemNegative),
                 cornerRaidus: 4,
                 accessibility: .init(
-                    label: L10n.CallVisualizer.ScreenSharing.Button.title,
+                    label: Localization.ScreenSharing.VisitorScreen.end,
                     isFontScalingEnabled: true
                 )
             ),

--- a/GliaWidgets/Sources/Theme/Theme+VisitorCode.swift
+++ b/GliaWidgets/Sources/Theme/Theme+VisitorCode.swift
@@ -13,14 +13,14 @@ extension Theme {
         )
 
         let actionButton = ActionButtonStyle(
-            title: L10n.CallVisualizer.VisitorCode.Action.refresh,
+            title: Localization.CallVisualizer.VisitorCode.Action.refresh,
             titleFont: font.buttonLabel,
             titleColor: color.baseLight,
             backgroundColor: .fill(color: color.primary)
         )
 
         let poweredBy = PoweredByStyle(
-            text: L10n.poweredBy,
+            text: Localization.General.poweredBy,
             font: font.caption,
             accessibility: .init(isFontScalingEnabled: true)
         )


### PR DESCRIPTION
All remaining strings that have a direct translation in the new Localization enum are now removed. The only strings remaining are the ones that need a translation layer, because they use variables.

MOB-2538