### PR TITLE
Remove space between user message and operator header.

### DIFF
--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
@@ -144,6 +144,10 @@ class ChatCoordinator: SubFlowCoordinator, FlowCoordinator {
 // MARK: Chat model
 extension ChatCoordinator {
     private func chatModel() -> ChatViewModel {
+        let chatType = Self.chatType(
+            startWithSecureTranscriptFlow: startWithSecureTranscriptFlow,
+            isAuthenticated: environment.isAuthenticated()
+        )
         let viewModel = ChatViewModel(
             interactor: interactor,
             alertConfiguration: viewFactory.theme.alertConfiguration,
@@ -155,8 +159,7 @@ extension ChatCoordinator {
             isWindowVisible: isWindowVisible,
             startAction: startAction,
             deliveredStatusText: viewFactory.theme.chat.visitorMessage.delivered,
-            // We should not show enqueueing state in case of secure transcript flow.
-            shouldSkipEnqueueingState: startWithSecureTranscriptFlow,
+            chatType: chatType,
             environment: Self.enviromentForChatModel(environment: environment, viewFactory: viewFactory)
         )
         viewModel.isInteractableCard = viewFactory.messageRenderer?.isInteractable
@@ -344,5 +347,22 @@ extension ChatCoordinator {
            stopSocketObservation: environment.stopSocketObservation,
            sendSelectedOptionValue: environment.sendSelectedOptionValue
        )
+    }
+}
+
+// MARK: - Static methods
+
+extension ChatCoordinator {
+    static func chatType(
+        startWithSecureTranscriptFlow: Bool,
+        isAuthenticated: Bool
+    ) -> ChatViewModel.ChatType {
+        if startWithSecureTranscriptFlow {
+            return .secureTranscript
+        } else if isAuthenticated {
+            return .authenticated
+        } else {
+            return .nonAuthenticated
+        }
     }
 }

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
@@ -267,7 +267,7 @@ extension ChatViewController {
             // Even though we are using the chat view model already,
             // if the engagement is not active, we still need to show
             // secure transcript UI.
-            if chatViewModel.shouldSkipEnqueueingState {
+            if chatViewModel.chatType == .secureTranscript {
                 return chatViewModel.activeEngagement != nil
                 ? .chat
                 : .secureTranscript(needsTextInput: true)

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Mock.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Mock.swift
@@ -11,6 +11,7 @@ extension ChatViewModel {
         isWindowVisible: ObservableValue<Bool> = .init(with: true),
         startAction: StartAction = .startEngagement,
         deliveredStatusText: String = "Delivered",
+        chatType: ChatViewModel.ChatType = .nonAuthenticated,
         environment: Environment = .mock
     ) -> ChatViewModel {
         ChatViewModel(
@@ -24,7 +25,7 @@ extension ChatViewModel {
             isWindowVisible: isWindowVisible,
             startAction: startAction,
             deliveredStatusText: deliveredStatusText,
-            shouldSkipEnqueueingState: false,
+            chatType: chatType,
             environment: environment
         )
     }

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -25,7 +25,7 @@ class ChatViewModelTests: XCTestCase {
             isWindowVisible: .init(with: true),
             startAction: .none,
             deliveredStatusText: "Delivered",
-            shouldSkipEnqueueingState: false,
+            chatType: .nonAuthenticated,
             environment: .init(
                 fetchFile: { _, _, _ in },
                 downloadSecureFile: { _, _, _ in .mock },
@@ -64,6 +64,48 @@ class ChatViewModelTests: XCTestCase {
         viewModel.sendChoiceCardResponse(choiceCardMock, to: "mocked-message-id")
 
         XCTAssertEqual(calls, [.sendSelectedOptionValue])
+    }
+
+    func test_secureTranscriptChatTypeCases() throws {
+        let viewModel: ChatViewModel = .mock(chatType: .secureTranscript)
+        viewModel.update(for: .enqueueing)
+        XCTAssertEqual(viewModel.queueOperatorSection.itemCount, 0)
+        viewModel.handle(pendingMessage: .mock())
+        XCTAssertEqual(viewModel.queueOperatorSection.itemCount, 1)
+    }
+
+    func test_authenticatedChatTypeCases() throws {
+        let viewModel: ChatViewModel = .mock(chatType: .authenticated)
+        viewModel.update(for: .enqueueing)
+        XCTAssertEqual(viewModel.queueOperatorSection.itemCount, 1)
+        viewModel.handle(pendingMessage: .mock())
+        XCTAssertEqual(viewModel.queueOperatorSection.itemCount, 1)
+    }
+
+    func test_nonAuthenticatedChatTypeCases() throws {
+        let viewModel: ChatViewModel = .mock(chatType: .nonAuthenticated)
+        viewModel.update(for: .enqueueing)
+        XCTAssertEqual(viewModel.queueOperatorSection.itemCount, 1)
+        viewModel.handle(pendingMessage: .mock())
+        XCTAssertEqual(viewModel.queueOperatorSection.itemCount, 1)
+    }
+
+    func test_chatTypeResponse() throws {
+        var chatType = ChatCoordinator.chatType(
+            startWithSecureTranscriptFlow: true,
+            isAuthenticated: true
+        )
+        XCTAssertEqual(chatType, .secureTranscript)
+        chatType = ChatCoordinator.chatType(
+            startWithSecureTranscriptFlow: false,
+            isAuthenticated: true
+        )
+        XCTAssertEqual(chatType, .authenticated)
+        chatType = ChatCoordinator.chatType(
+            startWithSecureTranscriptFlow: false,
+            isAuthenticated: false
+        )
+        XCTAssertEqual(chatType, .nonAuthenticated)
     }
 
     func test__startCallsSDKConfigureWithInteractorAndСonfigureWithConfiguration() throws {

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -49,7 +49,8 @@ final class GliaTests: XCTestCase {
         gliaEnv.fileManager = fileManager
         gliaEnv.coreSdk.configureWithInteractor = { _ in }
         gliaEnv.createFileUploadListModel = { _ in .mock() }
-
+        
+        gliaEnv.coreSdk.authentication = { _ in .mock }
         gliaEnv.coreSdk.configureWithConfiguration = { _, callback in callback?() }
         gliaEnv.coreSdk.queueForEngagement = { _, _, _, _, _, callback in
             callback(.mock, nil)


### PR DESCRIPTION
Currently during authenticated flow if engagements has been ended and then restarted, very noticeable white space will appear between last visitor message and connecting view. Once operator connects, and engagement starts, this white space goes away because that section is emptied out and replaced with operator image. This PR focuses on differentiating chat types because the code that caused this issue is needed for secure transcript but not for authenticated or non-Authenticated flows.

MOB-2593