### PR TITLE
Create backwards compatibility layer for operator name

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -180,6 +180,8 @@
 		3100EEFD293F757E00D57F71 /* SecureConversations.WelcomeStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3100EEFC293F757E00D57F71 /* SecureConversations.WelcomeStyle.swift */; };
 		3100EEFF293F7E0900D57F71 /* Theme+SecureConversationsWelcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3100EEFE293F7E0900D57F71 /* Theme+SecureConversationsWelcome.swift */; };
 		3115D45C29A4FD3F00D99561 /* SecureConversations.Availability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3115D45B29A4FD3F00D99561 /* SecureConversations.Availability.swift */; };
+		31184BDC2AA0AF4F00E4BC5D /* Localization+BackwardsCompatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31184BDB2AA0AF4F00E4BC5D /* Localization+BackwardsCompatibility.swift */; };
+		31184BDF2AA0C46000E4BC5D /* StringTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31184BDE2AA0C46000E4BC5D /* StringTemplateTests.swift */; };
 		311CAFCD29F8FAE20067B59F /* SecureConversations.TranscriptModel+CustomCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311CAFCC29F8FAE20067B59F /* SecureConversations.TranscriptModel+CustomCard.swift */; };
 		313EBD552943116E008E9597 /* SecureConversations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 313EBD542943116E008E9597 /* SecureConversations.swift */; };
 		3142696A29FFB712003DF62E /* Interactor.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3142696929FFB712003DF62E /* Interactor.Failing.swift */; };
@@ -904,6 +906,8 @@
 		3100EEFC293F757E00D57F71 /* SecureConversations.WelcomeStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.WelcomeStyle.swift; sourceTree = "<group>"; };
 		3100EEFE293F7E0900D57F71 /* Theme+SecureConversationsWelcome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Theme+SecureConversationsWelcome.swift"; sourceTree = "<group>"; };
 		3115D45B29A4FD3F00D99561 /* SecureConversations.Availability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.Availability.swift; sourceTree = "<group>"; };
+		31184BDB2AA0AF4F00E4BC5D /* Localization+BackwardsCompatibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Localization+BackwardsCompatibility.swift"; sourceTree = "<group>"; };
+		31184BDE2AA0C46000E4BC5D /* StringTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringTemplateTests.swift; sourceTree = "<group>"; };
 		311CAFCC29F8FAE20067B59F /* SecureConversations.TranscriptModel+CustomCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SecureConversations.TranscriptModel+CustomCard.swift"; sourceTree = "<group>"; };
 		313EBD542943116E008E9597 /* SecureConversations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.swift; sourceTree = "<group>"; };
 		3142696929FFB712003DF62E /* Interactor.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Interactor.Failing.swift; sourceTree = "<group>"; };
@@ -1982,6 +1986,7 @@
 				1A60AFA225667EA300E53F53 /* Assets.xcassets */,
 				31E35AB62A852C09006EC7FB /* Localizable.strings */,
 				1A60AFAC2566806000E53F53 /* Deprecated.strings */,
+				31184BDB2AA0AF4F00E4BC5D /* Localization+BackwardsCompatibility.swift */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -2522,6 +2527,14 @@
 			path = GliaWidgets/SecureConversations/Confirmation;
 			sourceTree = SOURCE_ROOT;
 		};
+		31184BDD2AA0C44B00E4BC5D /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				31184BDE2AA0C46000E4BC5D /* StringTemplateTests.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		313EBD53294310EE008E9597 /* SecureConversations */ = {
 			isa = PBXGroup;
 			children = (
@@ -2611,6 +2624,7 @@
 		7512A57827BF9FB800319DF1 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				31184BDD2AA0C44B00E4BC5D /* Extensions */,
 				84681A932A61840700DD7406 /* ChatViewModel */,
 				846429812A45DA5900943BD6 /* AlertViewController */,
 				846A5C4329F6BEB60049B29F /* Glia */,
@@ -4502,6 +4516,7 @@
 				84D2293E28D36B2A00F64FE7 /* UIColor+Hex.swift in Sources */,
 				75C1143629A406F00004E5F7 /* SecureConversations+RemoteConfig.swift in Sources */,
 				754CC61327E27BE2005676E9 /* Survey.SingleChoiceQuestionView.swift in Sources */,
+				31184BDC2AA0AF4F00E4BC5D /* Localization+BackwardsCompatibility.swift in Sources */,
 				1A0C9A6725C16DC400815406 /* Theme+Chat.swift in Sources */,
 				75940985298D38C2008B173A /* VisitorCodeCoordinator+DelegateEvent.swift in Sources */,
 				1A0C9AC225C9400000815406 /* CallDurationCounter.swift in Sources */,
@@ -4700,6 +4715,7 @@
 				EB03B00E27FFF6DD0058F6B1 /* CallViewTests.swift in Sources */,
 				3197F7AD29E6A5C8008EE9F7 /* SecureConversations.FileUploadListView.Mock.swift in Sources */,
 				AF29810929E045CE0005BD55 /* TranscriptModelTests.swift in Sources */,
+				31184BDF2AA0C46000E4BC5D /* StringTemplateTests.swift in Sources */,
 				7512A57727BE8A6700319DF1 /* InteractorTests.swift in Sources */,
 				AF29811529E6D76A0005BD55 /* FileDownloadTests.swift in Sources */,
 				C096B40B297EBDE400F0C552 /* VisitorCodeTests.swift in Sources */,

--- a/GliaWidgets/Resources/Localization+BackwardsCompatibility.swift
+++ b/GliaWidgets/Resources/Localization+BackwardsCompatibility.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension Localization {
+    static func operatorName(
+        _ name: String?,
+        on templateString: String? = nil
+    ) -> String {
+        guard
+            let templateString,
+            templateString.range(of: "{operatorName}") != nil
+        else {
+            return name ?? Localization.Engagement.defaultOperatorName
+        }
+
+        return templateString.withOperatorName(name)
+    }
+}

--- a/GliaWidgets/Sources/CallVisualizer/VideoCall/ViewModel/VideoCallViewModel.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VideoCall/ViewModel/VideoCallViewModel.swift
@@ -273,7 +273,7 @@ extension CallVisualizer.VideoCallViewModel {
             operatorImagePlaceholder = style.connect.connectOperator.operatorImage.placeholderImage
             setOperatorImage(from: imageUrl, animated: animated)
             operatorImageVisible = true
-            let firstText = style.connect.connecting.firstText?.withOperatorName(name)
+            let firstText = Localization.operatorName(name, on: style.connect.connecting.firstText)
             statusFirstText = .init(text: firstText, animated: animated)
             statusSecondText = .init(text: nil, animated: animated)
             statusStyle = style.connect.connecting
@@ -286,9 +286,8 @@ extension CallVisualizer.VideoCallViewModel {
             setOperatorImage(from: imageUrl, animated: animated)
             operatorImageVisible = false
             if let name = name {
-                let firstText = style.connect.connected.firstText?.withOperatorName(name)
+                let firstText = Localization.operatorName(name, on: style.connect.connected.firstText)
                 let secondText = style.connect.connected.secondText?
-                    .withOperatorName(name)
                     .withCallDuration("00:00")
                 statusFirstText = .init(text: firstText, animated: animated)
                 statusSecondText = .init(text: secondText, animated: animated)

--- a/GliaWidgets/Sources/Component/Connect/ConnectView.swift
+++ b/GliaWidgets/Sources/Component/Connect/ConnectView.swift
@@ -108,7 +108,7 @@ final class ConnectView: BaseView {
             operatorView.startAnimating(animated: animated)
             operatorView.imageView.setPlaceholderImage(style.connectOperator.operatorImage.placeholderImage)
             operatorView.imageView.setOperatorImage(fromUrl: imageUrl, animated: true)
-            let firstText = style.connecting.firstText?.withOperatorName(name)
+            let firstText = Localization.operatorName(name, on: style.connecting.firstText)
             statusView.setFirstText(firstText, animated: animated)
             statusView.setSecondText(nil, animated: animated)
             statusView.setStyle(style.connecting)
@@ -120,9 +120,8 @@ final class ConnectView: BaseView {
             operatorView.imageView.setPlaceholderImage(style.connectOperator.operatorImage.placeholderImage)
             operatorView.imageView.setOperatorImage(fromUrl: imageUrl, animated: true)
             if let name = name {
-                let firstText = style.connected.firstText?.withOperatorName(name)
+                let firstText = Localization.operatorName(name, on: style.connected.firstText)
                 let secondText = style.connected.secondText?
-                    .withOperatorName(name)
                     .withCallDuration("00:00")
                 statusView.setFirstText(firstText, animated: animated)
                 statusView.setSecondText(secondText, animated: animated)

--- a/GliaWidgets/Sources/Component/OperatorTypingIndicator/OperatorTypingIndicatorView.swift
+++ b/GliaWidgets/Sources/Component/OperatorTypingIndicator/OperatorTypingIndicatorView.swift
@@ -64,7 +64,10 @@ final class OperatorTypingIndicatorView: BaseView {
     }
 
     private func updateAccessibility() {
-        accessibilityLabel = style.accessibility.label.withOperatorName(accessibilityProperties.operatorName)
+        accessibilityLabel = Localization.operatorName(
+            accessibilityProperties.operatorName,
+            on: style.accessibility.label
+        )
     }
 }
 

--- a/GliaWidgets/Sources/Extensions/String+TemplateString.swift
+++ b/GliaWidgets/Sources/Extensions/String+TemplateString.swift
@@ -1,6 +1,6 @@
 extension String {
     func withOperatorName(_ name: String?) -> String {
-        let name = name ?? Localization.Engagement.defaultOperatorName
+        let name = name ?? L10n.Call.Operator.name
         return replacingOccurrences(of: "{operatorName}", with: name)
     }
 

--- a/GliaWidgets/Sources/Theme/Alert/MultipleMediaUpgradeAlertConfiguration.swift
+++ b/GliaWidgets/Sources/Theme/Alert/MultipleMediaUpgradeAlertConfiguration.swift
@@ -14,7 +14,7 @@ public struct MultipleMediaUpgradeAlertConfiguration {
 
     func withOperatorName(_ name: String?) -> MultipleMediaUpgradeAlertConfiguration {
         return MultipleMediaUpgradeAlertConfiguration(
-            title: title.withOperatorName(name),
+            title: Localization.operatorName(name, on: title),
             audioUpgradeAction: audioUpgradeAction,
             phoneUpgradeAction: phoneUpgradeAction,
             showsPoweredBy: showsPoweredBy

--- a/GliaWidgets/Sources/Theme/Alert/ScreenShareOfferAlertConfiguration.swift
+++ b/GliaWidgets/Sources/Theme/Alert/ScreenShareOfferAlertConfiguration.swift
@@ -22,8 +22,8 @@ public struct ScreenShareOfferAlertConfiguration {
 
     func withOperatorName(_ name: String?) -> ScreenShareOfferAlertConfiguration {
         return ScreenShareOfferAlertConfiguration(
-            title: title.withOperatorName(name),
-            message: message.withOperatorName(name),
+            title: Localization.operatorName(name, on: title),
+            message: Localization.operatorName(name, on: message),
             titleImage: titleImage,
             decline: decline,
             accept: accept,

--- a/GliaWidgets/Sources/Theme/Alert/SingleMediaUpgradeAlertConfiguration.swift
+++ b/GliaWidgets/Sources/Theme/Alert/SingleMediaUpgradeAlertConfiguration.swift
@@ -19,7 +19,7 @@ public struct SingleMediaUpgradeAlertConfiguration {
 
     func withOperatorName(_ name: String?) -> SingleMediaUpgradeAlertConfiguration {
         return SingleMediaUpgradeAlertConfiguration(
-            title: title.withOperatorName(name),
+            title: Localization.operatorName(name, on: title),
             titleImage: titleImage,
             decline: decline,
             accept: accept,

--- a/GliaWidgets/Sources/View/Chat/ChatView.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatView.swift
@@ -85,10 +85,15 @@ class ChatView: EngagementView {
             style: style.operatorTypingIndicator
         )
         typingIndicatorContainer.isAccessibilityElement = true
-        typingIndicatorContainer.accessibilityLabel =
-        style.operatorTypingIndicator.accessibility.label.withOperatorName(
-            OperatorTypingIndicatorView.AccessibilityProperties(operatorName: style.accessibility.operator).operatorName
+
+        let operatorName = OperatorTypingIndicatorView.AccessibilityProperties(
+            operatorName: style.accessibility.operator
+        ).operatorName
+        typingIndicatorContainer.accessibilityLabel = Localization.operatorName(
+            operatorName,
+            on: style.operatorTypingIndicator.accessibility.label
         )
+
         self.props = props
         super.init(
             with: style,

--- a/GliaWidgets/Sources/ViewModel/Call/CallViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Call/CallViewModel.swift
@@ -93,11 +93,7 @@ class CallViewModel: EngagementViewModel, ViewModel {
             action?(.queue)
         case .engaged:
             showConnecting()
-
-            let operatorName = L10n.Call.Operator.name.withOperatorName(
-                interactor.engagedOperator?.firstName
-            )
-
+            let operatorName = Localization.operatorName(interactor.engagedOperator?.firstName)
             action?(.setOperatorName(operatorName))
         case .ended:
             call.end()

--- a/GliaWidgetsTests/Sources/Extensions/StringTemplateTests.swift
+++ b/GliaWidgetsTests/Sources/Extensions/StringTemplateTests.swift
@@ -1,0 +1,22 @@
+import Foundation
+import XCTest
+@testable import GliaWidgets
+
+final class StringTemplateTests: XCTestCase {
+    func test_operatorWithTemplate() {
+        let operatorName = "Glia"
+        let string = "Operator: {operatorName}"
+
+        let compatibilityLayerResult = Localization.operatorName(operatorName, on: string)
+        XCTAssertEqual(compatibilityLayerResult, "Operator: Glia")
+
+        let templateResult = string.withOperatorName(operatorName)
+        XCTAssertEqual(compatibilityLayerResult, templateResult)
+    }
+
+    func test_operatorWithoutTemplate() {
+        let operatorName = Localization.operatorName("Glia", on: nil)
+
+        XCTAssertEqual(operatorName, "Glia")
+    }
+}


### PR DESCRIPTION
The idea is that if the string comes from the styling, there is a chance that the integrator has changed it to use their own string. Thus, the backwards compatibility layer checks if this is the case by searching for `{operatorName}`. If it finds it, then it replaces the operator name like before. However, if it doesn't, then it just uses the operator name directly. In six months, we can remove all the references to the old `{operatorName}` behavior, since this is not part of the new strings.

MOB-2507