### PR TITLE
Improve URLs handling in text messages

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -398,6 +398,7 @@
 		8491AF552AA0934A00CC3E72 /* GVA.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF542AA0934900CC3E72 /* GVA.Mock.swift */; };
 		8491AF572AA0964800CC3E72 /* ChatItem.Kind.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF562AA0964800CC3E72 /* ChatItem.Kind.Mock.swift */; };
 		8491AF632AA20F9D00CC3E72 /* GliaViewControllerDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF622AA20F9D00CC3E72 /* GliaViewControllerDelegateMock.swift */; };
+		8491AF602AA1EBB600CC3E72 /* TranscriptModelTests+URLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF5F2AA1EBB600CC3E72 /* TranscriptModelTests+URLs.swift */; };
 		84A318A12869ECFC00CA1DE5 /* Unavailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A318A02869ECFC00CA1DE5 /* Unavailable.swift */; };
 		84CFB7732822700000167258 /* Theme.Button.Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CFB7722822700000167258 /* Theme.Button.Accessibility.swift */; };
 		84D2292B28C61C8D00F64FE7 /* WKNavigationPolicyProvider.CustomResponseCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D2292A28C61C8D00F64FE7 /* WKNavigationPolicyProvider.CustomResponseCard.swift */; };
@@ -1123,6 +1124,7 @@
 		8491AF542AA0934900CC3E72 /* GVA.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GVA.Mock.swift; sourceTree = "<group>"; };
 		8491AF562AA0964800CC3E72 /* ChatItem.Kind.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatItem.Kind.Mock.swift; sourceTree = "<group>"; };
 		8491AF622AA20F9D00CC3E72 /* GliaViewControllerDelegateMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GliaViewControllerDelegateMock.swift; sourceTree = "<group>"; };
+		8491AF5F2AA1EBB600CC3E72 /* TranscriptModelTests+URLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TranscriptModelTests+URLs.swift"; sourceTree = "<group>"; };
 		84A318A02869ECFC00CA1DE5 /* Unavailable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Unavailable.swift; sourceTree = "<group>"; };
 		84CFB7722822700000167258 /* Theme.Button.Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.Button.Accessibility.swift; sourceTree = "<group>"; };
 		84D2292A28C61C8D00F64FE7 /* WKNavigationPolicyProvider.CustomResponseCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKNavigationPolicyProvider.CustomResponseCard.swift; sourceTree = "<group>"; };
@@ -2554,6 +2556,7 @@
 				AF4D821B29D6E572007763F8 /* TranscriptModel.DividedChatItemsForUnreadCountTests.swift */,
 				AF29810829E045CE0005BD55 /* TranscriptModelTests.swift */,
 				8491AF4F2A9CBB0400CC3E72 /* TranscriptModelTests+GVA.swift */,
+				8491AF5F2AA1EBB600CC3E72 /* TranscriptModelTests+URLs.swift */,
 			);
 			path = ChatTranscript;
 			sourceTree = "<group>";
@@ -4739,6 +4742,7 @@
 				AF4D821C29D6E572007763F8 /* TranscriptModel.DividedChatItemsForUnreadCountTests.swift in Sources */,
 				9A19927027D3BCAE00161AAE /* GCD.Failing.swift in Sources */,
 				3142696A29FFB712003DF62E /* Interactor.Failing.swift in Sources */,
+				8491AF602AA1EBB600CC3E72 /* TranscriptModelTests+URLs.swift in Sources */,
 				9A8130C427D9099F00220BBD /* FileDownload.Environment.Failing.swift in Sources */,
 				AF29811029E06E830005BD55 /* Availability.Environment.Failing.swift in Sources */,
 				8464297A2A44937600943BD6 /* AlertViewControllerTests.swift in Sources */,

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
@@ -11,7 +11,6 @@ extension SecureConversations {
 
         enum DelegateEvent {
             case showFile(LocalFile)
-            case openLink(URL)
             case showAlertAsView(
                 MessageAlertConfiguration,
                 accessibilityIdentifier: String?,
@@ -400,22 +399,8 @@ extension SecureConversations.TranscriptModel {
     }
 
     func linkTapped(_ url: URL) {
-        switch url.scheme?.lowercased() {
-        case "tel",
-            "mailto":
-            guard
-                environment.uiApplication.canOpenURL(url)
-            else { return }
-
-            environment.uiApplication.open(url)
-
-        case "http",
-            "https":
-            delegate?(.openLink(url))
-
-        default:
-            return
-        }
+        guard environment.uiApplication.canOpenURL(url) else { return }
+        environment.uiApplication.open(url)
     }
 }
 

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
@@ -131,14 +131,6 @@ class ChatCoordinator: SubFlowCoordinator, FlowCoordinator {
         quickLookController = controller
         navigationPresenter.present(controller.viewController)
     }
-
-    private func presentWebViewController(with url: URL) {
-        let configuration = SFSafariViewController.Configuration()
-        configuration.entersReaderIfAvailable = true
-        let safariViewController = SFSafariViewController(url: url, configuration: configuration)
-        safariViewController.view.accessibilityIdentifier = "safari_root_view"
-        navigationPresenter.present(safariViewController)
-    }
 }
 
 // MARK: Chat model
@@ -198,8 +190,6 @@ extension ChatCoordinator {
                 self?.presentQuickLookController(with: file)
             case .call:
                 self?.delegate?(.call)
-            case .openLink(let url):
-                self?.presentWebViewController(with: url)
             }
         }
 
@@ -279,8 +269,6 @@ extension ChatCoordinator {
             switch event {
             case .showFile(let file):
                 self?.presentQuickLookController(with: file)
-            case .openLink(let url):
-                self?.presentWebViewController(with: url)
             case let .showAlertAsView(conf, accessibilityIdentifier, dismissed):
                 controller()?.presentAlertAsView(
                     with: conf,

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -720,22 +720,8 @@ extension ChatViewModel {
     }
 
     func linkTapped(_ url: URL) {
-        switch url.scheme?.lowercased() {
-        case "tel",
-            "mailto":
-            guard
-                environment.uiApplication.canOpenURL(url)
-            else { return }
-
-            environment.uiApplication.open(url)
-
-        case "http",
-            "https":
-            delegate?(.openLink(url))
-
-        default:
-            return
-        }
+        guard environment.uiApplication.canOpenURL(url) else { return }
+        environment.uiApplication.open(url)
     }
 
     private func downloadTapped(_ download: FileDownload) {
@@ -915,7 +901,6 @@ extension ChatViewModel {
         case secureTranscriptUpgradedToLiveChat(ChatViewController)
         case showFile(LocalFile)
         case call
-        case openLink(URL)
     }
 
     enum StartAction {

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+URLs.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+URLs.swift
@@ -1,0 +1,99 @@
+@testable import GliaWidgets
+import XCTest
+
+extension SecureConversationsTranscriptModelTests {
+    func test_handleUrlWithPhoneOpensURLWithUIApplication() throws {
+        var calls: [Call] = []
+        let viewModel = createViewModel()
+        viewModel.environment.uiApplication.canOpenURL = { url in
+            calls.append(.canOpen(url))
+            return true
+        }
+        viewModel.environment.uiApplication.open = { url in
+            calls.append(.open(url))
+        }
+
+        let telUrl = try XCTUnwrap(URL(string: "tel:12345678"))
+        viewModel.linkTapped(telUrl)
+
+        XCTAssertEqual(calls, [.canOpen(telUrl), .open(telUrl)])
+    }
+
+    func test_handleUrlWithEmailOpensURLWithUIApplication() throws {
+        var calls: [Call] = []
+        let viewModel = createViewModel()
+        viewModel.environment.uiApplication.canOpenURL = { url in
+            calls.append(.canOpen(url))
+            return true
+        }
+        viewModel.environment.uiApplication.open = { url in
+            calls.append(.open(url))
+        }
+
+        let mailUrl = try XCTUnwrap(URL(string: "mailto:mock@mock.mock"))
+        viewModel.linkTapped(mailUrl)
+
+        XCTAssertEqual(calls, [.canOpen(mailUrl), .open(mailUrl)])
+    }
+
+    func test_handleUrlWithLinkOpensCalsLinkTapped() throws {
+        var calls: [Call] = []
+        let viewModel = createViewModel()
+        viewModel.environment.uiApplication.canOpenURL = { url in
+            calls.append(.canOpen(url))
+            return true
+        }
+        viewModel.environment.uiApplication.open = { url in
+            calls.append(.open(url))
+        }
+
+        let linkUrl = try XCTUnwrap(URL(string: "https://mock.mock"))
+        viewModel.linkTapped(linkUrl)
+
+        XCTAssertEqual(calls, [.canOpen(linkUrl), .open(linkUrl)])
+    }
+
+    func test_handleUrlWithRandomScheme() throws {
+        enum Call: Equatable { case canOpen(URL), open(URL) }
+
+        var calls: [Call] = []
+        let viewModel = createViewModel()
+        viewModel.environment.uiApplication.canOpenURL = { url in
+            calls.append(.canOpen(url))
+            return true
+        }
+        viewModel.environment.uiApplication.open = { url in
+            calls.append(.open(url))
+        }
+
+        let mockUrl = try XCTUnwrap(URL(string: "mock://mock"))
+        viewModel.linkTapped(mockUrl)
+
+        XCTAssertEqual(calls, [.canOpen(mockUrl), .open(mockUrl)])
+    }
+}
+
+private extension SecureConversationsTranscriptModelTests {
+    enum Call: Equatable { case canOpen(URL), open(URL) }
+
+    func createViewModel() -> TranscriptModel {
+        var modelEnv = TranscriptModel.Environment.failing
+        modelEnv.fileManager = .mock
+        modelEnv.createFileUploadListModel = { _ in .mock() }
+        modelEnv.listQueues = { callback in callback([], nil) }
+        let availabilityEnv = SecureConversations.Availability.Environment(
+            listQueues: modelEnv.listQueues,
+            queueIds: modelEnv.queueIds,
+            isAuthenticated: { true }
+        )
+
+        return TranscriptModel(
+            isCustomCardSupported: false,
+            environment: modelEnv,
+            availability: .init(environment: availabilityEnv),
+            deliveredStatusText: "",
+            interactor: .failing,
+            alertConfiguration: .mock()
+        )
+    }
+}


### PR DESCRIPTION
Before SDK opened `http(s)` links in `SafaryViewController`, `tel:` and `mailto:` links using `UIApplication.open` method. Deep links were skipped at all. Now any type of URL is opened using `UIApplication.open method` to align behaviour with GVA feature and Android SDK.

MOB-2605