### PR TITLE
Introduce `minimize()` public interface

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -397,6 +397,7 @@
 		8491AF522A9F813200CC3E72 /* SecureConversations.TranscriptModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF512A9F813200CC3E72 /* SecureConversations.TranscriptModel.swift */; };
 		8491AF552AA0934A00CC3E72 /* GVA.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF542AA0934900CC3E72 /* GVA.Mock.swift */; };
 		8491AF572AA0964800CC3E72 /* ChatItem.Kind.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF562AA0964800CC3E72 /* ChatItem.Kind.Mock.swift */; };
+		8491AF632AA20F9D00CC3E72 /* GliaViewControllerDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF622AA20F9D00CC3E72 /* GliaViewControllerDelegateMock.swift */; };
 		84A318A12869ECFC00CA1DE5 /* Unavailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A318A02869ECFC00CA1DE5 /* Unavailable.swift */; };
 		84CFB7732822700000167258 /* Theme.Button.Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CFB7722822700000167258 /* Theme.Button.Accessibility.swift */; };
 		84D2292B28C61C8D00F64FE7 /* WKNavigationPolicyProvider.CustomResponseCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D2292A28C61C8D00F64FE7 /* WKNavigationPolicyProvider.CustomResponseCard.swift */; };
@@ -1121,6 +1122,7 @@
 		8491AF512A9F813200CC3E72 /* SecureConversations.TranscriptModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.TranscriptModel.swift; sourceTree = "<group>"; };
 		8491AF542AA0934900CC3E72 /* GVA.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GVA.Mock.swift; sourceTree = "<group>"; };
 		8491AF562AA0964800CC3E72 /* ChatItem.Kind.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatItem.Kind.Mock.swift; sourceTree = "<group>"; };
+		8491AF622AA20F9D00CC3E72 /* GliaViewControllerDelegateMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GliaViewControllerDelegateMock.swift; sourceTree = "<group>"; };
 		84A318A02869ECFC00CA1DE5 /* Unavailable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Unavailable.swift; sourceTree = "<group>"; };
 		84CFB7722822700000167258 /* Theme.Button.Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.Button.Accessibility.swift; sourceTree = "<group>"; };
 		84D2292A28C61C8D00F64FE7 /* WKNavigationPolicyProvider.CustomResponseCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKNavigationPolicyProvider.CustomResponseCard.swift; sourceTree = "<group>"; };
@@ -3182,6 +3184,7 @@
 		846A5C4329F6BEB60049B29F /* Glia */ = {
 			isa = PBXGroup;
 			children = (
+				8491AF612AA20F8F00CC3E72 /* Mocks */,
 				7512A5A627C3926500319DF1 /* GliaTests.swift */,
 				846A5C4429F6BEFA0049B29F /* GliaTests+StartEngagement.swift */,
 			);
@@ -3263,6 +3266,14 @@
 			children = (
 				8491AF542AA0934900CC3E72 /* GVA.Mock.swift */,
 				8491AF562AA0964800CC3E72 /* ChatItem.Kind.Mock.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
+		8491AF612AA20F8F00CC3E72 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				8491AF622AA20F9D00CC3E72 /* GliaViewControllerDelegateMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -4757,6 +4768,7 @@
 				EB7A1508286D98000035AC62 /* FileUploader.Environment.Failing.swift in Sources */,
 				AF2355A229C9EC7E007D9896 /* IdCollectionTests.swift in Sources */,
 				8491AF572AA0964800CC3E72 /* ChatItem.Kind.Mock.swift in Sources */,
+				8491AF632AA20F9D00CC3E72 /* GliaViewControllerDelegateMock.swift in Sources */,
 				84681A952A61844000DD7406 /* ChatViewModelTests+Gva.swift in Sources */,
 				847A7643285A1914004044D1 /* FileUploadListViewModelTests.swift in Sources */,
 				9A1992E727D66C7400161AAE /* UIKitBased.Failing.swift in Sources */,

--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -138,6 +138,13 @@ public class Glia {
         startObservingInteractorEvents()
     }
 
+    /// Minimizes engagement view if ongoing engagement exists.
+    /// Use this function for hiding the engagement view programmatically during ongoing engagement.
+    /// If you do so, the operator bubble appears.
+    public func minimize() {
+        rootCoordinator?.minimize()
+    }
+
     /// Maximizes engagement view if ongoing engagment exists.
     /// Throws error if ongoing engagement not exist.
     /// Use this function for resuming engagement view If bubble is hidden programmatically and you need to

--- a/GliaWidgets/Sources/Component/Bubble/BubbleView.Mock.swift
+++ b/GliaWidgets/Sources/Component/Bubble/BubbleView.Mock.swift
@@ -1,12 +1,28 @@
 #if DEBUG
 extension BubbleView {
     static func mock(
-        with bubbleStyle: BubbleStyle,
-        environment: Environment
+        with bubbleStyle: BubbleStyle = .mock(),
+        environment: Environment = .mock()
     ) -> BubbleView {
         .init(
             with: bubbleStyle,
             environment: environment
+        )
+    }
+}
+
+extension BubbleView.Environment {
+    static func mock(
+        data: FoundationBased.Data = .mock,
+        uuid: @escaping () -> UUID = { .mock },
+        gcd: GCD = .mock,
+        imageViewCache: ImageView.Cache = .mock
+    ) -> BubbleView.Environment {
+        .init(
+            data: data,
+            uuid: uuid,
+            gcd: gcd,
+            imageViewCache: imageViewCache
         )
     }
 }

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Mock.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Mock.swift
@@ -5,7 +5,7 @@ extension EngagementCoordinator {
         viewFactory: ViewFactory = .mock(),
         sceneProvider: SceneProvider? = nil,
         engagementKind: EngagementKind = .audioCall,
-        screenShareHandler: ScreenShareHandler,
+        screenShareHandler: ScreenShareHandler = .mock,
         features: Features = .all,
         environment: Environment = .mock
     ) -> EngagementCoordinator {

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
@@ -9,6 +9,7 @@ class EngagementCoordinator: SubFlowCoordinator, FlowCoordinator {
         }
     }
 
+    var gliaViewController: GliaViewController?
     private let interactor: Interactor
     private let viewFactory: ViewFactory
     private weak var sceneProvider: SceneProvider?
@@ -21,7 +22,6 @@ class EngagementCoordinator: SubFlowCoordinator, FlowCoordinator {
     private let navigationController = NavigationController()
     private let navigationPresenter: NavigationPresenter
     private let gliaPresenter: GliaPresenter
-    private var gliaViewController: GliaViewController?
     private let kBubbleViewSize: CGFloat = 60.0
     private let features: Features
     private let environment: Environment
@@ -590,6 +590,9 @@ extension EngagementCoordinator: GliaViewControllerDelegate {
 }
 
 extension EngagementCoordinator {
+    func minimize() {
+        gliaViewController?.minimize(animated: true)
+    }
 
     func maximize() {
         gliaViewController?.maximize(animated: true)

--- a/GliaWidgets/Sources/ViewController/GliaViewController.Mock.swift
+++ b/GliaWidgets/Sources/ViewController/GliaViewController.Mock.swift
@@ -1,9 +1,9 @@
 #if DEBUG
 extension GliaViewController {
     static func mock(
-        bubbleView: BubbleView,
-        delegate: GliaViewControllerDelegate?,
-        features: Features
+        bubbleView: BubbleView = .mock(),
+        delegate: GliaViewControllerDelegate? = nil,
+        features: Features = .all
     ) -> GliaViewController {
         .init(
             bubbleView: bubbleView,

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -251,4 +251,37 @@ final class GliaTests: XCTestCase {
 
         XCTAssertEqual(resultingError as? GliaError, GliaError.clearingVisitorSessionDuringEngagementIsNotAllowed)
     }
+
+    func test_minimize() {
+        let sdk = Glia(environment: .failing)
+        let coordinator = EngagementCoordinator.mock()
+        let delegate = GliaViewControllerDelegateMock()
+        let gliaVC = GliaViewController.mock(delegate: delegate)
+        coordinator.gliaViewController = gliaVC
+        sdk.rootCoordinator = coordinator
+
+        sdk.minimize()
+
+        XCTAssertTrue(delegate.invokedEventCall)
+        XCTAssertEqual(delegate.invokedEventCallCount, 1)
+        XCTAssertEqual(delegate.invokedEventCallParameter, .minimized)
+        XCTAssertEqual(delegate.invokedEventCallParameterList, [.minimized])
+    }
+
+    func test_maximize() throws {
+        let sdk = Glia(environment: .failing)
+        let coordinator = EngagementCoordinator.mock()
+        let delegate = GliaViewControllerDelegateMock()
+        let gliaVC = GliaViewController.mock(delegate: delegate)
+        coordinator.gliaViewController = gliaVC
+        sdk.rootCoordinator = coordinator
+
+        try sdk.resume()
+
+        XCTAssertTrue(delegate.invokedEventCall)
+        XCTAssertEqual(delegate.invokedEventCallCount, 1)
+        XCTAssertEqual(delegate.invokedEventCallParameter, .maximized)
+        XCTAssertEqual(delegate.invokedEventCallParameterList, [.maximized])
+    }
 }
+

--- a/GliaWidgetsTests/Sources/Glia/Mocks/GliaViewControllerDelegateMock.swift
+++ b/GliaWidgetsTests/Sources/Glia/Mocks/GliaViewControllerDelegateMock.swift
@@ -1,0 +1,16 @@
+@testable import GliaWidgets
+import Foundation
+
+final class GliaViewControllerDelegateMock: GliaViewControllerDelegate {
+    var invokedEventCall = false
+    var invokedEventCallCount = 0
+    var invokedEventCallParameter: GliaViewControllerEvent?
+    var invokedEventCallParameterList = [GliaViewControllerEvent]()
+
+    func event(_ event: GliaViewControllerEvent) {
+        invokedEventCall = true
+        invokedEventCallCount += 1
+        invokedEventCallParameter = event
+        invokedEventCallParameterList.append(event)
+    }
+}

--- a/TestingApp/DeeplinkService/SettingsDeeplinkHandler.swift
+++ b/TestingApp/DeeplinkService/SettingsDeeplinkHandler.swift
@@ -1,4 +1,5 @@
 import UIKit
+import GliaWidgets
 
 struct SettingsDeeplinkHandler: DeeplinkHandler {
     enum Path: String {
@@ -18,6 +19,7 @@ struct SettingsDeeplinkHandler: DeeplinkHandler {
               let root = window?.rootViewController as? ViewController else {
             return false
         }
+        Glia.sharedInstance.minimize()
         root.presentSettings()
         return true
     }


### PR DESCRIPTION
This method minimizes Glia screens to the Bubble. It might be used by integrators during handling deep links. 
Added tests for `minimize()` and `resume()` methods.

MOB-2607