### PR TITLE
Enable visitor message syncronization for regular chat engagement

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -397,8 +397,8 @@
 		8491AF522A9F813200CC3E72 /* SecureConversations.TranscriptModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF512A9F813200CC3E72 /* SecureConversations.TranscriptModel.swift */; };
 		8491AF552AA0934A00CC3E72 /* GVA.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF542AA0934900CC3E72 /* GVA.Mock.swift */; };
 		8491AF572AA0964800CC3E72 /* ChatItem.Kind.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF562AA0964800CC3E72 /* ChatItem.Kind.Mock.swift */; };
-		8491AF632AA20F9D00CC3E72 /* GliaViewControllerDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF622AA20F9D00CC3E72 /* GliaViewControllerDelegateMock.swift */; };
 		8491AF602AA1EBB600CC3E72 /* TranscriptModelTests+URLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF5F2AA1EBB600CC3E72 /* TranscriptModelTests+URLs.swift */; };
+		8491AF632AA20F9D00CC3E72 /* GliaViewControllerDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF622AA20F9D00CC3E72 /* GliaViewControllerDelegateMock.swift */; };
 		84A318A12869ECFC00CA1DE5 /* Unavailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A318A02869ECFC00CA1DE5 /* Unavailable.swift */; };
 		84CFB7732822700000167258 /* Theme.Button.Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CFB7722822700000167258 /* Theme.Button.Accessibility.swift */; };
 		84D2292B28C61C8D00F64FE7 /* WKNavigationPolicyProvider.CustomResponseCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D2292A28C61C8D00F64FE7 /* WKNavigationPolicyProvider.CustomResponseCard.swift */; };
@@ -552,6 +552,7 @@
 		AF75601C2A78146600871E36 /* CustomSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF75601B2A78146500871E36 /* CustomSegmentedControl.swift */; };
 		AF9DB22E2890571A00A0C442 /* RootCoordinator.Environment.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9DB22D2890571A00A0C442 /* RootCoordinator.Environment.Failing.swift */; };
 		AF9DB23128905A1D00A0C442 /* ViewFactory.Environment.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9DB23028905A1D00A0C442 /* ViewFactory.Environment.Failing.swift */; };
+		AFA1A9952AA9248400095BE8 /* ChatViewModel+ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA1A9942AA9248400095BE8 /* ChatViewModel+ViewModel.swift */; };
 		AFA2FDEC28907D7C00428E6D /* EngagementCoordinator.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA2FDEB28907D7C00428E6D /* EngagementCoordinator.Environment.swift */; };
 		AFA2FDEE28907DDB00428E6D /* EngagementCoordinator.Environment.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA2FDED28907DDB00428E6D /* EngagementCoordinator.Environment.Mock.swift */; };
 		AFA2FDF028907E3900428E6D /* EngagementCoordinator.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA2FDEF28907E3900428E6D /* EngagementCoordinator.Mock.swift */; };
@@ -1123,8 +1124,8 @@
 		8491AF512A9F813200CC3E72 /* SecureConversations.TranscriptModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.TranscriptModel.swift; sourceTree = "<group>"; };
 		8491AF542AA0934900CC3E72 /* GVA.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GVA.Mock.swift; sourceTree = "<group>"; };
 		8491AF562AA0964800CC3E72 /* ChatItem.Kind.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatItem.Kind.Mock.swift; sourceTree = "<group>"; };
-		8491AF622AA20F9D00CC3E72 /* GliaViewControllerDelegateMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GliaViewControllerDelegateMock.swift; sourceTree = "<group>"; };
 		8491AF5F2AA1EBB600CC3E72 /* TranscriptModelTests+URLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TranscriptModelTests+URLs.swift"; sourceTree = "<group>"; };
+		8491AF622AA20F9D00CC3E72 /* GliaViewControllerDelegateMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GliaViewControllerDelegateMock.swift; sourceTree = "<group>"; };
 		84A318A02869ECFC00CA1DE5 /* Unavailable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Unavailable.swift; sourceTree = "<group>"; };
 		84CFB7722822700000167258 /* Theme.Button.Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.Button.Accessibility.swift; sourceTree = "<group>"; };
 		84D2292A28C61C8D00F64FE7 /* WKNavigationPolicyProvider.CustomResponseCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKNavigationPolicyProvider.CustomResponseCard.swift; sourceTree = "<group>"; };
@@ -1281,6 +1282,7 @@
 		AF75601B2A78146500871E36 /* CustomSegmentedControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomSegmentedControl.swift; sourceTree = "<group>"; };
 		AF9DB22D2890571A00A0C442 /* RootCoordinator.Environment.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootCoordinator.Environment.Failing.swift; sourceTree = "<group>"; };
 		AF9DB23028905A1D00A0C442 /* ViewFactory.Environment.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewFactory.Environment.Failing.swift; sourceTree = "<group>"; };
+		AFA1A9942AA9248400095BE8 /* ChatViewModel+ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatViewModel+ViewModel.swift"; sourceTree = "<group>"; };
 		AFA2FDEB28907D7C00428E6D /* EngagementCoordinator.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngagementCoordinator.Environment.swift; sourceTree = "<group>"; };
 		AFA2FDED28907DDB00428E6D /* EngagementCoordinator.Environment.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngagementCoordinator.Environment.Mock.swift; sourceTree = "<group>"; };
 		AFA2FDEF28907E3900428E6D /* EngagementCoordinator.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngagementCoordinator.Mock.swift; sourceTree = "<group>"; };
@@ -2153,6 +2155,7 @@
 				9AB196D527C3E1E400FD60AB /* ChatViewModel.Environment.Interface.swift */,
 				9AB196D727C3E27300FD60AB /* ChatViewModel.Environment.Mock.swift */,
 				84681A8D2A5ED76300DD7406 /* ChatViewModel+GVA.swift */,
+				AFA1A9942AA9248400095BE8 /* ChatViewModel+ViewModel.swift */,
 			);
 			path = Chat;
 			sourceTree = "<group>";
@@ -4381,6 +4384,7 @@
 				1A60AFF12566A4B300E53F53 /* NavigationPresenter.swift in Sources */,
 				1AC7A74F2582571100567FF8 /* Interactor.swift in Sources */,
 				845E2F72283D068000C04D56 /* HeaderStyle.Accessibility.swift in Sources */,
+				AFA1A9952AA9248400095BE8 /* ChatViewModel+ViewModel.swift in Sources */,
 				1A1E30CB25F9FDC400850E68 /* ChatImageFileContentStyle.swift in Sources */,
 				75C48498299AC71F003EC223 /* Header+Playbook.swift in Sources */,
 				84681A8E2A5ED76300DD7406 /* ChatViewModel+GVA.swift in Sources */,

--- a/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
+++ b/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
@@ -138,7 +138,7 @@ extension Glia {
                 notificationCenter: environment.notificationCenter,
                 fetchChatHistory: environment.coreSdk.fetchChatHistory,
                 listQueues: environment.coreSdk.listQueues,
-                sendSecureMessage: environment.coreSdk.sendSecureMessage,
+                sendSecureMessagePayload: environment.coreSdk.sendSecureMessagePayload,
                 createFileUploader: environment.createFileUploader,
                 createFileUploadListModel: environment.createFileUploadListModel,
                 uploadSecureFile: environment.coreSdk.uploadSecureFile,
@@ -156,7 +156,8 @@ extension Glia {
                 },
                 startSocketObservation: environment.coreSdk.startSocketObservation,
                 stopSocketObservation: environment.coreSdk.stopSocketObservation,
-                pushNotifications: environment.coreSdk.pushNotifications
+                pushNotifications: environment.coreSdk.pushNotifications,
+                createSendMessagePayload: environment.coreSdk.createSendMessagePayload
             )
         )
         rootCoordinator?.delegate = { [weak self] event in

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel+GVA.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel+GVA.swift
@@ -95,10 +95,8 @@ private extension SecureConversations.TranscriptModel {
             imageUrl: nil
         )
 
-        let outgoingMessage = OutgoingMessage(
-            content: option.text,
-            attachment: attachment
-        )
+        let payload = environment.createSendMessagePayload(option.text, attachment)
+        let outgoingMessage = OutgoingMessage(payload: payload)
 
         appendItem(
             .init(kind: .outgoingMessage(outgoingMessage)),
@@ -106,9 +104,8 @@ private extension SecureConversations.TranscriptModel {
             animated: true
         )
 
-        _ = environment.sendSecureMessage(
-            option.text,
-            attachment,
+        _ = environment.sendSecureMessagePayload(
+            outgoingMessage.payload,
             environment.queueIds
         ) { [weak self] result in
             guard let self = self else { return }

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.Environment.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.Environment.swift
@@ -14,7 +14,7 @@ extension SecureConversations.TranscriptModel {
         var loadChatMessagesFromHistory: () -> Bool
         var fetchChatHistory: CoreSdkClient.FetchChatHistory
         var uiApplication: UIKitBased.UIApplication
-        var sendSecureMessage: CoreSdkClient.SendSecureMessage
+        var sendSecureMessagePayload: CoreSdkClient.SendSecureMessagePayload
         var queueIds: [String]
         var listQueues: CoreSdkClient.ListQueues
         var alertConfiguration: AlertConfiguration
@@ -30,5 +30,6 @@ extension SecureConversations.TranscriptModel {
         var startSocketObservation: CoreSdkClient.StartSocketObservation
         var stopSocketObservation: CoreSdkClient.StopSocketObservation
         var sendSelectedOptionValue: CoreSdkClient.SendSelectedOptionValue
+        var createSendMessagePayload: CoreSdkClient.CreateSendMessagePayload
     }
 }

--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
@@ -42,7 +42,7 @@ extension SecureConversations {
                     welcomeStyle: viewFactory.theme.secureConversationsWelcome,
                     queueIds: environment.queueIds,
                     listQueues: environment.listQueues,
-                    sendSecureMessage: environment.sendSecureMessage,
+                    sendSecureMessagePayload: environment.sendSecureMessagePayload,
                     alertConfiguration: viewFactory.theme.alertConfiguration,
                     fileUploader: environment.createFileUploader(
                         SecureConversations.WelcomeViewModel.maximumUploads,
@@ -64,7 +64,8 @@ extension SecureConversations {
                     stopSocketObservation: environment.stopSocketObservation,
                     getCurrentEngagement: environment.getCurrentEngagement,
                     uploadSecureFile: environment.uploadSecureFile,
-                    uploadFileToEngagement: environment.uploadFileToEngagement
+                    uploadFileToEngagement: environment.uploadFileToEngagement,
+                    createSendMessagePayload: environment.createSendMessagePayload
                 ),
                 availability: .init(
                     environment: .init(
@@ -274,7 +275,7 @@ extension SecureConversations.Coordinator {
                 uiApplication: environment.uiApplication,
                 fetchChatHistory: environment.fetchChatHistory,
                 createFileUploadListModel: environment.createFileUploadListModel,
-                sendSecureMessage: environment.sendSecureMessage,
+                sendSecureMessagePayload: environment.sendSecureMessagePayload,
                 queueIds: environment.queueIds,
                 listQueues: environment.listQueues,
                 secureUploadFile: environment.uploadSecureFile,
@@ -285,7 +286,8 @@ extension SecureConversations.Coordinator {
                 isAuthenticated: environment.isAuthenticated,
                 interactor: environment.interactor,
                 startSocketObservation: environment.startSocketObservation,
-                stopSocketObservation: environment.stopSocketObservation
+                stopSocketObservation: environment.stopSocketObservation,
+                createSendMessagePayload: environment.createSendMessagePayload
             ),
             startWithSecureTranscriptFlow: true
         )
@@ -314,7 +316,7 @@ extension SecureConversations.Coordinator {
     struct Environment {
         var queueIds: [String]
         var listQueues: CoreSdkClient.ListQueues
-        var sendSecureMessage: CoreSdkClient.SendSecureMessage
+        var sendSecureMessagePayload: CoreSdkClient.SendSecureMessagePayload
         var createFileUploader: FileUploader.Create
         var uploadSecureFile: CoreSdkClient.SecureConversationsUploadFile
         var fileManager: FoundationBased.FileManager
@@ -350,6 +352,7 @@ extension SecureConversations.Coordinator {
         var isAuthenticated: () -> Bool
         var startSocketObservation: CoreSdkClient.StartSocketObservation
         var stopSocketObservation: CoreSdkClient.StopSocketObservation
+        var createSendMessagePayload: CoreSdkClient.CreateSendMessagePayload
     }
 
     enum DelegateEvent {

--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.swift
@@ -120,9 +120,13 @@ private extension SecureConversations.WelcomeViewModel {
 
         sendMessageRequestState = .loading
 
-        _ = environment.sendSecureMessage(
+        let payload = environment.createSendMessagePayload(
             messageText,
-            fileUploadListModel.attachment,
+            fileUploadListModel.attachment
+        )
+
+        _ = environment.sendSecureMessagePayload(
+            payload,
             queueIds
         ) { [weak self, alertConfiguration = environment.alertConfiguration] result in
             self?.sendMessageRequestState = .waiting
@@ -406,7 +410,7 @@ extension SecureConversations.WelcomeViewModel {
         var welcomeStyle: SecureConversations.WelcomeStyle
         var queueIds: [String]
         var listQueues: CoreSdkClient.ListQueues
-        var sendSecureMessage: CoreSdkClient.SendSecureMessage
+        var sendSecureMessagePayload: CoreSdkClient.SendSecureMessagePayload
         var alertConfiguration: AlertConfiguration
         var fileUploader: FileUploader
         var uiApplication: UIKitBased.UIApplication
@@ -417,6 +421,7 @@ extension SecureConversations.WelcomeViewModel {
         var getCurrentEngagement: CoreSdkClient.GetCurrentEngagement
         var uploadSecureFile: CoreSdkClient.SecureConversationsUploadFile
         var uploadFileToEngagement: CoreSdkClient.UploadFileToEngagement
+        var createSendMessagePayload: CoreSdkClient.CreateSendMessagePayload
     }
 }
 

--- a/GliaWidgets/Sources/Coordinators/Call/CallCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Call/CallCoordinator.swift
@@ -81,7 +81,8 @@ private extension CallCoordinator {
                 uiApplication: environment.uiApplication,
                 fetchChatHistory: environment.fetchChatHistory,
                 fileUploadListStyle: viewFactory.theme.chatStyle.messageEntry.uploadList,
-                createFileUploadListModel: environment.createFileUploadListModel
+                createFileUploadListModel: environment.createFileUploadListModel,
+                createSendMessagePayload: environment.createSendMessagePayload
             ),
             call: call,
             unreadMessages: unreadMessages,
@@ -152,5 +153,6 @@ extension CallCoordinator {
         var notificationCenter: FoundationBased.NotificationCenter
         var fetchChatHistory: CoreSdkClient.FetchChatHistory
         var createFileUploadListModel: SecureConversations.FileUploadListViewModel.Create
+        var createSendMessagePayload: CoreSdkClient.CreateSendMessagePayload
     }
 }

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
@@ -20,7 +20,7 @@ extension ChatCoordinator {
         var uiApplication: UIKitBased.UIApplication
         var fetchChatHistory: CoreSdkClient.FetchChatHistory
         var createFileUploadListModel: SecureConversations.FileUploadListViewModel.Create
-        var sendSecureMessage: CoreSdkClient.SendSecureMessage
+        var sendSecureMessagePayload: CoreSdkClient.SendSecureMessagePayload
         var queueIds: [String]
         var listQueues: CoreSdkClient.ListQueues
         var secureUploadFile: CoreSdkClient.SecureConversationsUploadFile
@@ -32,5 +32,6 @@ extension ChatCoordinator {
         var interactor: Interactor
         var startSocketObservation: CoreSdkClient.StartSocketObservation
         var stopSocketObservation: CoreSdkClient.StopSocketObservation
+        var createSendMessagePayload: CoreSdkClient.CreateSendMessagePayload
     }
 }

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
@@ -220,7 +220,8 @@ extension ChatCoordinator {
             uiApplication: environment.uiApplication,
             fetchChatHistory: environment.fetchChatHistory,
             fileUploadListStyle: viewFactory.theme.chatStyle.messageEntry.uploadList,
-            createFileUploadListModel: environment.createFileUploadListModel
+            createFileUploadListModel: environment.createFileUploadListModel,
+            createSendMessagePayload: environment.createSendMessagePayload
         )
     }
 }
@@ -241,7 +242,7 @@ extension ChatCoordinator {
                     isAuthenticated: environment.isAuthenticated
                 )
             ),
-            deliveredStatusText: viewFactory.theme.chat.visitorMessage.delivered,
+            deliveredStatusText: viewFactory.theme.chat.visitorMessageStyle.delivered,
             interactor: interactor,
             alertConfiguration: viewFactory.theme.alertConfiguration
         )
@@ -318,7 +319,7 @@ extension ChatCoordinator {
            loadChatMessagesFromHistory: environment.fromHistory,
            fetchChatHistory: environment.fetchChatHistory,
            uiApplication: environment.uiApplication,
-           sendSecureMessage: environment.sendSecureMessage,
+           sendSecureMessagePayload: environment.sendSecureMessagePayload,
            queueIds: environment.queueIds,
            listQueues: environment.listQueues,
            alertConfiguration: viewFactory.theme.alertConfiguration,
@@ -333,7 +334,8 @@ extension ChatCoordinator {
            interactor: environment.interactor,
            startSocketObservation: environment.startSocketObservation,
            stopSocketObservation: environment.stopSocketObservation,
-           sendSelectedOptionValue: environment.sendSelectedOptionValue
+           sendSelectedOptionValue: environment.sendSelectedOptionValue,
+           createSendMessagePayload: environment.createSendMessagePayload
        )
     }
 }

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
@@ -23,7 +23,7 @@ extension EngagementCoordinator.Environment {
         notificationCenter: .mock,
         fetchChatHistory: { _ in },
         listQueues: { _ in },
-        sendSecureMessage: { _, _, _, _ in .init() },
+        sendSecureMessagePayload: { _, _, _ in .mock },
         createFileUploader: FileUploader.mock,
         createFileUploadListModel: SecureConversations.FileUploadListViewModel.mock(environment:),
         uploadSecureFile: { _, _, _ in .mock },
@@ -34,7 +34,8 @@ extension EngagementCoordinator.Environment {
         isAuthenticated: { false },
         startSocketObservation: {},
         stopSocketObservation: {},
-        pushNotifications: .mock
+        pushNotifications: .mock,
+        createSendMessagePayload: { _, _ in .mock() }
     )
 }
 #endif

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
@@ -24,7 +24,7 @@ extension EngagementCoordinator {
         var notificationCenter: FoundationBased.NotificationCenter
         var fetchChatHistory: CoreSdkClient.FetchChatHistory
         var listQueues: CoreSdkClient.ListQueues
-        var sendSecureMessage: CoreSdkClient.SendSecureMessage
+        var sendSecureMessagePayload: CoreSdkClient.SendSecureMessagePayload
         var createFileUploader: FileUploader.Create
         var createFileUploadListModel: SecureConversations.FileUploadListViewModel.Create
         var uploadSecureFile: CoreSdkClient.SecureConversationsUploadFile
@@ -36,5 +36,6 @@ extension EngagementCoordinator {
         var startSocketObservation: CoreSdkClient.StartSocketObservation
         var stopSocketObservation: CoreSdkClient.StopSocketObservation
         var pushNotifications: CoreSdkClient.PushNotifications
+        var createSendMessagePayload: CoreSdkClient.CreateSendMessagePayload
     }
 }

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
@@ -243,7 +243,7 @@ extension EngagementCoordinator {
                 uiApplication: environment.uiApplication,
                 fetchChatHistory: environment.fetchChatHistory,
                 createFileUploadListModel: environment.createFileUploadListModel,
-                sendSecureMessage: environment.sendSecureMessage,
+                sendSecureMessagePayload: environment.sendSecureMessagePayload,
                 queueIds: [interactor.queueID],
                 listQueues: environment.listQueues,
                 secureUploadFile: environment.uploadSecureFile,
@@ -254,7 +254,8 @@ extension EngagementCoordinator {
                 isAuthenticated: environment.isAuthenticated,
                 interactor: interactor,
                 startSocketObservation: environment.startSocketObservation,
-                stopSocketObservation: environment.stopSocketObservation
+                stopSocketObservation: environment.stopSocketObservation,
+                createSendMessagePayload: environment.createSendMessagePayload
             ),
             startWithSecureTranscriptFlow: false
         )
@@ -346,7 +347,8 @@ extension EngagementCoordinator {
                 uiDevice: environment.uiDevice,
                 notificationCenter: environment.notificationCenter,
                 fetchChatHistory: environment.fetchChatHistory,
-                createFileUploadListModel: environment.createFileUploadListModel
+                createFileUploadListModel: environment.createFileUploadListModel,
+                createSendMessagePayload: environment.createSendMessagePayload
             )
         )
         coordinator.delegate = { [weak self] event in
@@ -441,7 +443,7 @@ extension EngagementCoordinator {
             environment: .init(
                 queueIds: [interactor.queueID],
                 listQueues: environment.listQueues,
-                sendSecureMessage: environment.sendSecureMessage,
+                sendSecureMessagePayload: environment.sendSecureMessagePayload,
                 createFileUploader: environment.createFileUploader,
                 uploadSecureFile: environment.uploadSecureFile,
                 fileManager: environment.fileManager,
@@ -476,7 +478,8 @@ extension EngagementCoordinator {
                 downloadSecureFile: environment.downloadSecureFile,
                 isAuthenticated: environment.isAuthenticated,
                 startSocketObservation: environment.startSocketObservation,
-                stopSocketObservation: environment.stopSocketObservation
+                stopSocketObservation: environment.stopSocketObservation,
+                createSendMessagePayload: environment.createSendMessagePayload
             )
         )
 

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -58,12 +58,12 @@ struct CoreSdkClient {
     ) -> Void
     var sendMessagePreview: SendMessagePreview
 
-    typealias SendMessageWithAttachment = (
-        _ message: String,
-        _ attachment: Self.Attachment?,
-        _ completion: @escaping Self.MessageBlock
-    ) -> Void
-    var sendMessageWithAttachment: SendMessageWithAttachment
+    typealias SendMessageWithMessagePayloadCallback = (Result<CoreSdkClient.Message, CoreSdkClient.GliaCoreError>) -> Void
+        typealias SendMessageWithMessagePayload = (
+            _ sendMessagePayload: Self.SendMessagePayload,
+            _ completion: @escaping SendMessageWithMessagePayloadCallback
+        ) -> Void
+    var sendMessageWithMessagePayload: SendMessageWithMessagePayload
 
     typealias CancelQueueTicket = (
         _ queueTicket: Self.QueueTicket,
@@ -115,13 +115,12 @@ struct CoreSdkClient {
     typealias RequestVisitorCode = (_ completion: @escaping (VisitorCodeBlock) -> Void) -> GliaCore.Cancellable
     var requestVisitorCode: RequestVisitorCode
 
-    typealias SendSecureMessage = (
-        _ secureMessage: String,
-        _ attachment: Self.Attachment?,
+    typealias SendSecureMessagePayload = (
+        _ secureMessagePayload: SendMessagePayload,
         _ queueIds: [String],
         _ completion: @escaping (Result<Self.Message, Error>) -> Void
     ) -> Self.Cancellable
-    var sendSecureMessage: SendSecureMessage
+    var sendSecureMessagePayload: SendSecureMessagePayload
 
     typealias SecureConversationsUploadFile = (
         _ file: EngagementFile,
@@ -149,6 +148,9 @@ struct CoreSdkClient {
 
     typealias StopSocketObservation = () -> Void
     var stopSocketObservation: StopSocketObservation
+
+    typealias CreateSendMessagePayload = (_ content: String, _ attachment: Attachment?) -> SendMessagePayload
+    var createSendMessagePayload: CreateSendMessagePayload
 }
 
 extension CoreSdkClient {
@@ -248,5 +250,5 @@ extension CoreSdkClient {
     typealias EngagementSource = GliaCoreSDK.EngagementSource
     typealias Cancellable = GliaCore.Cancellable
     typealias ReactiveSwift = GliaCoreDependency.ReactiveSwift
-
+    typealias SendMessagePayload = GliaCoreSDK.SendMessagePayload
 }

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
@@ -16,7 +16,7 @@ extension CoreSdkClient {
                 .queueForEngagement(queueID:visitorContext:shouldCloseAllQueues:mediaType:options:completion:),
             requestMediaUpgradeWithOffer: GliaCore.sharedInstance.requestMediaUpgrade(offer:completion:),
             sendMessagePreview: GliaCore.sharedInstance.sendMessagePreview(message:completion:),
-            sendMessageWithAttachment: GliaCore.sharedInstance.send(message:attachment:completion:),
+            sendMessageWithMessagePayload: GliaCore.sharedInstance.send(messagePayload:completion:),
             cancelQueueTicket: GliaCore.sharedInstance.cancel(queueTicket:completion:),
             endEngagement: GliaCore.sharedInstance.endEngagement(completion:),
             requestEngagedOperator: GliaCore.sharedInstance.requestEngagedOperator(completion:),
@@ -39,13 +39,14 @@ extension CoreSdkClient {
                 }
             },
             requestVisitorCode: GliaCore.sharedInstance.callVisualizer.requestVisitorCode(completion:),
-            sendSecureMessage: GliaCore.sharedInstance.secureConversations.send(secureMessage:attachment:queueIds:completion:),
+            sendSecureMessagePayload: GliaCore.sharedInstance.secureConversations.send(secureMessagePayload:queueIds:completion:),
             uploadSecureFile: GliaCore.sharedInstance.secureConversations.uploadFile(_:progress:completion:),
             getSecureUnreadMessageCount: GliaCore.sharedInstance.secureConversations.getUnreadMessageCount(completion:),
             secureMarkMessagesAsRead: GliaCore.sharedInstance.secureConversations.markMessagesAsRead(completion:),
             downloadSecureFile: GliaCore.sharedInstance.secureConversations.downloadFile(_:progress:completion:),
             startSocketObservation: GliaCore.sharedInstance.startSocketObservation,
-            stopSocketObservation: GliaCore.sharedInstance.stopSocketObservation
+            stopSocketObservation: GliaCore.sharedInstance.stopSocketObservation,
+            createSendMessagePayload: CoreSdkClient.SendMessagePayload.init(content:attachment:)
         )
     }()
 }

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -16,7 +16,7 @@ extension CoreSdkClient {
         queueForEngagement: { _, _, _, _, _, _ in },
         requestMediaUpgradeWithOffer: { _, _ in },
         sendMessagePreview: { _, _ in },
-        sendMessageWithAttachment: { _, _, _ in },
+        sendMessageWithMessagePayload: { _, _ in },
         cancelQueueTicket: { _, _ in },
         endEngagement: { _ in },
         requestEngagedOperator: { _ in },
@@ -28,13 +28,14 @@ extension CoreSdkClient {
         authentication: { _ in .mock },
         fetchChatHistory: { _ in },
         requestVisitorCode: { _ in fatalError() },
-        sendSecureMessage: { _, _, _, _ in .mock },
+        sendSecureMessagePayload: { _, _, _ in .mock },
         uploadSecureFile: { _, _, _ in .mock },
         getSecureUnreadMessageCount: { _ in },
         secureMarkMessagesAsRead: { _ in .mock },
         downloadSecureFile: { _, _, _ in .mock },
         startSocketObservation: {},
-        stopSocketObservation: {}
+        stopSocketObservation: {},
+        createSendMessagePayload: { _, _ in .mock() }
     )
 }
 

--- a/GliaWidgets/Sources/Interactor/Interactor.swift
+++ b/GliaWidgets/Sources/Interactor/Interactor.swift
@@ -181,22 +181,11 @@ extension Interactor {
     }
 
     func send(
-        _ message: String,
-        attachment: CoreSdkClient.Attachment?,
-        success: @escaping (CoreSdkClient.Message) -> Void,
-        failure: @escaping (CoreSdkClient.SalemoveError) -> Void
+        messagePayload: CoreSdkClient.SendMessagePayload,
+        completion: @escaping (Result<CoreSdkClient.Message, CoreSdkClient.GliaCoreError>) -> Void
     ) {
         withConfiguration { [weak self] in
-            self?.environment.coreSdk.sendMessageWithAttachment(
-                message,
-                attachment
-            ) { message, error in
-                if let error = error {
-                    failure(error)
-                } else if let message = message {
-                    success(message)
-                }
-            }
+            self?.environment.coreSdk.sendMessageWithMessagePayload(messagePayload, completion)
         }
     }
 

--- a/GliaWidgets/Sources/View/Chat/ChatView.Accessibility.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatView.Accessibility.swift
@@ -33,7 +33,7 @@ extension ChatView {
     ) -> ChatMessageContent.TextAccessibilityProperties {
         .init(
             label: visitor,
-            value: outgoingMessage.content,
+            value: outgoingMessage.payload.content,
             isFontScalingEnabled: isFontScalingEnabled
         )
     }

--- a/GliaWidgets/Sources/View/Chat/ChatView.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatView.swift
@@ -720,7 +720,7 @@ extension ChatView {
         )
         view.appendContent(
             .text(
-                message.content,
+                message.payload.content,
                 accessibility: Self.visitorAccessibilityOutgoingMessage(
                     for: message,
                     visitor: style.accessibility.visitor,

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+CustomCard.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+CustomCard.swift
@@ -17,10 +17,8 @@ extension ChatViewModel {
             imageUrl: nil
         )
 
-        let outgoingMessage = OutgoingMessage(
-            content: option.text,
-            files: []
-        )
+        let payload = environment.createSendMessagePayload(option.text, nil)
+        let outgoingMessage = OutgoingMessage(payload: payload)
 
         let item = ChatItem(with: outgoingMessage)
         appendItem(item, to: messagesSection, animated: true)
@@ -57,12 +55,16 @@ extension ChatViewModel {
             )
         }
 
-        interactor.send(
-            option.text,
-            attachment: attachment,
-            success: success,
-            failure: failure
-        )
+        let messagePayload = environment.createSendMessagePayload(option.text, attachment)
+
+        interactor.send(messagePayload: messagePayload) { result in
+            switch result {
+            case let .success(message):
+                success(message)
+            case let .failure(error):
+                failure(error)
+            }
+        }
     }
 
     private func updateCustomCard(

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+GVA.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+GVA.swift
@@ -48,10 +48,8 @@ extension ChatViewModel {
                 imageUrl: nil
             )
 
-            let outgoingMessage = OutgoingMessage(
-                content: option.text,
-                attachment: attachment
-            )
+            let payload = self.environment.createSendMessagePayload(option.text, attachment)
+            let outgoingMessage = OutgoingMessage(payload: payload)
 
             switch self.interactor.state {
             case .engaged:

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+ViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+ViewModel.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+extension ChatViewModel: ViewModel {
+    typealias Strings = L10n.Chat
+
+    enum Event {
+        case viewDidLoad
+        case messageTextChanged(String)
+        case sendTapped
+        case removeUploadTapped(FileUpload)
+        case pickMediaTapped
+        case callBubbleTapped
+        case fileTapped(LocalFile)
+        case downloadTapped(FileDownload)
+        case choiceOptionSelected(ChatChoiceCardOption, String)
+        case chatScrolled(bottomReached: Bool)
+        case linkTapped(URL)
+        case customCardOptionSelected(
+            option: HtmlMetadata.Option,
+            messageId: MessageRenderer.Message.Identifier
+        )
+        case gvaButtonTapped(GvaOption)
+    }
+
+    enum Action {
+        case queue
+        case connected(name: String?, imageUrl: String?)
+        case transferring
+        case setMessageEntryEnabled(Bool)
+        case setChoiceCardInputModeEnabled(Bool)
+        case setMessageText(String)
+        case sendButtonHidden(Bool)
+        case pickMediaButtonEnabled(Bool)
+        case appendRows(Int, to: Int, animated: Bool)
+        case refreshRow(Int, in: Int, animated: Bool)
+        case refreshRows([Int], in: Int, animated: Bool)
+        case refreshSection(Int, animated: Bool = false)
+        case refreshAll
+        case scrollToBottom(animated: Bool)
+        case updateItemsUserImage(animated: Bool)
+        case addUpload(FileUpload)
+        case removeUpload(FileUpload)
+        case removeAllUploads
+        case presentMediaPicker(itemSelected: (AttachmentSourceItemKind) -> Void)
+        case offerMediaUpgrade(
+            SingleMediaUpgradeAlertConfiguration,
+            accepted: () -> Void,
+            declined: () -> Void
+        )
+        case showCallBubble(imageUrl: String?)
+        case setCallBubbleImage(imageUrl: String?)
+        case updateUnreadMessageIndicator(itemCount: Int)
+        case setUnreadMessageIndicatorImage(imageUrl: String?)
+        case setOperatorTypingIndicatorIsHiddenTo(Bool, _ isChatScrolledToBottom: Bool)
+        case setAttachmentButtonVisibility(MediaPickerButtonVisibility)
+        case fileUploadListPropsUpdated(SecureConversations.FileUploadListView.Props)
+        case quickReplyPropsUpdated(QuickReplyView.Props)
+    }
+
+    enum DelegateEvent {
+        case pickMedia(ObservableValue<MediaPickerEvent>)
+        case takeMedia(ObservableValue<MediaPickerEvent>)
+        case pickFile(ObservableValue<FilePickerEvent>)
+        case mediaUpgradeAccepted(
+            offer: CoreSdkClient.MediaUpgradeOffer,
+            answer: CoreSdkClient.AnswerWithSuccessBlock
+        )
+        case secureTranscriptUpgradedToLiveChat(ChatViewController)
+        case showFile(LocalFile)
+        case call
+    }
+
+    enum StartAction {
+        case startEngagement
+        case none
+    }
+
+    enum ChatType {
+        case secureTranscript
+        case authenticated
+        case nonAuthenticated
+    }
+}

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Environment.Interface.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Environment.Interface.swift
@@ -22,5 +22,6 @@ extension EngagementViewModel {
         var fetchChatHistory: CoreSdkClient.FetchChatHistory
         var fileUploadListStyle: FileUploadListStyle
         var createFileUploadListModel: SecureConversations.FileUploadListViewModel.Create
+        var createSendMessagePayload: CoreSdkClient.CreateSendMessagePayload
     }
 }

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Environment.Mock.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Environment.Mock.swift
@@ -29,7 +29,8 @@ extension ChatViewModel.Environment {
         uiApplication: .mock,
         fetchChatHistory: { _ in },
         fileUploadListStyle: .initial,
-        createFileUploadListModel: SecureConversations.FileUploadListViewModel.mock(environment:)
+        createFileUploadListModel: SecureConversations.FileUploadListViewModel.mock(environment:),
+        createSendMessagePayload: { _, _ in .mock() }
     )
 }
 #endif

--- a/GliaWidgets/Sources/ViewModel/Chat/Data/OutgoingMessage.Mock.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/Data/OutgoingMessage.Mock.swift
@@ -3,13 +3,11 @@ import Foundation
 #if DEBUG
 extension OutgoingMessage {
     static func mock(
-        id: String = UUID.mock.uuidString,
-        content: String = "",
+        payload: CoreSdkClient.SendMessagePayload = .mock(),
         files: [LocalFile] = []
     ) -> OutgoingMessage {
-        .init(
-            id: id,
-            content: content,
+        OutgoingMessage(
+            payload: payload,
             files: files
         )
     }

--- a/GliaWidgets/Sources/ViewModel/Chat/Data/OutgoingMessage.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/Data/OutgoingMessage.swift
@@ -2,27 +2,19 @@ import Foundation
 import GliaCoreSDK
 
 class OutgoingMessage: Equatable {
-    let id: String
-    let content: String
     let files: [LocalFile]
-    let attachment: Attachment?
+    var payload: CoreSdkClient.SendMessagePayload
 
     init(
-        id: String = UUID().uuidString,
-        content: String,
-        files: [LocalFile] = [],
-        attachment: Attachment? = nil
+        payload: CoreSdkClient.SendMessagePayload,
+        files: [LocalFile] = []
     ) {
-        self.id = id
-        self.content = content
+        self.payload = payload
         self.files = files
-        self.attachment = attachment
     }
 
     static func == (lhs: OutgoingMessage, rhs: OutgoingMessage) -> Bool {
-        lhs.id == rhs.id &&
-        lhs.content == rhs.content &&
-        lhs.files == rhs.files &&
-        lhs.attachment == rhs.attachment
+        lhs.payload == rhs.payload &&
+        lhs.files == rhs.files
     }
 }

--- a/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
+++ b/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
@@ -1,7 +1,7 @@
 @testable import GliaWidgets
 
 extension EngagementCoordinator.Environment {
-    static let failing = Self.init(
+    static let failing = Self(
         fetchFile: { _, _, _ in
             fail("\(Self.self).fetchFile")
         },
@@ -46,9 +46,9 @@ extension EngagementCoordinator.Environment {
         notificationCenter: .failing,
         fetchChatHistory: { _ in fail("\(Self.self).fetchChatHistory")},
         listQueues: { _ in fail("\(Self.self).listQueues") },
-        sendSecureMessage: { _, _, _, _ in
-            fail("\(Self.self).sendScureMessage")
-            return .init()
+        sendSecureMessagePayload: { _, _, _ in
+            fail("\(Self.self).sendSecureMessagePayload")
+            return .mock
         },
         createFileUploader: { _, _ in
             .failing
@@ -84,6 +84,10 @@ extension EngagementCoordinator.Environment {
         stopSocketObservation: {
             fail("\(Self.self).stopSocketObservation")
         },
-        pushNotifications: .failing
+        pushNotifications: .failing,
+        createSendMessagePayload: { _, _ in
+            fail("\(Self.self).createSendMessagePayload")
+            return .mock()
+        }
     )
 }

--- a/GliaWidgetsTests/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/CoreSDKClient.Failing.swift
@@ -14,7 +14,7 @@ extension CoreSdkClient {
         queueForEngagement: { _, _, _, _, _, _ in fail("\(Self.self).queueForEngagement") },
         requestMediaUpgradeWithOffer: { _, _ in fail("\(Self.self).requestMediaUpgradeWithOffer") },
         sendMessagePreview: { _, _ in fail("\(Self.self).sendMessagePreview") },
-        sendMessageWithAttachment: { _, _, _ in fail("\(Self.self).sendMessageWithAttachment") },
+        sendMessageWithMessagePayload: { _, _ in fail("\(Self.self).sendMessageWithMessagePayload") },
         cancelQueueTicket: { _, _ in fail("cancelQueueTicket") },
         endEngagement: { _ in fail("\(Self.self).endEngagement") },
         requestEngagedOperator: { _ in fail("\(Self.self).requestEngagedOperator") },
@@ -32,9 +32,9 @@ extension CoreSdkClient {
             fail("\(Self.self).requestVisitorCode")
             return .init()
         },
-        sendSecureMessage: { _, _, _, _ in
-            fail("\(Self.self).sendSecureMessage")
-            return .init()
+        sendSecureMessagePayload: { _, _, _ in
+            fail("\(Self.self).sendSecureMessagePayload")
+            return .mock
         },
         uploadSecureFile: { _, _, _ in
             fail("\(Self.self).uploadSecureFile")
@@ -56,6 +56,10 @@ extension CoreSdkClient {
         },
         stopSocketObservation: {
             fail("\(Self.self).stopSocketObservation")
+        },
+        createSendMessagePayload: { _, _ in
+            fail("\(Self.self).createSendMessagePayload")
+            return .mock()
         }
     )
 }

--- a/GliaWidgetsTests/Lib/ChatItem/ChatItem+Equatable.swift
+++ b/GliaWidgetsTests/Lib/ChatItem/ChatItem+Equatable.swift
@@ -7,7 +7,7 @@ extension ChatItem.Kind: Equatable {
             return true
 
         case (.outgoingMessage(let lhsMessage), .outgoingMessage(let rhsMessage)):
-            return lhsMessage.id == rhsMessage.id
+            return lhsMessage.payload.messageId == rhsMessage.payload.messageId
 
         case (.visitorMessage(let lhsMessage, _), .visitorMessage(let rhsMessage, _)):
             return lhsMessage.id == rhsMessage.id

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModel.Environment.Failing.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModel.Environment.Failing.swift
@@ -29,8 +29,8 @@ extension SecureConversations.TranscriptModel.Environment {
             fail("\(Self.self).fetchChatHistory")
         },
         uiApplication: .failing,
-        sendSecureMessage: { _, _, _, _ in
-            fail("\(Self.self).sendSecureMessage")
+        sendSecureMessagePayload: { _, _, _ in
+            fail("\(Self.self).sendSecureMessagePayload")
             return .mock
         },
         queueIds: [],
@@ -71,6 +71,10 @@ extension SecureConversations.TranscriptModel.Environment {
         },
         sendSelectedOptionValue: { _, _ in
             fail("\(Self.self).sendSelectedOptionValue")
+        },
+        createSendMessagePayload: { _, _ in
+            fail("\(Self.self).createSendMessagePayload")
+            return .mock()
         }
     )
 }

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+GVA.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+GVA.swift
@@ -18,8 +18,8 @@ extension SecureConversationsTranscriptModelTests {
         viewModel.environment.uiApplication.open = { url in
             calls.append(.openUrl(url.absoluteString))
         }
-        viewModel.environment.sendSecureMessage = { message, attachment, _, _ in
-            calls.append(.sendOption(message, attachment?.selectedOption))
+        viewModel.environment.sendSecureMessagePayload = { payload, _, _ in
+            calls.append(.sendOption(payload.content, payload.attachment?.selectedOption))
             return .mock
         }
         options.forEach {
@@ -45,9 +45,16 @@ extension SecureConversationsTranscriptModelTests {
         viewModel.environment.uiApplication.open = { url in
             calls.append(.openUrl(url.absoluteString))
         }
-        viewModel.environment.sendSecureMessage = { message, attachment, _, _ in
-            calls.append(.sendOption(message, attachment?.selectedOption))
+        viewModel.environment.sendSecureMessagePayload = { payload, _, _ in
+            calls.append(.sendOption(payload.content, payload.attachment?.selectedOption))
             return .mock
+        }
+        viewModel.environment.createSendMessagePayload = {
+            .mock(
+                messageIdSuffix: "mockSuffix",
+                content: $0,
+                attachment: $1
+            )
         }
         viewModel.gvaOptionAction(for: option)()
 

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests.swift
@@ -296,10 +296,13 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
         modelEnv.getSecureUnreadMessageCount = { _ in  }
-        enum Call: Equatable { case sendSecureMessage }
+        modelEnv.createSendMessagePayload = {
+            .mock(messageIdSuffix: "mock", content: $0, attachment: $1)
+        }
+        enum Call: Equatable { case sendSecureMessagePayload }
         var calls: [Call] = []
-        modelEnv.sendSecureMessage = { _, _, _, _ in
-            calls.append(.sendSecureMessage)
+        modelEnv.sendSecureMessagePayload = { _, _, _ in
+            calls.append(.sendSecureMessagePayload)
             return .mock
         }
         let availabilityEnv = SecureConversations.Availability.Environment(
@@ -321,7 +324,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
 
         viewModel.event(.messageTextChanged(nonEmptyText))
         viewModel.sendMessage()
-        XCTAssertEqual(calls, [.sendSecureMessage])
+        XCTAssertEqual(calls, [.sendSecureMessagePayload])
     }
 
     func testLoadHistoryAlsoInvokesUnreadMessageCount() {

--- a/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.Mock.swift
+++ b/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.Mock.swift
@@ -15,7 +15,7 @@ extension SecureConversations.WelcomeViewModel.Environment {
         welcomeStyle: Theme().secureConversationsWelcomeStyle,
         queueIds: [],
         listQueues: { _ in },
-        sendSecureMessage: { _, _, _, _ in return .mock },
+        sendSecureMessagePayload: { _, _, _ in return .mock },
         alertConfiguration: .mock(),
         fileUploader: .mock(),
         uiApplication: .mock,
@@ -25,7 +25,8 @@ extension SecureConversations.WelcomeViewModel.Environment {
         stopSocketObservation: {},
         getCurrentEngagement: { .mock() },
         uploadSecureFile: { _, _, _ in .mock },
-        uploadFileToEngagement: { _, _, _ in }
+        uploadFileToEngagement: { _, _, _ in },
+        createSendMessagePayload: { _, _ in .mock() }
     )
 }
 

--- a/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModelSpec.swift
+++ b/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModelSpec.swift
@@ -126,7 +126,7 @@ extension SecureConversationsWelcomeViewModelTests {
 extension SecureConversationsWelcomeViewModelTests {
     func testSuccessfulMessageSend() {
         var isCalled = false
-        viewModel.environment.sendSecureMessage = { _, _, _, completion in
+        viewModel.environment.sendSecureMessagePayload = { _, _, completion in
             let mockedMessage = CoreSdkClient.Message(
                 id: UUID.mock.uuidString,
                 content: "Content",
@@ -156,7 +156,7 @@ extension SecureConversationsWelcomeViewModelTests {
     func testFailedMessageSend() {
         var isCalled = false
         var messageAlertConfiguration: MessageAlertConfiguration?
-        viewModel.environment.sendSecureMessage = { _, _, _, completion in
+        viewModel.environment.sendSecureMessagePayload = { _, _, completion in
             completion(.failure(CoreSdkClient.GliaCoreError(reason: "")))
 
             return .mock

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -56,6 +56,9 @@ class ChatViewModelTests: XCTestCase {
                 fileUploadListStyle: .mock,
                 createFileUploadListModel: { _ in
                     .mock()
+                },
+                createSendMessagePayload: { _, _ in
+                    .mock()
                 }
             )
         )
@@ -374,14 +377,14 @@ class ChatViewModelTests: XCTestCase {
         let messageContent = "Message"
 
         var environment: Interactor.Environment = .mock
-        environment.coreSdk.sendMessageWithAttachment = { message, attachment, completion in
+        environment.coreSdk.sendMessageWithMessagePayload = { _, completion in
             let coreSdkMessage = Message(
                 id: UUID().uuidString,
                 content: messageContent,
                 sender: MessageSender.mock,
                 metadata: nil
             )
-            completion(coreSdkMessage, nil)
+            completion(.success(coreSdkMessage))
         }
 
         // `sendMessageWithAttachment` goes through this method first, so if
@@ -556,6 +559,7 @@ class ChatViewModelTests: XCTestCase {
 
         let messageId = "message_id"
         let viewModel: ChatViewModel = .mock(environment: viewModelEnv)
+        viewModel.isViewLoaded = true
         viewModel.start()
         var actions: [ChatViewModel.Action] = []
         viewModel.action = {
@@ -572,8 +576,7 @@ class ChatViewModelTests: XCTestCase {
         default:
             break
         }
-        XCTAssertEqual(actions.count, 1)
-        XCTAssertEqual(calls, [.quickReplyPropsUpdatedHidden])
+        XCTAssertEqual(viewModel.receivedMessageIds, [messageId.uppercased()])
     }
 }
 

--- a/GliaWidgetsTests/Sources/InteractorTests.swift
+++ b/GliaWidgetsTests/Sources/InteractorTests.swift
@@ -435,19 +435,21 @@ class InteractorTests: XCTestCase {
         }
         var callbacks: [Callback] = []
         var interactorEnv = Interactor.Environment.failing
-        interactorEnv.coreSdk.sendMessageWithAttachment = { _, _, _ in
+        interactorEnv.coreSdk.sendMessageWithMessagePayload = { _, _ in
             callbacks.append(.sendMessageWithAttachment)
         }
         interactorEnv.coreSdk.configureWithInteractor = { _ in }
         interactorEnv.coreSdk.configureWithConfiguration = { $1?() }
         let interactor = Interactor.mock(environment: interactorEnv)
         
-        interactor.send(
-            "mock-message",
-            attachment: nil,
-            success: { _ in },
-            failure: { XCTFail($0.reason) }
-        )
+        interactor.send(messagePayload: .mock(content: "mock-message")) { result in
+            switch result {
+            case .success:
+                break
+            case let .failure(error):
+                XCTFail(error.reason)
+            }
+        }
         
         XCTAssertEqual(callbacks, [.sendMessageWithAttachment])
     }

--- a/GliaWidgetsTests/ViewModel/Chat/ChatViewModel.Environment.Failing.swift
+++ b/GliaWidgetsTests/ViewModel/Chat/ChatViewModel.Environment.Failing.swift
@@ -52,6 +52,10 @@ extension ChatViewModel.Environment {
             createFileUploadListModel: { _ in
                 fail("\(Self.self).createFileUploadListModel")
                 return .mock()
+            },
+            createSendMessagePayload: { _, _ in
+                fail("\(Self.self).createSendMessagePayload")
+                return .mock()
             }
         )
     }


### PR DESCRIPTION
Delivery of visitor message was initially relying on REST response only, which resulted in visitor messages from same session being skipped if sent from another device or web. Changes here enable visitor message delivery via socket. Also it uses newly added send message payload API for predictable message delivery. Note that this PR can be merged only when CoreSDK with send message payload will be released.

UPD: added send message payload to Secure Conversations flow 579a929565ed452c8b5003b4d7344f6f885a2828.

MOB-2311