### PR TITLE
Remove unnecessary accessibility hint in Call Visualizer

### DIFF
--- a/GliaWidgets/Localization.swift
+++ b/GliaWidgets/Localization.swift
@@ -118,12 +118,6 @@ internal enum Localization {
       internal static let message = Localization.tr("Localizable", "call_visualizer.screen_sharing.message", fallback: "Your Screen is Being Shared")
       /// Screen Sharing
       internal static let title = Localization.tr("Localizable", "call_visualizer.screen_sharing.title", fallback: "Screen Sharing")
-      internal enum Message {
-        internal enum Accessibility {
-          /// Message label
-          internal static let hint = Localization.tr("Localizable", "call_visualizer.screen_sharing.message.accessibility.hint", fallback: "Message label")
-        }
-      }
     }
     internal enum VisitorCode {
       /// Your Visitor Code

--- a/GliaWidgets/Resources/en.lproj/Localizable.strings
+++ b/GliaWidgets/Resources/en.lproj/Localizable.strings
@@ -90,7 +90,6 @@
 "call.video.operator.accessibility.label" = "Operator's Video";
 "call.video.visitor.accessibility.label" = "Your Video";
 "call_visualizer.screen_sharing.message" = "Your Screen is Being Shared";
-"call_visualizer.screen_sharing.message.accessibility.hint" = "Message label";
 "call_visualizer.screen_sharing.title" = "Screen Sharing";
 "call_visualizer.visitor_code.action.close" = "Close";
 "call_visualizer.visitor_code.action.refresh" = "Refresh";

--- a/GliaWidgets/Sources/CallVisualizer/ScreenSharing/View/ScreenSharingView.swift
+++ b/GliaWidgets/Sources/CallVisualizer/ScreenSharing/View/ScreenSharingView.swift
@@ -37,7 +37,6 @@ extension CallVisualizer {
             $0.numberOfLines = 2
             $0.textAlignment = .center
             $0.accessibilityIdentifier = "end_screen_sharing_message"
-            $0.accessibilityHint = L10n.CallVisualizer.ScreenSharing.Accessibility.messageHint
         }
         private lazy var endScreenSharingButton = ActionButton(props: props.endScreenSharing).make {
             $0.setImage(props.style.buttonIcon, for: .normal)


### PR DESCRIPTION
This string is not needed as a hint because we are working with a label, so the text of the label itself is the hint. Same PR has been done for custom-locales branch, but without this PR, all ios-sdk-widgets snapshot tests will fail.

MOB-2614