### PR TITLE
Fix for SingleChoiceResponse message duplications

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -399,6 +399,7 @@
 		8491AF572AA0964800CC3E72 /* ChatItem.Kind.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF562AA0964800CC3E72 /* ChatItem.Kind.Mock.swift */; };
 		8491AF602AA1EBB600CC3E72 /* TranscriptModelTests+URLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF5F2AA1EBB600CC3E72 /* TranscriptModelTests+URLs.swift */; };
 		8491AF632AA20F9D00CC3E72 /* GliaViewControllerDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF622AA20F9D00CC3E72 /* GliaViewControllerDelegateMock.swift */; };
+		8491AF652AAB281500CC3E72 /* ChatViewModelTests+CustomCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF642AAB281500CC3E72 /* ChatViewModelTests+CustomCard.swift */; };
 		84A318A12869ECFC00CA1DE5 /* Unavailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A318A02869ECFC00CA1DE5 /* Unavailable.swift */; };
 		84CFB7732822700000167258 /* Theme.Button.Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CFB7722822700000167258 /* Theme.Button.Accessibility.swift */; };
 		84D2292B28C61C8D00F64FE7 /* WKNavigationPolicyProvider.CustomResponseCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D2292A28C61C8D00F64FE7 /* WKNavigationPolicyProvider.CustomResponseCard.swift */; };
@@ -1126,6 +1127,7 @@
 		8491AF562AA0964800CC3E72 /* ChatItem.Kind.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatItem.Kind.Mock.swift; sourceTree = "<group>"; };
 		8491AF5F2AA1EBB600CC3E72 /* TranscriptModelTests+URLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TranscriptModelTests+URLs.swift"; sourceTree = "<group>"; };
 		8491AF622AA20F9D00CC3E72 /* GliaViewControllerDelegateMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GliaViewControllerDelegateMock.swift; sourceTree = "<group>"; };
+		8491AF642AAB281500CC3E72 /* ChatViewModelTests+CustomCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatViewModelTests+CustomCard.swift"; sourceTree = "<group>"; };
 		84A318A02869ECFC00CA1DE5 /* Unavailable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Unavailable.swift; sourceTree = "<group>"; };
 		84CFB7722822700000167258 /* Theme.Button.Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.Button.Accessibility.swift; sourceTree = "<group>"; };
 		84D2292A28C61C8D00F64FE7 /* WKNavigationPolicyProvider.CustomResponseCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKNavigationPolicyProvider.CustomResponseCard.swift; sourceTree = "<group>"; };
@@ -3141,6 +3143,7 @@
 				84681A962A61851700DD7406 /* Mocks */,
 				7512A57927BF9FCD00319DF1 /* ChatViewModelTests.swift */,
 				84681A942A61844000DD7406 /* ChatViewModelTests+Gva.swift */,
+				8491AF642AAB281500CC3E72 /* ChatViewModelTests+CustomCard.swift */,
 			);
 			path = ChatViewModel;
 			sourceTree = "<group>";
@@ -4773,6 +4776,7 @@
 				9ACC25D227B4727500BC5335 /* CoreSDKClient.Failing.swift in Sources */,
 				84265E07298AE96B00D65842 /* ScreenSharingViewModelTests.swift in Sources */,
 				EB9ADB51280EBD4E00FAE8A4 /* InteractorStateTests.swift in Sources */,
+				8491AF652AAB281500CC3E72 /* ChatViewModelTests+CustomCard.swift in Sources */,
 				EB7A1508286D98000035AC62 /* FileUploader.Environment.Failing.swift in Sources */,
 				AF2355A229C9EC7E007D9896 /* IdCollectionTests.swift in Sources */,
 				8491AF572AA0964800CC3E72 /* ChatItem.Kind.Mock.swift in Sources */,

--- a/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
+++ b/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
@@ -117,7 +117,6 @@ extension Glia {
             features: features,
             environment: .init(
                 fetchFile: environment.coreSdk.fetchFile,
-                sendSelectedOptionValue: environment.coreSdk.sendSelectedOptionValue,
                 uploadFileToEngagement: environment.coreSdk.uploadFileToEngagement,
                 audioSession: environment.audioSession,
                 uuid: environment.uuid,

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.Environment.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.Environment.swift
@@ -29,7 +29,6 @@ extension SecureConversations.TranscriptModel {
         var interactor: Interactor
         var startSocketObservation: CoreSdkClient.StartSocketObservation
         var stopSocketObservation: CoreSdkClient.StopSocketObservation
-        var sendSelectedOptionValue: CoreSdkClient.SendSelectedOptionValue
         var createSendMessagePayload: CoreSdkClient.CreateSendMessagePayload
     }
 }

--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
@@ -258,7 +258,6 @@ extension SecureConversations.Coordinator {
             startAction: .startEngagement,
             environment: .init(
                 fetchFile: environment.fetchFile,
-                sendSelectedOptionValue: environment.sendSelectedOptionValue,
                 uploadFileToEngagement: environment.uploadFileToEngagement,
                 fileManager: environment.fileManager,
                 data: environment.data,
@@ -340,7 +339,6 @@ extension SecureConversations.Coordinator {
         var showsCallBubble: Bool
         var screenShareHandler: ScreenShareHandler
         var isWindowVisible: ObservableValue<Bool>
-        var sendSelectedOptionValue: CoreSdkClient.SendSelectedOptionValue
         var uploadFileToEngagement: CoreSdkClient.UploadFileToEngagement
         var getCurrentEngagement: CoreSdkClient.GetCurrentEngagement
         var submitSurveyAnswer: CoreSdkClient.SubmitSurveyAnswer

--- a/GliaWidgets/Sources/Coordinators/Call/CallCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Call/CallCoordinator.swift
@@ -64,7 +64,6 @@ private extension CallCoordinator {
             environment: .init(
                 fetchFile: environment.fetchFile,
                 downloadSecureFile: environment.downloadSecureFile,
-                sendSelectedOptionValue: environment.sendSelectedOptionValue,
                 uploadFileToEngagement: environment.uploadFileToEngagement,
                 fileManager: environment.fileManager,
                 data: environment.data,
@@ -133,7 +132,6 @@ extension CallCoordinator {
     struct Environment {
         var fetchFile: CoreSdkClient.FetchFile
         var downloadSecureFile: CoreSdkClient.DownloadSecureFile
-        var sendSelectedOptionValue: CoreSdkClient.SendSelectedOptionValue
         var uploadFileToEngagement: CoreSdkClient.UploadFileToEngagement
         var fileManager: FoundationBased.FileManager
         var data: FoundationBased.Data

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
@@ -3,7 +3,6 @@ import Foundation
 extension ChatCoordinator {
     struct Environment {
         var fetchFile: CoreSdkClient.FetchFile
-        var sendSelectedOptionValue: CoreSdkClient.SendSelectedOptionValue
         var uploadFileToEngagement: CoreSdkClient.UploadFileToEngagement
         var fileManager: FoundationBased.FileManager
         var data: FoundationBased.Data

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
@@ -203,7 +203,6 @@ extension ChatCoordinator {
         ChatViewModel.Environment(
             fetchFile: environment.fetchFile,
             downloadSecureFile: environment.downloadSecureFile,
-            sendSelectedOptionValue: environment.sendSelectedOptionValue,
             uploadFileToEngagement: environment.uploadFileToEngagement,
             fileManager: environment.fileManager,
             data: environment.data,
@@ -334,7 +333,6 @@ extension ChatCoordinator {
            interactor: environment.interactor,
            startSocketObservation: environment.startSocketObservation,
            stopSocketObservation: environment.stopSocketObservation,
-           sendSelectedOptionValue: environment.sendSelectedOptionValue,
            createSendMessagePayload: environment.createSendMessagePayload
        )
     }

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
@@ -2,7 +2,6 @@
 extension EngagementCoordinator.Environment {
     static let mock = Self(
         fetchFile: { _, _, _ in },
-        sendSelectedOptionValue: { _, _ in },
         uploadFileToEngagement: { _, _, _ in },
         audioSession: .mock,
         uuid: { .mock },

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
@@ -3,7 +3,6 @@ import Foundation
 extension EngagementCoordinator {
     struct Environment {
         var fetchFile: CoreSdkClient.FetchFile
-        var sendSelectedOptionValue: CoreSdkClient.SendSelectedOptionValue
         var uploadFileToEngagement: CoreSdkClient.UploadFileToEngagement
         var audioSession: Glia.Environment.AudioSession
         var uuid: () -> UUID

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
@@ -226,7 +226,6 @@ extension EngagementCoordinator {
             startAction: startAction,
             environment: .init(
                 fetchFile: environment.fetchFile,
-                sendSelectedOptionValue: environment.sendSelectedOptionValue,
                 uploadFileToEngagement: environment.uploadFileToEngagement,
                 fileManager: environment.fileManager,
                 data: environment.data,
@@ -328,7 +327,6 @@ extension EngagementCoordinator {
             environment: .init(
                 fetchFile: environment.fetchFile,
                 downloadSecureFile: environment.downloadSecureFile,
-                sendSelectedOptionValue: environment.sendSelectedOptionValue,
                 uploadFileToEngagement: environment.uploadFileToEngagement,
                 fileManager: environment.fileManager,
                 data: environment.data,
@@ -467,7 +465,6 @@ extension EngagementCoordinator {
                 showsCallBubble: false,
                 screenShareHandler: screenShareHandler,
                 isWindowVisible: isWindowVisible,
-                sendSelectedOptionValue: environment.sendSelectedOptionValue,
                 uploadFileToEngagement: environment.uploadFileToEngagement,
                 getCurrentEngagement: environment.getCurrentEngagement,
                 submitSurveyAnswer: environment.submitSurveyAnswer,

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -16,12 +16,6 @@ struct CoreSdkClient {
     ) -> Void
     var updateVisitorInfo: UpdateVisitorInfo
 
-    typealias SendSelectedOptionValue = (
-        _ singleChoiceOption: SingleChoiceOption,
-        _ completion: @escaping (Result<Self.Message, Error>) -> Void
-    ) -> Void
-    var sendSelectedOptionValue: SendSelectedOptionValue
-
     typealias ConfigureWithConfiguration = (
         _ sdkConfiguration: Self.Salemove.Configuration,
         _ completion: (() -> Void)?

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
@@ -8,7 +8,6 @@ extension CoreSdkClient {
             clearSession: GliaCore.sharedInstance.clearSession,
             fetchVisitorInfo: GliaCore.sharedInstance.fetchVisitorInfo(_:),
             updateVisitorInfo: GliaCore.sharedInstance.updateVisitorInfo(_:completion:),
-            sendSelectedOptionValue: GliaCore.sharedInstance.send(option:completion:),
             configureWithConfiguration: GliaCore.sharedInstance.configure(with:completion:),
             configureWithInteractor: GliaCore.sharedInstance.configure(interactor:),
             listQueues: GliaCore.sharedInstance.listQueues(completion:),

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -9,7 +9,6 @@ extension CoreSdkClient {
         clearSession: {},
         fetchVisitorInfo: { _ in },
         updateVisitorInfo: { _, _ in },
-        sendSelectedOptionValue: { _, _ in },
         configureWithConfiguration: { _, _ in },
         configureWithInteractor: { _ in },
         listQueues: { _ in },

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+ChoiceCards.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+ChoiceCards.swift
@@ -3,8 +3,19 @@ import GliaCoreSDK
 
 extension ChatViewModel {
     func sendChoiceCardResponse(_ option: ChatChoiceCardOption, to messageId: String) {
-        guard let option = option.asSingleChoiceOption() else { return }
-        environment.sendSelectedOptionValue(option) { [weak self] result in
+        guard let text = option.text else { return }
+        let attachment = CoreSdkClient.Attachment(
+            type: .singleChoiceResponse,
+            selectedOption: option.value,
+            options: nil,
+            files: nil,
+            imageUrl: nil
+        )
+
+        let payload = self.environment.createSendMessagePayload(text, attachment)
+        registerReceivedMessage(messageId: payload.messageId.rawValue)
+
+        interactor.send(messagePayload: payload) { [weak self] result in
             guard let self = self else { return }
 
             switch result {

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+CustomCard.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+CustomCard.swift
@@ -17,8 +17,10 @@ extension ChatViewModel {
             imageUrl: nil
         )
 
-        let payload = environment.createSendMessagePayload(option.text, nil)
+        let payload = environment.createSendMessagePayload(option.text, attachment)
         let outgoingMessage = OutgoingMessage(payload: payload)
+
+        registerReceivedMessage(messageId: payload.messageId.rawValue)
 
         let item = ChatItem(with: outgoingMessage)
         appendItem(item, to: messagesSection, animated: true)
@@ -32,7 +34,6 @@ extension ChatViewModel {
                 selectedOption: option,
                 isActive: false
             )
-
             self.replace(
                 outgoingMessage,
                 uploads: [],
@@ -55,9 +56,7 @@ extension ChatViewModel {
             )
         }
 
-        let messagePayload = environment.createSendMessagePayload(option.text, attachment)
-
-        interactor.send(messagePayload: messagePayload) { result in
+        interactor.send(messagePayload: payload) { result in
             switch result {
             case let .success(message):
                 success(message)

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Environment.Interface.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Environment.Interface.swift
@@ -4,7 +4,6 @@ extension EngagementViewModel {
     struct Environment {
         var fetchFile: CoreSdkClient.FetchFile
         var downloadSecureFile: CoreSdkClient.DownloadSecureFile
-        var sendSelectedOptionValue: CoreSdkClient.SendSelectedOptionValue
         var uploadFileToEngagement: CoreSdkClient.UploadFileToEngagement
         var fileManager: FoundationBased.FileManager
         var data: FoundationBased.Data

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Environment.Mock.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Environment.Mock.swift
@@ -6,7 +6,6 @@ extension ChatViewModel.Environment {
     static let mock = Self(
         fetchFile: { _, _, _ in },
         downloadSecureFile: { _, _, _ in .mock },
-        sendSelectedOptionValue: { _, _ in },
         uploadFileToEngagement: { _, _, _ in },
         fileManager: .mock,
         data: .mock,

--- a/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
+++ b/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
@@ -5,9 +5,6 @@ extension EngagementCoordinator.Environment {
         fetchFile: { _, _, _ in
             fail("\(Self.self).fetchFile")
         },
-        sendSelectedOptionValue: { _, _ in
-            fail("\(Self.self).sendSelectedOptionValue")
-        },
         uploadFileToEngagement: { _, _, _ in
             fail("\(Self.self).uploadFileToEngagement")
         },

--- a/GliaWidgetsTests/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/CoreSDKClient.Failing.swift
@@ -7,7 +7,6 @@ extension CoreSdkClient {
         clearSession: { fail("\(Self.self).clearSession") },
         fetchVisitorInfo: { _ in fail("\(Self.self).fetchVisitorInfo") },
         updateVisitorInfo: { _, _ in fail("\(Self.self).updateVisitorInfo") },
-        sendSelectedOptionValue: { _, _ in fail("\(Self.self).sendSelectedOptionValue") },
         configureWithConfiguration: { _, _ in fail("\(Self.self).configureWithConfiguration") },
         configureWithInteractor: { _ in fail("\(Self.self).configureWithInteractor") },
         listQueues: {_ in fail("\(Self.self).listQueues") },

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModel.Environment.Failing.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModel.Environment.Failing.swift
@@ -69,9 +69,6 @@ extension SecureConversations.TranscriptModel.Environment {
         stopSocketObservation: {
             fail("\(Self.self).stopSocketObservation")
         },
-        sendSelectedOptionValue: { _, _ in
-            fail("\(Self.self).sendSelectedOptionValue")
-        },
         createSendMessagePayload: { _, _ in
             fail("\(Self.self).createSendMessagePayload")
             return .mock()

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+CustomCard.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+CustomCard.swift
@@ -1,0 +1,43 @@
+@testable import GliaWidgets
+import XCTest
+
+extension ChatViewModelTests {
+    func test_customCardOptionAction() {
+        enum Call: Equatable { case sendOption(String?, String?) }
+
+        let option = HtmlMetadata.Option(text: "text", value: "value")
+        var calls: [Call] = []
+
+        var interactorEnv = Interactor.Environment.failing
+        // To ensure `sendMessageWithMessagePayload` is not called in case of Postback Button
+        interactorEnv.coreSdk.sendMessageWithMessagePayload = { _, _ in
+            XCTFail("createSendMessagePayload should not be called")
+        }
+        interactorEnv.gcd.mainQueue.asyncIfNeeded = { _ in }
+        interactorEnv.coreSdk.queueForEngagement = { _, _, _, _, _, _ in }
+        interactorEnv.coreSdk.configureWithInteractor = { _ in }
+        interactorEnv.coreSdk.sendMessageWithMessagePayload = { payload, _ in
+            calls.append(.sendOption(payload.content, payload.attachment?.selectedOption))
+        }
+        let interactorMock = Interactor.mock(environment: interactorEnv)
+        interactorMock.state = .engaged(nil)
+        interactorMock.isConfigurationPerformed = true
+
+        var env = ChatViewModel.Environment.failing()
+        env.fileManager.fileExistsAtPath = { _ in true }
+        env.fileManager.createDirectoryAtUrlWithIntermediateDirectories = { _, _, _ in }
+        env.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
+        env.createFileUploadListModel = { _ in .mock() }
+        env.createSendMessagePayload = { content, attachment in
+            .mock(content: content, attachment: attachment)
+        }
+        viewModel = .mock(interactor: interactorMock, environment: env)
+
+        viewModel.sendSelectedCustomCardOption(
+            option,
+            for: .init(rawValue: "mock")
+        )
+
+        XCTAssertEqual(calls, [.sendOption("text", "value")])
+    }
+}

--- a/GliaWidgetsTests/ViewModel/Chat/ChatViewModel.Environment.Failing.swift
+++ b/GliaWidgetsTests/ViewModel/Chat/ChatViewModel.Environment.Failing.swift
@@ -12,9 +12,6 @@ extension ChatViewModel.Environment {
                 fail("\(Self.self).downloadSecureFile")
                 return .mock
             },
-            sendSelectedOptionValue: { _, _ in
-                fail("\(Self.self).sendSelectedOptionValue")
-            },
             uploadFileToEngagement: { _, _, _ in
                 fail("\(Self.self).uploadFileToEngagement")
             },


### PR DESCRIPTION
With introduction of visitor messages delivered by socket we are now able to receive messages from web and other devices simultaneously. For regular chat messages all changes in Widgets were done accordingly, but other functionality that involves visitor send message request-response may not take it to account, such as response and custom cards. This commit fixes duplications of sent SingleChoiceResponse messages coming from API response and sockets.

Also `sendSelectedOptionValue` internal interface was removed, because now we use `sendMessageWithPayload` one

MOB-2624