### PR TITLE
Make chat call upgrade to audio view ADA compliant

### DIFF
--- a/GliaWidgets/Sources/View/Chat/Upgrade/ChatCallUpgradeView.swift
+++ b/GliaWidgets/Sources/View/Chat/Upgrade/ChatCallUpgradeView.swift
@@ -51,6 +51,7 @@ class ChatCallUpgradeView: UIView {
 
         textLabel.text = style.text
         textLabel.font = style.textFont
+        textLabel.numberOfLines = 0
         textLabel.textColor = style.textColor
         textLabel.textAlignment = .center
 

--- a/SnapshotTests/ChatCallUpgradeViewDynamicTypeFontTests.swift
+++ b/SnapshotTests/ChatCallUpgradeViewDynamicTypeFontTests.swift
@@ -5,7 +5,7 @@ import XCTest
 final class ChatCallUpgradeViewDynamicTypeFontTests: SnapshotTestCase {
     func test_chatCallUpgradeViewToAudio_extra3Large() {
         let upgradeView = ChatCallUpgradeView(with: Theme.mock().chat.audioUpgrade, duration: .init(with: .zero))
-        upgradeView.frame = .init(origin: .zero, size: .init(width: 300, height: 120))
+        upgradeView.frame = .init(origin: .zero, size: .init(width: 300, height: 160))
         assertSnapshot(
             matching: upgradeView,
             as: .extra3LargeFontStrategy
@@ -14,7 +14,7 @@ final class ChatCallUpgradeViewDynamicTypeFontTests: SnapshotTestCase {
 
     func test_chatCallUpgradeViewToVideo_extra3Large() {
         let upgradeView = ChatCallUpgradeView(with: Theme.mock().chat.videoUpgrade, duration: .init(with: .zero))
-        upgradeView.frame = .init(origin: .zero, size: .init(width: 300, height: 120))
+        upgradeView.frame = .init(origin: .zero, size: .init(width: 300, height: 160))
         assertSnapshot(
             matching: upgradeView,
             as: .extra3LargeFontStrategy


### PR DESCRIPTION
This PR fixes the issue that the time is partially hidden under the view's bounds.

Snapshot reference PR: https://github.com/salemove/ios-widgets-snapshots/pull/43

MOB-2484