### PR TITLE
Enable 'powered by Glia' in default Theme

### DIFF
--- a/GliaWidgets/Sources/Theme/Theme+AlertConfiguration.swift
+++ b/GliaWidgets/Sources/Theme/Theme+AlertConfiguration.swift
@@ -16,7 +16,7 @@ extension Theme {
             negativeTitle: Alert.Action.no,
             positiveTitle: Alert.Action.yes,
             switchButtonBackgroundColors: true,
-            showsPoweredBy: false
+            showsPoweredBy: true
         )
         let operatorEndedEngagement = SingleActionAlertConfiguration(
             title: Alert.OperatorEndedEngagement.title,


### PR DESCRIPTION
White labeling has to be on by default in Theme for ending engagement dialog. These changes make it so in default Theme for ending chat engagement. Listing here other screens to compare with Android (listed in ticket description). Note, that eded engagement does not have white label.

MOB-2577

<img src="https://github.com/salemove/ios-sdk-widgets/assets/3148347/cbd0a6cb-844e-4270-af16-bb93d3d18971" width="428" height="926">
<img src="https://github.com/salemove/ios-sdk-widgets/assets/3148347/75487d1a-d33e-4468-b404-8147fc91fdf2" width="428" height="926">
<img src="https://github.com/salemove/ios-sdk-widgets/assets/3148347/75eb2ab4-d109-4bf0-b5b5-11289391a117" width="428" height="926">
<img src="https://github.com/salemove/ios-sdk-widgets/assets/3148347/0bd8ff1d-b5c5-43b9-833e-0d84355a29b1" width="428" height="926">
<img src="https://github.com/salemove/ios-sdk-widgets/assets/3148347/21d3117f-ba58-4bab-ac1f-0374c2521cd6" width="428" height="926">
<img src="https://github.com/salemove/ios-sdk-widgets/assets/3148347/9d248497-301f-4528-a44a-d60dffed1ed5" width="428" height="926">
