### PR TITLE
Cover changes introduced by Web synchronization with unit tests

### DIFF
--- a/GliaWidgets/Sources/Interactor/Interactor.swift
+++ b/GliaWidgets/Sources/Interactor/Interactor.swift
@@ -71,7 +71,7 @@ class Interactor {
             }
         }
     }
-    private var environment: Environment
+    var environment: Environment
 
     init(
         configuration: Configuration,

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -930,3 +930,13 @@ extension ChatViewModel {
         }
     }
 }
+
+#if DEBUG
+extension ChatViewModel {
+    /// Sets text and immediately sends it. Used for testing.
+    func invokeSetTextAndSendMessage(text: String) {
+        self.messageText = text
+        self.sendMessage()
+    }
+}
+#endif


### PR DESCRIPTION
With changes added by enabling visitor messages to be delivered via socket and using send message payload API (#752 ), new logic for message processing has been introduced to handle messages delivered via web-socket and via REST API. These tests cover situations were message via socket gets delivered before REST API and vice versa, to ensure that no visitor message duplications occur.

MOB-2638