### PR TITLE
#R Fix visitor-on-hold and unread message count in bubble-view

### DIFF
--- a/GliaWidgets/Sources/Component/Bubble/BubbleView.swift
+++ b/GliaWidgets/Sources/Component/Bubble/BubbleView.swift
@@ -28,7 +28,7 @@ class BubbleView: BaseView {
     private let style: BubbleStyle
     private var userImageView: UserImageView?
     private var badgeView: BadgeView?
-    private var onHoldView: OnHoldOverlayView?
+    private let onHoldView: OnHoldOverlayView
     private let environment: Environment
 
     init(
@@ -37,6 +37,9 @@ class BubbleView: BaseView {
     ) {
         self.style = style
         self.environment = environment
+        self.onHoldView = OnHoldOverlayView(style: style.onHoldOverlay)
+        self.onHoldView.clipsToBounds = true
+
         super.init()
     }
 
@@ -54,25 +57,25 @@ class BubbleView: BaseView {
             byRoundingCorners: .allCorners,
             cornerRadii: CGSize(width: cornerRadius, height: cornerRadius)
         ).cgPath
+
+        onHoldView.frame = userImageView?.bounds ?? .zero
+        onHoldView.layer.cornerRadius = cornerRadius
     }
 
     func showOnHoldView() {
-        onHoldView?.removeFromSuperview()
+        onHoldView.removeFromSuperview()
+        // In case of badge-view being shown
+        // place on-hold view under it.
+        if let badgeView {
+            insertSubview(onHoldView, belowSubview: badgeView)
+        } else {
+            addSubview(onHoldView)
+        }
 
-        guard
-            let userImageView = userImageView
-        else { return }
-
-        let onHoldView = OnHoldOverlayView(style: style.onHoldOverlay)
-        self.onHoldView = onHoldView
-
-        userImageView.addSubview(onHoldView)
-        onHoldView.layoutInSuperview().activate()
     }
 
     func hideOnHoldView() {
-        onHoldView?.removeFromSuperview()
-        onHoldView = nil
+        onHoldView.removeFromSuperview()
     }
 
     func setBadge(itemCount: Int) {
@@ -145,8 +148,10 @@ class BubbleView: BaseView {
     private func setView(_ view: UIView) {
         subviews.first?.removeFromSuperview()
         view.isUserInteractionEnabled = false
-
-        addSubview(view)
+        // Insert view at the zero index
+        // to be under other views, like on-hold
+        // and unread-count views.
+        insertSubview(view, at: 0)
         view.layoutInSuperview().activate()
     }
 

--- a/GliaWidgets/Sources/Component/Bubble/BubbleWindow.swift
+++ b/GliaWidgets/Sources/Component/Bubble/BubbleWindow.swift
@@ -107,6 +107,12 @@ private class BubbleViewController: UIViewController {
                 right: edgeInset
             )
         )
+        // Once `bubbleView` is added to view hierarchy,
+        // we re-render its `isVisitorOnHold` state,
+        // to properly display it. Otherwise it may
+        // not show up due to invalid ('zero') size.
+        let isOnHold = bubbleView.isVisitorOnHold
+        bubbleView.isVisitorOnHold = isOnHold
     }
 }
 


### PR DESCRIPTION
Address visitor-on-hold and unread message count in 'bubble' view being incorrectly displayed for initial 'minimised' state during audio engagement.

MOB-2644

<img src="https://github.com/salemove/ios-sdk-widgets/assets/3148347/8196f6ae-e424-4c71-98c1-4cc9ac0fb443" width="428" height="926">