### PR TITLE
#R Fix pending message duplication for authenticated visitor when engagement starts

### DIFF
--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -663,6 +663,16 @@ extension ChatViewModel {
             return
         }
 
+        // Discard pending message delivered via socket to
+        // avoid message duplication. Currently pending messages
+        // stay in pending section whole session.
+        for pendingMessage in self.pendingSection.items {
+            if case let .outgoingMessage(outgoingPendingMessage) = pendingMessage.kind,
+                outgoingPendingMessage.payload.messageId.rawValue.uppercased() == message.id.uppercased() {
+                return
+            }
+        }
+
         registerReceivedMessage(messageId: message.id)
 
         let receivedMessage = message


### PR DESCRIPTION
In order to keep existing behaviour and avoid message duplication, messages placed in pending section, once delivered via socket will be discarded.

MOB-2650