### PR TITLE
Fix attachment button visibility

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -399,6 +399,7 @@
 		8491AF602AA1EBB600CC3E72 /* TranscriptModelTests+URLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF5F2AA1EBB600CC3E72 /* TranscriptModelTests+URLs.swift */; };
 		8491AF632AA20F9D00CC3E72 /* GliaViewControllerDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF622AA20F9D00CC3E72 /* GliaViewControllerDelegateMock.swift */; };
 		8491AF652AAB281500CC3E72 /* ChatViewModelTests+CustomCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF642AAB281500CC3E72 /* ChatViewModelTests+CustomCard.swift */; };
+		8491AF672AB8707600CC3E72 /* ChatViewModelTests+Transferring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF662AB8707600CC3E72 /* ChatViewModelTests+Transferring.swift */; };
 		84A318A12869ECFC00CA1DE5 /* Unavailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A318A02869ECFC00CA1DE5 /* Unavailable.swift */; };
 		84CFB7732822700000167258 /* Theme.Button.Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CFB7722822700000167258 /* Theme.Button.Accessibility.swift */; };
 		84D2292B28C61C8D00F64FE7 /* WKNavigationPolicyProvider.CustomResponseCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D2292A28C61C8D00F64FE7 /* WKNavigationPolicyProvider.CustomResponseCard.swift */; };
@@ -1126,6 +1127,7 @@
 		8491AF5F2AA1EBB600CC3E72 /* TranscriptModelTests+URLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TranscriptModelTests+URLs.swift"; sourceTree = "<group>"; };
 		8491AF622AA20F9D00CC3E72 /* GliaViewControllerDelegateMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GliaViewControllerDelegateMock.swift; sourceTree = "<group>"; };
 		8491AF642AAB281500CC3E72 /* ChatViewModelTests+CustomCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatViewModelTests+CustomCard.swift"; sourceTree = "<group>"; };
+		8491AF662AB8707600CC3E72 /* ChatViewModelTests+Transferring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatViewModelTests+Transferring.swift"; sourceTree = "<group>"; };
 		84A318A02869ECFC00CA1DE5 /* Unavailable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Unavailable.swift; sourceTree = "<group>"; };
 		84CFB7722822700000167258 /* Theme.Button.Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.Button.Accessibility.swift; sourceTree = "<group>"; };
 		84D2292A28C61C8D00F64FE7 /* WKNavigationPolicyProvider.CustomResponseCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKNavigationPolicyProvider.CustomResponseCard.swift; sourceTree = "<group>"; };
@@ -3141,6 +3143,7 @@
 				7512A57927BF9FCD00319DF1 /* ChatViewModelTests.swift */,
 				84681A942A61844000DD7406 /* ChatViewModelTests+Gva.swift */,
 				8491AF642AAB281500CC3E72 /* ChatViewModelTests+CustomCard.swift */,
+				8491AF662AB8707600CC3E72 /* ChatViewModelTests+Transferring.swift */,
 			);
 			path = ChatViewModel;
 			sourceTree = "<group>";
@@ -4786,6 +4789,7 @@
 				AF29811229E42F3C0005BD55 /* AvailabilityTests.swift in Sources */,
 				9AE05CB32805C9D900871321 /* ChatViewModel.Environment.Failing.swift in Sources */,
 				7552DFB12A6FB7DF0093519B /* ChatMessageTests.swift in Sources */,
+				8491AF672AB8707600CC3E72 /* ChatViewModelTests+Transferring.swift in Sources */,
 				AFEF5C7429929A8D005C3D8D /* SecureConversations.FileUploadListViewModel.Environment.Failing.swift in Sources */,
 				9A3E1D9D27BA7741005634EB /* FoundationBased.Failing.swift in Sources */,
 				9A3E1D8427B67F1B005634EB /* Helper.swift in Sources */,

--- a/GliaWidgets/Sources/View/Chat/Entry/ChatMessageEntryView.swift
+++ b/GliaWidgets/Sources/View/Chat/Entry/ChatMessageEntryView.swift
@@ -287,7 +287,6 @@ extension ChatMessageEntryView {
 
 enum MediaPickerButtonVisibility {
     enum ToggledBy {
-        case choiceCard
         case enagagementConnection(isConnected: Bool)
         case secureMessaging
     }
@@ -299,8 +298,6 @@ extension MediaPickerButtonVisibility {
     var isHidden: Bool {
         switch self {
         case .disabled:
-            return true
-        case .enabled(.choiceCard):
             return true
         case let .enabled(.enagagementConnection(isConnected)):
             return !isConnected

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -58,7 +58,6 @@ class ChatViewModel: EngagementViewModel {
         guard environment.getCurrentEngagement() != nil else {
             return .enabled(.enagagementConnection(isConnected: false))
         }
-        guard !isChoiceCardInputModeEnabled else { return .enabled(.choiceCard) }
         return .enabled(.enagagementConnection(isConnected: environment.getCurrentEngagement() != nil))
     }
 
@@ -313,6 +312,7 @@ extension ChatViewModel {
 extension ChatViewModel {
     private func onEngagementTransferring() {
         action?(.setMessageEntryEnabled(false))
+        action?(.setAttachmentButtonVisibility(.disabled))
         appendItem(.init(kind: .transferring), to: messagesSection, animated: true)
         action?(.scrollToBottom(animated: true))
         endScreenSharing()
@@ -320,6 +320,7 @@ extension ChatViewModel {
 
     private func onEngagementTransferred() {
         action?(.setMessageEntryEnabled(true))
+        action?(.setAttachmentButtonVisibility(mediaPickerButtonVisibility))
 
         let engagedOperator = interactor.engagedOperator
         action?(.setCallBubbleImage(imageUrl: engagedOperator?.picture?.url))

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Transferring.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Transferring.swift
@@ -1,0 +1,79 @@
+@testable import GliaWidgets
+import GliaCoreSDK
+import XCTest
+
+extension ChatViewModelTests {
+    func test_mediaButtonVisibilityDuringTransferring() throws {
+        enum Call: Equatable {
+            enum Visibility { case enabled, disabled }
+            case updateVisibility(Visibility)
+        }
+
+        var calls: [Call] = []
+
+        var interactorEnv = Interactor.Environment.failing
+        // To ensure `sendMessageWithMessagePayload` is not called in case of Postback Button
+        interactorEnv.coreSdk.sendMessageWithMessagePayload = { _, _ in
+            XCTFail("createSendMessagePayload should not be called")
+        }
+        interactorEnv.gcd.mainQueue.asyncIfNeeded = { $0() }
+        interactorEnv.coreSdk.queueForEngagement = { _, _ in }
+        interactorEnv.coreSdk.configureWithInteractor = { _ in }
+        let interactorMock = Interactor.mock(environment: interactorEnv)
+        interactorMock.isConfigurationPerformed = true
+
+        var env = ChatViewModel.Environment.failing()
+        env.fileManager.fileExistsAtPath = { _ in true }
+        env.fileManager.createDirectoryAtUrlWithIntermediateDirectories = { _, _, _ in }
+        env.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
+        env.createFileUploadListModel = { _ in .mock() }
+        env.createSendMessagePayload = { _, _ in .mock() }
+        let site: CoreSdkClient.Site = try .mock(
+            allowedFileSenders: .init(operator: true, visitor: true)
+        )
+        env.fetchSiteConfigurations = { completion in
+            completion(.success(site))
+        }
+        env.getCurrentEngagement = { .mock() }
+        viewModel = .mock(interactor: interactorMock, environment: env)
+
+        viewModel.action = { action in
+            switch action {
+            case let .setAttachmentButtonVisibility(visibility):
+                switch visibility {
+                case .enabled:
+                    calls.append(.updateVisibility(.enabled))
+                case .disabled:
+                    calls.append(.updateVisibility(.disabled))
+                }
+            default:
+                break
+            }
+        }
+        interactorMock.state = .engaged(nil)
+        XCTAssertEqual(
+            calls,
+            [.updateVisibility(.enabled)]
+        )
+
+        interactorMock.notify(.engagementTransferring)
+        XCTAssertEqual(
+            calls,
+            [
+                .updateVisibility(.enabled),
+                .updateVisibility(.disabled)
+            ]
+        )
+
+        interactorMock.notify(.engagementTransferred(GliaCoreSDK.Operator.mock()))
+
+        XCTAssertEqual(
+            calls,
+            [
+                .updateVisibility(.enabled),
+                .updateVisibility(.disabled),
+                .updateVisibility(.enabled)
+            ]
+        )
+    }
+}


### PR DESCRIPTION
Before attachment button was hidden when Response/Custom card was received. Now the button visibility behaviour is aligned with entry field blocking behaviour. If sending media is allowed in site setting, now the button is hidden only during enqueueing and transferring state.

MOB-2636