### PR TITLE
Add landscape snapshot tests

### DIFF
--- a/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
+++ b/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
@@ -124,7 +124,7 @@ extension Glia {
                 startSocketObservation: environment.coreSdk.startSocketObservation,
                 stopSocketObservation: environment.coreSdk.stopSocketObservation,
                 pushNotifications: environment.coreSdk.pushNotifications,
-                createSendMessagePayload: environment.coreSdk.createSendMessagePayload, 
+                createSendMessagePayload: environment.coreSdk.createSendMessagePayload,
                 orientationManager: environment.orientationManager
             )
         )

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
@@ -34,7 +34,7 @@ extension EngagementCoordinator.Environment {
         startSocketObservation: {},
         stopSocketObservation: {},
         pushNotifications: .mock,
-        createSendMessagePayload: { _, _ in .mock() }, 
+        createSendMessagePayload: { _, _ in .mock() },
         orientationManager: .mock()
     )
 }

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
@@ -477,7 +477,7 @@ extension EngagementCoordinator {
                 isAuthenticated: environment.isAuthenticated,
                 startSocketObservation: environment.startSocketObservation,
                 stopSocketObservation: environment.stopSocketObservation,
-                createSendMessagePayload: environment.createSendMessagePayload, 
+                createSendMessagePayload: environment.createSendMessagePayload,
                 orientationManager: environment.orientationManager
             )
         )

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Live.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Live.swift
@@ -27,7 +27,7 @@ extension Glia.Environment {
         createFileUploader: FileUploader.init(maximumUploads:environment:),
         createFileUploadListModel: SecureConversations.FileUploadListViewModel.init,
         screenShareHandler: ScreenShareHandler.create(),
-        messagesWithUnreadCountLoaderScheduler: CoreSdkClient.ReactiveSwift.QueueScheduler.main, 
+        messagesWithUnreadCountLoaderScheduler: CoreSdkClient.ReactiveSwift.QueueScheduler.main,
         orientationManager: .init(environment: .init(
             uiApplication: .live,
             uiDevice: .live,

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Mock.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Mock.swift
@@ -25,7 +25,7 @@ extension Glia.Environment {
         createFileUploader: FileUploader.mock,
         createFileUploadListModel: SecureConversations.FileUploadListViewModel.mock(environment:),
         screenShareHandler: .mock,
-        messagesWithUnreadCountLoaderScheduler: CoreSdkClient.reactiveSwiftDateSchedulerMock, 
+        messagesWithUnreadCountLoaderScheduler: CoreSdkClient.reactiveSwiftDateSchedulerMock,
         orientationManager: .mock()
     )
 }

--- a/SnapshotTests/AlertViewControllerDynamicTypeFontTests.swift
+++ b/SnapshotTests/AlertViewControllerDynamicTypeFontTests.swift
@@ -15,6 +15,11 @@ final class AlertViewControllerDynamicTypeFontTests: SnapshotTestCase {
             as: .extra3LargeFontStrategy,
             named: nameForDevice()
         )
+        assertSnapshot(
+            matching: alert,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
+        )
     }
 
     func test_mediaUpgradeOffer_extra3Large() {
@@ -27,6 +32,11 @@ final class AlertViewControllerDynamicTypeFontTests: SnapshotTestCase {
             matching: alert,
             as: .extra3LargeFontStrategy,
             named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: alert,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 
@@ -41,6 +51,11 @@ final class AlertViewControllerDynamicTypeFontTests: SnapshotTestCase {
             as: .extra3LargeFontStrategy,
             named: nameForDevice()
         )
+        assertSnapshot(
+            matching: alert,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
+        )
     }
 
     func test_singleAction_extra3Large() {
@@ -53,6 +68,11 @@ final class AlertViewControllerDynamicTypeFontTests: SnapshotTestCase {
             matching: alert,
             as: .extra3LargeFontStrategy,
             named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: alert,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 

--- a/SnapshotTests/AlertViewControllerLayoutTests.swift
+++ b/SnapshotTests/AlertViewControllerLayoutTests.swift
@@ -2,7 +2,7 @@
 import SnapshotTesting
 import XCTest
 
-class AlertViewControllerLayoutTests: SnapshotTestCase {
+final class AlertViewControllerLayoutTests: SnapshotTestCase {
     func test_screenSharingOffer() {
         let alert = alert(ofKind: .screenShareOffer(
             .mock(),
@@ -13,6 +13,11 @@ class AlertViewControllerLayoutTests: SnapshotTestCase {
             matching: alert,
             as: .image,
             named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: alert,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 
@@ -27,6 +32,11 @@ class AlertViewControllerLayoutTests: SnapshotTestCase {
             as: .image,
             named: nameForDevice()
         )
+        assertSnapshot(
+            matching: alert,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
+        )
     }
 
     func test_messageAlert() {
@@ -40,6 +50,11 @@ class AlertViewControllerLayoutTests: SnapshotTestCase {
             as: .image,
             named: nameForDevice()
         )
+        assertSnapshot(
+            matching: alert,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
+        )
     }
 
     func test_singleAction() {
@@ -52,6 +67,11 @@ class AlertViewControllerLayoutTests: SnapshotTestCase {
             matching: alert,
             as: .image,
             named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: alert,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 

--- a/SnapshotTests/AlertViewControllerTests.swift
+++ b/SnapshotTests/AlertViewControllerTests.swift
@@ -3,7 +3,7 @@ import AccessibilitySnapshot
 import SnapshotTesting
 import XCTest
 
-class AlertViewControllerTests: SnapshotTestCase {
+final class AlertViewControllerTests: SnapshotTestCase {
     func test_screenSharingOffer() {
         let alert = alert(ofKind: .screenShareOffer(
             .mock(),

--- a/SnapshotTests/BubbleViewDynamicTypeFontTests.swift
+++ b/SnapshotTests/BubbleViewDynamicTypeFontTests.swift
@@ -7,10 +7,14 @@ final class BubbleViewDynamicTypeFontTests: SnapshotTestCase {
     func test_bubble_extra3Large() {
         let bubble = ViewFactory.mock().makeBubbleView()
         bubble.frame = .init(origin: .zero, size: .init(width: 50, height: 50))
-        // If shadow will cause failing test locally or on CI, we should disable it.
         assertSnapshot(
             matching: bubble,
             as: .extra3LargeFontStrategy
+        )
+        assertSnapshot(
+            matching: bubble,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 }

--- a/SnapshotTests/BubbleViewLayoutTests.swift
+++ b/SnapshotTests/BubbleViewLayoutTests.swift
@@ -2,11 +2,18 @@
 import SnapshotTesting
 import XCTest
 
-class BubbleViewLayoutTests: SnapshotTestCase {
+final class BubbleViewLayoutTests: SnapshotTestCase {
     func test_bubble() {
         let bubble = ViewFactory.mock().makeBubbleView()
         bubble.frame = .init(origin: .zero, size: .init(width: 50, height: 50))
-        // If shadow will cause failing test locally or on CI, we should disable it.
-        assertSnapshot(matching: bubble, as: .image)
+        assertSnapshot(
+            matching: bubble,
+            as: .image
+        )
+        assertSnapshot(
+            matching: bubble,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
+        )
     }
 }

--- a/SnapshotTests/BubbleViewVoiceOverTests.swift
+++ b/SnapshotTests/BubbleViewVoiceOverTests.swift
@@ -3,11 +3,10 @@ import AccessibilitySnapshot
 import SnapshotTesting
 import XCTest
 
-class BubbleViewVoiceOverTests: SnapshotTestCase {
+final class BubbleViewVoiceOverTests: SnapshotTestCase {
     func test_bubble() {
         let bubble = ViewFactory.mock().makeBubbleView()
         bubble.frame = .init(origin: .zero, size: .init(width: 50, height: 50))
-        // If shadow will cause failing test locally or on CI, we should disable it.
         assertSnapshot(matching: bubble, as: .accessibilityImage(precision: SnapshotTestCase.possiblePrecision))
     }
 }

--- a/SnapshotTests/CallViewControllerDynamicTypeFontTests.swift
+++ b/SnapshotTests/CallViewControllerDynamicTypeFontTests.swift
@@ -11,6 +11,11 @@ final class CallViewControllerDynamicTypeFontTests: SnapshotTestCase {
             as: .extra3LargeFontStrategy,
             named: nameForDevice()
         )
+        assertSnapshot(
+            matching: viewController,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
+        )
     }
 
     func test_audioCallConnectingState_extra3Large() throws {
@@ -20,6 +25,11 @@ final class CallViewControllerDynamicTypeFontTests: SnapshotTestCase {
             matching: viewController,
             as: .extra3LargeFontStrategy,
             named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: viewController,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 
@@ -31,6 +41,11 @@ final class CallViewControllerDynamicTypeFontTests: SnapshotTestCase {
             as: .extra3LargeFontStrategy,
             named: nameForDevice()
         )
+        assertSnapshot(
+            matching: viewController,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
+        )
     }
 
     func test_mockVideoCallConnectingState_extra3Large() throws {
@@ -40,6 +55,11 @@ final class CallViewControllerDynamicTypeFontTests: SnapshotTestCase {
             matching: viewController,
             as: .extra3LargeFontStrategy,
             named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: viewController,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 
@@ -51,6 +71,11 @@ final class CallViewControllerDynamicTypeFontTests: SnapshotTestCase {
             as: .extra3LargeFontStrategy,
             named: nameForDevice()
         )
+        assertSnapshot(
+            matching: viewController,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
+        )
     }
 
     func test_mockVideoCallConnectedState_extra3Large() throws {
@@ -60,6 +85,11 @@ final class CallViewControllerDynamicTypeFontTests: SnapshotTestCase {
             matching: viewController,
             as: .extra3LargeFontStrategy,
             named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: viewController,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 }

--- a/SnapshotTests/CallViewControllerLayoutTests.swift
+++ b/SnapshotTests/CallViewControllerLayoutTests.swift
@@ -2,7 +2,7 @@
 import SnapshotTesting
 import XCTest
 
-class CallViewControllerLayoutTests: SnapshotTestCase {
+final class CallViewControllerLayoutTests: SnapshotTestCase {
     func test_audioCallQueueState() throws {
         let viewController = try CallViewController.mockAudioCallQueueState()
         viewController.view.frame = UIScreen.main.bounds
@@ -10,6 +10,11 @@ class CallViewControllerLayoutTests: SnapshotTestCase {
             matching: viewController,
             as: .image,
             named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: viewController,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 
@@ -21,6 +26,11 @@ class CallViewControllerLayoutTests: SnapshotTestCase {
             as: .image,
             named: nameForDevice()
         )
+        assertSnapshot(
+            matching: viewController,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
+        )
     }
 
     func test_audioCallConnectedState() throws {
@@ -30,6 +40,11 @@ class CallViewControllerLayoutTests: SnapshotTestCase {
             matching: viewController,
             as: .image,
             named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: viewController,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 
@@ -41,6 +56,11 @@ class CallViewControllerLayoutTests: SnapshotTestCase {
             as: .image,
             named: nameForDevice()
         )
+        assertSnapshot(
+            matching: viewController,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
+        )
     }
 
     func test_mockVideoCallQueueState() throws {
@@ -51,6 +71,11 @@ class CallViewControllerLayoutTests: SnapshotTestCase {
             as: .image,
             named: nameForDevice()
         )
+        assertSnapshot(
+            matching: viewController,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
+        )
     }
 
     func test_mockVideoCallConnectedState() throws {
@@ -60,6 +85,11 @@ class CallViewControllerLayoutTests: SnapshotTestCase {
             matching: viewController,
             as: .image,
             named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: viewController,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 }

--- a/SnapshotTests/CallViewControllerVoiceOverTests.swift
+++ b/SnapshotTests/CallViewControllerVoiceOverTests.swift
@@ -3,7 +3,7 @@ import AccessibilitySnapshot
 import SnapshotTesting
 import XCTest
 
-class CallViewControllerVoiceOverTests: SnapshotTestCase {
+final class CallViewControllerVoiceOverTests: SnapshotTestCase {
     func test_audioCallQueueState() throws {
         let viewController = try CallViewController.mockAudioCallQueueState()
         viewController.view.frame = UIScreen.main.bounds

--- a/SnapshotTests/ChatCallUpgradeViewDynamicTypeFontTests.swift
+++ b/SnapshotTests/ChatCallUpgradeViewDynamicTypeFontTests.swift
@@ -10,6 +10,11 @@ final class ChatCallUpgradeViewDynamicTypeFontTests: SnapshotTestCase {
             matching: upgradeView,
             as: .extra3LargeFontStrategy
         )
+        assertSnapshot(
+            matching: upgradeView,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
+        )
     }
 
     func test_chatCallUpgradeViewToVideo_extra3Large() {
@@ -18,6 +23,11 @@ final class ChatCallUpgradeViewDynamicTypeFontTests: SnapshotTestCase {
         assertSnapshot(
             matching: upgradeView,
             as: .extra3LargeFontStrategy
+        )
+        assertSnapshot(
+            matching: upgradeView,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 }

--- a/SnapshotTests/ChatCallUpgradeViewLayoutTests.swift
+++ b/SnapshotTests/ChatCallUpgradeViewLayoutTests.swift
@@ -2,13 +2,18 @@
 import SnapshotTesting
 import XCTest
 
-class ChatCallUpgradeViewLayoutTests: SnapshotTestCase {
+final class ChatCallUpgradeViewLayoutTests: SnapshotTestCase {
     func test_chatCallUpgradeViewToAudio() {
         let upgradeView = ChatCallUpgradeView(with: Theme.mock().chat.audioUpgrade, duration: .init(with: .zero))
         upgradeView.frame = .init(origin: .zero, size: .init(width: 300, height: 120))
         assertSnapshot(
             matching: upgradeView,
             as: .image
+        )
+        assertSnapshot(
+            matching: upgradeView,
+            as: .image,
+            named: nameForDevice(.landscape)
         )
     }
 
@@ -18,6 +23,11 @@ class ChatCallUpgradeViewLayoutTests: SnapshotTestCase {
         assertSnapshot(
             matching: upgradeView,
             as: .image
+        )
+        assertSnapshot(
+            matching: upgradeView,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 }

--- a/SnapshotTests/ChatCallUpgradeViewVoiceOverTests.swift
+++ b/SnapshotTests/ChatCallUpgradeViewVoiceOverTests.swift
@@ -3,7 +3,7 @@ import AccessibilitySnapshot
 import SnapshotTesting
 import XCTest
 
-class ChatCallUpgradeViewVoiceOverTests: SnapshotTestCase {
+final class ChatCallUpgradeViewVoiceOverTests: SnapshotTestCase {
     func test_chatCallUpgradeViewToAudio() {
         let upgradeView = ChatCallUpgradeView(with: Theme.mock().chat.audioUpgrade, duration: .init(with: .zero))
         upgradeView.frame = .init(origin: .zero, size: .init(width: 300, height: 120))

--- a/SnapshotTests/ChatViewControllerDynamicTypeFontTests.swift
+++ b/SnapshotTests/ChatViewControllerDynamicTypeFontTests.swift
@@ -11,6 +11,11 @@ final class ChatViewControllerDynamicTypeFontTests: SnapshotTestCase {
             as: .extra3LargeFontStrategy,
             named: nameForDevice()
         )
+        assertSnapshot(
+            matching: viewController,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
+        )
     }
 
     func test_visitorUploadedFileStates_extra3Large() throws {
@@ -21,6 +26,11 @@ final class ChatViewControllerDynamicTypeFontTests: SnapshotTestCase {
             as: .extra3LargeFontStrategy,
             named: nameForDevice()
         )
+        assertSnapshot(
+            matching: viewController,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
+        )
     }
 
     func test_choiceCard_extra3Large() throws {
@@ -30,6 +40,11 @@ final class ChatViewControllerDynamicTypeFontTests: SnapshotTestCase {
             matching: viewController,
             as: .extra3LargeFontStrategy,
             named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: viewController,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 
@@ -49,7 +64,12 @@ final class ChatViewControllerDynamicTypeFontTests: SnapshotTestCase {
         assertSnapshot(
             matching: viewController,
             as: .extra3LargeFontStrategy,
-            named: self.nameForDevice()
+            named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: viewController,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 }

--- a/SnapshotTests/ChatViewControllerLayoutTests.swift
+++ b/SnapshotTests/ChatViewControllerLayoutTests.swift
@@ -2,7 +2,7 @@
 import SnapshotTesting
 import XCTest
 
-class ChatViewControllerLayoutTests: SnapshotTestCase {
+final class ChatViewControllerLayoutTests: SnapshotTestCase {
     func test_messagesFromHistory() {
         let viewController = ChatViewController.mockHistoryMessagesScreen()
         viewController.view.frame = UIScreen.main.bounds
@@ -10,6 +10,11 @@ class ChatViewControllerLayoutTests: SnapshotTestCase {
             matching: viewController,
             as: .image,
             named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: viewController,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 
@@ -21,6 +26,11 @@ class ChatViewControllerLayoutTests: SnapshotTestCase {
             as: .image,
             named: nameForDevice()
         )
+        assertSnapshot(
+            matching: viewController,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
+        )
     }
 
     func test_choiceCard() throws {
@@ -30,6 +40,11 @@ class ChatViewControllerLayoutTests: SnapshotTestCase {
             matching: viewController,
             as: .image,
             named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: viewController,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 
@@ -41,6 +56,11 @@ class ChatViewControllerLayoutTests: SnapshotTestCase {
             as: .image,
             named: nameForDevice()
         )
+        assertSnapshot(
+            matching: viewController,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
+        )
     }
 
     func test_gvaResponseText() throws {
@@ -51,6 +71,11 @@ class ChatViewControllerLayoutTests: SnapshotTestCase {
             as: .image,
             named: nameForDevice()
         )
+        assertSnapshot(
+            matching: viewController,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
+        )
     }
 
     func test_gvaGalleryCard() throws {
@@ -60,6 +85,11 @@ class ChatViewControllerLayoutTests: SnapshotTestCase {
             matching: viewController,
             as: .image,
             named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: viewController,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 
@@ -79,7 +109,12 @@ class ChatViewControllerLayoutTests: SnapshotTestCase {
         assertSnapshot(
             matching: view,
             as: .image,
-            named: self.nameForDevice()
+            named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: view,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 
@@ -99,7 +134,12 @@ class ChatViewControllerLayoutTests: SnapshotTestCase {
         assertSnapshot(
             matching: viewController,
             as: .image,
-            named: self.nameForDevice()
+            named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: viewController,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 }

--- a/SnapshotTests/ChatViewControllerVoiceOverTests.swift
+++ b/SnapshotTests/ChatViewControllerVoiceOverTests.swift
@@ -3,7 +3,7 @@ import AccessibilitySnapshot
 import SnapshotTesting
 import XCTest
 
-class ChatViewControllerVoiceOverTests: SnapshotTestCase {
+final class ChatViewControllerVoiceOverTests: SnapshotTestCase {
     func test_messagesFromHistory() {
         let viewController = ChatViewController.mockHistoryMessagesScreen()
         viewController.view.frame = UIScreen.main.bounds

--- a/SnapshotTests/ScreenShareViewControllerDynamicTypeFontTests.swift
+++ b/SnapshotTests/ScreenShareViewControllerDynamicTypeFontTests.swift
@@ -28,6 +28,11 @@ final class ScreenShareViewControllerDynamicTypeFontTests: SnapshotTestCase {
             as: .extra3LargeFontStrategy,
             named: nameForDevice()
         )
+        assertSnapshot(
+            matching: screenShareViewController,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
+        )
     }
 }
 // swiftlint:enable type_name

--- a/SnapshotTests/ScreenShareViewControllerLayoutTests.swift
+++ b/SnapshotTests/ScreenShareViewControllerLayoutTests.swift
@@ -2,7 +2,7 @@
 import SnapshotTesting
 import XCTest
 
-class ScreenShareViewControllerLayoutTests: SnapshotTestCase {
+final class ScreenShareViewControllerLayoutTests: SnapshotTestCase {
     func testScreenShareViewController() {
         let theme = Theme()
         let font = theme.font
@@ -26,6 +26,11 @@ class ScreenShareViewControllerLayoutTests: SnapshotTestCase {
             matching: screenShareViewController,
             as: .image,
             named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: screenShareViewController,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 }

--- a/SnapshotTests/ScreenShareViewControllerTests.swift
+++ b/SnapshotTests/ScreenShareViewControllerTests.swift
@@ -3,7 +3,7 @@ import AccessibilitySnapshot
 import SnapshotTesting
 import XCTest
 
-class ScreenShareViewControllerTests: SnapshotTestCase {
+final class ScreenShareViewControllerTests: SnapshotTestCase {
     func testScreenShareViewController() {
         let theme = Theme()
         let font = theme.font

--- a/SnapshotTests/SecureConversationsConfirmationScreenDynamicTypeFontTests.swift
+++ b/SnapshotTests/SecureConversationsConfirmationScreenDynamicTypeFontTests.swift
@@ -20,7 +20,12 @@ final class SecureConversationsConfirmationScreenDynamicTypeFontTests: SnapshotT
         assertSnapshot(
             matching: viewController.view,
             as: .extra3LargeFontStrategy,
-            named: self.nameForDevice()
+            named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: viewController.view,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 }

--- a/SnapshotTests/SecureConversationsConfirmationScreenLayoutTests.swift
+++ b/SnapshotTests/SecureConversationsConfirmationScreenLayoutTests.swift
@@ -2,7 +2,7 @@
 import SnapshotTesting
 import XCTest
 
-class SecureConversationsConfirmationScreenLayoutTests: SnapshotTestCase {
+final class SecureConversationsConfirmationScreenLayoutTests: SnapshotTestCase {
     let theme = Theme.mock()
 
     func test_confirmationView() {
@@ -19,7 +19,12 @@ class SecureConversationsConfirmationScreenLayoutTests: SnapshotTestCase {
         assertSnapshot(
             matching: viewController,
             as: .image,
-            named: self.nameForDevice()
+            named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: viewController,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 }

--- a/SnapshotTests/SecureConversationsConfirmationScreenTests.swift
+++ b/SnapshotTests/SecureConversationsConfirmationScreenTests.swift
@@ -3,7 +3,7 @@ import AccessibilitySnapshot
 import SnapshotTesting
 import XCTest
 
-class SecureConversationsConfirmationScreenTests: SnapshotTestCase {
+final class SecureConversationsConfirmationScreenTests: SnapshotTestCase {
     let theme = Theme.mock()
 
     func test_confirmationView() {

--- a/SnapshotTests/SecureConversationsWelcomeScreenDynamicTypeFontTests.swift
+++ b/SnapshotTests/SecureConversationsWelcomeScreenDynamicTypeFontTests.swift
@@ -21,7 +21,12 @@ final class SecureConversationsWelcomeScreenDynamicTypeFontTests: SnapshotTestCa
         assertSnapshot(
             matching: viewController.view,
             as: .extra3LargeFontStrategy,
-            named: self.nameForDevice()
+            named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: viewController.view,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 
@@ -43,7 +48,12 @@ final class SecureConversationsWelcomeScreenDynamicTypeFontTests: SnapshotTestCa
         assertSnapshot(
             matching: viewController.view,
             as: .extra3LargeFontStrategy,
-            named: self.nameForDevice()
+            named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: viewController.view,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 
@@ -59,7 +69,12 @@ final class SecureConversationsWelcomeScreenDynamicTypeFontTests: SnapshotTestCa
         assertSnapshot(
             matching: viewController.view,
             as: .extra3LargeFontStrategy,
-            named: self.nameForDevice()
+            named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: viewController.view,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 

--- a/SnapshotTests/SecureConversationsWelcomeScreenLayoutTests.swift
+++ b/SnapshotTests/SecureConversationsWelcomeScreenLayoutTests.swift
@@ -2,7 +2,7 @@
 import SnapshotTesting
 import XCTest
 
-class SecureConversationsWelcomeScreenLayoutTests: SnapshotTestCase {
+final class SecureConversationsWelcomeScreenLayoutTests: SnapshotTestCase {
     let theme = Theme.mock()
 
     func test_welcomeView() {
@@ -20,7 +20,12 @@ class SecureConversationsWelcomeScreenLayoutTests: SnapshotTestCase {
         assertSnapshot(
             matching: viewController.view,
             as: .image,
-            named: self.nameForDevice()
+            named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: viewController.view,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 
@@ -42,7 +47,12 @@ class SecureConversationsWelcomeScreenLayoutTests: SnapshotTestCase {
         assertSnapshot(
             matching: viewController.view,
             as: .image,
-            named: self.nameForDevice()
+            named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: viewController.view,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 
@@ -58,7 +68,12 @@ class SecureConversationsWelcomeScreenLayoutTests: SnapshotTestCase {
         assertSnapshot(
             matching: viewController.view,
             as: .image,
-            named: self.nameForDevice()
+            named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: viewController.view,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 

--- a/SnapshotTests/SecureConversationsWelcomeScreenTests.swift
+++ b/SnapshotTests/SecureConversationsWelcomeScreenTests.swift
@@ -3,7 +3,7 @@ import AccessibilitySnapshot
 import SnapshotTesting
 import XCTest
 
-class SecureConversationsWelcomeScreenTests: SnapshotTestCase {
+final class SecureConversationsWelcomeScreenTests: SnapshotTestCase {
     let theme = Theme.mock()
 
     func test_welcomeView() {

--- a/SnapshotTests/SnapshotTestCase.swift
+++ b/SnapshotTests/SnapshotTestCase.swift
@@ -50,15 +50,46 @@ extension SnapshotTestCase {
         }
     }
 
-    func nameForDevice(baseName: String? = nil) -> String {
+    /// This method sets the name for the snapshot tests by taking one parameter. 
+    /// Depending of the case passed in, either prefix, suffix, or nothing
+    /// additional will be added to the the base name. The method returns a string.
+    func nameForDevice(_ baseName: NameForDevice = .portrait) -> String {
         let size = UIScreen.main.bounds.size
         let scale = UIScreen.main.scale
         let version = UIDevice.current.systemVersion
         let deviceName = "\(Int(size.width))x\(Int(size.height))-\(version)-\(Int(scale))x"
 
-        return [baseName, deviceName]
-            .compactMap { $0 }
-            .joined(separator: "-")
+        switch baseName {
+        case let .baseName(value):
+            return [value, deviceName]
+                .compactMap { $0 }
+                .joined(separator: "-")
+        case .portrait:
+            return "\(deviceName)"
+        case .landscape:
+            return "\(deviceName)-landscape"
+        }
+    }
+
+    /// All available cases for the snapshot tests name. This Enum
+    /// conforms to ExpressibleByStringLiteral allowing a string to be
+    /// passed instead of a case, that will convert it to baseName case.
+    ///
+    /// - baseName(String?) case is a string that can be added as prefix
+    /// to the test name
+    ///
+    /// - portrait case serves as a default case for snapshot tests and
+    /// won't add anything additional to the name
+    ///
+    /// - landscape case will add suffix to the end of the name
+    enum NameForDevice: ExpressibleByStringLiteral {
+        case baseName(String?)
+        case portrait
+        case landscape
+
+        init(stringLiteral value: String) {
+            self = .baseName(value)
+        }
     }
 }
 
@@ -188,16 +219,32 @@ extension Snapshotting where Value == UIView, Format == UIImage {
             )
         )
     }
+
+    static var extra3LargeFontStrategyLandscape: Self {
+        let traits = UITraitCollection(traitsFrom: [
+            .init(preferredContentSizeCategory: .accessibilityExtraExtraExtraLarge)
+        ] + commonTraitCollection)
+
+        return Self.image(traits: traits)
+    }
+
+    static var imageLandscape: Self {
+        let traits = UITraitCollection(traitsFrom: [
+            .init(preferredContentSizeCategory: .medium),
+        ] + commonTraitCollection)
+
+        return Self.image(traits: traits)
+    }
+
+    private static var commonTraitCollection: [UITraitCollection] = [
+        .init(layoutDirection: .leftToRight),
+        .init(userInterfaceIdiom: .phone),
+        .init(horizontalSizeClass: .regular),
+        .init(verticalSizeClass: .compact),
+    ]
 }
 
 extension Snapshotting where Value == UIViewController, Format == UIImage {
-    private static var commonTraitCollection: [UITraitCollection] = [
-            .init(layoutDirection: .leftToRight),
-            .init(userInterfaceIdiom: .phone),
-            .init(horizontalSizeClass: .regular),
-            .init(verticalSizeClass: .compact),
-        ]
-
     static var extra3LargeFontStrategyLandscape: Self {
         let traits = UITraitCollection(traitsFrom: [
             .init(preferredContentSizeCategory: .accessibilityExtraExtraExtraLarge)
@@ -219,4 +266,11 @@ extension Snapshotting where Value == UIViewController, Format == UIImage {
 
         return Self.image(on: viewImageConfig)
     }
+
+    private static var commonTraitCollection: [UITraitCollection] = [
+        .init(layoutDirection: .leftToRight),
+        .init(userInterfaceIdiom: .phone),
+        .init(horizontalSizeClass: .regular),
+        .init(verticalSizeClass: .compact),
+    ]
 }

--- a/SnapshotTests/SurveyViewControllerDynamicTypeFontTests.swift
+++ b/SnapshotTests/SurveyViewControllerDynamicTypeFontTests.swift
@@ -4,32 +4,59 @@ import XCTest
 
 final class SurveyViewControllerDynamicTypeFontTests: SnapshotTestCase {
     func test_emptySurvey_extra3Large() {
-        let viewController = Survey.ViewController(viewFactory: .mock(), environment: .init(notificationCenter: .mock), props: .emptyPropsMock())
+        let viewController = Survey.ViewController(
+            viewFactory: .mock(),
+            environment: .init(notificationCenter: .mock),
+            props: .emptyPropsMock()
+        )
         viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
             as: .extra3LargeFontStrategy,
             named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: viewController,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 
     func test_filledSurvey_extra3Large() {
-        let viewController = Survey.ViewController(viewFactory: .mock(), environment: .init(notificationCenter: .mock), props: .filledPropsMock())
+        let viewController = Survey.ViewController(
+            viewFactory: .mock(),
+            environment: .init(notificationCenter: .mock),
+            props: .filledPropsMock()
+        )
         viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
             as: .extra3LargeFontStrategy,
             named: nameForDevice()
         )
+        assertSnapshot(
+            matching: viewController,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
+        )
     }
 
     func test_emptySurveyErrorState_extra3Large() {
-        let viewController = Survey.ViewController(viewFactory: .mock(), environment: .init(notificationCenter: .mock), props: .errorPropsMock())
+        let viewController = Survey.ViewController(
+            viewFactory: .mock(),
+            environment: .init(notificationCenter: .mock),
+            props: .errorPropsMock()
+        )
         viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
             as: .extra3LargeFontStrategy,
             named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: viewController,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 }

--- a/SnapshotTests/SurveyViewControllerLayoutTests.swift
+++ b/SnapshotTests/SurveyViewControllerLayoutTests.swift
@@ -2,34 +2,61 @@
 import SnapshotTesting
 import XCTest
 
-class SurveyViewControllerLayoutTests: SnapshotTestCase {
+final class SurveyViewControllerLayoutTests: SnapshotTestCase {
     func test_emptySurvey() {
-        let viewController = Survey.ViewController(viewFactory: .mock(), environment: .init(notificationCenter: .mock), props: .emptyPropsMock())
+        let viewController = Survey.ViewController(
+            viewFactory: .mock(),
+            environment: .init(notificationCenter: .mock),
+            props: .emptyPropsMock()
+        )
         viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
             as: .image,
             named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: viewController,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 
     func test_filledSurvey() {
-        let viewController = Survey.ViewController(viewFactory: .mock(), environment: .init(notificationCenter: .mock), props: .filledPropsMock())
+        let viewController = Survey.ViewController(
+            viewFactory: .mock(),
+            environment: .init(notificationCenter: .mock),
+            props: .filledPropsMock()
+        )
         viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
             as: .image,
             named: nameForDevice()
         )
+        assertSnapshot(
+            matching: viewController,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
+        )
     }
 
     func test_emptySurveyErrorState() {
-        let viewController = Survey.ViewController(viewFactory: .mock(), environment: .init(notificationCenter: .mock), props: .errorPropsMock())
+        let viewController = Survey.ViewController(
+            viewFactory: .mock(),
+            environment: .init(notificationCenter: .mock),
+            props: .errorPropsMock()
+        )
         viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
             as: .image,
             named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: viewController,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 }

--- a/SnapshotTests/SurveyViewControllerVoiceOverTests.swift
+++ b/SnapshotTests/SurveyViewControllerVoiceOverTests.swift
@@ -3,9 +3,13 @@ import AccessibilitySnapshot
 import SnapshotTesting
 import XCTest
 
-class SurveyViewControllerVoiceOverTests: SnapshotTestCase {
+final class SurveyViewControllerVoiceOverTests: SnapshotTestCase {
     func test_emptySurvey() {
-        let viewController = Survey.ViewController(viewFactory: .mock(), environment: .init(notificationCenter: .mock), props: .emptyPropsMock())
+        let viewController = Survey.ViewController(
+            viewFactory: .mock(),
+            environment: .init(notificationCenter: .mock),
+            props: .emptyPropsMock()
+        )
         viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
@@ -15,7 +19,11 @@ class SurveyViewControllerVoiceOverTests: SnapshotTestCase {
     }
 
     func test_filledSurvey() {
-        let viewController = Survey.ViewController(viewFactory: .mock(), environment: .init(notificationCenter: .mock), props: .filledPropsMock())
+        let viewController = Survey.ViewController(
+            viewFactory: .mock(),
+            environment: .init(notificationCenter: .mock),
+            props: .filledPropsMock()
+        )
         viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,
@@ -25,7 +33,11 @@ class SurveyViewControllerVoiceOverTests: SnapshotTestCase {
     }
 
     func test_emptySurveyErrorState() {
-        let viewController = Survey.ViewController(viewFactory: .mock(), environment: .init(notificationCenter: .mock), props: .errorPropsMock())
+        let viewController = Survey.ViewController(
+            viewFactory: .mock(),
+            environment: .init(notificationCenter: .mock),
+            props: .errorPropsMock()
+        )
         viewController.view.frame = UIScreen.main.bounds
         assertSnapshot(
             matching: viewController,

--- a/SnapshotTests/VideoCallViewControllerDynamicTypeFontTests.swift
+++ b/SnapshotTests/VideoCallViewControllerDynamicTypeFontTests.swift
@@ -56,6 +56,11 @@ final class VideoCallViewControllerDynamicTypeFontTests: SnapshotTestCase {
             as: .extra3LargeFontStrategy,
             named: nameForDevice()
         )
+        assertSnapshot(
+            matching: videoCallViewController,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
+        )
     }
 }
 // swiftlint:enable type_name

--- a/SnapshotTests/VideoCallViewControllerLayoutTests.swift
+++ b/SnapshotTests/VideoCallViewControllerLayoutTests.swift
@@ -2,7 +2,7 @@
 import SnapshotTesting
 import XCTest
 
-class VideoCallViewControllerLayoutTests: SnapshotTestCase {
+final class VideoCallViewControllerLayoutTests: SnapshotTestCase {
     func testVideoCallViewController() {
         let videoCallViewProps: CallVisualizer.VideoCallView.Props = .mock(
             buttonBarProps: .mock(
@@ -54,6 +54,11 @@ class VideoCallViewControllerLayoutTests: SnapshotTestCase {
             matching: videoCallViewController,
             as: .image,
             named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: videoCallViewController,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 }

--- a/SnapshotTests/VideoCallViewControllerTests.swift
+++ b/SnapshotTests/VideoCallViewControllerTests.swift
@@ -3,7 +3,7 @@ import AccessibilitySnapshot
 import SnapshotTesting
 import XCTest
 
-class VideoCallViewControllerTests: SnapshotTestCase {
+final class VideoCallViewControllerTests: SnapshotTestCase {
     func testVideoCallViewController() {
         let videoCallViewProps: CallVisualizer.VideoCallView.Props = .mock(
             buttonBarProps: .mock(

--- a/SnapshotTests/VisitorCodeViewControllerDynamicTypeFontTests.swift
+++ b/SnapshotTests/VisitorCodeViewControllerDynamicTypeFontTests.swift
@@ -19,6 +19,11 @@ final class VisitorCodeViewControllerDynamicTypeFontTests: SnapshotTestCase {
             as: .extra3LargeFontStrategy,
             named: nameForDevice()
         )
+        assertSnapshot(
+            matching: visitorCodeViewController,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
+        )
     }
 
     func testVisitorCodeAlertWhenError() {
@@ -35,6 +40,11 @@ final class VisitorCodeViewControllerDynamicTypeFontTests: SnapshotTestCase {
             matching: visitorCodeViewController,
             as: .extra3LargeFontStrategy,
             named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: visitorCodeViewController,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 
@@ -53,6 +63,11 @@ final class VisitorCodeViewControllerDynamicTypeFontTests: SnapshotTestCase {
             as: .extra3LargeFontStrategy,
             named: nameForDevice()
         )
+        assertSnapshot(
+            matching: visitorCodeViewController,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
+        )
     }
 
     func testVisitorCodeEmbeddedWhenLoading() {
@@ -69,6 +84,11 @@ final class VisitorCodeViewControllerDynamicTypeFontTests: SnapshotTestCase {
             matching: visitorCodeViewController,
             as: .extra3LargeFontStrategy,
             named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: visitorCodeViewController,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 
@@ -87,6 +107,11 @@ final class VisitorCodeViewControllerDynamicTypeFontTests: SnapshotTestCase {
             as: .extra3LargeFontStrategy,
             named: nameForDevice()
         )
+        assertSnapshot(
+            matching: visitorCodeViewController,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
+        )
     }
     func testVisitorCodeEmbeddedWhenSuccess() {
         let props: CallVisualizer.VisitorCodeViewController.Props = .init(
@@ -102,6 +127,11 @@ final class VisitorCodeViewControllerDynamicTypeFontTests: SnapshotTestCase {
             matching: visitorCodeViewController,
             as: .extra3LargeFontStrategy,
             named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: visitorCodeViewController,
+            as: .extra3LargeFontStrategyLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 }

--- a/SnapshotTests/VisitorCodeViewControllerLayoutTests.swift
+++ b/SnapshotTests/VisitorCodeViewControllerLayoutTests.swift
@@ -2,7 +2,7 @@
 import SnapshotTesting
 import XCTest
 
-class VisitorCodeViewControllerLayoutTests: SnapshotTestCase {
+final class VisitorCodeViewControllerLayoutTests: SnapshotTestCase {
     func testVisitorCodeAlertWhenLoading() {
         let props: CallVisualizer.VisitorCodeViewController.Props = .init(
             visitorCodeViewProps: .init(
@@ -17,6 +17,11 @@ class VisitorCodeViewControllerLayoutTests: SnapshotTestCase {
             matching: visitorCodeViewController,
             as: .image,
             named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: visitorCodeViewController,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 
@@ -35,6 +40,11 @@ class VisitorCodeViewControllerLayoutTests: SnapshotTestCase {
             as: .accessibilityImage(precision: Self.possiblePrecision),
             named: nameForDevice()
         )
+        assertSnapshot(
+            matching: visitorCodeViewController,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
+        )
     }
 
     func testVisitorCodeAlertWhenSuccess() {
@@ -51,6 +61,11 @@ class VisitorCodeViewControllerLayoutTests: SnapshotTestCase {
             matching: visitorCodeViewController,
             as: .accessibilityImage(precision: Self.possiblePrecision),
             named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: visitorCodeViewController,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 
@@ -69,6 +84,11 @@ class VisitorCodeViewControllerLayoutTests: SnapshotTestCase {
             as: .accessibilityImage(precision: Self.possiblePrecision),
             named: nameForDevice()
         )
+        assertSnapshot(
+            matching: visitorCodeViewController,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
+        )
     }
 
     func testVisitorCodeEmbeddedWhenError() {
@@ -86,6 +106,11 @@ class VisitorCodeViewControllerLayoutTests: SnapshotTestCase {
             as: .accessibilityImage(precision: Self.possiblePrecision),
             named: nameForDevice()
         )
+        assertSnapshot(
+            matching: visitorCodeViewController,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
+        )
     }
     func testVisitorCodeEmbeddedWhenSuccess() {
         let props: CallVisualizer.VisitorCodeViewController.Props = .init(
@@ -101,6 +126,11 @@ class VisitorCodeViewControllerLayoutTests: SnapshotTestCase {
             matching: visitorCodeViewController,
             as: .accessibilityImage(precision: Self.possiblePrecision),
             named: nameForDevice()
+        )
+        assertSnapshot(
+            matching: visitorCodeViewController,
+            as: .imageLandscape,
+            named: nameForDevice(.landscape)
         )
     }
 }

--- a/SnapshotTests/VisitorCodeViewControllerTests.swift
+++ b/SnapshotTests/VisitorCodeViewControllerTests.swift
@@ -3,7 +3,7 @@ import AccessibilitySnapshot
 import SnapshotTesting
 import XCTest
 
-class VisitorCodeViewControllerTests: SnapshotTestCase {
+final class VisitorCodeViewControllerTests: SnapshotTestCase {
     func testVisitorCodeAlertWhenLoading() {
         let props: CallVisualizer.VisitorCodeViewController.Props = .init(
             visitorCodeViewProps: .init(


### PR DESCRIPTION
This PR adds snapshot tests in landscape mode for regular and large font types.

Snapshot PR: https://github.com/salemove/ios-widgets-snapshots/pull/49

MOB-2683