### PR TITLE
Add missing accessibility identifier and introduce new view modifier

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -519,6 +519,7 @@
 		AF10ED8F29BF849A00E85309 /* UnreadMessageDividerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF10ED8E29BF849A00E85309 /* UnreadMessageDividerView.swift */; };
 		AF10ED9129BF85C700E85309 /* UnreadMessageDividerStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF10ED9029BF85C700E85309 /* UnreadMessageDividerStyle.swift */; };
 		AF11F30728BE6F0C002ACEB4 /* UIAlertController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF11F30628BE6F0C002ACEB4 /* UIAlertController+Extensions.swift */; };
+		AF18F1D52ABD954500121627 /* View+Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF18F1D42ABD954500121627 /* View+Accessibility.swift */; };
 		AF22C8852A6154780004BF3C /* AlertViewControllerLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF22C8842A6154780004BF3C /* AlertViewControllerLayoutTests.swift */; };
 		AF22C8872A6182AF0004BF3C /* BubbleViewLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF22C8862A6182AF0004BF3C /* BubbleViewLayoutTests.swift */; };
 		AF22C8892A6184C50004BF3C /* CallViewControllerLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF22C8882A6184C50004BF3C /* CallViewControllerLayoutTests.swift */; };
@@ -1256,6 +1257,7 @@
 		AF10ED8E29BF849A00E85309 /* UnreadMessageDividerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnreadMessageDividerView.swift; sourceTree = "<group>"; };
 		AF10ED9029BF85C700E85309 /* UnreadMessageDividerStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnreadMessageDividerStyle.swift; sourceTree = "<group>"; };
 		AF11F30628BE6F0C002ACEB4 /* UIAlertController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+Extensions.swift"; sourceTree = "<group>"; };
+		AF18F1D42ABD954500121627 /* View+Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Accessibility.swift"; sourceTree = "<group>"; };
 		AF22C8842A6154780004BF3C /* AlertViewControllerLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertViewControllerLayoutTests.swift; sourceTree = "<group>"; };
 		AF22C8862A6182AF0004BF3C /* BubbleViewLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BubbleViewLayoutTests.swift; sourceTree = "<group>"; };
 		AF22C8882A6184C50004BF3C /* CallViewControllerLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallViewControllerLayoutTests.swift; sourceTree = "<group>"; };
@@ -3530,6 +3532,7 @@
 			isa = PBXGroup;
 			children = (
 				C06152D42AB1BC1300063BF8 /* Font+Extensions.swift */,
+				AF18F1D42ABD954500121627 /* View+Accessibility.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -4523,6 +4526,7 @@
 				845876B1282A9EAF007AC3DF /* CheckboxView.Props.Accessibility.swift in Sources */,
 				1A4AF5CD25AEF4A0002CD0F4 /* AlertViewController+Message.swift in Sources */,
 				AFCF8A5C2A02AB3000B7ABB3 /* OutgoingMessage.Mock.swift in Sources */,
+				AF18F1D52ABD954500121627 /* View+Accessibility.swift in Sources */,
 				C0D2F08F29A61A8D00803B47 /* VideoCallViewController.Mock.swift in Sources */,
 				1A7CA8242574D68E0047CBBE /* ConnectStatusView.swift in Sources */,
 				845E2F78283E2D4200C04D56 /* PoweredByStyle.swift in Sources */,

--- a/GliaWidgets/SecureConversations/Confirmation/SecureConversations.ConfirmationViewModel.swift
+++ b/GliaWidgets/SecureConversations/Confirmation/SecureConversations.ConfirmationViewModel.swift
@@ -55,12 +55,14 @@ extension SecureConversations.ConfirmationViewSwiftUI.Model {
                 self?.delegate?(.closeTapped)
             }),
             style: style.header.closeButton,
+            accessibilityIdentifier: "header_close_button",
             isEnabled: true,
             isHidden: false
         )
 
         let endScreenShareButtonProps: HeaderButtonSwiftUI.Model = .init(
             style: style.header.endScreenShareButton,
+            accessibilityIdentifier: "header_end_screen_sharing_button",
             isEnabled: false,
             isHidden: true
         )

--- a/GliaWidgets/SwiftUI/Components/Buttons/HeaderButtonSwiftUI.swift
+++ b/GliaWidgets/SwiftUI/Components/Buttons/HeaderButtonSwiftUI.swift
@@ -19,7 +19,8 @@ struct HeaderButtonSwiftUI: View {
             .accessibility(label: Text(model.style.accessibility.label))
             .accessibility(addTraits: .isButton)
             .accessibility(removeTraits: .isImage)
-            .onTapGesture(perform: model.tap.callAsFunction)
+            .onTapGesture(perform: model.tap.execute)
+            .migrationAccessibilityIdentifier(model.accessibilityIdentifier)
     }
 }
 
@@ -27,6 +28,7 @@ extension HeaderButtonSwiftUI {
     final class Model: ObservableObject {
         var tap: Cmd
         var style: HeaderButtonStyle
+        var accessibilityIdentifier: String
         var size: CGSize
         var isEnabled: Bool
         var isHidden: Bool
@@ -34,6 +36,7 @@ extension HeaderButtonSwiftUI {
         init(
             tap: Cmd = .nop,
             style: HeaderButtonStyle,
+            accessibilityIdentifier: String,
             size: CGSize = CGSize(width: 14, height: 14),
             isEnabled: Bool,
             isHidden: Bool
@@ -43,6 +46,7 @@ extension HeaderButtonSwiftUI {
             self.size = size
             self.isEnabled = isEnabled
             self.isHidden = isHidden
+            self.accessibilityIdentifier = accessibilityIdentifier
         }
     }
 }

--- a/GliaWidgets/SwiftUI/Extensions/View+Accessibility.swift
+++ b/GliaWidgets/SwiftUI/Extensions/View+Accessibility.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+/// Accessibility identifier view modifier for resolving between
+/// deprecated and new method to specify accessibility identifier.
+struct MigrationAccessibilityIdentifierModifier: ViewModifier {
+    let identifier: String
+
+    func body(content: Content) -> some View {
+        if #available(iOS 14, *) {
+            content.accessibilityIdentifier(identifier)
+        } else {
+            content.accessibility(identifier: identifier)
+        }
+    }
+}
+
+/// Modifier for specifying accessibility identifier for avoiding deprecation warning.
+extension View {
+    func migrationAccessibilityIdentifier(_ identifier: String) -> some View {
+        self.modifier(MigrationAccessibilityIdentifierModifier(identifier: identifier))
+    }
+}


### PR DESCRIPTION
After migration to SwiftUI, Secure Conversation’s Confirmation header close button is missing 'header_close_button' identifier, which results in acceptance tests failure. Since we are constrained to iOS 13 deployment target, it made sense to add dedicated view modifier to resolve between depreciated and new methods for providing accessibility identifier to avoid deprecation warnings. This modifier will become obsolete once we bump up deployment target to iOS 14.

MOB-2694