### PR TITLE
#F Get company name from custom locales

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -1690,7 +1690,6 @@
 			isa = PBXGroup;
 			children = (
 				3146C9412AB1850A0047D8CC /* Resources */,
-				7552DFB22A6FBC6E0093519B /* CoreSdk */,
 				7552DFAF2A6FB37E0093519B /* ChatMessage */,
 				846A5C3729D18D220049B29F /* ScreenShareHandler */,
 				AFEF5C7229929A73005C3D8D /* SecureConversations */,
@@ -2686,13 +2685,6 @@
 				7552DFB02A6FB7DF0093519B /* ChatMessageTests.swift */,
 			);
 			path = ChatMessage;
-			sourceTree = "<group>";
-		};
-		7552DFB22A6FBC6E0093519B /* CoreSdk */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = CoreSdk;
 			sourceTree = "<group>";
 		};
 		755D186329A6A4B10009F5E8 /* WelcomeStyle */ = {

--- a/GliaWidgets/Public/Configuration/Configuration+Mock.swift
+++ b/GliaWidgets/Public/Configuration/Configuration+Mock.swift
@@ -7,12 +7,14 @@ extension Configuration {
     static func mock(
         authMethod: AuthorizationMethod = .siteApiKey(id: "site-api-key-id", secret: "site-api-key-secret"),
         environment: Environment = .beta,
-        site: String = "site-id"
+        site: String = "site-id",
+        companyName: String = ""
     ) -> Self {
         Configuration(
             authorizationMethod: authMethod,
             environment: environment,
-            site: site
+            site: site,
+            companyName: companyName
         )
     }
 }

--- a/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
+++ b/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
@@ -46,6 +46,16 @@ extension Glia {
             interactor.queueIds = queueIds
         }
 
+        theme.chat.connect.queue.firstText = companyName(
+            using: interactor,
+            currentName: theme.chat.connect.queue.firstText
+        )
+
+        theme.call.connect.queue.firstText = companyName(
+            using: interactor,
+            currentName: theme.call.connect.queue.firstText
+        )
+
         let viewFactory = ViewFactory(
             with: theme,
             messageRenderer: messageRenderer,
@@ -67,6 +77,35 @@ extension Glia {
             engagementKind: engagementKind,
             features: features
         )
+    }
+
+    func companyName(
+        using interactor: Interactor,
+        currentName: String?
+    ) -> String {
+        // As the default value is empty, it means that the integrator
+        // has set a value on the theme itself. Return that same value.
+        if let currentName, !currentName.isEmpty {
+            return currentName
+        }
+
+        let companyNameStringKey = "general.company_name"
+
+        // Company name has been set on the custom locale.
+        if let remoteCompanyName = stringProviding?.getRemoteString(companyNameStringKey) {
+            return remoteCompanyName
+        }
+        // Integrator has not set a company name in the custom locale,
+        // but has set it on the configuration.
+        else if !interactor.configuration.companyName.isEmpty {
+            return interactor.configuration.companyName
+        }
+        // Integrator has not set a company name anywhere, use the default.
+        else {
+            // This will return the fallback value every time, because we have
+            // already determined that the remote string is empty.
+            return Localization.General.companyName
+        }
     }
 
     func startRootCoordinator(
@@ -124,7 +163,7 @@ extension Glia {
                 startSocketObservation: environment.coreSdk.startSocketObservation,
                 stopSocketObservation: environment.coreSdk.stopSocketObservation,
                 pushNotifications: environment.coreSdk.pushNotifications,
-                createSendMessagePayload: environment.coreSdk.createSendMessagePayload, 
+                createSendMessagePayload: environment.coreSdk.createSendMessagePayload,
                 orientationManager: environment.orientationManager
             )
         )

--- a/GliaWidgets/Sources/Theme/Theme+Call.swift
+++ b/GliaWidgets/Sources/Theme/Theme+Call.swift
@@ -68,7 +68,7 @@ extension Theme {
             )
         )
         let queue = ConnectStatusStyle(
-            firstText: Localization.General.companyName,
+            firstText: "",
             firstTextFont: font.header1,
             firstTextFontColor: color.baseLight,
             firstTextStyle: .title1,

--- a/GliaWidgets/Sources/Theme/Theme+Chat.swift
+++ b/GliaWidgets/Sources/Theme/Theme+Chat.swift
@@ -70,7 +70,7 @@ extension Theme {
             )
         )
         let queue = ConnectStatusStyle(
-            firstText: Localization.General.companyName,
+            firstText: "",
             firstTextFont: font.header1,
             firstTextFontColor: color.baseDark,
             firstTextStyle: .title1,

--- a/GliaWidgets/Sources/ViewController/Call/CallViewController.Mock.swift
+++ b/GliaWidgets/Sources/ViewController/Call/CallViewController.Mock.swift
@@ -43,6 +43,7 @@ extension CallViewController {
             startWith: startAction
         )
         let theme = Theme.mock()
+        theme.call.connect.queue.firstText = "CompanyName"
         let viewFactEnv = ViewFactory.Environment.mock
         let viewFactory: ViewFactory = .mock(
             theme: theme,
@@ -217,6 +218,7 @@ extension CallViewController {
             startWith: startAction
         )
         let theme = Theme.mock()
+        theme.call.connect.queue.firstText = "CompanyName"
         let viewFactEnv = ViewFactory.Environment.mock
         let viewFactory: ViewFactory = .mock(
             theme: theme,

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
@@ -51,4 +51,127 @@ extension GliaTests {
         XCTAssertTrue(interactor.isConfigurationPerformed)
         XCTAssertEqual(calls, [.configureWithInteractor, .configureWithConfiguration])
     }
+
+    func testCompanyNameIsReceivedFromTheme() throws {
+        var environment = Glia.Environment.failing
+        var resultingViewFactory: ViewFactory?
+
+        environment.createRootCoordinator = { _, viewFactory, _, _, _, _, _ in
+            resultingViewFactory = viewFactory
+
+            return .mock(
+                interactor: .mock(environment: .failing),
+                viewFactory: viewFactory,
+                sceneProvider: nil,
+                engagementKind: .none,
+                screenShareHandler: .mock,
+                features: [],
+                environment: .failing
+            )
+        }
+
+        let sdk = Glia(environment: environment)
+
+        let theme = Theme()
+        theme.call.connect.queue.firstText = "Glia 1"
+        theme.chat.connect.queue.firstText = "Glia 2"
+
+        try sdk.configure(with: .mock())
+        try sdk.startEngagement(engagementKind: .chat, in: ["queueId"], theme: theme)
+
+        let configuredSdkTheme = resultingViewFactory?.theme
+        XCTAssertEqual(configuredSdkTheme?.call.connect.queue.firstText, "Glia 1")
+        XCTAssertEqual(configuredSdkTheme?.chat.connect.queue.firstText, "Glia 2")
+    }
+
+    func testCompanyNameIsReceivedFromRemoteStrings() throws {
+        var environment = Glia.Environment.failing
+        var resultingViewFactory: ViewFactory?
+
+        environment.createRootCoordinator = { _, viewFactory, _, _, _, _, _ in
+            resultingViewFactory = viewFactory
+
+            return .mock(
+                interactor: .mock(environment: .failing),
+                viewFactory: viewFactory,
+                sceneProvider: nil,
+                engagementKind: .none,
+                screenShareHandler: .mock,
+                features: [],
+                environment: .failing
+            )
+        }
+
+        environment.coreSdk.localeProvider.getRemoteString = { _ in "Glia" }
+        environment.coreSdk.configureWithInteractor = { _ in }
+        environment.coreSdk.configureWithConfiguration = { _, completion in
+            completion?()
+        }
+        environment.coreSdk.getCurrentEngagement = { nil }
+
+        let sdk = Glia(environment: environment)
+
+        try sdk.configure(with: .mock()) { }
+        try sdk.startEngagement(engagementKind: .chat, in: ["queueId"])
+
+        let configuredSdkTheme = resultingViewFactory?.theme
+        XCTAssertEqual(configuredSdkTheme?.call.connect.queue.firstText, "Glia")
+        XCTAssertEqual(configuredSdkTheme?.chat.connect.queue.firstText, "Glia")
+    }
+
+    func testCompanyNameIsReceivedFromConfiguration() throws {
+        var environment = Glia.Environment.failing
+        var resultingViewFactory: ViewFactory?
+
+        environment.createRootCoordinator = { _, viewFactory, _, _, _, _, _ in
+            resultingViewFactory = viewFactory
+
+            return .mock(
+                interactor: .mock(environment: .failing),
+                viewFactory: viewFactory,
+                sceneProvider: nil,
+                engagementKind: .none,
+                screenShareHandler: .mock,
+                features: [],
+                environment: .failing
+            )
+        }
+
+        let sdk = Glia(environment: environment)
+
+        try sdk.configure(with: .mock(companyName: "Glia"))
+        try sdk.startEngagement(engagementKind: .chat, in: ["queueId"])
+
+        let configuredSdkTheme = resultingViewFactory?.theme
+        XCTAssertEqual(configuredSdkTheme?.call.connect.queue.firstText, "Glia")
+        XCTAssertEqual(configuredSdkTheme?.chat.connect.queue.firstText, "Glia")
+    }
+
+    func testCompanyNameIsReceivedFromLocalStrings() throws {
+        var environment = Glia.Environment.failing
+        var resultingViewFactory: ViewFactory?
+
+        environment.createRootCoordinator = { _, viewFactory, _, _, _, _, _ in
+            resultingViewFactory = viewFactory
+
+            return .mock(
+                interactor: .mock(environment: .failing),
+                viewFactory: viewFactory,
+                sceneProvider: nil,
+                engagementKind: .none,
+                screenShareHandler: .mock,
+                features: [],
+                environment: .failing
+            )
+        }
+
+        let sdk = Glia(environment: environment)
+
+        try sdk.configure(with: .mock())
+        try sdk.startEngagement(engagementKind: .chat, in: ["queueId"])
+
+        let configuredSdkTheme = resultingViewFactory?.theme
+        XCTAssertEqual(configuredSdkTheme?.call.connect.queue.firstText, "CompanyName")
+        XCTAssertEqual(configuredSdkTheme?.chat.connect.queue.firstText, "CompanyName")
+    }
 }

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -49,7 +49,7 @@ final class GliaTests: XCTestCase {
         gliaEnv.fileManager = fileManager
         gliaEnv.coreSdk.configureWithInteractor = { _ in }
         gliaEnv.createFileUploadListModel = { _ in .mock() }
-        
+        gliaEnv.coreSdk.localeProvider.getRemoteString = { _ in nil }
         gliaEnv.coreSdk.authentication = { _ in .mock }
         gliaEnv.coreSdk.configureWithConfiguration = { _, callback in callback?() }
         gliaEnv.coreSdk.queueForEngagement = { _, callback in
@@ -284,4 +284,3 @@ final class GliaTests: XCTestCase {
         XCTAssertEqual(delegate.invokedEventCallParameterList, [.maximized])
     }
 }
-


### PR DESCRIPTION
In this commit, support for adding a company name from custom locales is added.
However, if the integrator has set this name through the theme, that one is used
instead of the custom locales. Also, in case the custom locale doesn't have a
string for the company name, but the integrator has specified a company name
through the configuration of the SDK, then that is used. Finally, if neither of
the previous possibilies have been used, then the local fallbacks are used.
Together, the first and the last point mean that there are no backwards
compatibility issues, as if the integrator hasn't set any name, still the
local fallback will be displayed, which is "CompanyName". If they have, then
that is used immediately without caring about configuration or custom locales.

MOB-2686