### PR TITLE
Fix accessiblity identifier for confirmation button

### DIFF
--- a/GliaWidgets/SecureConversations/Confirmation/SecureConversations.ConfirmationView.swift
+++ b/GliaWidgets/SecureConversations/Confirmation/SecureConversations.ConfirmationView.swift
@@ -80,7 +80,7 @@ private extension SecureConversations.ConfirmationViewSwiftUI {
                 .background(SwiftUI.Color(model.style.checkMessagesButtonStyle.backgroundColor))
                 .cornerRadius(4)
         }
-        .migrationAccessibilityIdentifier("secureConversations_confirmationCheckMessages_button")
+        .migrationAccessibilityIdentifier("secureConversations_welcomeCheckMessages_button")
         .migrationAccessibilityLabel(model.style.checkMessagesButtonStyle.accessibility.label)
         .migrationAccessibilityHint(model.style.checkMessagesButtonStyle.accessibility.hint)
     }


### PR DESCRIPTION
This PR fixes the identifier that lead to acceptance tests to fail