### PR TITLE
#F Change priority of company name algorithm

### DIFF
--- a/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
+++ b/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
@@ -48,12 +48,12 @@ extension Glia {
 
         theme.chat.connect.queue.firstText = companyName(
             using: interactor,
-            currentName: theme.chat.connect.queue.firstText
+            themeCompanyName: theme.chat.connect.queue.firstText
         )
 
         theme.call.connect.queue.firstText = companyName(
             using: interactor,
-            currentName: theme.call.connect.queue.firstText
+            themeCompanyName: theme.call.connect.queue.firstText
         )
 
         let viewFactory = ViewFactory(
@@ -81,19 +81,20 @@ extension Glia {
 
     func companyName(
         using interactor: Interactor,
-        currentName: String?
+        themeCompanyName: String?
     ) -> String {
-        // As the default value is empty, it means that the integrator
-        // has set a value on the theme itself. Return that same value.
-        if let currentName, !currentName.isEmpty {
-            return currentName
-        }
-
         let companyNameStringKey = "general.company_name"
 
-        // Company name has been set on the custom locale.
-        if let remoteCompanyName = stringProviding?.getRemoteString(companyNameStringKey) {
+        // Company name has been set on the custom locale and is not empty.
+        if let remoteCompanyName = stringProviding?.getRemoteString(companyNameStringKey),
+            !remoteCompanyName.isEmpty {
             return remoteCompanyName
+        }
+        // As the default value in the theme is not empty, it means that
+        // the integrator has set a value on the theme itself. Return that
+        // same value.
+        else if let themeCompanyName, !themeCompanyName.isEmpty {
+            return themeCompanyName
         }
         // Integrator has not set a company name in the custom locale,
         // but has set it on the configuration.


### PR DESCRIPTION
Before, the UiTheme took the highest priority in the algorithm to determine the company name. Now the remote company name has the highest priority, with the added constraint that it cannot be empty, as this will be the default value on the default locale. In case it is empty, the UiTheme will come afterwards, then the SDK configuration, and finally the local fallback.

MOB-2733