### PR TITLE
#F Add powered by to leave queue alert

### DIFF
--- a/GliaWidgets/Sources/Theme/Theme+AlertConfiguration.swift
+++ b/GliaWidgets/Sources/Theme/Theme+AlertConfiguration.swift
@@ -6,7 +6,7 @@ extension Theme {
             negativeTitle: Localization.General.no,
             positiveTitle: Localization.General.yes,
             switchButtonBackgroundColors: true,
-            showsPoweredBy: false
+            showsPoweredBy: showsPoweredBy
         )
         let endEngagement = ConfirmationAlertConfiguration(
             title: Localization.Engagement.End.Confirmation.header,
@@ -14,7 +14,7 @@ extension Theme {
             negativeTitle: Localization.General.no,
             positiveTitle: Localization.General.yes,
             switchButtonBackgroundColors: true,
-            showsPoweredBy: true
+            showsPoweredBy: showsPoweredBy
         )
         let operatorEndedEngagement = SingleActionAlertConfiguration(
             title: Localization.Engagement.Ended.header,


### PR DESCRIPTION
This commit syncs the leave queue alert to how Android works. Also, the end engagement alert now uses the `showsPoweredBy` variable. This means that it will now respect the global setting rather than always setting it as yes. This would bring issues if a client pays for hiding powered by, as it would be wrongly shown in that case.

MOB-2742