### PR TITLE
#F Fix visitor code spinner animation

### DIFF
--- a/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeView.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeView.swift
@@ -227,6 +227,7 @@ extension CallVisualizer {
             rotation.toValue = CGFloat.pi * 2
             rotation.duration = 1.0
             rotation.repeatCount = Float.infinity
+            rotation.isRemovedOnCompletion = false
             spinnerView.tintColor = props.style.loadingProgressColor
             spinnerView.layer.add(rotation, forKey: "Spin")
         }


### PR DESCRIPTION
The `isRemovedOnCompletion` property was missing, which meant that the animation never ran, and the spinner was always static. Now the animation runs forever until removed.

MOB-2743