### PR TITLE
#R Connecting state issue fixes

### DIFF
--- a/GliaWidgets/Sources/ViewModel/Call/CallViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Call/CallViewModel.swift
@@ -72,7 +72,20 @@ class CallViewModel: EngagementViewModel, ViewModel {
         super.start()
 
         update(for: call.kind.value)
-        update(for: interactor.state)
+
+        // In the case when SDK is configured once and then
+        // visitor has several Audio/Video engagements in a raw,
+        // after ending each of them, `interactor.state` has `.ended` value,
+        // which causes calling `call.end()` on the start of the next
+        // Audio/Video engagement. That `call.end()` breaks the flow and SDK does not
+        // handle `connected` state properly. So we need to skip handling `.ended` state
+        // on the start of a new engagement.
+        switch interactor.state {
+        case .ended:
+            break
+        default:
+            update(for: interactor.state)
+        }
 
         switch startWith {
         case .engagement(let mediaType):

--- a/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
@@ -11,6 +11,8 @@ class EngagementViewModel: CommonEngagementModel {
     let alertConfiguration: AlertConfiguration
     let environment: Environment
     let screenShareHandler: ScreenShareHandler
+    // Need to keep strong reference of `activeEngagement`,
+    // to be able to fetch survey after ending engagement
     var activeEngagement: CoreSdkClient.Engagement?
 
     private(set) var isViewActive = ObservableValue<Bool>(with: false)
@@ -225,10 +227,10 @@ class EngagementViewModel: CommonEngagementModel {
     }
 
     func endSession() {
-        interactor.endSession {
-            self.engagementDelegate?(.finished)
-        } failure: { _ in
-            self.engagementDelegate?(.finished)
+        interactor.endSession { [weak self] in
+            self?.engagementDelegate?(.finished)
+        } failure: { [weak self] _ in
+            self?.engagementDelegate?(.finished)
         }
         self.screenShareHandler.stop(nil)
     }

--- a/GliaWidgetsTests/Sources/CallViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/CallViewModelTests.swift
@@ -335,4 +335,16 @@ class CallViewModelTests: XCTestCase {
 
         XCTAssertEqual(call.kind.value, .audio)
     }
+
+    func test_startMethodDoesNotHandleInteractorStateEnded() {
+        let interactor: Interactor = .mock()
+        interactor.state = .ended(.byOperator)
+        let call: Call = .mock()
+        let viewModel: CallViewModel = .mock(interactor: interactor, call: call)
+
+        XCTAssertEqual(call.state.value, .none)
+        viewModel.start()
+
+        XCTAssertEqual(call.state.value, .none)
+    }
 }

--- a/TestingApp/Main.storyboard
+++ b/TestingApp/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -21,7 +21,7 @@
                                 <rect key="frame" x="0.0" y="48" width="414" height="814"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="A3Y-Xf-Ufg">
-                                        <rect key="frame" x="0.0" y="16" width="414" height="827.5"/>
+                                        <rect key="frame" x="0.0" y="16" width="414" height="873.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Configuration" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4l1-DH-Wkd">
                                                 <rect key="frame" x="155.5" y="0.0" width="103.5" height="20.5"/>
@@ -64,8 +64,23 @@
                                                 <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="CoL-67-2P6">
+                                                <rect key="frame" x="64.5" y="116" width="285" height="31"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Configure SDK before each engagement" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jkf-af-iEo">
+                                                        <rect key="frame" x="0.0" y="0.0" width="228" height="31"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                        <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rZ7-2H-jwc">
+                                                        <rect key="frame" x="236" y="0.0" width="51" height="31"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="main_auto_configure_sdk_toggle"/>
+                                                    </switch>
+                                                </subviews>
+                                            </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="qwv-F0-vOF">
-                                                <rect key="frame" x="74" y="116" width="266" height="30"/>
+                                                <rect key="frame" x="74" y="162" width="266" height="30"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zmv-pl-N2H">
                                                         <rect key="frame" x="0.0" y="0.0" width="68" height="30"/>
@@ -103,13 +118,13 @@
                                                 </subviews>
                                             </stackView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Utils" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fwb-CM-wR2">
-                                                <rect key="frame" x="190" y="161" width="34" height="20.5"/>
+                                                <rect key="frame" x="190" y="207" width="34" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="P9U-ba-KVy">
-                                                <rect key="frame" x="179.5" y="196.5" width="55" height="30"/>
+                                                <rect key="frame" x="179.5" y="242.5" width="55" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_resume_button"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="mbg-qw-hCC"/>
@@ -120,7 +135,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0wb-9L-Csn">
-                                                <rect key="frame" x="161" y="241.5" width="92" height="30"/>
+                                                <rect key="frame" x="161" y="287.5" width="92" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_clearSession_button"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="wht-81-BI4"/>
@@ -131,7 +146,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pHy-59-v7T">
-                                                <rect key="frame" x="163" y="286.5" width="88" height="30"/>
+                                                <rect key="frame" x="163" y="332.5" width="88" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_authenticate_button"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="ezp-dJ-Nup"/>
@@ -142,7 +157,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ojd-PF-wje">
-                                                <rect key="frame" x="119" y="331.5" width="176" height="30"/>
+                                                <rect key="frame" x="119" y="377.5" width="176" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_secureConversations_button"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="Nk7-ud-fyb"/>
@@ -155,7 +170,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3Ys-xS-zdq">
-                                                <rect key="frame" x="126" y="376.5" width="162" height="30"/>
+                                                <rect key="frame" x="126" y="422.5" width="162" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_endEngagement_button"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="QkV-yj-Sti"/>
@@ -166,7 +181,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tYL-hF-sF1">
-                                                <rect key="frame" x="152" y="421.5" width="110" height="30"/>
+                                                <rect key="frame" x="152" y="467.5" width="110" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_visitorInfo_button"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
@@ -176,13 +191,13 @@
                                                 </connections>
                                             </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="UI customization" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E1e-uA-HuC">
-                                                <rect key="frame" x="143.5" y="466.5" width="127.5" height="20.5"/>
+                                                <rect key="frame" x="143.5" y="512.5" width="127.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ezc-iY-PbB">
-                                                <rect key="frame" x="141" y="502" width="132" height="30"/>
+                                                <rect key="frame" x="141" y="548" width="132" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_endEngagement_button"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="Nef-0j-qW7"/>
@@ -193,13 +208,13 @@
                                                 </connections>
                                             </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VisitorCode" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tI8-TQ-jWA">
-                                                <rect key="frame" x="162.5" y="547" width="89" height="20.5"/>
+                                                <rect key="frame" x="162.5" y="593" width="89" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="1gR-qB-lno">
-                                                <rect key="frame" x="90.5" y="582.5" width="233" height="30"/>
+                                                <rect key="frame" x="90.5" y="628.5" width="233" height="30"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YnU-rR-gCc">
                                                         <rect key="frame" x="0.0" y="0.0" width="88" height="30"/>
@@ -228,7 +243,7 @@
                                                 </subviews>
                                             </stackView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7mi-et-ybT">
-                                                <rect key="frame" x="0.0" y="627.5" width="414" height="200"/>
+                                                <rect key="frame" x="0.0" y="673.5" width="414" height="200"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="200" id="GaG-7F-RUb"/>
@@ -263,6 +278,7 @@
                     </view>
                     <connections>
                         <outlet property="VisitorCodeView" destination="7mi-et-ybT" id="guR-OT-e1w"/>
+                        <outlet property="autoConfigureSdkToggle" destination="rZ7-2H-jwc" id="nAr-zX-vTy"/>
                         <outlet property="configureButton" destination="4yC-lN-tH2" id="sAf-jg-YTC"/>
                         <outlet property="secureConversationsButton" destination="ojd-PF-wje" id="kN8-zY-QYl"/>
                         <outlet property="toggleAuthenticateButton" destination="pHy-59-v7T" id="9rO-74-dfE"/>
@@ -270,7 +286,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="132" y="94"/>
+            <point key="canvasLocation" x="132" y="84"/>
         </scene>
     </scenes>
     <resources>


### PR DESCRIPTION
On SDK configuration, interactor instance is created and has .none state. When Call screen is loaded, its start() method is called which executes some updates based on current interactor.state. When configure method is called before each engagement start (like we currently do in WidgetsSDK Testing app), CallViewModel.start() does nothing, because interactor.state is .none. But when WidgesSDK is configured once (for example on the app launch), the same interactor instance is used for all subsequent engagements. When you end first engagement (Chat/Audio/Video, probably CV also), interactor.state is .ended. Then if you start new Audio/Video engagement, CallViewModel.start() calls CallViewModel.call.end() method, which breaks something and connecting state becomes infinite. 

This commit fixes calling CallViewModel.call.end() on Audio/Video engagement start. 
The toggle (UISwitch) was added to Main screen, that provides the ability to disable/enable SDK configuration before each engagement.

MOB-2730