### PR TITLE
Update GliaCoreSDK to 1.1.4 and remove GliaWidgetsXcf

### DIFF
--- a/GliaWidgets.podspec
+++ b/GliaWidgets.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   }
   s.exclude_files         = ['GliaWidgets/Window/**']
 
-  s.dependency 'GliaCoreSDK', '1.1.3'
+  s.dependency 'GliaCoreSDK', '1.1.4'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -11,10 +11,6 @@ let package = Package(
         .library(
             name: "GliaWidgets",
             targets: ["GliaWidgetsSDK"]
-        ),
-        .library(
-            name: "GliaWidgets-xcframework",
-            targets: ["GliaWidgetsSDK-xcframework"]
         )
     ],
     targets: [
@@ -35,13 +31,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "GliaCoreSDK",
-            url: "https://github.com/salemove/ios-bundle/releases/download/1.1.3/GliaCoreSDK.xcframework.zip",
-            checksum: "ffffc1a4bdbf467b076823d604cf8a628c78fd49a7ceda6dd423f569a13c5fa3"
-        ),
-        .binaryTarget(
-            name: "GliaWidgetsXcf",
-            url: "https://github.com/salemove/ios-sdk-widgets/releases/download/2.0.6/GliaWidgetsXcf.xcframework.zip",
-            checksum: "27dd290835cc21e8191d16d128c8b4d19a7bda8f34029821626eefd91a7c448b"
+            url: "https://github.com/salemove/ios-bundle/releases/download/1.1.4/GliaCoreSDK.xcframework.zip",
+            checksum: "cc06b73535b6cbbc2e0cc27c3571368cb1a021ca5485eb907e7cf9581696f0bb"
         ),
         .target(
             name: "GliaWidgets",
@@ -63,16 +54,6 @@ let package = Package(
                 "TwilioVoice",
                 "WebRTC",
                 "GliaWidgets"
-            ]
-        ),
-        .target(
-            name: "GliaWidgetsSDK-xcframework",
-            dependencies: [
-                "GliaCoreSDK",
-                "GliaWidgetsXcf",
-                "GliaCoreDependency",
-                "TwilioVoice",
-                "WebRTC"
             ]
         )
     ]

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
     - AccessibilitySnapshot/Core
     - SnapshotTesting (~> 1.0)
   - GliaCoreDependency (1.2)
-  - GliaCoreSDK (1.1.3):
+  - GliaCoreSDK (1.1.4):
     - GliaCoreDependency (= 1.2)
     - TwilioVoice (= 6.3.1)
     - WebRTC-lib (= 96.0.0)
@@ -34,7 +34,7 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   AccessibilitySnapshot: a91e4a69f870188b51f43863d9fc7269d07cdd93
   GliaCoreDependency: 87b3897f0d85321ecf77f1faa829211ad527e54d
-  GliaCoreSDK: cae2181c8d19f39609c727a8c2a2268e256f5746
+  GliaCoreSDK: 94a986c0a0eae705a9abb763bc4c4fcb01f9b013
   SnapshotTesting: 6141c48b6aa76ead61431ca665c14ab9a066c53b
   SwiftLint: 13280e21cdda6786ad908dc6e416afe5acd1fcb7
   TwilioVoice: 098a959181d4607921f5822d3c9f13043ea4075b

--- a/templates/GliaWidgets.podspec
+++ b/templates/GliaWidgets.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   }
   s.exclude_files         = ['GliaWidgets/Window/**']
 
-  s.dependency 'GliaCoreSDK', '1.1.3'
+  s.dependency 'GliaCoreSDK', '1.1.4'
 end

--- a/templates/Package.swift
+++ b/templates/Package.swift
@@ -11,10 +11,6 @@ let package = Package(
         .library(
             name: "GliaWidgets",
             targets: ["GliaWidgetsSDK"]
-        ),
-        .library(
-            name: "GliaWidgets-xcframework",
-            targets: ["GliaWidgetsSDK-xcframework"]
         )
     ],
     targets: [
@@ -38,11 +34,6 @@ let package = Package(
             url: "https://github.com/salemove/ios-bundle/releases/download/${CORE_SDK_VERSION}/GliaCoreSDK.xcframework.zip",
             checksum: "${CORE_SDK_CHECKSUM}"
         ),
-        .binaryTarget(
-            name: "GliaWidgetsXcf",
-            url: "https://github.com/salemove/ios-sdk-widgets/releases/download/2.0.1/GliaWidgetsXcf.xcframework.zip",
-            checksum: "26f6e0bc6e32f4223f635d8de8aa4877338aed7a323f2127a05980f347ac1f9a"
-        ),
         .target(
             name: "GliaWidgets",
             path: "GliaWidgets",
@@ -63,16 +54,6 @@ let package = Package(
                 "TwilioVoice",
                 "WebRTC",
                 "GliaWidgets"
-            ]
-        ),
-        .target(
-            name: "GliaWidgetsSDK-xcframework",
-            dependencies: [
-                "GliaCoreSDK",
-                "GliaWidgetsXcf",
-                "GliaCoreDependency",
-                "TwilioVoice",
-                "WebRTC"
             ]
         )
     ]


### PR DESCRIPTION
Update GliaCoreSDK to 1.1.4 and remove GliaWidgetsXcf.

**Jira issue:**
https://glia.atlassian.net/browse/MOB-2746

**What was solved?**

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
