### PR TITLE
#I Remove L10n usage from unit tests

### DIFF
--- a/GliaWidgets/Sources/CallVisualizer/ScreenSharing/View/ScreenSharingView.swift
+++ b/GliaWidgets/Sources/CallVisualizer/ScreenSharing/View/ScreenSharingView.swift
@@ -53,7 +53,7 @@ extension CallVisualizer.ScreenSharingView {
             .padding(.horizontal, 60)
         })
         .migrationAccessibilityIdentifier("end_screen_sharing_button")
-        .migrationAccessibilityLabel(L10n.CallVisualizer.ScreenSharing.Accessibility.buttonLabel)
-        .migrationAccessibilityHint(L10n.CallVisualizer.ScreenSharing.Accessibility.buttonHint)
+        .migrationAccessibilityLabel(Localization.ScreenSharing.VisitorScreen.End.title)
+        .migrationAccessibilityHint(Localization.ScreenSharing.VisitorScreen.End.Accessibility.hint)
     }
 }

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+ViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+ViewModel.swift
@@ -1,8 +1,6 @@
 import Foundation
 
 extension ChatViewModel: ViewModel {
-    typealias Strings = L10n.Chat
-
     enum Event {
         case viewDidLoad
         case messageTextChanged(String)

--- a/SnapshotTests/VideoCallViewControllerDynamicTypeFontTests.swift
+++ b/SnapshotTests/VideoCallViewControllerDynamicTypeFontTests.swift
@@ -12,29 +12,29 @@ final class VideoCallViewControllerDynamicTypeFontTests: SnapshotTestCase {
                     videButton: .mock(
                         inactive: .activeMock(
                             image: Asset.callVideoActive.image,
-                            title: L10n.Call.Buttons.Video.title,
-                            accessibility: .init(label: L10n.Call.Accessibility.Buttons.Video.Active.label)
+                            title: Localization.Engagement.Video.title,
+                            accessibility: .init(label: Localization.General.selected)
                         )
                     ),
                     muteButton: .mock(
                         inactive: .inactiveMock(
                             image: Asset.callMuteInactive.image,
-                            title: L10n.Call.Buttons.Mute.Inactive.title,
-                            accessibility: .init(label: L10n.Call.Accessibility.Buttons.Mute.Inactive.label)
+                            title: Localization.Call.Mute.button,
+                            accessibility: .init(label: "")
                         )
                     ),
                     speakerButton: .mock(
                         inactive: .inactiveMock(
                             image: Asset.callSpeakerInactive.image,
-                            title: L10n.Call.Buttons.Speaker.title,
-                            accessibility: .init(label: L10n.Call.Accessibility.Buttons.Speaker.Inactive.label)
+                            title: Localization.Call.Speaker.button,
+                            accessibility: .init(label: "")
                         )
                     ),
                     minimizeButton: .mock(
                         inactive: .inactiveMock(
                             image: Asset.callMiminize.image,
-                            title: L10n.Call.Buttons.Minimize.title,
-                            accessibility: .init(label: L10n.Call.Accessibility.Buttons.Minimize.Inactive.label)
+                            title: Localization.Engagement.MinimizeVideo.button,
+                            accessibility: .init(label: "")
                         )
                     ),
                     badge: .mock()

--- a/SnapshotTests/VideoCallViewControllerLayoutTests.swift
+++ b/SnapshotTests/VideoCallViewControllerLayoutTests.swift
@@ -11,29 +11,29 @@ final class VideoCallViewControllerLayoutTests: SnapshotTestCase {
                     videButton: .mock(
                         inactive: .activeMock(
                             image: Asset.callVideoActive.image,
-                            title: L10n.Call.Buttons.Video.title,
-                            accessibility: .init(label: L10n.Call.Accessibility.Buttons.Video.Active.label)
+                            title: Localization.Engagement.Video.title,
+                            accessibility: .init(label: Localization.General.selected)
                         )
                     ),
                     muteButton: .mock(
                         inactive: .inactiveMock(
                             image: Asset.callMuteInactive.image,
-                            title: L10n.Call.Buttons.Mute.Inactive.title,
-                            accessibility: .init(label: L10n.Call.Accessibility.Buttons.Mute.Inactive.label)
+                            title: Localization.Call.Mute.button,
+                            accessibility: .init(label: "")
                         )
                     ),
                     speakerButton: .mock(
                         inactive: .inactiveMock(
                             image: Asset.callSpeakerInactive.image,
-                            title: L10n.Call.Buttons.Speaker.title,
-                            accessibility: .init(label: L10n.Call.Accessibility.Buttons.Speaker.Inactive.label)
+                            title: Localization.Call.Speaker.button,
+                            accessibility: .init(label: "")
                         )
                     ),
                     minimizeButton: .mock(
                         inactive: .inactiveMock(
                             image: Asset.callMiminize.image,
-                            title: L10n.Call.Buttons.Minimize.title,
-                            accessibility: .init(label: L10n.Call.Accessibility.Buttons.Minimize.Inactive.label)
+                            title: Localization.Engagement.MinimizeVideo.button,
+                            accessibility: .init(label: "")
                         )
                     ),
                     badge: .mock()

--- a/SnapshotTests/VideoCallViewControllerVoiceOverTests.swift
+++ b/SnapshotTests/VideoCallViewControllerVoiceOverTests.swift
@@ -12,29 +12,29 @@ final class VideoCallViewControllerVoiceOverTests: SnapshotTestCase {
                     videButton: .mock(
                         inactive: .activeMock(
                             image: Asset.callVideoActive.image,
-                            title: L10n.Call.Buttons.Video.title,
-                            accessibility: .init(label: L10n.Call.Accessibility.Buttons.Video.Active.label)
+                            title: Localization.Engagement.Video.title,
+                            accessibility: .init(label: Localization.General.selected)
                         )
                     ),
                     muteButton: .mock(
                         inactive: .inactiveMock(
                             image: Asset.callMuteInactive.image,
-                            title: L10n.Call.Buttons.Mute.Inactive.title,
-                            accessibility: .init(label: L10n.Call.Accessibility.Buttons.Mute.Inactive.label)
+                            title: Localization.Call.Mute.button,
+                            accessibility: .init(label: "")
                         )
                     ),
                     speakerButton: .mock(
                         inactive: .inactiveMock(
                             image: Asset.callSpeakerInactive.image,
-                            title: L10n.Call.Buttons.Speaker.title,
-                            accessibility: .init(label: L10n.Call.Accessibility.Buttons.Speaker.Inactive.label)
+                            title: Localization.Call.Speaker.button,
+                            accessibility: .init(label: "")
                         )
                     ),
                     minimizeButton: .mock(
                         inactive: .inactiveMock(
                             image: Asset.callMiminize.image,
-                            title: L10n.Call.Buttons.Minimize.title,
-                            accessibility: .init(label: L10n.Call.Accessibility.Buttons.Minimize.Inactive.label)
+                            title: Localization.Engagement.MinimizeVideo.button,
+                            accessibility: .init(label: "")
                         )
                     ),
                     badge: .mock()


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-2747

**What was solved?**
There were some tests that still used L10n strings, which are now deprecated.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
