### PR TITLE
Fix hiding of text input for Secure Transcript flow

### DIFF
--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
@@ -59,7 +59,11 @@ extension SecureConversations {
         var availability: Availability
         var interactor: Interactor
 
-        private (set) var isSecureConversationsAvailable: Bool = true
+        private (set) var isSecureConversationsAvailable: Bool = true {
+            didSet {
+                action?(.transcript(.messageCenterAvailabilityUpdated))
+            }
+        }
 
         var siteConfiguration: CoreSdkClient.Site?
 
@@ -175,6 +179,7 @@ extension SecureConversations {
                     let configuration = self.environment.alertConfiguration.unavailableMessageCenter
                     self.reportMessageCenterUnavailable(configuration: configuration)
                 case .success(.unavailable(.unauthenticated)):
+                    self.isSecureConversationsAvailable = false
                     let configuration = self.environment.alertConfiguration.unavailableMessageCenterForBeingUnauthenticated
                     self.reportMessageCenterUnavailable(configuration: configuration)
                 }
@@ -746,3 +751,12 @@ extension SecureConversations.TranscriptModel {
 
     }
 }
+
+#if DEBUG
+extension SecureConversations.TranscriptModel {
+    /// Setter for `isSecureConversationsAvailable`. Used in unit tests.
+    func setIsSecureConversationsAvailable(_ available: Bool) {
+        self.isSecureConversationsAvailable = available
+    }
+}
+#endif

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
@@ -168,6 +168,8 @@ final class ChatViewController: EngagementViewController, PopoverPresenter {
                 view?.messageEntryView.uploadListView.props = fileUploadListProps
             case let .quickReplyPropsUpdated(props):
                 view?.renderQuickReply(props: props)
+            case .transcript(.messageCenterAvailabilityUpdated):
+                break
             }
             self?.renderProps()
         }

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+ViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+ViewModel.swift
@@ -21,6 +21,10 @@ extension ChatViewModel: ViewModel {
     }
 
     enum Action {
+        /// Actions specific for `TranscriptModel`.
+        enum TranscriptAction {
+            case messageCenterAvailabilityUpdated
+        }
         case queue
         case connected(name: String?, imageUrl: String?)
         case transferring
@@ -53,6 +57,7 @@ extension ChatViewModel: ViewModel {
         case setAttachmentButtonVisibility(MediaPickerButtonVisibility)
         case fileUploadListPropsUpdated(SecureConversations.FileUploadListView.Props)
         case quickReplyPropsUpdated(QuickReplyView.Props)
+        case transcript(TranscriptAction)
     }
 
     enum DelegateEvent {


### PR DESCRIPTION

MOB-2734

**Jira issue:**
https://glia.atlassian.net/browse/MOB-2734

**What was solved?**
Fixed hiding of text input for Secure Transcript flow when Secure Message Center is unavailable.


**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
<img src="https://github.com/salemove/ios-sdk-widgets/assets/3148347/64dbe894-99be-4134-ad8f-add598c669f4" width="390" height="844">