### PR TITLE
Fix dependency update lane

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -184,7 +184,7 @@ workflows:
         - command: update
     - fastlane@3:
         inputs:
-        - lane: ios create_pr_for_dependencies_update
+        - lane: ios create_pr_for_dependencies_update version:$VERSION checksum:$CHECKSUM
   upload_to_appstore_connect:
     steps:
     - activate-ssh-key@4:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -86,7 +86,7 @@ platform :ios do
     update_core_sdk_version(core_sdk_version: version, core_sdk_checksum: checksum)
 
     branch_name = 'dependencies-update'
-    message = "Update dependencies declared in `Podfile`"
+    message = "Update dependencies declared in `Podfile` and `Package.swift`"
 
     sh "cd .. && scripts/commit_unstaged_changes.sh '#{branch_name}' '#{message}'"
     create_pull_request(
@@ -108,8 +108,8 @@ platform :ios do
     core_sdk_checksum = options[:core_sdk_checksum]
     UI.user_error!("No Core SDK checksum specified") unless !core_sdk_checksum.nil?
 
+    sh("sed -i '' \"s/.*GliaCoreSDK.*/  s.dependency 'GliaCoreSDK', '#{core_sdk_version}'/g\" ../templates/GliaWidgets.podspec")
     sh("cp ../templates/GliaWidgets.podspec ../GliaWidgets.podspec")
-    sh("sed -i '' \"s/.*GliaCoreSDK.*/  s.dependency 'GliaCoreSDK', '#{core_sdk_version}'/g\" ../GliaWidgets.podspec")
     sh("sed -i '' \"s/.*  s.version.*/  s.version               = '#{project_version}'/g\" ../GliaWidgets.podspec")
 
     sh("cp ../templates/Package.swift ../Package.swift")


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-2770

**What was solved?**
There is a workflow in ios-bundle repository called "Post Release" which gets the version and the checksum from the latest version, sends it to an `update-dependencies` workflow in ios-sdk-widgets, which then executes a Fastlane lane that uses that info, updates the templates, and generates the new files. However for some reason, these version and checksum parameters weren't used in the calling of the Fastlane lane. Now they are called.

Also, now the replacement of the Core SDK version is done first in the template, then the template is copied to the root folder, and then it is adjusted for the latest Widgets version. This way, the root podspec and the  template podspec always have correct Core version. Before, the template was copied first and then the replacement of the Core SDK was done. This meant the template was always out of date.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
