### PR TITLE
Add possibility to change `Podfile.lock` in Post Release workflow

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -108,12 +108,27 @@ platform :ios do
     core_sdk_checksum = options[:core_sdk_checksum]
     UI.user_error!("No Core SDK checksum specified") unless !core_sdk_checksum.nil?
 
+    # Changes to GliaWidgets.podspec
     sh("sed -i '' \"s/.*GliaCoreSDK.*/  s.dependency 'GliaCoreSDK', '#{core_sdk_version}'/g\" ../templates/GliaWidgets.podspec")
     sh("cp ../templates/GliaWidgets.podspec ../GliaWidgets.podspec")
     sh("sed -i '' \"s/.*  s.version.*/  s.version               = '#{project_version}'/g\" ../GliaWidgets.podspec")
 
+    # Changes to Package.swift
     sh("cp ../templates/Package.swift ../Package.swift")
     sh("sed -i '' 's/\${CORE_SDK_VERSION}/#{core_sdk_version}/' ../Package.swift")
     sh("sed -i '' 's/\${CORE_SDK_CHECKSUM}/#{core_sdk_checksum}/' ../Package.swift")
+
+    core_sdk_podspec_url = "https://raw.githubusercontent.com/CocoaPods/Specs/e98c1e8af87c48b4f9e7e5e8635509ed246a615e/Specs/b/d/d/GliaCoreSDK/#{core_sdk_version}/GliaCoreSDK.podspec.json"
+
+    # Generate the Podfile checksum by downloading its JSON representation, generating the checksum, and then
+    # getting the checksum value only without any additional output.
+    core_sdk_podfile_checksum = sh("curl -s GET #{core_sdk_podspec_url} | openssl sha1 | awk {'print $2'}")
+
+    # The previous command has a newline at the end.
+    stripped_core_sdk_podfile_checksum = core_sdk_podfile_checksum.strip
+
+    # Changes to Podfile.lock
+    sh("sed -i '' \"s/.*  - GliaCoreSDK(.*/  - GliaCoreSDK (#{core_sdk_version}):/g\" ../Podfile.lock")
+    sh("sed -i '' \"s/.*  GliaCoreSDK:.*/  GliaCoreSDK: #{stripped_core_sdk_podfile_checksum}/g\" ../Podfile.lock")
   end
 end


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-2773

**What was solved?**
The Post Release workflow in ios-bundle executes code in ios-sdk-widgets, which sets in place the new version and package checksum. It however omitted the Podfile.lock, which meant that you still had to manually update it. This PR changes the version also in the Podfile.lock, while also changing the Glia Core SDK Podfile checksum.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
