### PR TITLE
Re-create interactor before engagement start

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -370,6 +370,8 @@
 		846A5C4029ED83C50049B29F /* CallVisualizer.Coordinator.DelegateEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846A5C3F29ED83C50049B29F /* CallVisualizer.Coordinator.DelegateEvent.swift */; };
 		846A5C4529F6BEFA0049B29F /* GliaTests+StartEngagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846A5C4429F6BEFA0049B29F /* GliaTests+StartEngagement.swift */; };
 		846E822828996A5C008EFBF0 /* AlertViewControllerVoiceOverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846E822728996A5C008EFBF0 /* AlertViewControllerVoiceOverTests.swift */; };
+		847956362AD96AD7004EF60C /* CoreSDKConfigurator.Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847956352AD96AD7004EF60C /* CoreSDKConfigurator.Interface.swift */; };
+		847956402ADED7A2004EF60C /* CallVisualizer+Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8479563F2ADED7A2004EF60C /* CallVisualizer+Action.swift */; };
 		847A7643285A1914004044D1 /* FileUploadListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847A7642285A1914004044D1 /* FileUploadListViewModelTests.swift */; };
 		8491AF002A6FB44200CC3E72 /* GvaGalleryCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AEFF2A6FB44200CC3E72 /* GvaGalleryCardCell.swift */; };
 		8491AF022A6FBBBA00CC3E72 /* GvaGalleryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF012A6FBBBA00CC3E72 /* GvaGalleryListView.swift */; };
@@ -575,6 +577,8 @@
 		AFEF5C6F29928DB0005C3D8D /* SecureConversations.FileUploadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFEF5C6E29928DB0005C3D8D /* SecureConversations.FileUploadView.swift */; };
 		AFEF5C7129929601005C3D8D /* SecureConversations.FilePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFEF5C7029929601005C3D8D /* SecureConversations.FilePreviewView.swift */; };
 		AFEF5C7429929A8D005C3D8D /* SecureConversations.FileUploadListViewModel.Environment.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFEF5C7329929A8D005C3D8D /* SecureConversations.FileUploadListViewModel.Environment.Failing.swift */; };
+		AFF9542A2ADD8DB600C277E0 /* CoreSDKConfigurator.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF954292ADD8DB600C277E0 /* CoreSDKConfigurator.Mock.swift */; };
+		AFF9542C2ADDA10600C277E0 /* CoreSDKConfigurator.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF9542B2ADDA10600C277E0 /* CoreSDKConfigurator.Failing.swift */; };
 		B757AD4073B49FF0A17D071D /* Pods_TestingApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE3A89412171262DF9CD8ABA /* Pods_TestingApp.framework */; };
 		C0175A0F2A55A624001FACDE /* ChatMessagaEntryViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0175A0E2A55A624001FACDE /* ChatMessagaEntryViewTests.swift */; };
 		C0175A112A55AA3E001FACDE /* ChatMessageEntryView.+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0175A102A55AA3E001FACDE /* ChatMessageEntryView.+Mock.swift */; };
@@ -1106,6 +1110,8 @@
 		846A5C3F29ED83C50049B29F /* CallVisualizer.Coordinator.DelegateEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallVisualizer.Coordinator.DelegateEvent.swift; sourceTree = "<group>"; };
 		846A5C4429F6BEFA0049B29F /* GliaTests+StartEngagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GliaTests+StartEngagement.swift"; sourceTree = "<group>"; };
 		846E822728996A5C008EFBF0 /* AlertViewControllerVoiceOverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertViewControllerVoiceOverTests.swift; sourceTree = "<group>"; };
+		847956352AD96AD7004EF60C /* CoreSDKConfigurator.Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSDKConfigurator.Interface.swift; sourceTree = "<group>"; };
+		8479563F2ADED7A2004EF60C /* CallVisualizer+Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CallVisualizer+Action.swift"; sourceTree = "<group>"; };
 		847A7642285A1914004044D1 /* FileUploadListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadListViewModelTests.swift; sourceTree = "<group>"; };
 		8491AEFF2A6FB44200CC3E72 /* GvaGalleryCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GvaGalleryCardCell.swift; sourceTree = "<group>"; };
 		8491AF012A6FBBBA00CC3E72 /* GvaGalleryListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GvaGalleryListView.swift; sourceTree = "<group>"; };
@@ -1315,6 +1321,8 @@
 		AFEF5C6E29928DB0005C3D8D /* SecureConversations.FileUploadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FileUploadView.swift; sourceTree = "<group>"; };
 		AFEF5C7029929601005C3D8D /* SecureConversations.FilePreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FilePreviewView.swift; sourceTree = "<group>"; };
 		AFEF5C7329929A8D005C3D8D /* SecureConversations.FileUploadListViewModel.Environment.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FileUploadListViewModel.Environment.Failing.swift; sourceTree = "<group>"; };
+		AFF954292ADD8DB600C277E0 /* CoreSDKConfigurator.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSDKConfigurator.Mock.swift; sourceTree = "<group>"; };
+		AFF9542B2ADDA10600C277E0 /* CoreSDKConfigurator.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSDKConfigurator.Failing.swift; sourceTree = "<group>"; };
 		B45FBFA4E2F1D31E83A1CC3A /* Pods_GliaWidgets.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GliaWidgets.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0175A0E2A55A624001FACDE /* ChatMessagaEntryViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessagaEntryViewTests.swift; sourceTree = "<group>"; };
 		C0175A102A55AA3E001FACDE /* ChatMessageEntryView.+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatMessageEntryView.+Mock.swift"; sourceTree = "<group>"; };
@@ -1707,6 +1715,7 @@
 				9A3E1D9C27BA7741005634EB /* FoundationBased.Failing.swift */,
 				84D5B9652A15204400807F92 /* QuickLookBased.Failing.swift */,
 				9A1992E627D66C7400161AAE /* UIKitBased.Failing.swift */,
+				AFF9542B2ADDA10600C277E0 /* CoreSDKConfigurator.Failing.swift */,
 			);
 			path = GliaWidgetsTests;
 			sourceTree = "<group>";
@@ -2065,6 +2074,7 @@
 				1A60AFC62566865F00E53F53 /* Coordinator */,
 				1A60AF6825656C0200E53F53 /* Coordinators */,
 				75940940298D378A008B173A /* CoreSDKClient */,
+				847956342AD96AA8004EF60C /* CoreSDKConfigurator */,
 				1A1E309425F8CA3400850E68 /* Download */,
 				1A60B025256806D500E53F53 /* Extensions */,
 				1A8366AE25FF409B005FE7EE /* File */,
@@ -2887,6 +2897,7 @@
 				7594096A298D38C2008B173A /* CallVisualizer.BubbleIcon.swift */,
 				7594097B298D38C2008B173A /* CallVisualizer+Environment.swift */,
 				7594097C298D38C2008B173A /* CallVisualizer.swift */,
+				8479563F2ADED7A2004EF60C /* CallVisualizer+Action.swift */,
 			);
 			path = CallVisualizer;
 			sourceTree = "<group>";
@@ -3202,6 +3213,15 @@
 				846A5C4429F6BEFA0049B29F /* GliaTests+StartEngagement.swift */,
 			);
 			path = Glia;
+			sourceTree = "<group>";
+		};
+		847956342AD96AA8004EF60C /* CoreSDKConfigurator */ = {
+			isa = PBXGroup;
+			children = (
+				847956352AD96AD7004EF60C /* CoreSDKConfigurator.Interface.swift */,
+				AFF954292ADD8DB600C277E0 /* CoreSDKConfigurator.Mock.swift */,
+			);
+			path = CoreSDKConfigurator;
 			sourceTree = "<group>";
 		};
 		8491AEFE2A6FB40B00CC3E72 /* Gallery */ = {
@@ -4666,6 +4686,7 @@
 				845E2F88283FB49F00C04D56 /* Theme.Survey.BooleanQuestion.Accessibility.swift in Sources */,
 				C06A7584296EC9DC006B69A2 /* NumberSlotStyle.Accessibility.swift in Sources */,
 				8491AF212A7D1F7900CC3E72 /* ChatView.GvaGallery.swift in Sources */,
+				847956402ADED7A2004EF60C /* CallVisualizer+Action.swift in Sources */,
 				AF10ED8D29BA210500E85309 /* SecureConversations.MessagesWithUnreadCountLoader.swift in Sources */,
 				C0D2F04A2992765F00803B47 /* VideoCallView.OperatorImageView.swift in Sources */,
 				755D186F29A6A6160009F5E8 /* WelcomeStyle+MessageTextViewDisabledStyle.swift in Sources */,
@@ -4695,11 +4716,13 @@
 				1A60B0042567F25600E53F53 /* Header.swift in Sources */,
 				1A4674CD25ED08A30078FA1C /* MediaPickerController.swift in Sources */,
 				1A63B2F6257A469A00508478 /* AlertPresenter.swift in Sources */,
+				847956362AD96AD7004EF60C /* CoreSDKConfigurator.Interface.swift in Sources */,
 				1A0452EA25DBE259000DA0C1 /* MessageButton.swift in Sources */,
 				9AE0A7602821904400725946 /* FontScaling.Environment.Interface.swift in Sources */,
 				9A19926627D3BA3A00161AAE /* GCD.Interface.swift in Sources */,
 				3197F7B829F7C318008EE9F7 /* SecureConversations.CommonEngagementModel.swift in Sources */,
 				31DD41652A57105400F92612 /* SecureConversations.TranscriptModel.Environment.swift in Sources */,
+				AFF9542A2ADD8DB600C277E0 /* CoreSDKConfigurator.Mock.swift in Sources */,
 				1A277A1225FA604E009FE131 /* ChatFileContentView.swift in Sources */,
 				75B7BD802A39D5A70060794D /* Layoutable.swift in Sources */,
 				845876AB282A959C007AC3DF /* SingleChoiceQuestionView.Props.Accessibility.swift in Sources */,
@@ -4893,6 +4916,7 @@
 				7552DFB12A6FB7DF0093519B /* ChatMessageTests.swift in Sources */,
 				8491AF672AB8707600CC3E72 /* ChatViewModelTests+Transferring.swift in Sources */,
 				AFEF5C7429929A8D005C3D8D /* SecureConversations.FileUploadListViewModel.Environment.Failing.swift in Sources */,
+				AFF9542C2ADDA10600C277E0 /* CoreSDKConfigurator.Failing.swift in Sources */,
 				9A3E1D9D27BA7741005634EB /* FoundationBased.Failing.swift in Sources */,
 				9A3E1D8427B67F1B005634EB /* Helper.swift in Sources */,
 				C0175A0F2A55A624001FACDE /* ChatMessagaEntryViewTests.swift in Sources */,

--- a/GliaWidgets/Public/Glia/Glia.RemoteConfiguration.swift
+++ b/GliaWidgets/Public/Glia/Glia.RemoteConfiguration.swift
@@ -40,7 +40,7 @@ extension Glia {
             uiConfig: uiConfig,
             assetsBuilder: assetsBuilder
         )
-        if let config = interactor?.configuration {
+        if let config = configuration {
             theme.showsPoweredBy = !config.isWhiteLabelApp
             theme.chat.connect.queue.firstText = config.companyName
             theme.call.connect.queue.firstText = config.companyName

--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -94,7 +94,7 @@ public class Glia {
     var uiConfig: RemoteConfiguration?
     var assetsBuilder: RemoteConfiguration.AssetsBuilder = .standard
 
-    var configuration: Configuration?
+    private(set) var configuration: Configuration?
 
     init(environment: Environment) {
         self.environment = environment
@@ -375,6 +375,7 @@ extension Glia {
 
 #if DEBUG
 extension Glia {
+    /// Used for unit tests only
     var isConfigured: Bool {
         configuration != nil
     }

--- a/GliaWidgets/Sources/CallVisualizer/CallVisualizer+Action.swift
+++ b/GliaWidgets/Sources/CallVisualizer/CallVisualizer+Action.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension CallVisualizer {
+    enum Action {
+        case visitorCodeIsRequested
+    }
+}

--- a/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
+++ b/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
@@ -13,6 +13,7 @@ import GliaCoreSDK
 ///  3. Handling engagement, featuring video calling, screen sharing, and much more in future.
 public final class CallVisualizer {
     private var environment: Environment
+    var delegate: ((Action) -> Void)?
     lazy var coordinator: Coordinator = {
         var theme = Theme()
         if let uiConfig = environment.uiConfig() {
@@ -80,6 +81,7 @@ public final class CallVisualizer {
     /// - Parameter source: The current viewController to present from.
     ///
     public func showVisitorCodeViewController(from source: UIViewController) {
+        delegate?(.visitorCodeIsRequested)
         coordinator.showVisitorCodeViewController(by: .alert(source))
     }
 
@@ -103,6 +105,7 @@ public final class CallVisualizer {
         into container: UIView,
         onEngagementAccepted: @escaping () -> Void
     ) {
+        delegate?(.visitorCodeIsRequested)
         coordinator.showVisitorCodeViewController(
             by: .embedded(container, onEngagementAccepted: onEngagementAccepted)
         )

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
@@ -195,7 +195,8 @@ extension EngagementCoordinator {
             },
             endEditing: { viewController.view.endEditing(true) },
             updateProps: { viewController.props = $0 },
-            onError: { _ in
+            onError: { [weak self] _ in
+                guard let self else { return }
                 viewController.presentAlert(
                     with: self.viewFactory.theme.alertConfiguration.unexpectedError
                 )

--- a/GliaWidgets/Sources/CoreSDKConfigurator/CoreSDKConfigurator.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKConfigurator/CoreSDKConfigurator.Interface.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+struct CoreSDKConfigurator {
+    var configureWithInteractor: CoreSdkClient.ConfigureWithInteractor
+    var configureWithConfiguration: (Configuration, (() -> Void)?) throws -> Void
+}
+
+extension CoreSDKConfigurator {
+    static func create(coreSdk: CoreSdkClient) -> Self {
+        .init(
+            configureWithInteractor: coreSdk.configureWithInteractor,
+            configureWithConfiguration: { configuration, completion in
+                let sdkConfiguration = try CoreSdkClient.Salemove.Configuration(
+                    siteId: configuration.site,
+                    region: configuration.environment.region,
+                    authorizingMethod: configuration.authorizationMethod.coreAuthorizationMethod,
+                    pushNotifications: configuration.pushNotifications.coreSdk
+                )
+                coreSdk.configureWithConfiguration(sdkConfiguration) {
+                    completion?()
+                }
+            }
+        )
+    }
+}

--- a/GliaWidgets/Sources/CoreSDKConfigurator/CoreSDKConfigurator.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKConfigurator/CoreSDKConfigurator.Mock.swift
@@ -1,0 +1,8 @@
+#if DEBUG
+extension CoreSDKConfigurator {
+    static let mock = CoreSDKConfigurator(
+        configureWithInteractor: { _ in },
+        configureWithConfiguration: { _, _ in }
+    )
+}
+#endif

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Interface.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Interface.swift
@@ -45,6 +45,7 @@ extension Glia {
         var screenShareHandler: ScreenShareHandler
         var messagesWithUnreadCountLoaderScheduler: CoreSdkClient.ReactiveSwift.DateScheduler
         var orientationManager: OrientationManager
+        var coreSDKConfigurator: CoreSDKConfigurator
     }
 }
 

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Live.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Live.swift
@@ -32,7 +32,8 @@ extension Glia.Environment {
             uiApplication: .live,
             uiDevice: .live,
             notificationCenter: .live
-        ))
+        )),
+        coreSDKConfigurator: .create(coreSdk: .live)
     )
 }
 

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Mock.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Mock.swift
@@ -26,7 +26,8 @@ extension Glia.Environment {
         createFileUploadListModel: SecureConversations.FileUploadListViewModel.mock(environment:),
         screenShareHandler: .mock,
         messagesWithUnreadCountLoaderScheduler: CoreSdkClient.reactiveSwiftDateSchedulerMock,
-        orientationManager: .mock()
+        orientationManager: .mock(),
+        coreSDKConfigurator: .mock
     )
 }
 

--- a/GliaWidgets/Sources/Interactor/Interactor.Mock.swift
+++ b/GliaWidgets/Sources/Interactor/Interactor.Mock.swift
@@ -3,12 +3,12 @@ import Foundation
 
 extension Interactor {
     static func mock(
-        configuration: Configuration = .mock(),
+        visitorContext: Configuration.VisitorContext? = nil,
         queueId: String = UUID.mock.uuidString,
         environment: Environment = .mock
     ) -> Interactor {
         .init(
-            configuration: configuration,
+            visitorContext: visitorContext,
             queueIds: [queueId],
             environment: environment
         )

--- a/GliaWidgets/Sources/Interactor/Interactor.swift
+++ b/GliaWidgets/Sources/Interactor/Interactor.swift
@@ -80,10 +80,6 @@ class Interactor {
         self.environment = environment
     }
 
-    deinit {
-        print("☠️", Self.self, ObjectIdentifier(self))
-    }
-
     func addObserver(_ observer: AnyObject, handler: @escaping EventHandler) {
         guard !observers.contains(where: { $0().0 === observer }) else { return }
         observers.append { [weak observer] in (observer, handler) }

--- a/GliaWidgets/Sources/Observable/ObservableValue.swift
+++ b/GliaWidgets/Sources/Observable/ObservableValue.swift
@@ -39,7 +39,7 @@ class ObservableValue<T: Any> {
                 // was that `update` closure
                 // must always run on main queue, I added
                 // this check. But we must use some
-                // battle-tested solutuion like ReactiveSwift or Combine.
+                // battle-tested solution like ReactiveSwift or Combine.
                 // That will allow us to use proper schedulers for UI, unit tests etc.
                 if Thread.isMainThread {
                     update(new, old)

--- a/GliaWidgets/Sources/ViewController/Call/CallViewController.Mock.swift
+++ b/GliaWidgets/Sources/ViewController/Call/CallViewController.Mock.swift
@@ -19,11 +19,9 @@ extension CallViewController {
     }
 
     static func mockAudioCallQueueState() throws -> CallViewController {
-        let conf = Configuration.mock()
         let queueId = UUID.mock.uuidString
         let interactorEnv = Interactor.Environment.mock
         let interactor = Interactor.mock(
-            configuration: conf,
             queueId: queueId,
             environment: interactorEnv
         )
@@ -55,11 +53,9 @@ extension CallViewController {
     }
 
     static func mockAudioCallConnectingState() throws -> CallViewController {
-        let conf = Configuration.mock()
         let queueId = UUID.mock.uuidString
         let interactorEnv = Interactor.Environment.mock
         let interactor = Interactor.mock(
-            configuration: conf,
             queueId: queueId,
             environment: interactorEnv
         )
@@ -90,14 +86,12 @@ extension CallViewController {
     }
 
     static func mockAudioCallConnectedState() throws -> CallViewController {
-        let conf = Configuration.mock()
         let queueId = UUID.mock.uuidString
         var interactorEnv = Interactor.Environment.mock
         interactorEnv.coreSdk.configureWithConfiguration = { _, callback in
             callback?()
         }
         let interactor = Interactor.mock(
-            configuration: conf,
             queueId: queueId,
             environment: interactorEnv
         )
@@ -146,11 +140,9 @@ extension CallViewController {
     }
 
     static func mockVideoCallConnectingState() throws -> CallViewController {
-        let conf = Configuration.mock()
         let queueId = UUID.mock.uuidString
         let interactorEnv = Interactor.Environment.mock
         let interactor = Interactor.mock(
-            configuration: conf,
             queueId: queueId,
             environment: interactorEnv
         )
@@ -194,11 +186,9 @@ extension CallViewController {
     }
 
     static func mockVideoCallQueueState() throws -> CallViewController {
-        let conf = Configuration.mock()
         let queueId = UUID.mock.uuidString
         let interactorEnv = Interactor.Environment.mock
         let interactor = Interactor.mock(
-            configuration: conf,
             queueId: queueId,
             environment: interactorEnv
         )
@@ -230,11 +220,9 @@ extension CallViewController {
     }
 
     static func mockVideoCallConnectedState() throws -> CallViewController {
-        let conf = Configuration.mock()
         let queueId = UUID.mock.uuidString
         let interactorEnv = Interactor.Environment.mock
         let interactor = Interactor.mock(
-            configuration: conf,
             queueId: queueId,
             environment: interactorEnv
         )

--- a/GliaWidgetsTests/CoreSDKConfigurator.Failing.swift
+++ b/GliaWidgetsTests/CoreSDKConfigurator.Failing.swift
@@ -1,0 +1,12 @@
+@testable import GliaWidgets
+
+extension CoreSDKConfigurator {
+    static let failing = Self.init(
+        configureWithInteractor: { _ in
+            fail("\(Self.self).configureWithInteractor")
+        },
+        configureWithConfiguration: { _, _ in
+            fail("\(Self.self).configureWithConfiguration")
+        }
+    )
+}

--- a/GliaWidgetsTests/Glia.Environment.Failing.swift
+++ b/GliaWidgetsTests/Glia.Environment.Failing.swift
@@ -55,7 +55,8 @@ extension Glia.Environment {
         },
         screenShareHandler: .mock,
         messagesWithUnreadCountLoaderScheduler: CoreSdkClient.reactiveSwiftDateSchedulerMock, 
-        orientationManager: .mock()
+        orientationManager: .mock(),
+        coreSDKConfigurator: .failing
     )
 }
 

--- a/GliaWidgetsTests/Interactor/Interactor.Failing.swift
+++ b/GliaWidgetsTests/Interactor/Interactor.Failing.swift
@@ -3,7 +3,7 @@ import Foundation
 
 extension Interactor {
     static let failing = Interactor(
-        configuration: .mock(),
+        visitorContext: nil,
         queueIds: ["mocked-id"],
         environment: .failing
     )

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+CustomCard.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+CustomCard.swift
@@ -21,7 +21,7 @@ extension ChatViewModelTests {
         }
         let interactorMock = Interactor.mock(environment: interactorEnv)
         interactorMock.state = .engaged(nil)
-        interactorMock.isConfigurationPerformed = true
+//        interactorMock.isConfigurationPerformed = true
 
         var env = ChatViewModel.Environment.failing()
         env.fileManager.fileExistsAtPath = { _ in true }

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+CustomCard.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+CustomCard.swift
@@ -21,7 +21,6 @@ extension ChatViewModelTests {
         }
         let interactorMock = Interactor.mock(environment: interactorEnv)
         interactorMock.state = .engaged(nil)
-//        interactorMock.isConfigurationPerformed = true
 
         var env = ChatViewModel.Environment.failing()
         env.fileManager.fileExistsAtPath = { _ in true }

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Gva.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Gva.swift
@@ -58,7 +58,7 @@ extension ChatViewModelTests {
         }
         let interactorMock = Interactor.mock(environment: interactorEnv)
         interactorMock.state = .engaged(nil)
-        interactorMock.isConfigurationPerformed = true
+//        interactorMock.isConfigurationPerformed = true
 
         viewModel = .mock(interactor: interactorMock, environment: env)
 
@@ -80,7 +80,7 @@ extension ChatViewModelTests {
 
         let interactorMock = Interactor.mock(environment: interactorEnv)
         interactorMock.state = .none
-        interactorMock.isConfigurationPerformed = true
+//        interactorMock.isConfigurationPerformed = true
 
         var env = ChatViewModel.Environment.failing()
         env.fileManager.fileExistsAtPath = { _ in true }
@@ -136,7 +136,7 @@ extension ChatViewModelTests {
         }
         let interactorMock = Interactor.mock(environment: interactorEnv)
         interactorMock.state = .engaged(nil)
-        interactorMock.isConfigurationPerformed = true
+//        interactorMock.isConfigurationPerformed = true
         let viewModel = ChatViewModel.mock(interactor: interactorMock, environment: env)
 
         let messagesSectionIndex = 3

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Gva.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Gva.swift
@@ -58,7 +58,6 @@ extension ChatViewModelTests {
         }
         let interactorMock = Interactor.mock(environment: interactorEnv)
         interactorMock.state = .engaged(nil)
-//        interactorMock.isConfigurationPerformed = true
 
         viewModel = .mock(interactor: interactorMock, environment: env)
 
@@ -80,7 +79,6 @@ extension ChatViewModelTests {
 
         let interactorMock = Interactor.mock(environment: interactorEnv)
         interactorMock.state = .none
-//        interactorMock.isConfigurationPerformed = true
 
         var env = ChatViewModel.Environment.failing()
         env.fileManager.fileExistsAtPath = { _ in true }
@@ -136,7 +134,6 @@ extension ChatViewModelTests {
         }
         let interactorMock = Interactor.mock(environment: interactorEnv)
         interactorMock.state = .engaged(nil)
-//        interactorMock.isConfigurationPerformed = true
         let viewModel = ChatViewModel.mock(interactor: interactorMock, environment: env)
 
         let messagesSectionIndex = 3

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Transferring.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Transferring.swift
@@ -20,7 +20,6 @@ extension ChatViewModelTests {
         interactorEnv.coreSdk.queueForEngagement = { _, _ in }
         interactorEnv.coreSdk.configureWithInteractor = { _ in }
         let interactorMock = Interactor.mock(environment: interactorEnv)
-//        interactorMock.isConfigurationPerformed = true
 
         var env = ChatViewModel.Environment.failing()
         env.fileManager.fileExistsAtPath = { _ in true }

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Transferring.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Transferring.swift
@@ -20,7 +20,7 @@ extension ChatViewModelTests {
         interactorEnv.coreSdk.queueForEngagement = { _, _ in }
         interactorEnv.coreSdk.configureWithInteractor = { _ in }
         let interactorMock = Interactor.mock(environment: interactorEnv)
-        interactorMock.isConfigurationPerformed = true
+//        interactorMock.isConfigurationPerformed = true
 
         var env = ChatViewModel.Environment.failing()
         env.fileManager.fileExistsAtPath = { _ in true }

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -111,32 +111,6 @@ class ChatViewModelTests: XCTestCase {
         )
         XCTAssertEqual(chatType, .nonAuthenticated)
     }
-
-    func test__startCallsSDKConfigureWithInteractorAndСonfigureWithConfiguration() throws {
-        var interactorEnv = Interactor.Environment.init(
-            coreSdk: .failing,
-            gcd: .mock
-        )
-        enum Calls {
-            case configureWithConfiguration, configureWithInteractor
-        }
-        var calls: [Calls] = []
-        interactorEnv.coreSdk.configureWithConfiguration = { _, _ in
-            calls.append(.configureWithConfiguration)
-        }
-        interactorEnv.coreSdk.configureWithInteractor = { _ in
-            calls.append(.configureWithInteractor)
-        }
-        let interactor = Interactor.mock(environment: interactorEnv)
-        var viewModelEnv = ChatViewModel.Environment.failing(fetchChatHistory: { $0(.success([])) })
-        viewModelEnv.createFileUploadListModel = { _ in .mock() }
-        viewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
-        viewModelEnv.fileManager.createDirectoryAtUrlWithIntermediateDirectories = { _, _, _ in }
-        viewModelEnv.loadChatMessagesFromHistory = { true }
-        let viewModel = ChatViewModel.mock(interactor: interactor, environment: viewModelEnv)
-        viewModel.start()
-        XCTAssertEqual(calls, [.configureWithInteractor, .configureWithConfiguration])
-    }
     
     func test_onInteractorStateEngagedClearsChatQueueSection() throws {
         var viewModelEnv = ChatViewModel.Environment.failing()

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
@@ -282,8 +282,8 @@ extension GliaTests {
         }
 
         environment.coreSdk.localeProvider.getRemoteString = { _ in "" }
-        environment.coreSdk.configureWithInteractor = { _ in }
-        environment.coreSdk.configureWithConfiguration = { _, completion in
+        environment.coreSDKConfigurator.configureWithInteractor = { _ in }
+        environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             // Simulating what happens in the Widgets when the configuration gets done
             Glia.sharedInstance.stringProviding = StringProviding(
                 getRemoteString: environment.coreSdk.localeProvider.getRemoteString

--- a/TestingApp/ViewController/ViewController.swift
+++ b/TestingApp/ViewController/ViewController.swift
@@ -56,10 +56,8 @@ class ViewController: UIViewController {
     }
 
     @IBAction private func chatTapped() {
-        do {
+        catchingError {
             try presentGlia(.chat)
-        } catch {
-            showErrorAlert(using: error)
         }
     }
 


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-2752

**What was solved?**
Before these changes when visitor had subsequent engagements, but SDK was configured only once, interactor instance created on configuration step kept incorrect (not initial) state. As a result, SDK started to behave incorrectly. So we decided to not try to find each bug, but re-create interactor each time on start engagement action or requesting visitor code.
This commit adds this functionality.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?
