### PR TITLE
Add updating the widgets version in Cortex Financial when releasing

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -89,6 +89,7 @@ workflows:
     - cache-push@2: {}
     after_run:
     - _increment_project_version
+    - increment_widgets_version_in_cortex_financial
   development-build:
     steps:
     - activate-ssh-key@4:
@@ -126,6 +127,40 @@ workflows:
         - webhook_url: $SLACK_IOS_WEBHOOK
     - cache-push@2: {}
     description: Workflow for creating builds of development branch. Triggered on each push to development branch, notifies over email + Slack (external)
+  increment_widgets_version_in_cortex_financial:
+    steps:
+    - script@1:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # make pipelines' return status equal the last command to exit with a non-zero status, or zero if all commands exit successfully
+            set -o pipefail
+            # debug log
+            set -x
+
+            curl https://app.bitrise.io/app/$CORTEX_DEMO_APP_SLUG/build/start.json -L --data \
+            '{
+                "hook_info": {
+                    "type": "bitrise",
+                    "build_trigger_token": "'"$CORTEX_DEMO_BUILD_TRIGGER_TOKEN"'"
+                },
+                "build_params": {
+                    "branch": "master",
+                    "workflow_id": "update_dependencies",
+                    "environments": [{
+                        "mapped_to": "VERSION",
+                        "value": "'"$NEW_VERSION"'",
+                        "is_expand": false
+                    }]
+                },
+                "triggered_by":"curl"
+            }'
+    envs:
+    - opts:
+        is_expand: false
+      VERSION_INCREMENT_TYPE: patch
   pull-request:
     steps:
     - activate-ssh-key@4:


### PR DESCRIPTION

**Jira issue:**
https://glia.atlassian.net/browse/MOB-2783

**What was solved?**
The new version of the Widgets SDK, which is represented in the Bitrise workflow as `$NEW_VERSION`, is sent to a script that executes the `update_dependencies` workflow in Cortex Financial. Then, in the Cortex side, the version of the widgets will be increased and a new PR made. As this is part of the `deployment` workflow for the widgets, this means that upon releasing widgets, nothing needs to be done from our side to update Cortex (apart from approving the PR in Cortex).

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
