### PR TITLE
Show LO confirmation alert based on toggle

### DIFF
--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -426,13 +426,15 @@ extension CoreSdkClient.Site {
         id: UUID = .mock,
         allowedFileSenders: AllowedFileSenders.Mock = .mock,
         maskingRegularExpressions: [String] = [],
-        visitorAppDefaultLocale: String = "en-US"
+        visitorAppDefaultLocale: String = "en-US",
+        mobileConfirmDialog: Bool = true
     ) throws -> Self {
         struct Mock: Codable {
             let id: UUID
             let allowedFileSenders: CoreSdkClient.Site.AllowedFileSenders.Mock
             let maskingRegularExpressions: [String]
             let visitorAppDefaultLocale: String
+            let mobileConfirmDialog: Bool
         }
         return try JSONDecoder()
             .decode(
@@ -443,7 +445,8 @@ extension CoreSdkClient.Site {
                             id: id,
                             allowedFileSenders: allowedFileSenders,
                             maskingRegularExpressions: maskingRegularExpressions,
-                            visitorAppDefaultLocale: visitorAppDefaultLocale
+                            visitorAppDefaultLocale: visitorAppDefaultLocale,
+                            mobileConfirmDialog: mobileConfirmDialog
                         )
                     )
             )

--- a/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
@@ -163,7 +163,18 @@ class EngagementViewModel: CommonEngagementModel {
                 )
             })
         case let .enqueueing(mediaType):
-            showLiveObservationConfirmation(in: mediaType)
+            environment.fetchSiteConfigurations { result in
+                switch result {
+                case let .success(site):
+                    if site.mobileConfirmDialog == false {
+                        self.enqueue(mediaType: mediaType)
+                    } else {
+                        self.showLiveObservationConfirmation(in: mediaType)
+                    }
+                case .failure:
+                    self.showAlert(with: self.alertConfiguration.unexpectedError, dismissed: nil)
+                }
+            }
         default:
             break
         }

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -703,13 +703,21 @@ class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.receivedMessageIds, [])
     }
 
-    func test_liveObservationAlertPresentationInitiatedWhenInteractorStateIsEnqueuing() {
+    func test_liveObservationAlertPresentationInitiatedWhenInteractorStateIsEnqueuing() throws {
         enum Call {
             case showLiveObservationAlert
         }
         var calls: [Call] = []
         let interactor: Interactor = .mock()
-        let viewModel: ChatViewModel = .mock(interactor: interactor)
+        let site: CoreSdkClient.Site = try .mock()
+        var viewModelEnvironment: EngagementViewModel.Environment = .mock
+        viewModelEnvironment.fetchSiteConfigurations = { completion in
+            completion(.success(site))
+        }
+        let viewModel: ChatViewModel = .mock(
+            interactor: interactor,
+            environment: viewModelEnvironment
+        )
         viewModel.engagementAction = { action in
             switch action {
             case .showLiveObservationConfirmation:
@@ -722,18 +730,25 @@ class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(calls, [.showLiveObservationAlert])
     }
 
-    func test_liveObservationAllowTriggersEnqueue() {
+    func test_liveObservationAllowTriggersEnqueue() throws {
         var interactorEnv: Interactor.Environment = .mock
         interactorEnv.coreSdk.queueForEngagement = { _, completion in
             completion(.success(.mock))
         }
 
         let interactor: Interactor = .mock(environment: interactorEnv)
-        interactor.isConfigurationPerformed = true
-
         var alertConfig: LiveObservation.Confirmation?
+        let site: CoreSdkClient.Site = try .mock()
+        
+        var viewModelEnvironment: EngagementViewModel.Environment = .mock
+        viewModelEnvironment.fetchSiteConfigurations = { completion in
+            completion(.success(site))
+        }
+        let viewModel: ChatViewModel = .mock(
+            interactor: interactor,
+            environment: viewModelEnvironment
+        )
 
-        let viewModel: ChatViewModel = .mock(interactor: interactor)
         viewModel.engagementAction = { action in
             switch action {
             case let .showLiveObservationConfirmation(config):
@@ -747,7 +762,7 @@ class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(interactor.state, .enqueued(.mock))
     }
 
-    func test_liveObservationDeclineTriggersNone() {
+    func test_liveObservationDeclineTriggersNone() throws {
         enum Call {
             case queueForEngagement
         }
@@ -758,11 +773,17 @@ class ChatViewModelTests: XCTestCase {
         }
 
         let interactor: Interactor = .mock(environment: interactorEnv)
-        interactor.isConfigurationPerformed = true
-
         var alertConfig: LiveObservation.Confirmation?
+        let site: CoreSdkClient.Site = try .mock()
 
-        let viewModel: ChatViewModel = .mock(interactor: interactor)
+        var viewModelEnvironment: EngagementViewModel.Environment = .mock
+        viewModelEnvironment.fetchSiteConfigurations = { completion in
+            completion(.success(site))
+        }
+        let viewModel: ChatViewModel = .mock(
+            interactor: interactor,
+            environment: viewModelEnvironment
+        )
         viewModel.engagementAction = { action in
             switch action {
             case let .showLiveObservationConfirmation(config):

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -60,7 +60,7 @@ final class GliaTests: XCTestCase {
             completion?()
         }
         gliaEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
-
+        gliaEnv.coreSdk.fetchSiteConfigurations = { _ in }
         gliaEnv.uuid = { .mock }
         gliaEnv.gcd.mainQueue.asyncIfNeeded = { callback in callback() }
 
@@ -132,6 +132,7 @@ final class GliaTests: XCTestCase {
         gliaEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion?()
         }
+        gliaEnv.callVisualizerPresenter = .init(presenter: { nil })
         gliaEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
 
         let sdk = Glia(environment: gliaEnv)


### PR DESCRIPTION

**Jira issue:**
https://glia.atlassian.net/browse/MOB-2707

**What was solved?**

This PR will take into account the possibility of toggling out LO confirmation alert, meaning that engagement can start without explicitly allowing LO. The toggle is fetch from the site information

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
