### PR TITLE
Introduce new `configure` interface with non-optional completion

### DIFF
--- a/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
+++ b/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
@@ -18,7 +18,7 @@ extension Glia {
     ///   - `GliaError.engagementExists
     ///   - `GliaError.sdkIsNotConfigured`
     ///
-    /// - Important: Note, that `configure(with:queueID:visitorContext:)` must be called initially prior to this method,
+    /// - Important: Note, that `configure(with:uiConfig:assetsBuilder:completion:)` must be called initially prior to this method,
     /// because `GliaError.sdkIsNotConfigured` will occur otherwise.
     ///
     public func startEngagement(
@@ -28,7 +28,10 @@ extension Glia {
         features: Features = .all,
         sceneProvider: SceneProvider? = nil
     ) throws {
-        guard !queueIds.isEmpty else { throw GliaError.startingEngagementWithNoQueueIdsIsNotAllowed }
+        let trimmedQueueIds = queueIds
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard !trimmedQueueIds.isEmpty else { throw GliaError.startingEngagementWithNoQueueIdsIsNotAllowed }
         guard engagement == .none else { throw GliaError.engagementExists }
         guard let configuration = self.configuration else { throw GliaError.sdkIsNotConfigured }
         if let engagement = environment.coreSdk.getCurrentEngagement(),
@@ -39,7 +42,7 @@ extension Glia {
         // Creates interactor instance
         let createdInteractor = setupInteractor(
             configuration: configuration,
-            queueIds: queueIds
+            queueIds: trimmedQueueIds
         )
 
         theme.chat.connect.queue.firstText = companyName(

--- a/GliaWidgets/Public/Glia/Glia.Deprecated.swift
+++ b/GliaWidgets/Public/Glia/Glia.Deprecated.swift
@@ -2,7 +2,7 @@ import GliaCoreSDK
 
 extension Glia {
     /// Deprecated.
-    @available(*, unavailable, message: "Use configure(with:queueId:uiConfig:assetsBuilder:completion:) instead.")
+    @available(*, unavailable, message: "Use configure(with:uiConfig:assetsBuilder:completion:) instead.")
     public func configure(
         with configuration: Configuration,
         queueId: String,
@@ -183,6 +183,27 @@ extension Glia {
             features: features,
             sceneProvider: sceneProvider
         )
+    }
+
+    /// Deprecated, use the `configure` method that provides a `Result` in its completion instead.
+    @available(*, deprecated, message: "Use the `configure` method that provides a `Result` in its completion instead.")
+    public func configure(
+        with configuration: Configuration,
+        uiConfig: RemoteConfiguration? = nil,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder = .standard,
+        completion: (() -> Void)? = nil
+    ) throws {
+        try configure(
+            with: configuration,
+            uiConfig: uiConfig,
+            assetsBuilder: assetsBuilder
+        ) { result in
+            defer {
+                completion?()
+            }
+            guard case let .failure(error) = result else { return }
+            debugPrint("💥 Core SDK configuration is not valid. Unexpected error='\(error)'.")
+        }
     }
 }
 

--- a/GliaWidgets/Public/Glia/Glia.RemoteConfiguration.swift
+++ b/GliaWidgets/Public/Glia/Glia.RemoteConfiguration.swift
@@ -18,7 +18,7 @@ extension Glia {
     ///   - `GliaError.engagementExists
     ///   - `GliaError.sdkIsNotConfigured`
     ///
-    /// - Important: Note, that `configure(with:queueID:visitorContext:)` must be called initially prior to this method,
+    /// - Important: Note, that `configure(with:uiConfig:assetsBuilder:completion:)` must be called initially prior to this method,
     /// because `GliaError.sdkIsNotConfigured` will occur otherwise.
     ///
     public func startEngagementWithConfig(

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -19,7 +19,7 @@ struct CoreSdkClient {
 
     typealias ConfigureWithConfiguration = (
         _ sdkConfiguration: Self.Salemove.Configuration,
-        _ completion: (() -> Void)?
+        _ completion: @escaping Self.ConfigureCompletion
     ) -> Void
     var configureWithConfiguration: ConfigureWithConfiguration
 
@@ -249,4 +249,5 @@ extension CoreSdkClient {
     typealias Cancellable = GliaCore.Cancellable
     typealias ReactiveSwift = GliaCoreDependency.ReactiveSwift
     typealias SendMessagePayload = GliaCoreSDK.SendMessagePayload
+    typealias ConfigureCompletion = GliaCoreSDK.GliaCore.ConfigureCompletion
 }

--- a/GliaWidgets/Sources/CoreSDKConfigurator/CoreSDKConfigurator.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKConfigurator/CoreSDKConfigurator.Interface.swift
@@ -2,7 +2,7 @@ import Foundation
 
 struct CoreSDKConfigurator {
     var configureWithInteractor: CoreSdkClient.ConfigureWithInteractor
-    var configureWithConfiguration: (Configuration, (() -> Void)?) throws -> Void
+    var configureWithConfiguration: (Configuration, @escaping (Result<Void, Error>) -> Void) throws -> Void
 }
 
 extension CoreSDKConfigurator {
@@ -16,9 +16,7 @@ extension CoreSDKConfigurator {
                     authorizingMethod: configuration.authorizationMethod.coreAuthorizationMethod,
                     pushNotifications: configuration.pushNotifications.coreSdk
                 )
-                coreSdk.configureWithConfiguration(sdkConfiguration) {
-                    completion?()
-                }
+                coreSdk.configureWithConfiguration(sdkConfiguration, completion)
             }
         )
     }

--- a/GliaWidgets/Sources/ViewController/Call/CallViewController.Mock.swift
+++ b/GliaWidgets/Sources/ViewController/Call/CallViewController.Mock.swift
@@ -86,7 +86,7 @@ extension CallViewController {
         let queueId = UUID.mock.uuidString
         var interactorEnv = Interactor.Environment.mock
         interactorEnv.coreSdk.configureWithConfiguration = { _, callback in
-            callback?()
+            callback(.success(()))
         }
         let interactor = Interactor.mock(
             queueId: queueId,

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
@@ -199,7 +199,7 @@ extension ChatViewController {
         chatViewModelEnv.fetchChatHistory = { $0(.success([])) }
         var interEnv = Interactor.Environment.mock
         interEnv.coreSdk.configureWithConfiguration = { _, callback in
-            callback?()
+            callback(.success(()))
         }
         let interactor = Interactor.mock(environment: interEnv)
         let generateUUID = UUID.incrementing
@@ -540,7 +540,7 @@ extension ChatViewController {
         chatViewModelEnv.fetchChatHistory = { $0(.success(messages)) }
         var interEnv = Interactor.Environment.mock
         interEnv.coreSdk.configureWithConfiguration = { _, callback in
-            callback?()
+            callback(.success(()))
         }
         let interactor = Interactor.mock(environment: interEnv)
         let chatViewModel = ChatViewModel.mock(interactor: interactor, environment: chatViewModelEnv)

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -367,7 +367,7 @@ class ChatViewModelTests: XCTestCase {
         // we use the mocked one, which doesn't execute the completion,
         // `sendMessageWithAttachment` will not be executed.
         environment.coreSdk.configureWithConfiguration = { _, completion in
-            completion?()
+            completion(.success(()))
         }
 
         let viewModel: ChatViewModel = .mock(
@@ -595,7 +595,7 @@ class ChatViewModelTests: XCTestCase {
         let interactor = Interactor.failing
         interactor.environment.gcd.mainQueue.asyncIfNeeded = { $0() }
         interactor.environment.coreSdk.configureWithInteractor = { _ in }
-        interactor.environment.coreSdk.configureWithConfiguration = { _, callback in callback?() }
+        interactor.environment.coreSdk.configureWithConfiguration = { _, callback in callback(.success(())) }
         interactor.environment.coreSdk.sendMessagePreview = { _, _ in }
         interactor.environment.coreSdk.sendMessageWithMessagePayload = { _, completion in
             completion(.success(.mock(id: expectedMessageId)))
@@ -645,7 +645,7 @@ class ChatViewModelTests: XCTestCase {
         let interactor = Interactor.failing
         interactor.environment.gcd.mainQueue.asyncIfNeeded = { $0() }
         interactor.environment.coreSdk.configureWithInteractor = { _ in }
-        interactor.environment.coreSdk.configureWithConfiguration = { _, callback in callback?() }
+        interactor.environment.coreSdk.configureWithConfiguration = { _, callback in callback(.success(())) }
         interactor.environment.coreSdk.sendMessagePreview = { _, _ in }
         interactor.environment.coreSdk.sendMessageWithMessagePayload = { [weak viewModel] _, completion in
             // Deliver message via socket before REST API response.

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
@@ -11,7 +11,7 @@ extension GliaTests {
     func testStartEngagementThrowsErrorWhenEngagementAlreadyExists() throws {
         var sdkEnv = Glia.Environment.failing
         sdkEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
-            completion?()
+            completion(.success(()))
         }
         let sdk = Glia(environment: sdkEnv)
         sdk.rootCoordinator = .mock(engagementKind: .chat, screenShareHandler: .mock)
@@ -30,9 +30,9 @@ extension GliaTests {
     func testStartEngagementThrowsErrorDuringActiveCallVisualizerEngagement() throws {
         let sdk = Glia(environment: .failing)
         sdk.environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
-            completion?()
+            completion(.success(()))
         }
-        try sdk.configure(with: .mock())
+        try sdk.configure(with: .mock()) {}
         sdk.environment.coreSdk.getCurrentEngagement = { .mock(source: .callVisualizer) }
 
         XCTAssertThrowsError(
@@ -67,7 +67,7 @@ extension GliaTests {
         }
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             calls.append(.configureWithConfiguration)
-            completion?()
+            completion(.success(()))
         }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
         environment.createRootCoordinator = { _, _, _, _, _, _, _ in
@@ -99,7 +99,7 @@ extension GliaTests {
             )
         }
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
-            completion?()
+            completion(.success(()))
         }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
@@ -110,8 +110,13 @@ extension GliaTests {
         theme.call.connect.queue.firstText = "Glia 1"
         theme.chat.connect.queue.firstText = "Glia 2"
 
-        try sdk.configure(with: .mock())
-        try sdk.startEngagement(engagementKind: .chat, in: ["queueId"], theme: theme)
+        try sdk.configure(with: .mock()) {
+            do {
+                try sdk.startEngagement(engagementKind: .chat, in: ["queueId"], theme: theme)
+            } catch {
+                XCTFail("startEngagement unexpectedly failed with error \(error), but should succeed instead.")
+            }
+        }
 
         let configuredSdkTheme = resultingViewFactory?.theme
         XCTAssertEqual(configuredSdkTheme?.call.connect.queue.firstText, "Glia 1")
@@ -138,7 +143,7 @@ extension GliaTests {
 
         environment.coreSdk.localeProvider.getRemoteString = { _ in "Glia" }
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
-            completion?()
+            completion(.success(()))
         }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.getCurrentEngagement = { nil }
@@ -150,8 +155,13 @@ extension GliaTests {
         theme.call.connect.queue.firstText = "Glia 1"
         theme.chat.connect.queue.firstText = "Glia 2"
 
-        try sdk.configure(with: .mock()) { }
-        try sdk.startEngagement(engagementKind: .chat, in: ["queueId"], theme: theme)
+        try sdk.configure(with: .mock()) {
+            do {
+                try sdk.startEngagement(engagementKind: .chat, in: ["queueId"], theme: theme)
+            } catch {
+                XCTFail("startEngagement unexpectedly failed with error \(error), but should succeed instead.")
+            }
+        }
 
         let configuredSdkTheme = resultingViewFactory?.theme
         XCTAssertEqual(configuredSdkTheme?.call.connect.queue.firstText, "Glia")
@@ -176,15 +186,20 @@ extension GliaTests {
             )
         }
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
-            completion?()
+            completion(.success(()))
         }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
 
         let sdk = Glia(environment: environment)
 
-        try sdk.configure(with: .mock(companyName: "Glia"))
-        try sdk.startEngagement(engagementKind: .chat, in: ["queueId"])
+        try sdk.configure(with: .mock(companyName: "Glia")) {
+            do {
+                try sdk.startEngagement(engagementKind: .chat, in: ["queueId"])
+            } catch {
+                XCTFail("startEngagement unexpectedly failed with error \(error), but should succeed instead.")
+            }
+        }
 
         let configuredSdkTheme = resultingViewFactory?.theme
         XCTAssertEqual(configuredSdkTheme?.call.connect.queue.firstText, "Glia")
@@ -209,15 +224,20 @@ extension GliaTests {
             )
         }
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
-            completion?()
+            completion(.success(()))
         }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
 
         let sdk = Glia(environment: environment)
 
-        try sdk.configure(with: .mock())
-        try sdk.startEngagement(engagementKind: .chat, in: ["queueId"])
+        try sdk.configure(with: .mock()) {
+            do {
+                try sdk.startEngagement(engagementKind: .chat, in: ["queueId"])
+            } catch {
+                XCTFail("startEngagement unexpectedly failed with error \(error), but should succeed instead.")
+            }
+        }
 
         let configuredSdkTheme = resultingViewFactory?.theme
         XCTAssertEqual(configuredSdkTheme?.call.connect.queue.firstText, "Company Name")
@@ -244,7 +264,7 @@ extension GliaTests {
 
         environment.coreSdk.localeProvider.getRemoteString = { _ in "" }
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
-            completion?()
+            completion(.success(()))
         }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.getCurrentEngagement = { nil }
@@ -255,8 +275,13 @@ extension GliaTests {
         theme.call.connect.queue.firstText = "Glia 1"
         theme.chat.connect.queue.firstText = "Glia 2"
 
-        try sdk.configure(with: .mock())
-        try sdk.startEngagement(engagementKind: .chat, in: ["queueId"], theme: theme)
+        try sdk.configure(with: .mock()) {
+            do {
+                try sdk.startEngagement(engagementKind: .chat, in: ["queueId"], theme: theme)
+            } catch {
+                XCTFail("startEngagement unexpectedly failed with error \(error), but should succeed instead.")
+            }
+        }
 
         let configuredSdkTheme = resultingViewFactory?.theme
         XCTAssertEqual(configuredSdkTheme?.call.connect.queue.firstText, "Glia 1")
@@ -288,14 +313,14 @@ extension GliaTests {
             Glia.sharedInstance.stringProviding = StringProviding(
                 getRemoteString: environment.coreSdk.localeProvider.getRemoteString
             )
-            completion?()
+            completion(.success(()))
         }
         environment.coreSdk.getCurrentEngagement = { nil }
 
         let sdk = Glia(environment: environment)
         try sdk.configure(with: .mock(), completion: {})
         try sdk.startEngagement(engagementKind: .chat, in: ["queueId"])
-        
+
         let configuredSdkTheme = resultingViewFactory?.theme
         let localFallbackCompanyName = "Company Name"
         XCTAssertEqual(configuredSdkTheme?.call.connect.queue.firstText, localFallbackCompanyName)

--- a/GliaWidgetsTests/Sources/InteractorTests.swift
+++ b/GliaWidgetsTests/Sources/InteractorTests.swift
@@ -99,7 +99,7 @@ class InteractorTests: XCTestCase {
         var callbacks: [Callback] = []
         var interactorEnv = Interactor.Environment.failing
         interactorEnv.coreSdk.configureWithInteractor = { _ in }
-        interactorEnv.coreSdk.configureWithConfiguration = { $1?() }
+        interactorEnv.coreSdk.configureWithConfiguration = { $1(.success(())) }
         interactorEnv.coreSdk.queueForEngagement = { _, _ in }
         interactorEnv.gcd = .mock
         let interactor = Interactor.mock(environment: interactorEnv)
@@ -131,7 +131,7 @@ class InteractorTests: XCTestCase {
         var callbacks: [Callback] = []
         var interactorEnv = Interactor.Environment.failing
         interactorEnv.coreSdk.configureWithInteractor = { _ in }
-        interactorEnv.coreSdk.configureWithConfiguration = { $1?() }
+        interactorEnv.coreSdk.configureWithConfiguration = { $1(.success(())) }
         interactorEnv.coreSdk.queueForEngagement = { _, completion in
             completion(.success(.mock))
         }
@@ -166,7 +166,7 @@ class InteractorTests: XCTestCase {
         var callbacks: [Callback] = []
         var interactorEnv = Interactor.Environment.failing
         interactorEnv.coreSdk.configureWithInteractor = { _ in }
-        interactorEnv.coreSdk.configureWithConfiguration = { $1?() }
+        interactorEnv.coreSdk.configureWithConfiguration = { $1(.success(())) }
         interactorEnv.coreSdk.queueForEngagement = { _, completion in
             completion(.failure(.mock()))
         }
@@ -380,7 +380,7 @@ class InteractorTests: XCTestCase {
             callbacks.append(.sendMessageWithAttachment)
         }
         interactorEnv.coreSdk.configureWithInteractor = { _ in }
-        interactorEnv.coreSdk.configureWithConfiguration = { $1?() }
+        interactorEnv.coreSdk.configureWithConfiguration = { $1(.success(())) }
         let interactor = Interactor.mock(environment: interactorEnv)
         
         interactor.send(messagePayload: .mock(content: "mock-message")) { result in


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-xxx

**What was solved?**
New `configure` interface with non-optional completion was introduced 

PR also includes several improvements:
- filtering out empty queueIds;
- deprecating of old `configure` method;
- replace checking interactor existence with configuration one to ensure SDK is configured;
- improve error handling in TestingApp

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [x] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
