### PR TITLE
Do a repo-update on update-dependencies Bitrise workflow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -214,9 +214,19 @@ workflows:
             set -x
 
             git checkout development
-    - cocoapods-install@2:
+    - script@1:
         inputs:
-        - command: update
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # make pipelines' return status equal the last command to exit with a non-zero status, or zero if all commands exit successfully
+            set -o pipefail
+            # debug log
+            set -x
+
+            cd $BITRISE_SOURCE_DIR
+            pod update --repo-update
     - fastlane@3:
         inputs:
         - lane: ios create_pr_for_dependencies_update version:$VERSION checksum:$CHECKSUM

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -117,18 +117,5 @@ platform :ios do
     sh("cp ../templates/Package.swift ../Package.swift")
     sh("sed -i '' 's/\${CORE_SDK_VERSION}/#{core_sdk_version}/' ../Package.swift")
     sh("sed -i '' 's/\${CORE_SDK_CHECKSUM}/#{core_sdk_checksum}/' ../Package.swift")
-
-    core_sdk_podspec_url = "https://raw.githubusercontent.com/CocoaPods/Specs/e98c1e8af87c48b4f9e7e5e8635509ed246a615e/Specs/b/d/d/GliaCoreSDK/#{core_sdk_version}/GliaCoreSDK.podspec.json"
-
-    # Generate the Podfile checksum by downloading its JSON representation, generating the checksum, and then
-    # getting the checksum value only without any additional output.
-    core_sdk_podfile_checksum = sh("curl -s GET #{core_sdk_podspec_url} | openssl sha1 | awk {'print $2'}")
-
-    # The previous command has a newline at the end.
-    stripped_core_sdk_podfile_checksum = core_sdk_podfile_checksum.strip
-
-    # Changes to Podfile.lock
-    sh("sed -i '' \"s/.*  - GliaCoreSDK(.*/  - GliaCoreSDK (#{core_sdk_version}):/g\" ../Podfile.lock")
-    sh("sed -i '' \"s/.*  GliaCoreSDK:.*/  GliaCoreSDK: #{stripped_core_sdk_podfile_checksum}/g\" ../Podfile.lock")
   end
 end


### PR DESCRIPTION

**Jira issue:**
https://glia.atlassian.net/browse/MOB-2816

**What was solved?**
The update-dependencies workflow wasn't finding the latest version of the Core SDK because the Bitrise Cocoapods cache is updated over the weekend. Now, the update also does a --repo-update and thus it will pick up the updated version. This means that messing with the Podfile.lock is not necessary and these instructions have been deleted from Fastlane.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
