### PR TITLE
Fix messageText transition from TranscriptModel to ChatViewModel

### DIFF
--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.SecureConverstaions.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.SecureConverstaions.swift
@@ -14,6 +14,7 @@ extension ChatViewModel {
                 upload.environment.uploadFile = .toEngagement(environment.uploadFileToEngagement)
                 return upload
             }
+        event(.messageTextChanged(transcript.messageText))
         // Since we have modified file upload list view model,
         // we need to report about this change manually
         // to keep UI in sync with data.

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -34,7 +34,7 @@ class ChatViewModel: EngagementViewModel {
 
     private let downloader: FileDownloader
     private let deliveredStatusText: String
-    private var messageText = "" {
+    private (set) var messageText = "" {
         didSet {
             validateMessage()
             sendMessagePreview(messageText)

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -454,6 +454,7 @@ class ChatViewModelTests: XCTestCase {
                 break
             }
         }
+        transcriptModel.event(.messageTextChanged("mock"))
         chatViewModel.migrate(from: transcriptModel)
 
         let itemKind = chatViewModel.pendingSection.items.first(
@@ -481,6 +482,7 @@ class ChatViewModelTests: XCTestCase {
         }))
         XCTAssertTrue(chatViewModel.isViewActive.value)
         XCTAssertEqual(chatViewModel.isViewLoaded, transcriptModel.isViewLoaded)
+        XCTAssertEqual(chatViewModel.messageText, transcriptModel.messageText)
         enum Call: Equatable {
             case scrollToBottom(animated: Bool)
         }


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-2820

**What was solved?**
Previously if visitor initiated SecureConversation engagement and pre-filled new message on the Transcript screen, and then operator accepted the engagement, send message button disappeared form the visitor screen.

This PR fixes missing message text happened during transition from TranscriptModel to ChatViewModel when operator accepted an engagement.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
