### PR TITLE
LO: Add indicator about starting session

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -222,7 +222,11 @@
 		7512A5A727C3926500319DF1 /* GliaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7512A5A627C3926500319DF1 /* GliaTests.swift */; };
 		7529F2B427E1D503004D3581 /* Survey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7529F2B327E1D503004D3581 /* Survey.swift */; };
 		7529F2B627E1EB9A004D3581 /* Survey.ButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7529F2B527E1EB9A004D3581 /* Survey.ButtonView.swift */; };
+		752A83382AF5977B005E468D /* SerialQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 752A83372AF5977B005E468D /* SerialQueue.swift */; };
+		752A833A2AF59EAE005E468D /* SnackBar+Presenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 752A83392AF59EAE005E468D /* SnackBar+Presenter.swift */; };
+		752A833C2AF59EDB005E468D /* SnackBar+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 752A833B2AF59EDB005E468D /* SnackBar+View.swift */; };
 		753A56B927CFEB730050D8E6 /* ChatViewModel.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AB196DF27C401F600FD60AB /* ChatViewModel.Mock.swift */; };
+		753B05F82AFC1D750084611E /* SerialQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 753B05F72AFC1D750084611E /* SerialQueueTests.swift */; };
 		754313CB2870A65400C9C1C6 /* SettingsViewController.Props.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754313CA2870A65400C9C1C6 /* SettingsViewController.Props.swift */; };
 		754313CD2870B1C400C9C1C6 /* UserDefaultsStored.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754313CC2870B1C400C9C1C6 /* UserDefaultsStored.swift */; };
 		754313CF2870E64600C9C1C6 /* Configuration.Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754313CE2870E64600C9C1C6 /* Configuration.Extensions.swift */; };
@@ -303,6 +307,9 @@
 		75CF8D6329B7DD8300CB1524 /* SecureConversations+ConfirmationStyle+RemoteConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75CF8D6229B7DD8300CB1524 /* SecureConversations+ConfirmationStyle+RemoteConfig.swift */; };
 		75CF8D9129C3A85C00CB1524 /* SecureConversationsWelcomeScreenVoiceOverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75CF8D9029C3A85C00CB1524 /* SecureConversationsWelcomeScreenVoiceOverTests.swift */; };
 		75CF8DAD29C8F2B500CB1524 /* SecureConversationsConfirmationScreenVoiceOverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75CF8DAC29C8F2B500CB1524 /* SecureConversationsConfirmationScreenVoiceOverTests.swift */; };
+		75D987F82AF2BA500016A702 /* RemoteConfiguration+SnackBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75D987F72AF2BA500016A702 /* RemoteConfiguration+SnackBar.swift */; };
+		75D987FA2AF2BB330016A702 /* Theme+SnackBarStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75D987F92AF2BB330016A702 /* Theme+SnackBarStyle.swift */; };
+		75D987FC2AF2D9F90016A702 /* SnackBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75D987FB2AF2D9F90016A702 /* SnackBar.swift */; };
 		75F58EE127E7D5300065BA2D /* Survey.ViewController.Props.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75F58EE027E7D5300065BA2D /* Survey.ViewController.Props.swift */; };
 		75FF151427F3A2D600FE7BE2 /* Theme+Survey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FF151327F3A2D600FE7BE2 /* Theme+Survey.swift */; };
 		75FF151727F4E13900FE7BE2 /* Theme.Survey.BooleanQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FF151627F4E13900FE7BE2 /* Theme.Survey.BooleanQuestion.swift */; };
@@ -971,6 +978,10 @@
 		7512A5A627C3926500319DF1 /* GliaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GliaTests.swift; sourceTree = "<group>"; };
 		7529F2B327E1D503004D3581 /* Survey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Survey.swift; sourceTree = "<group>"; };
 		7529F2B527E1EB9A004D3581 /* Survey.ButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Survey.ButtonView.swift; sourceTree = "<group>"; };
+		752A83372AF5977B005E468D /* SerialQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerialQueue.swift; sourceTree = "<group>"; };
+		752A83392AF59EAE005E468D /* SnackBar+Presenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SnackBar+Presenter.swift"; sourceTree = "<group>"; };
+		752A833B2AF59EDB005E468D /* SnackBar+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SnackBar+View.swift"; sourceTree = "<group>"; };
+		753B05F72AFC1D750084611E /* SerialQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerialQueueTests.swift; sourceTree = "<group>"; };
 		754313CA2870A65400C9C1C6 /* SettingsViewController.Props.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.Props.swift; sourceTree = "<group>"; };
 		754313CC2870B1C400C9C1C6 /* UserDefaultsStored.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsStored.swift; sourceTree = "<group>"; };
 		754313CE2870E64600C9C1C6 /* Configuration.Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.Extensions.swift; sourceTree = "<group>"; };
@@ -1047,6 +1058,9 @@
 		75CF8D6229B7DD8300CB1524 /* SecureConversations+ConfirmationStyle+RemoteConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SecureConversations+ConfirmationStyle+RemoteConfig.swift"; sourceTree = "<group>"; };
 		75CF8D9029C3A85C00CB1524 /* SecureConversationsWelcomeScreenVoiceOverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversationsWelcomeScreenVoiceOverTests.swift; sourceTree = "<group>"; };
 		75CF8DAC29C8F2B500CB1524 /* SecureConversationsConfirmationScreenVoiceOverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversationsConfirmationScreenVoiceOverTests.swift; sourceTree = "<group>"; };
+		75D987F72AF2BA500016A702 /* RemoteConfiguration+SnackBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteConfiguration+SnackBar.swift"; sourceTree = "<group>"; };
+		75D987F92AF2BB330016A702 /* Theme+SnackBarStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Theme+SnackBarStyle.swift"; sourceTree = "<group>"; };
+		75D987FB2AF2D9F90016A702 /* SnackBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnackBar.swift; sourceTree = "<group>"; };
 		75F58EE027E7D5300065BA2D /* Survey.ViewController.Props.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Survey.ViewController.Props.swift; sourceTree = "<group>"; };
 		75FF151327F3A2D600FE7BE2 /* Theme+Survey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Theme+Survey.swift"; sourceTree = "<group>"; };
 		75FF151627F4E13900FE7BE2 /* Theme.Survey.BooleanQuestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.Survey.BooleanQuestion.swift; sourceTree = "<group>"; };
@@ -2052,6 +2066,7 @@
 				8491AF0B2A7A9C9200CC3E72 /* Chat */,
 				75FF151527F4E11000FE7BE2 /* Survey */,
 				1A60AF7925656E0500E53F53 /* Theme.swift */,
+				75D987F92AF2BB330016A702 /* Theme+SnackBarStyle.swift */,
 				9A19926D27D3BB7800161AAE /* Theme.Mock.swift */,
 				1A0C9A6625C16DC400815406 /* Theme+Chat.swift */,
 				1A0C9A6C25C16EED00815406 /* Theme+Call.swift */,
@@ -2698,6 +2713,7 @@
 				EB7A1509286D98270035AC62 /* FileUploaderTests.swift */,
 				C03A8046292BA76D00DDECA6 /* ChatViewControllerTests.swift */,
 				C03A8048292BC8DB00DDECA6 /* CallViewControllerTests.swift */,
+				753B05F72AFC1D750084611E /* SerialQueueTests.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -2818,6 +2834,7 @@
 			isa = PBXGroup;
 			children = (
 				7594093B298D376A008B173A /* RemoteConfiguration.swift */,
+				75D987F72AF2BA500016A702 /* RemoteConfiguration+SnackBar.swift */,
 				75C1143329A3F58E0004E5F7 /* RemoteConfiguration+SecureConversationsWelcomeScreen.swift */,
 				7594093A298D376A008B173A /* RemoteConfiguration+AssetsBuilder.swift */,
 				84265E6A29912E2100D65842 /* RemoteConfiguration+CallVisualizer.swift */,
@@ -2958,6 +2975,17 @@
 				845876A3282A8FEF007AC3DF /* ScaleQuestionView */,
 			);
 			path = Components;
+			sourceTree = "<group>";
+		};
+		75D987F22AF29EF50016A702 /* SnackBarView */ = {
+			isa = PBXGroup;
+			children = (
+				75D987FB2AF2D9F90016A702 /* SnackBar.swift */,
+				752A833B2AF59EDB005E468D /* SnackBar+View.swift */,
+				752A83392AF59EAE005E468D /* SnackBar+Presenter.swift */,
+				752A83372AF5977B005E468D /* SerialQueue.swift */,
+			);
+			path = SnackBarView;
 			sourceTree = "<group>";
 		};
 		75FF151527F4E11000FE7BE2 /* Survey */ = {
@@ -3770,6 +3798,7 @@
 		C0E948012AB1D5B100890026 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				75D987F22AF29EF50016A702 /* SnackBarView */,
 				C0E948072AB1D69C00890026 /* Header */,
 				C0E948022AB1D5BC00890026 /* Buttons */,
 				C07F62782AC2D2E8003EFC97 /* BackgroundSwiftUI.swift */,
@@ -4380,6 +4409,7 @@
 				75FF151D27F4F8E000FE7BE2 /* Theme.Survey.InputQuestion.swift in Sources */,
 				8491AF0A2A78FED700CC3E72 /* GvaGalleryListViewStyle.swift in Sources */,
 				845E2F9D283FCB1400C04D56 /* Theme.Survey.Checkbox.Accessibility.swift in Sources */,
+				752A833C2AF59EDB005E468D /* SnackBar+View.swift in Sources */,
 				C0D2F0542993CCD100803B47 /* VideoCallView.CallButtonBar.swift in Sources */,
 				1AC7A77B25838AE800567FF8 /* ChatItem.swift in Sources */,
 				9A3E1D8C27B6B888005634EB /* FileDownload.Environment.Mock.swift in Sources */,
@@ -4530,6 +4560,8 @@
 				C07FA04B29AF83B900E9FB7F /* ActionButton.Mock.swift in Sources */,
 				C0D2F08C29A4EBA900803B47 /* VIdeoCallView.Environment.Mock.swift in Sources */,
 				313EBD552943116E008E9597 /* SecureConversations.swift in Sources */,
+				752A83382AF5977B005E468D /* SerialQueue.swift in Sources */,
+				752A833A2AF59EAE005E468D /* SnackBar+Presenter.swift in Sources */,
 				7529F2B627E1EB9A004D3581 /* Survey.ButtonView.swift in Sources */,
 				C49A29E42614A29700819269 /* FilePreviewView.swift in Sources */,
 				1A5F815F258A43E600A605DA /* Section.swift in Sources */,
@@ -4572,6 +4604,7 @@
 				845E2F8E283FB5B500C04D56 /* Theme.Survey.SingleQuestion.Accessibility.swift in Sources */,
 				C47901B725ED2FB0007EE195 /* AlertViewController+ScreenShareOffer.swift in Sources */,
 				1A8366B025FF40AB005FE7EE /* LocalFile.swift in Sources */,
+				75D987F82AF2BA500016A702 /* RemoteConfiguration+SnackBar.swift in Sources */,
 				84265E62298D7B2900D65842 /* ScreenSharingCoordinator+DelegateEvent.swift in Sources */,
 				C0D2F048299272D100803B47 /* VideoCallView.ConnectOperatorView.swift in Sources */,
 				9A3E1D8A27B6B824005634EB /* FileDownload.Environment.Interface.swift in Sources */,
@@ -4610,6 +4643,7 @@
 				C0175A2A2A67D499001FACDE /* GvaStyle.swift in Sources */,
 				1A8B61D625C974D0000D780E /* ChatCallUpgradeStyle.swift in Sources */,
 				3100D92D296E946600DEC9CE /* SecureConversations.ConfirmationViewModel.swift in Sources */,
+				75D987FC2AF2D9F90016A702 /* SnackBar.swift in Sources */,
 				3100EEFB293F363100D57F71 /* SecureConversations.WelcomeView.swift in Sources */,
 				1A475BBC25DFA10100296D55 /* UnreadMessagesHandler.swift in Sources */,
 				845E2F85283FA90200C04D56 /* Theme.Survey.ValidationError.Accessibility.swift in Sources */,
@@ -4761,6 +4795,7 @@
 				31DD41652A57105400F92612 /* SecureConversations.TranscriptModel.Environment.swift in Sources */,
 				AFF9542A2ADD8DB600C277E0 /* CoreSDKConfigurator.Mock.swift in Sources */,
 				1A277A1225FA604E009FE131 /* ChatFileContentView.swift in Sources */,
+				75D987FA2AF2BB330016A702 /* Theme+SnackBarStyle.swift in Sources */,
 				75B7BD802A39D5A70060794D /* Layoutable.swift in Sources */,
 				845876AB282A959C007AC3DF /* SingleChoiceQuestionView.Props.Accessibility.swift in Sources */,
 				9AB3402327FC859E006E0FE2 /* CallButtonStyle.StateStyle.Accessibility.swift in Sources */,
@@ -4896,6 +4931,7 @@
 				C03A8049292BC8DB00DDECA6 /* CallViewControllerTests.swift in Sources */,
 				84D5B9662A15204400807F92 /* QuickLookBased.Failing.swift in Sources */,
 				84602A772AEA5BEA0031E606 /* ProximityManager.Failing.swift in Sources */,
+				753B05F82AFC1D750084611E /* SerialQueueTests.swift in Sources */,
 				84681A982A61853300DD7406 /* GvaOption.Mock.swift in Sources */,
 				AF6AB34B2989517100003645 /* FileUploader.Failing.swift in Sources */,
 				EB03B00E27FFF6DD0058F6B1 /* CallViewTests.swift in Sources */,

--- a/GliaWidgets/Localization.swift
+++ b/GliaWidgets/Localization.swift
@@ -401,6 +401,8 @@ internal enum Localization {
   internal enum General {
     /// Accept
     internal static var accept: String { Localization.tr("Localizable", "general.accept", fallback: "Accept") }
+    /// Allow
+    internal static var allow: String { Localization.tr("Localizable", "general.allow", fallback: "Allow") }
     /// Back
     internal static var back: String { Localization.tr("Localizable", "general.back", fallback: "Back") }
     /// Browse
@@ -485,9 +487,13 @@ internal enum Localization {
   internal enum LiveObservation {
     internal enum Confirm {
       /// Please allow the {companyName} representative to view this application screen for improved support.
-      internal static let message = Localization.tr("Localizable", "live_observation.confirm.message", fallback: "Please allow the {companyName} representative to view this application screen for improved support.")
+      internal static var message: String { Localization.tr("Localizable", "live_observation.confirm.message", fallback: "Please allow the {companyName} representative to view this application screen for improved support.") }
       /// Before We Continue
-      internal static let title = Localization.tr("Localizable", "live_observation.confirm.title", fallback: "Before We Continue")
+      internal static var title: String { Localization.tr("Localizable", "live_observation.confirm.title", fallback: "Before We Continue") }
+    }
+    internal enum Indicator {
+      /// App screen is visible to the agent
+      internal static var message: String { Localization.tr("Localizable", "live_observation.indicator.message", fallback: "App screen is visible to the agent") }
     }
   }
   internal enum MediaUpgrade {

--- a/GliaWidgets/Resources/en.lproj/Localizable.strings
+++ b/GliaWidgets/Resources/en.lproj/Localizable.strings
@@ -226,3 +226,5 @@
 "visitor_code.failed" = "Could not load the visitor code. Please try refreshing.";
 "live_observation.confirm.title" = "Before We Continue";
 "live_observation.confirm.message" = "Please allow the {companyName} representative to view this application screen for improved support.";
+"live_observation.confirm.message" = "Please allow the {companyName} representative to view this application screen for improved support.";
+"live_observation.indicator.message" = "App screen is visible to the agent";

--- a/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
@@ -3,6 +3,8 @@ import UIKit
 
 extension CallVisualizer {
     final class Coordinator {
+        private let snackBar = SnackBar()
+
         init(environment: Environment) {
             self.environment = environment
             self.bubbleView = environment.viewFactory.makeBubbleView()
@@ -150,6 +152,7 @@ extension CallVisualizer {
             environment.fetchSiteConfigurations { [weak self] result in
                 switch result {
                 case let .success(site):
+                    self?.showSnackBarMessage(Localization.LiveObservation.Indicator.message)
                     if site.mobileConfirmDialog == true {
                         self?.showConfirmationAlert()
                     }
@@ -429,6 +432,29 @@ private extension CallVisualizer.Coordinator {
         replaceable.dismiss(animated: true) {
             presenting?.present(alert, animated: true)
         }
+    }
+
+    func showSnackBarMessage(_ text: String) {
+        guard let style = visitorCodeCoordinator?.theme.snackBar else { return }
+        snackBar.present(
+            text: Localization.LiveObservation.Indicator.message,
+            style: style,
+            for: topMostViewController,
+            timerProviding: environment.timerProviding
+        )
+    }
+
+    private var topMostViewController: UIViewController {
+        let window = UIApplication.shared.windows.first { $0.isKeyWindow }
+        guard var presenter = window?.rootViewController else {
+            fatalError("Could not find UIViewController to present on")
+        }
+
+        while let presentedViewController = presenter.presentedViewController {
+            presenter = presentedViewController
+        }
+
+        return presenter
     }
 }
 

--- a/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeCoordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeCoordinator.swift
@@ -3,7 +3,7 @@ import UIKit
 extension CallVisualizer {
     class VisitorCodeCoordinator: FlowCoordinator {
         typealias ViewController = UIViewController
-        private let theme: Theme
+        let theme: Theme
 
         var delegate: ((DelegateEvent) -> Void)?
         var environment: Environment

--- a/GliaWidgets/Sources/Coordinators/Call/CallCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Call/CallCoordinator.swift
@@ -98,7 +98,8 @@ private extension CallCoordinator {
             viewModel: viewModel,
             viewFactory: viewFactory,
             environment: .init(
-                notificationCenter: environment.notificationCenter
+                notificationCenter: environment.notificationCenter,
+                timerProviding: environment.timerProviding
             )
         )
     }

--- a/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration+SnackBar.swift
+++ b/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration+SnackBar.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+extension RemoteConfiguration {
+    public struct SnackBar: Codable {
+        let background: Color?
+        let text: Color?
+    }
+}

--- a/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration.swift
+++ b/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration.swift
@@ -10,6 +10,7 @@ public struct RemoteConfiguration: Codable {
     let callVisualizer: CallVisualizer?
     let secureConversationsWelcomeScreen: SecureConversationsWelcomeScreen?
     let secureConversationsConfirmationScreen: SecureConversationsConfirmationScreen?
+    let snackBar: SnackBar?
 }
 
 extension RemoteConfiguration {

--- a/GliaWidgets/Sources/Theme/Theme+SnackBarStyle.swift
+++ b/GliaWidgets/Sources/Theme/Theme+SnackBarStyle.swift
@@ -1,0 +1,71 @@
+import UIKit
+
+extension Theme {
+    var snackBarStyle: SnackBarStyle {
+        .init(
+            background: color.baseDark,
+            textColor: color.baseLight,
+            textFont: .font(weight: .regular, size: 17),
+            accessibility: .init(isFontScalingEnabled: true)
+        )
+    }
+
+    var invertedSnackBarStyle: SnackBarStyle {
+        .init(
+            background: color.baseLight,
+            textColor: color.baseDark,
+            textFont: .font(weight: .regular, size: 17),
+            accessibility: .init(isFontScalingEnabled: true)
+        )
+    }
+
+    public struct SnackBarStyle: Equatable {
+        /// View's background color
+        public var background: UIColor
+        /// Snack message text color.
+        public var textColor: UIColor
+        /// Snack message text font.
+        public var textFont: UIFont
+        /// Style accessibility.
+        public var accessibility: Accessibility
+    }
+}
+
+extension Theme.SnackBarStyle {
+    mutating func apply(
+        configuration: RemoteConfiguration.SnackBar?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
+        configuration?.text?
+            .value
+            .first
+            .map { .init(hex: $0) }
+            .unwrap { textColor = $0 }
+
+        configuration?.background?
+            .value
+            .first
+            .map { .init(hex: $0) }
+            .unwrap { background = $0 }
+
+        UIFont.convertToFont(
+            uiFont: assetsBuilder.fontBuilder(.init(size: 17, style: .regular)),
+            textStyle: .title3
+        ).unwrap { textFont = $0 }
+    }
+
+    /// Accessibility properties for Text.
+    public struct Accessibility: Equatable {
+        /// Flag that provides font dynamic type by setting `adjustsFontForContentSizeCategory` for component that supports it.
+        public var isFontScalingEnabled: Bool
+
+        ///
+        /// - Parameter isFontScalingEnabled: Flag that provides font dynamic type by setting `adjustsFontForContentSizeCategory` for component that supports it.
+        public init(isFontScalingEnabled: Bool) {
+            self.isFontScalingEnabled = isFontScalingEnabled
+        }
+
+        /// Accessibility is not supported intentionally.
+        public static let unsupported = Self(isFontScalingEnabled: false)
+    }
+}

--- a/GliaWidgets/Sources/Theme/Theme.swift
+++ b/GliaWidgets/Sources/Theme/Theme.swift
@@ -23,24 +23,24 @@ public class Theme {
     public var font: ThemeFont
 
     /// Chat view style.
-    public lazy var chat: ChatStyle = { return chatStyle }()
+    public lazy var chat: ChatStyle = { chatStyle }()
 
     /// Call view style.
-    public lazy var call: CallStyle = { return callStyle }()
+    public lazy var call: CallStyle = { callStyle }()
 
     /// Secure conversations welcome style.
     public lazy var secureConversationsWelcome: SecureConversations.WelcomeStyle = {
-        return secureConversationsWelcomeStyle
+        secureConversationsWelcomeStyle
     }()
 
     /// Alert view style.
-    public lazy var alert: AlertStyle = { return alertStyle }()
+    public lazy var alert: AlertStyle = { alertStyle }()
 
     /// Configurations for the alerts.
-    public lazy var alertConfiguration: AlertConfiguration = { return alertConfigurationStyle }()
+    public lazy var alertConfiguration: AlertConfiguration = { alertConfigurationStyle }()
 
     /// Style of the minimized bubble.
-    public lazy var minimizedBubble: BubbleStyle = { return minimizedBubbleStyle }()
+    public lazy var minimizedBubble: BubbleStyle = { minimizedBubbleStyle }()
 
     /// Survey view style.
     public lazy var survey: SurveyStyle = .default(
@@ -50,16 +50,22 @@ public class Theme {
     )
 
     /// Call Visualizer Visitor Code view style.
-    public lazy var visitorCode: VisitorCodeStyle = { return visitorCodeStyle }()
+    public lazy var visitorCode: VisitorCodeStyle = { visitorCodeStyle }()
 
     /// Call Visualizer Screen Sharing View style.
-    public lazy var screenSharing: ScreenSharingViewStyle = { return screenSharingStyle }()
+    public lazy var screenSharing: ScreenSharingViewStyle = { screenSharingStyle }()
 
     // Confirmation Screen in Secure Conversation flow style.
     public lazy var secureConversationsConfirmation: SecureConversations.ConfirmationStyle = defaultSecureConversationsConfirmationStyle
 
     /// Controls the visibility of the "Powered by" text and image.
     public var showsPoweredBy: Bool
+
+    /// Snack bar View style.
+    public lazy var snackBar: SnackBarStyle = { snackBarStyle }()
+
+    /// Inverted snack bar View style.
+    public lazy var invertedSnackBar: SnackBarStyle = { invertedSnackBarStyle }()
 
     /// Initilizes the theme with base color and font style.
     ///
@@ -131,6 +137,10 @@ public class Theme {
         )
         secureConversationsConfirmation.apply(
             configuration: config.secureConversationsConfirmationScreen,
+            assetsBuilder: assetsBuilder
+        )
+        snackBar.apply(
+            configuration: config.snackBar,
             assetsBuilder: assetsBuilder
         )
     }

--- a/GliaWidgets/Sources/ViewController/Call/CallViewController.Mock.swift
+++ b/GliaWidgets/Sources/ViewController/Call/CallViewController.Mock.swift
@@ -10,7 +10,8 @@ extension CallViewController {
             viewModel: viewModel,
             viewFactory: viewFactory,
             environment: .init(
-                notificationCenter: .mock
+                notificationCenter: .mock,
+                timerProviding: .mock
             )
         )
     }

--- a/GliaWidgets/Sources/ViewController/Call/CallViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Call/CallViewController.swift
@@ -3,6 +3,7 @@ import UIKit
 final class CallViewController: EngagementViewController {
     private let viewModel: CallViewModel
     private let environment: Environment
+    let snackBar = SnackBar()
 
     init(viewModel: CallViewModel, viewFactory: ViewFactory, environment: Environment) {
         self.environment = environment
@@ -66,6 +67,7 @@ final class CallViewController: EngagementViewController {
         }
 
         self.viewModel.action = { [weak self] action in
+            guard let self else { return }
             switch action {
             case .queue:
                 view.setConnectState(.queue, animated: false)
@@ -104,7 +106,7 @@ final class CallViewController: EngagementViewController {
                 let button = CallButton.Kind(with: button)
                 view.buttonBar.setButton(button, badgeItemCount: itemCount)
             case .offerMediaUpgrade(let conf, accepted: let accepted, declined: let declined):
-                self?.offerMediaUpgrade(with: conf, accepted: accepted, declined: declined)
+                self.offerMediaUpgrade(with: conf, accepted: accepted, declined: declined)
             case .setRemoteVideo(let streamView):
                 view.remoteVideoView.streamView = streamView
             case .setLocalVideo(let streamView):
@@ -113,6 +115,14 @@ final class CallViewController: EngagementViewController {
                 view.isVisitrOnHold = isOnHold
             case .transferring:
                 view.setConnectState(.transferring, animated: true)
+            case .showSnackBarView(let text):
+                self.snackBar.present(
+                    text: text,
+                    style: self.viewFactory.theme.invertedSnackBar,
+                    for: self,
+                    bottomOffset: -100,
+                    timerProviding: self.environment.timerProviding
+                )
             }
         }
     }
@@ -178,5 +188,6 @@ private extension CallButton.State {
 extension CallViewController {
     struct Environment {
         var notificationCenter: FoundationBased.NotificationCenter
+        var timerProviding: FoundationBased.Timer.Providing
     }
 }

--- a/GliaWidgets/Sources/ViewModel/Call/CallViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Call/CallViewModel.swift
@@ -112,6 +112,7 @@ class CallViewModel: EngagementViewModel, ViewModel {
             showConnecting()
             let operatorName = interactor.engagedOperator?.firstName ?? Localization.Engagement.defaultOperator
             action?(.setOperatorName(operatorName))
+            action?(.showSnackBarView(text: Localization.LiveObservation.Indicator.message))
         case .ended:
             call.end()
         default:
@@ -546,6 +547,7 @@ extension CallViewModel {
         case setRemoteVideo(CoreSdkClient.StreamView?)
         case setLocalVideo(CoreSdkClient.StreamView?)
         case setVisitorOnHold(isOnHold: Bool)
+        case showSnackBarView(text: String)
     }
 
     enum DelegateEvent {

--- a/GliaWidgets/SwiftUI/Components/SnackBarView/SerialQueue.swift
+++ b/GliaWidgets/SwiftUI/Components/SnackBarView/SerialQueue.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// The queue with serial strategy. Not thread-safe.
+/// Allows to synchronise operations and build serial
+/// queue to achive use case when SDK have to do some
+/// operations only after the previous one is done.
+final class SerialQueue {
+    /// Adds operation to end of  serial queue
+    func addOperation(_ op: Operation) {
+        let needToRun = queue.isEmpty
+        queue.append(op)
+        if needToRun {
+            run()
+        }
+    }
+
+    // MARK: - Private
+
+    private(set) var queue = [Operation]()
+
+    private func run() {
+        guard let operation = queue.first else { return }
+
+        operation.didFinish = { [weak self] in
+            self?.queue.removeFirst()
+            self?.run()
+        }
+        operation.run()
+    }
+}
+
+extension SerialQueue {
+    /// Defines operation for using in SerialQueue.
+    ///
+    ///
+    /// Example of implementation that waits for
+    /// `seconds` and executes `done` for the operation:
+    /// ```swift
+    /// extension SerialQueue.Operation {
+    ///     static func timeout(seconds: Int) -> Self {
+    ///         .init(
+    ///             action: { done in
+    ///                 DispatchQueue.main.asyncAfter(
+    ///                     deadline: .now() + .seconds(seconds),
+    ///                     execute: done
+    ///                 )
+    ///             }
+    ///         )
+    ///     }
+    /// }
+    /// ```
+    final class Operation {
+        var didFinish: (() -> Void)?
+        let action: (_ done: @escaping() -> Void) -> Void
+
+        init(action: @escaping (_ done: @escaping () -> Void) -> Void) {
+            self.action = action
+        }
+
+        func run() {
+            action(didFinish ?? {})
+        }
+    }
+}

--- a/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar+Presenter.swift
+++ b/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar+Presenter.swift
@@ -1,0 +1,86 @@
+import Combine
+import SwiftUI
+import UIKit
+
+extension SnackBar {
+    final class Presenter {
+        weak var parentViewController: UIViewController?
+
+        let hostingController: UIHostingController<ContentView>
+        let updatePublisher: CurrentValueSubject<ContentView.ViewState, Never>
+
+        private let environment: Environment
+        private var serialQueue = SerialQueue()
+        private var timer: FoundationBased.Timer?
+
+        init(
+            parentViewController: UIViewController,
+            style: Theme.SnackBarStyle,
+            environment: Environment
+        ) {
+            self.parentViewController = parentViewController
+            let publisher = CurrentValueSubject<ContentView.ViewState, Never>(.disappear)
+            self.updatePublisher = publisher
+            self.hostingController = .init(
+                rootView: .init(
+                    style: style,
+                    publisher: publisher.eraseToAnyPublisher()
+                )
+            )
+            self.environment = environment
+        }
+
+        func add() {
+            guard let parent = parentViewController else { return }
+            remove()
+
+            parent.addChild(hostingController)
+            hostingController.willMove(toParent: parent)
+            parent.view.addSubview(hostingController.view)
+            hostingController.didMove(toParent: parent)
+            hostingController.view.backgroundColor = .clear
+
+            hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+             NSLayoutConstraint.activate([
+                hostingController.view.topAnchor.constraint(greaterThanOrEqualTo: parent.view.topAnchor),
+                hostingController.view.bottomAnchor.constraint(equalTo: parent.view.bottomAnchor),
+                hostingController.view.leadingAnchor.constraint(equalTo: parent.view.leadingAnchor),
+                hostingController.view.trailingAnchor.constraint(equalTo: parent.view.trailingAnchor)
+             ])
+        }
+
+        func remove() {
+            parentViewController?.children
+                .filter { $0 as? UIHostingController<ContentView> != nil }
+                .forEach { $0.removeFromParent() }
+        }
+
+        func show(
+            text: String,
+            with offset: CGFloat
+        ) {
+            serialQueue.addOperation(
+                .init { [weak self] done in
+                    self?.hostingController.rootView.offset = offset
+                    self?.updatePublisher.send(.appear(text))
+
+                    self?.timer?.invalidate()
+
+                    self?.timer = self?.environment.timerProviding.scheduledTimer(
+                        withTimeInterval: 3,
+                        repeats: false
+                    ) { [weak self] _ in
+                        self?.updatePublisher.send(.disappear)
+                        done()
+                    }
+                }
+            )
+        }
+    }
+}
+
+extension SnackBar.Presenter {
+    struct Environment {
+        let timerProviding: FoundationBased.Timer.Providing
+    }
+}

--- a/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar+View.swift
+++ b/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar+View.swift
@@ -1,0 +1,68 @@
+import Combine
+import SwiftUI
+
+extension SnackBar {
+    struct ContentView: View {
+        enum ViewState { case appear(String), disappear }
+        let publisher: AnyPublisher<ViewState, Never>
+
+        @State private var text = ""
+        @State private var currentOffset: CGFloat = 300
+        let style: Theme.SnackBarStyle
+        var offset: CGFloat = 0
+
+        init(
+            style: Theme.SnackBarStyle,
+            publisher: AnyPublisher<ViewState, Never>
+        ) {
+            self.style = style
+            self.publisher = publisher
+        }
+
+        var body: some View {
+            Text(text)
+                .padding()
+                .frame(maxWidth: .infinity)
+                .background(SwiftUI.Color(style.background))
+                .cornerRadius(4)
+                .foregroundColor(SwiftUI.Color(style.textColor))
+                .font(.convert(style.textFont))
+                .padding()
+                .offset(y: currentOffset)
+                .onReceive(publisher) { newState in
+                    switch newState {
+                    case .appear(let text):
+                        self.text = text
+                        withAnimation {
+                            self.currentOffset = offset
+                        }
+                    case .disappear:
+                        withAnimation {
+                            self.currentOffset = 300
+                        }
+                    }
+                }
+        }
+    }
+
+}
+
+struct SnackBarContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        SnackBar.ContentView(
+            style: .defaultStyle,
+            publisher: CurrentValueSubject<SnackBar.ContentView.ViewState, Never>(
+                .appear("SnackBar.ContentView.Previews")
+            ).eraseToAnyPublisher()
+        )
+    }
+}
+
+extension Theme.SnackBarStyle {
+    static let defaultStyle: Self = .init(
+        background: .init(hex: "#2C0735"),
+        textColor: .init(hex: "#FFFFFF"),
+        textFont: UIFont.systemFont(ofSize: 17, weight: .regular),
+        accessibility: .init(isFontScalingEnabled: true)
+    )
+}

--- a/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar.swift
+++ b/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar.swift
@@ -1,0 +1,27 @@
+import Combine
+import SwiftUI
+import UIKit
+
+struct SnackBar {
+    func present(
+        text: String,
+        style: Theme.SnackBarStyle,
+        for presenter: UIViewController,
+        bottomOffset: CGFloat = 0,
+        timerProviding: FoundationBased.Timer.Providing
+    ) {
+        let existedPresenter = Self.presenters.first(where: { $0.parentViewController === presenter })
+        let presenter = existedPresenter ?? Presenter(
+            parentViewController: presenter,
+            style: style,
+            environment: .init(timerProviding: timerProviding)
+        )
+        if existedPresenter == nil {
+            Self.presenters.append(presenter)
+            presenter.add()
+        }
+        presenter.show(text: text, with: bottomOffset)
+    }
+
+    static private(set) var presenters = [Presenter]()
+}

--- a/GliaWidgetsTests/Sources/CallViewControllerTests.swift
+++ b/GliaWidgetsTests/Sources/CallViewControllerTests.swift
@@ -10,7 +10,8 @@ class CallViewControllerTests: XCTestCase {
                 viewModel: CallViewModel.mock(environment: CallViewModel.Environment.mock),
                 viewFactory: ViewFactory.mock(),
                 environment: .init(
-                    notificationCenter: .mock
+                    notificationCenter: .mock,
+                    timerProviding: .mock
                 )
             )
             weakViewController = viewController

--- a/GliaWidgetsTests/Sources/SerialQueueTests.swift
+++ b/GliaWidgetsTests/Sources/SerialQueueTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import XCTest
+
+@testable import GliaWidgets
+
+final class SerialQueueTests: XCTestCase {
+    var queue = SerialQueue()
+
+    override func setUp() {
+        queue = .init()
+        super.setUp()
+    }
+
+    func test_addOperation() {
+        var performed = [String]()
+        queue.addOperation(
+            .traceable {
+                performed.append("operation-performed")
+            }
+        )
+        XCTAssertEqual(performed, ["operation-performed"])
+        XCTAssertTrue(queue.queue.isEmpty)
+    }
+
+    func test_addOperationSequence() {
+        var performed = [String]()
+        queue.addOperation(
+            .traceable {
+                performed.append("operation-a")
+            }
+        )
+        queue.addOperation(
+            .traceable {
+                performed.append("operation-b")
+            }
+        )
+        XCTAssertEqual(performed, ["operation-a", "operation-b"])
+        XCTAssertTrue(queue.queue.isEmpty)
+    }
+}
+
+extension SerialQueue.Operation {
+    static func traceable(onPerform: @escaping () -> Void) -> SerialQueue.Operation {
+        return .init { done in
+            onPerform()
+            done()
+        }
+    }
+}


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-2709

**What was solved?**
Introduced UI part using SwiftUI for presenting Live Observation indicator on top of UI during CallVisualizer and Audio/Video engagement.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**

https://github.com/salemove/ios-sdk-widgets/assets/125041274/757b79c6-9396-4dd3-91d9-cb9a0e9b7e6d


