### PR TITLE
Add Snapshot-test-for-Live-Observation

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -668,6 +668,10 @@
 		C0E948042AB1D5D200890026 /* ActionButtonSwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E948032AB1D5D200890026 /* ActionButtonSwiftUI.swift */; };
 		C0E948062AB1D64700890026 /* HeaderButtonSwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E948052AB1D64700890026 /* HeaderButtonSwiftUI.swift */; };
 		C0E948092AB1D6AB00890026 /* HeaderSwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E948082AB1D6AB00890026 /* HeaderSwiftUI.swift */; };
+		C0EC58CC2B0275DE00E78C70 /* SnackBarLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EC58CB2B0275DE00E78C70 /* SnackBarLayoutTests.swift */; };
+		C0EC58CE2B02775100E78C70 /* SnackBar+View+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EC58CD2B02775100E78C70 /* SnackBar+View+Mock.swift */; };
+		C0EC58D02B028FB100E78C70 /* SnackBarVoiceOverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EC58CF2B028FB100E78C70 /* SnackBarVoiceOverTests.swift */; };
+		C0EC58D22B02909500E78C70 /* SnackBarDynamicTypeFontTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EC58D12B02909500E78C70 /* SnackBarDynamicTypeFontTests.swift */; };
 		C2B201AEDBE3A53369DF524F /* Pods_GliaWidgetsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CCF7E6C5499635E67EF6A604 /* Pods_GliaWidgetsTests.framework */; };
 		C4119E06268F41D1004DFEFB /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C4119E05268F41D1004DFEFB /* Main.storyboard */; };
 		C42463742673ABE10082C135 /* ScreenShareHandler.Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42463732673ABE10082C135 /* ScreenShareHandler.Interface.swift */; };
@@ -1426,6 +1430,10 @@
 		C0E948032AB1D5D200890026 /* ActionButtonSwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionButtonSwiftUI.swift; sourceTree = "<group>"; };
 		C0E948052AB1D64700890026 /* HeaderButtonSwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderButtonSwiftUI.swift; sourceTree = "<group>"; };
 		C0E948082AB1D6AB00890026 /* HeaderSwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderSwiftUI.swift; sourceTree = "<group>"; };
+		C0EC58CB2B0275DE00E78C70 /* SnackBarLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnackBarLayoutTests.swift; sourceTree = "<group>"; };
+		C0EC58CD2B02775100E78C70 /* SnackBar+View+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SnackBar+View+Mock.swift"; sourceTree = "<group>"; };
+		C0EC58CF2B028FB100E78C70 /* SnackBarVoiceOverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnackBarVoiceOverTests.swift; sourceTree = "<group>"; };
+		C0EC58D12B02909500E78C70 /* SnackBarDynamicTypeFontTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnackBarDynamicTypeFontTests.swift; sourceTree = "<group>"; };
 		C4119E05268F41D1004DFEFB /* Main.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		C42463732673ABE10082C135 /* ScreenShareHandler.Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenShareHandler.Interface.swift; sourceTree = "<group>"; };
 		C43C12F82694B14900C37E1B /* GliaPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GliaPresenter.swift; sourceTree = "<group>"; };
@@ -2981,6 +2989,7 @@
 			isa = PBXGroup;
 			children = (
 				75D987FB2AF2D9F90016A702 /* SnackBar.swift */,
+				C0EC58CD2B02775100E78C70 /* SnackBar+View+Mock.swift */,
 				752A833B2AF59EDB005E468D /* SnackBar+View.swift */,
 				752A83392AF59EAE005E468D /* SnackBar+Presenter.swift */,
 				752A83372AF5977B005E468D /* SerialQueue.swift */,
@@ -3439,6 +3448,9 @@
 				AF22C8982A61AE930004BF3C /* VisitorCodeViewControllerLayoutTests.swift */,
 				AF03A7C22A6EDF490081887D /* VisitorCodeViewControllerDynamicTypeFontTests.swift */,
 				AF755FD92A71583900871E36 /* BubbleWindowLayoutTests.swift */,
+				C0EC58CB2B0275DE00E78C70 /* SnackBarLayoutTests.swift */,
+				C0EC58D12B02909500E78C70 /* SnackBarDynamicTypeFontTests.swift */,
+				C0EC58CF2B028FB100E78C70 /* SnackBarVoiceOverTests.swift */,
 			);
 			path = SnapshotTests;
 			sourceTree = "<group>";
@@ -4418,6 +4430,7 @@
 				C0D2F07C29A4E47200803B47 /* ConnectOperatorView.Mock.swift in Sources */,
 				C08D776028F583D7000461E5 /* Array+Extensions.swift in Sources */,
 				9AE9E4B727E1E30500BFE239 /* MockHelpers.swift in Sources */,
+				C0EC58CE2B02775100E78C70 /* SnackBar+View+Mock.swift in Sources */,
 				8464297D2A459E7D00943BD6 /* UIViewController+Replaceble.swift in Sources */,
 				1A2DA72625EF892600032611 /* FilePickerController.swift in Sources */,
 				1ABD6C9625B6F46700D56EFA /* AlertViewController+SingleMediaUpgrade.swift in Sources */,
@@ -5058,6 +5071,8 @@
 			files = (
 				846E822828996A5C008EFBF0 /* AlertViewControllerVoiceOverTests.swift in Sources */,
 				AF03A7BB2A6ED73E0081887D /* SecureConversationsWelcomeScreenDynamicTypeFontTests.swift in Sources */,
+				C0EC58CC2B0275DE00E78C70 /* SnackBarLayoutTests.swift in Sources */,
+				C0EC58D22B02909500E78C70 /* SnackBarDynamicTypeFontTests.swift in Sources */,
 				75CF8D9129C3A85C00CB1524 /* SecureConversationsWelcomeScreenVoiceOverTests.swift in Sources */,
 				AF22C8972A61A9BF0004BF3C /* VideoCallViewControllerLayoutTests.swift in Sources */,
 				C07F62772AC1BA2B003EFC97 /* UIViewController+Extensions.swift in Sources */,
@@ -5069,6 +5084,7 @@
 				AF22C8852A6154780004BF3C /* AlertViewControllerLayoutTests.swift in Sources */,
 				AF22C8872A6182AF0004BF3C /* BubbleViewLayoutTests.swift in Sources */,
 				AF03A7C12A6EDE190081887D /* VideoCallViewControllerDynamicTypeFontTests.swift in Sources */,
+				C0EC58D02B028FB100E78C70 /* SnackBarVoiceOverTests.swift in Sources */,
 				C07FA05029B0E41A00E9FB7F /* VideoCallViewControllerVoiceOverTests.swift in Sources */,
 				C07FA05029B0E41A00E9FB7F /* VideoCallViewControllerVoiceOverTests.swift in Sources */,
 				AF755FDA2A71583900871E36 /* BubbleWindowLayoutTests.swift in Sources */,

--- a/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.Mock.swift
+++ b/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.Mock.swift
@@ -58,6 +58,16 @@ extension ConfirmationAlertConfiguration {
     static func mock() -> Self {
         .init(showsPoweredBy: true)
     }
+
+    static func liveObservationMock() -> Self {
+        .init(
+            title: "Live Observation Confirmation",
+            message: "This is mock message",
+            negativeTitle: "Cancel",
+            positiveTitle: "Allow",
+            showsPoweredBy: true
+        )
+    }
 }
 
 extension SingleMediaUpgradeAlertConfiguration {

--- a/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar+View+Mock.swift
+++ b/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar+View+Mock.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+import Combine
+
+extension SnackBar.ContentView {
+    static func mock() -> UIViewController {
+        let publisher = CurrentValueSubject<ViewState, Never>(.disappear)
+        let snackbar: SnackBar.ContentView = .init(
+            style: .defaultStyle,
+            publisher: publisher.eraseToAnyPublisher(),
+            isAnimated: false
+        )
+        let view = UIHostingController(rootView: snackbar)
+        let vc = UIViewController()
+
+        let hostingController: UIHostingController<SnackBar.ContentView>
+        hostingController = UIHostingController(rootView: snackbar)
+        hostingController.willMove(toParent: vc)
+        vc.addChild(hostingController)
+        vc.view.addSubview(hostingController.view)
+        hostingController.didMove(toParent: vc)
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            hostingController.view.topAnchor.constraint(equalTo: vc.view.topAnchor),
+            hostingController.view.bottomAnchor.constraint(equalTo: vc.view.bottomAnchor),
+            hostingController.view.leadingAnchor.constraint(equalTo: vc.view.leadingAnchor),
+            hostingController.view.trailingAnchor.constraint(equalTo: vc.view.trailingAnchor)
+        ])
+
+        publisher.send(.appear("This is mock snackbar"))
+        return view
+    }
+}

--- a/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar+View.swift
+++ b/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar+View.swift
@@ -10,13 +10,16 @@ extension SnackBar {
         @State private var currentOffset: CGFloat = 300
         let style: Theme.SnackBarStyle
         var offset: CGFloat = 0
+        let isAnimated: Bool
 
         init(
             style: Theme.SnackBarStyle,
-            publisher: AnyPublisher<ViewState, Never>
+            publisher: AnyPublisher<ViewState, Never>,
+            isAnimated: Bool = true
         ) {
             self.style = style
             self.publisher = publisher
+            self.isAnimated = isAnimated
         }
 
         var body: some View {
@@ -33,18 +36,26 @@ extension SnackBar {
                     switch newState {
                     case .appear(let text):
                         self.text = text
-                        withAnimation {
+                        if isAnimated {
+                            withAnimation {
+                                self.currentOffset = offset
+                            }
+                        } else {
                             self.currentOffset = offset
                         }
+
                     case .disappear:
-                        withAnimation {
+                        if isAnimated {
+                            withAnimation {
+                                self.currentOffset = 300
+                            }
+                        } else {
                             self.currentOffset = 300
                         }
                     }
                 }
         }
     }
-
 }
 
 struct SnackBarContentView_Previews: PreviewProvider {

--- a/SnapshotTests/AlertViewControllerDynamicTypeFontTests.swift
+++ b/SnapshotTests/AlertViewControllerDynamicTypeFontTests.swift
@@ -51,4 +51,14 @@ final class AlertViewControllerDynamicTypeFontTests: SnapshotTestCase {
         )
         return viewController
     }
+
+    func test_liveObservationConfirmationAlert() {
+        let alert = alert(ofKind: .liveObservationConfirmation(
+            .liveObservationMock(),
+            accepted: {},
+            declined: {}
+        ))
+        alert.assertSnapshot(as: .extra3LargeFont, in: .portrait)
+        alert.assertSnapshot(as: .extra3LargeFont, in: .landscape)
+    }
 }

--- a/SnapshotTests/AlertViewControllerLayoutTests.swift
+++ b/SnapshotTests/AlertViewControllerLayoutTests.swift
@@ -50,4 +50,14 @@ final class AlertViewControllerLayoutTests: SnapshotTestCase {
         )
         return viewController
     }
+
+    func test_liveObservationConfirmationAlert() {
+        let alert = alert(ofKind: .liveObservationConfirmation(
+            .liveObservationMock(),
+            accepted: {},
+            declined: {}
+        ))
+        alert.assertSnapshot(as: .image, in: .portrait)
+        alert.assertSnapshot(as: .image, in: .landscape)
+    }
 }

--- a/SnapshotTests/AlertViewControllerVoiceOverTests.swift
+++ b/SnapshotTests/AlertViewControllerVoiceOverTests.swift
@@ -40,6 +40,15 @@ final class AlertViewControllerVoiceOverTests: SnapshotTestCase {
         alert.assertSnapshot(as: .accessibilityImage)
     }
 
+    func test_liveObservationConfirmationAlert() {
+        let alert = alert(ofKind: .liveObservationConfirmation(
+            .liveObservationMock(),
+            accepted: {},
+            declined: {}
+        ))
+        alert.assertSnapshot(as: .accessibilityImage)
+    }
+
     private func alert(ofKind kind: AlertViewController.Kind) -> AlertViewController {
         let viewController = AlertViewController(
             kind: kind,

--- a/SnapshotTests/SnackBarDynamicTypeFontTests.swift
+++ b/SnapshotTests/SnackBarDynamicTypeFontTests.swift
@@ -1,0 +1,11 @@
+@testable import GliaWidgets
+import SnapshotTesting
+import XCTest
+
+final class SnackBarDynamicTypeFontTests: SnapshotTestCase {
+    func testSnackbar() {
+        let view = SnackBar.ContentView.mock()
+        view.assertSnapshot(as: .extra3LargeFont, in: .portrait)
+        view.assertSnapshot(as: .extra3LargeFont, in: .landscape)
+    }
+}

--- a/SnapshotTests/SnackBarLayoutTests.swift
+++ b/SnapshotTests/SnackBarLayoutTests.swift
@@ -1,0 +1,11 @@
+@testable import GliaWidgets
+import SnapshotTesting
+import XCTest
+
+final class SnackBarLayoutTests: SnapshotTestCase {
+    func testSnackbar() {
+        let view = SnackBar.ContentView.mock()
+        view.assertSnapshot(as: .image, in: .portrait)
+        view.assertSnapshot(as: .image, in: .landscape)
+    }
+}

--- a/SnapshotTests/SnackBarVoiceOverTests.swift
+++ b/SnapshotTests/SnackBarVoiceOverTests.swift
@@ -1,0 +1,10 @@
+@testable import GliaWidgets
+import SnapshotTesting
+import XCTest
+
+final class SnackBarVoiceOverTests: SnapshotTestCase {
+    func testSnackbar() {
+        let view = SnackBar.ContentView.mock()
+        view.assertSnapshot(as: .accessibilityImage, in: .portrait)
+    }
+}


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-2718

**What was solved?**

Snapshot tests for LO related alert and snackbar

Snapshot image reference PR - https://github.com/salemove/ios-widgets-snapshots/pull/58

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
