### PR TITLE
Confirmation dialog link buttons

### DIFF
--- a/GliaWidgets/Localization+StringProviding.swift
+++ b/GliaWidgets/Localization+StringProviding.swift
@@ -6,12 +6,15 @@ extension Localization {
         _ key: String,
         _ args: CVarArg...,
         fallback value: String,
-        stringProviding: StringProviding? = Glia.sharedInstance.stringProviding,
+        // Usage of shared instance there is acceptable, because it's global method.
+        // But it should not be followed with other features in future,
+        // because it causes problems in tests.
+        stringProviding: StringProvidingPhase? = Glia.sharedInstance.stringProvidingPhase,
         bundleManaging: BundleManaging = .live
     ) -> String {
         guard
             let stringProviding,
-            let remoteString = stringProviding.getRemoteString(key)
+            let remoteString = stringProviding(key)
         else {
             let format = bundleManaging.current().localizedString(forKey: key, value: value, table: table)
             return String(format: format, locale: Locale.current, arguments: args)

--- a/GliaWidgets/Localization.swift
+++ b/GliaWidgets/Localization.swift
@@ -315,6 +315,32 @@ internal enum Localization {
       /// Chat
       internal static var title: String { Localization.tr("Localizable", "engagement.chat.title", fallback: "Chat") }
     }
+    internal enum Confirm {
+      /// Please allow the {companyName} representative to view this application screen for improved support.
+      internal static var message: String { Localization.tr("Localizable", "engagement.confirm.message", fallback: "Please allow the {companyName} representative to view this application screen for improved support.") }
+      /// Before We Continue
+      internal static var title: String { Localization.tr("Localizable", "engagement.confirm.title", fallback: "Before We Continue") }
+      internal enum Link1 {
+        /// Terms and Conditions
+        internal static var text: String { Localization.tr("Localizable", "engagement.confirm.link1.text", fallback: "Terms and Conditions") }
+        /// http://some_company.com/terms_and_conditions
+        internal static var url: String { Localization.tr("Localizable", "engagement.confirm.link1.url", fallback: "") }
+        internal enum Accessibility {
+          /// Terms and Conditions
+          internal static var label: String { Localization.tr("Localizable", "engagement.confirm.link1.accessibility.label", fallback: "Terms and Conditions") }
+        }
+      }
+      internal enum Link2 {
+        /// Privacy Policies
+        internal static var text: String { Localization.tr("Localizable", "engagement.confirm.link2.text", fallback: "Privacy Policies") }
+        /// http://some_company.com/privacy_policies
+        internal static var url: String { Localization.tr("Localizable", "engagement.confirm.link2.url", fallback: "") }
+        internal enum Accessibility {
+          /// Privacy Policies
+          internal static var label: String { Localization.tr("Localizable", "engagement.confirm.link2.accessibility.label", fallback: "Privacy Policies") }
+        }
+      }
+    }
     internal enum ConnectionScreen {
       /// Connecting with {operatorName}
       internal static var connectWith: String { Localization.tr("Localizable", "engagement.connection_screen.connect_with", fallback: "Connecting with {operatorName}") }
@@ -485,12 +511,6 @@ internal enum Localization {
     }
   }
   internal enum LiveObservation {
-    internal enum Confirm {
-      /// Please allow the {companyName} representative to view this application screen for improved support.
-      internal static var message: String { Localization.tr("Localizable", "live_observation.confirm.message", fallback: "Please allow the {companyName} representative to view this application screen for improved support.") }
-      /// Before We Continue
-      internal static var title: String { Localization.tr("Localizable", "live_observation.confirm.title", fallback: "Before We Continue") }
-    }
     internal enum Indicator {
       /// App screen is visible to the agent
       internal static var message: String { Localization.tr("Localizable", "live_observation.indicator.message", fallback: "App screen is visible to the agent") }

--- a/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
+++ b/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
@@ -76,7 +76,7 @@ extension Glia {
         let companyNameStringKey = "general.company_name"
 
         // Company name has been set on the custom locale and is not empty.
-        if let remoteCompanyName = stringProviding?.getRemoteString(companyNameStringKey),
+        if let remoteCompanyName = stringProvidingPhase(companyNameStringKey),
             !remoteCompanyName.isEmpty {
             return remoteCompanyName
         }
@@ -113,9 +113,9 @@ extension Glia {
         // Live Observation Confirmation Alert Message
         let companyName = companyName(
             using: configuration,
-            themeCompanyName: theme.alertConfiguration.liveObservationConfirmation.message
+            themeCompanyName: nil
         )
-        var liveObservationConfirmationMessage = Localization.LiveObservation.Confirm.message.withCompanyName(companyName)
+        var liveObservationConfirmationMessage = Localization.Engagement.Confirm.message.withCompanyName(companyName)
         theme.alertConfiguration.liveObservationConfirmation.message = liveObservationConfirmationMessage
 
         return theme

--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -57,7 +57,7 @@ public class Glia {
     /// Used to monitor engagement state changes.
     public var onEvent: ((GliaEvent) -> Void)?
 
-    var stringProviding: StringProviding?
+    var stringProvidingPhase: StringProvidingPhase = .notConfigured
 
     public lazy var callVisualizer = CallVisualizer(
         environment: .init(
@@ -149,7 +149,7 @@ public class Glia {
                 self.configuration = configuration
 
                 let getRemoteString = self.environment.coreSdk.localeProvider.getRemoteString
-                self.stringProviding = .init(getRemoteString: getRemoteString)
+                self.stringProvidingPhase = .configured(getRemoteString)
 
                 if let engagement = self.environment.coreSdk.getCurrentEngagement(),
                    engagement.source == .callVisualizer {

--- a/GliaWidgets/Resources/en.lproj/Localizable.strings
+++ b/GliaWidgets/Resources/en.lproj/Localizable.strings
@@ -224,7 +224,13 @@
 "media_upgrade.video.one_way.title" = "{operatorName} has offered you to see their video";
 "media_upgrade.video.two_way.title" = "{operatorName} has offered you to upgrade to video";
 "visitor_code.failed" = "Could not load the visitor code. Please try refreshing.";
-"live_observation.confirm.title" = "Before We Continue";
-"live_observation.confirm.message" = "Please allow the {companyName} representative to view this application screen for improved support.";
-"live_observation.confirm.message" = "Please allow the {companyName} representative to view this application screen for improved support.";
+"engagement.confirm.title" = "Before We Continue";
+"engagement.confirm.message" = "Please allow the {companyName} representative to view this application screen for improved support.";
+"engagement.confirm.link1.text" = "Terms and Conditions";
+"engagement.confirm.link1.url" = "http://some_company.com/terms_and_conditions";
+"engagement.confirm.link1.accessibility.label" = "Terms and Conditions";
+"engagement.confirm.link2.text" = "Privacy Policies";
+"engagement.confirm.link2.url" = "http://some_company.com/privacy_policies";
+"engagement.confirm.link2.accessibility.label" = "Privacy Policies";
+
 "live_observation.indicator.message" = "App screen is visible to the agent";

--- a/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
@@ -131,6 +131,9 @@ extension CallVisualizer {
             let alert = AlertViewController(
                 kind: .liveObservationConfirmation(
                     environment.viewFactory.theme.alertConfiguration.liveObservationConfirmation,
+                    link: { _ in
+                        // TODO: Add navigating to WebView controller
+                    },
                     accepted: { [weak self] in
                         self?.alertViewController = nil
                         self?.closeVisitorCode()

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -174,7 +174,7 @@ extension CoreSdkClient {
 
 extension CoreSdkClient {
     struct LocaleProvider {
-        typealias CustomLocaleGetRemoteString = ((String) -> String?)
+        typealias CustomLocaleGetRemoteString = (String) -> String?
         var getRemoteString: CustomLocaleGetRemoteString
     }
 }

--- a/GliaWidgets/Sources/LiveObservation/LiveObservationConfirmation.swift
+++ b/GliaWidgets/Sources/LiveObservation/LiveObservationConfirmation.swift
@@ -3,6 +3,7 @@ import Foundation
 extension LiveObservation {
     struct Confirmation {
         let conf: ConfirmationAlertConfiguration
+        let link: (URL) -> Void
         let accepted: () -> Void
         let declined: () -> Void
     }

--- a/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration.swift
+++ b/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration.swift
@@ -49,6 +49,7 @@ extension RemoteConfiguration {
         let message: Text?
         let backgroundColor: Color?
         let closeButtonColor: Color?
+        let linkButton: Button?
         let positiveButton: Button?
         let negativeButton: Button?
         let buttonAxis: Axis?

--- a/GliaWidgets/Sources/Theme/Alert/ConfirmationAlertConfiguration.swift
+++ b/GliaWidgets/Sources/Theme/Alert/ConfirmationAlertConfiguration.swift
@@ -6,6 +6,12 @@ public struct ConfirmationAlertConfiguration {
     /// Message of the alert.
     public var message: String?
 
+    /// First link button url value.
+    public var firstLinkButtonUrl: String?
+
+    /// Second link button url value.
+    public var secondLinkButtonUrl: String?
+
     /// Title of the negative action button.
     public var negativeTitle: String?
 

--- a/GliaWidgets/Sources/Theme/Theme+Alert.swift
+++ b/GliaWidgets/Sources/Theme/Theme+Alert.swift
@@ -1,5 +1,25 @@
 extension Theme {
     var alertStyle: AlertStyle {
+        let firstLinkAction = ActionButtonStyle(
+            title: Localization.Engagement.Confirm.Link1.text,
+            titleFont: font.buttonLabel,
+            titleColor: color.primary,
+            backgroundColor: .fill(color: .clear),
+            accessibility: .init(
+                label: Localization.Engagement.Confirm.Link1.Accessibility.label,
+                isFontScalingEnabled: true
+            )
+        )
+        let secondLinkAction = ActionButtonStyle(
+            title: Localization.Engagement.Confirm.Link2.text,
+            titleFont: font.buttonLabel,
+            titleColor: color.primary,
+            backgroundColor: .fill(color: .clear),
+            accessibility: .init(
+                label: Localization.Engagement.Confirm.Link2.Accessibility.label,
+                isFontScalingEnabled: true
+            )
+        )
         let negativeAction = ActionButtonStyle(
             title: Localization.General.no,
             titleFont: font.buttonLabel,
@@ -33,6 +53,8 @@ extension Theme {
             messageColor: color.baseDark,
             backgroundColor: .fill(color: color.baseLight),
             closeButtonColor: .fill(color: color.baseNormal),
+            firstLinkAction: firstLinkAction,
+            secondLinkAction: secondLinkAction,
             actionAxis: .horizontal,
             positiveAction: positiveAction,
             negativeAction: negativeAction,

--- a/GliaWidgets/Sources/Theme/Theme+AlertConfiguration.swift
+++ b/GliaWidgets/Sources/Theme/Theme+AlertConfiguration.swift
@@ -134,8 +134,10 @@ extension Theme {
         )
 
         let liveObservationConfirmation = ConfirmationAlertConfiguration(
-            title: Localization.LiveObservation.Confirm.title,
-            message: Localization.LiveObservation.Confirm.message,
+            title: Localization.Engagement.Confirm.title,
+            message: Localization.Engagement.Confirm.message,
+            firstLinkButtonUrl: Localization.Engagement.Confirm.Link1.url,
+            secondLinkButtonUrl: Localization.Engagement.Confirm.Link2.url,
             negativeTitle: Localization.General.cancel,
             positiveTitle: Localization.General.allow,
             switchButtonBackgroundColors: true,

--- a/GliaWidgets/Sources/View/Common/Alert/AlertStyle.swift
+++ b/GliaWidgets/Sources/View/Common/Alert/AlertStyle.swift
@@ -29,6 +29,12 @@ public struct AlertStyle: Equatable {
     /// Color of the close button.
     public var closeButtonColor: ColorType
 
+    /// Style of the first link action button.
+    public var firstLinkAction: ActionButtonStyle
+
+    /// Style of the second link action button.
+    public var secondLinkAction: ActionButtonStyle
+
     /// Direction of the action buttons.
     public var actionAxis: NSLayoutConstraint.Axis
 
@@ -55,6 +61,8 @@ public struct AlertStyle: Equatable {
     ///   - messageTextStyle: Text style of the message text.
     ///   - backgroundColor: Background color of the view.
     ///   - closeButtonColor: Color of the close button.
+    ///   - firstLinkAction: Style of the first link action button.
+    ///   - secondLinkAction: Style of the second link action button.
     ///   - actionAxis: Direction of the action buttons.
     ///   - positiveAction: Style of a positive action button.
     ///   - negativeAction: Style of a negative action button.
@@ -71,6 +79,8 @@ public struct AlertStyle: Equatable {
         messageTextStyle: UIFont.TextStyle = .body,
         backgroundColor: ColorType,
         closeButtonColor: ColorType,
+        firstLinkAction: ActionButtonStyle,
+        secondLinkAction: ActionButtonStyle,
         actionAxis: NSLayoutConstraint.Axis,
         positiveAction: ActionButtonStyle,
         negativeAction: ActionButtonStyle,
@@ -86,6 +96,8 @@ public struct AlertStyle: Equatable {
         self.messageTextStyle = messageTextStyle
         self.backgroundColor = backgroundColor
         self.closeButtonColor = closeButtonColor
+        self.firstLinkAction = firstLinkAction
+        self.secondLinkAction = secondLinkAction
         self.actionAxis = actionAxis
         self.positiveAction = positiveAction
         self.negativeAction = negativeAction
@@ -98,6 +110,14 @@ public struct AlertStyle: Equatable {
         configuration: RemoteConfiguration.Alert?,
         assetsBuilder: RemoteConfiguration.AssetsBuilder
     ) {
+        firstLinkAction.apply(
+            configuration: configuration?.linkButton,
+            assetsBuilder: assetsBuilder
+        )
+        secondLinkAction.apply(
+            configuration: configuration?.linkButton,
+            assetsBuilder: assetsBuilder
+        )
         positiveAction.apply(
             configuration: configuration?.positiveButton,
             assetsBuilder: assetsBuilder

--- a/GliaWidgets/Sources/View/Common/Alert/AlertView.swift
+++ b/GliaWidgets/Sources/View/Common/Alert/AlertView.swift
@@ -64,6 +64,8 @@ class AlertView: BaseView {
     private let titleLabel = UILabel().makeView()
     private let messageLabel = UILabel().makeView()
     private let stackView = UIStackView().makeView()
+    private let topContentStackView = UIStackView().makeView()
+    private let linkButtonStackView = UIStackView().makeView()
     private let actionsStackView = UIStackView().makeView()
     private let kContentInsets = UIEdgeInsets(top: 28, left: 32, bottom: 28, right: 32)
     private let kCornerRadius: CGFloat = 30
@@ -101,6 +103,11 @@ class AlertView: BaseView {
         ).cgPath
     }
 
+    func addLinkButton(_ contentView: UIView) {
+        linkButtonStackView.isHidden = false
+        linkButtonStackView.addArrangedSubview(contentView)
+    }
+
     func addActionView(_ actionView: UIView) {
         actionsStackView.addArrangedSubview(actionView)
     }
@@ -119,11 +126,22 @@ class AlertView: BaseView {
         stackView.axis = .vertical
         stackView.spacing = 16
         stackView.addArrangedSubviews([
-            titleImageViewContainer,
-            titleLabel,
-            messageLabel,
+            topContentStackView,
+            linkButtonStackView,
             actionsStackView
         ])
+
+        topContentStackView.axis = .vertical
+        topContentStackView.spacing = 16
+        topContentStackView.addArrangedSubviews([
+            titleImageViewContainer,
+            titleLabel,
+            messageLabel
+        ])
+
+        linkButtonStackView.isHidden = true
+        linkButtonStackView.axis = .vertical
+        linkButtonStackView.spacing = 12
 
         titleImageView.contentMode = .scaleAspectFit
         titleImageView.tintColor = style.titleImageColor

--- a/GliaWidgets/Sources/ViewController/Common/Alert/AlertViewController+LiveObservationConfirmation.swift
+++ b/GliaWidgets/Sources/ViewController/Common/Alert/AlertViewController+LiveObservationConfirmation.swift
@@ -3,6 +3,7 @@ import UIKit
 extension AlertViewController {
     func makeLiveObservationAlertView(
         with conf: ConfirmationAlertConfiguration,
+        link: @escaping (URL) -> Void,
         accepted: @escaping () -> Void,
         declined: @escaping () -> Void
     ) -> AlertView {
@@ -12,11 +13,28 @@ extension AlertViewController {
         alertView.showsPoweredBy = conf.showsPoweredBy
         alertView.showsCloseButton = false
 
-        var declineButtonStyle = viewFactory.theme.alert.negativeAction
+        let alertStyle = viewFactory.theme.alert
+        var declineButtonStyle = alertStyle.negativeAction
         declineButtonStyle.title = conf.negativeTitle ?? ""
 
-        var acceptButtonStyle = viewFactory.theme.alert.positiveAction
+        var acceptButtonStyle = alertStyle.positiveAction
         acceptButtonStyle.title = conf.positiveTitle ?? ""
+
+        if let firstLinkButton = linkButton(
+            for: conf.firstLinkButtonUrl,
+            style: alertStyle.firstLinkAction,
+            action: .init(closure: link)
+        ) {
+            alertView.addLinkButton(firstLinkButton)
+        }
+
+        if let secondLinkButton = linkButton(
+            for: conf.secondLinkButtonUrl,
+            style: alertStyle.secondLinkAction,
+            action: .init(closure: link)
+        ) {
+            alertView.addLinkButton(secondLinkButton)
+        }
 
         let declineButton = ActionButton(
             props: .init(
@@ -35,5 +53,22 @@ extension AlertViewController {
         alertView.addActionView(acceptButton)
 
         return alertView
+    }
+
+    private func linkButton(
+        for url: String?,
+        style: ActionButtonStyle,
+        action: Command<URL>
+    ) -> ActionButton? {
+        guard let buttonUrlString = url,
+              let buttonUrl = URL(string: buttonUrlString)
+        else { return nil }
+        return ActionButton(
+            props: .init(
+                style: style,
+                height: 34,
+                tap: .init { action(buttonUrl) }
+            )
+        )
     }
 }

--- a/GliaWidgets/Sources/ViewController/Common/Alert/AlertViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Common/Alert/AlertViewController.swift
@@ -30,6 +30,7 @@ class AlertViewController: UIViewController, Replaceable {
 
         case liveObservationConfirmation(
             ConfirmationAlertConfiguration,
+            link: (URL) -> Void,
             accepted: () -> Void,
             declined: () -> Void
         )
@@ -136,38 +137,43 @@ class AlertViewController: UIViewController, Replaceable {
 
     private func makeAlertView() -> AlertView {
         switch kind {
-        case .message(let conf, let accessibilityIdentifier, let dismissed):
+        case let .message(conf, accessibilityIdentifier, dismissed):
             return makeMessageAlertView(
                 with: conf,
                 accessibilityIdentifier: accessibilityIdentifier,
                 dismissed: dismissed
             )
-        case .confirmation(let conf, let accessibilityIdentifier, let confirmed):
+        case let .confirmation(conf, accessibilityIdentifier, confirmed):
             return makeConfirmationAlertView(
                 with: conf,
                 accessibilityIdentifier: accessibilityIdentifier,
                 confirmed: confirmed
             )
-        case .singleAction(let conf, let accessibilityIdentifier, let actionTapped):
+        case let .singleAction(conf, accessibilityIdentifier, actionTapped):
             return makeSingleActionAlertView(
                 with: conf,
                 accessibilityIdentifier: accessibilityIdentifier,
                 actionTapped: actionTapped
             )
-        case .singleMediaUpgrade(let conf, accepted: let accepted, declined: let declined):
+        case let .singleMediaUpgrade(conf, accepted, declined):
             return makeMediaUpgradeAlertView(
                 with: conf,
                 accepted: accepted,
                 declined: declined
             )
-        case .screenShareOffer(let conf, accepted: let accepted, declined: let declined):
+        case let .screenShareOffer(conf, accepted, declined):
             return makeScreenShareOfferAlertView(
                 with: conf,
                 accepted: accepted,
                 declined: declined
             )
-        case .liveObservationConfirmation(let conf, let accepted, let declined):
-            return makeLiveObservationAlertView(with: conf, accepted: accepted, declined: declined)
+        case let .liveObservationConfirmation(conf, link, accepted, declined):
+            return makeLiveObservationAlertView(
+                with: conf,
+                link: link,
+                accepted: accepted,
+                declined: declined
+            )
         }
     }
 

--- a/GliaWidgets/Sources/ViewController/EngagementViewController.swift
+++ b/GliaWidgets/Sources/ViewController/EngagementViewController.swift
@@ -93,6 +93,7 @@ class EngagementViewController: UIViewController, AlertPresenter, MediaUpgradePr
         let alert = AlertViewController(
             kind: .liveObservationConfirmation(
                 config.conf,
+                link: config.link,
                 accepted: config.accepted,
                 declined: config.declined
             ),

--- a/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
@@ -345,6 +345,9 @@ extension EngagementViewModel {
     ) -> LiveObservation.Confirmation {
         .init(
             conf: self.alertConfiguration.liveObservationConfirmation,
+            link: { _ in
+                // TODO: Add navigating to WebView controller
+            },
             accepted: { [weak self] in
                 self?.enqueue(mediaType: mediaType)
             },

--- a/GliaWidgets/StringProviding.swift
+++ b/GliaWidgets/StringProviding.swift
@@ -1,5 +1,19 @@
 import Foundation
 
-struct StringProviding {
-    var getRemoteString: ((String) -> String?)
+enum StringProvidingPhase {
+    case notConfigured
+    case configured((String) -> String?)
+
+    var getRemoteString: ((String) -> String?)? {
+        switch self {
+        case .notConfigured:
+            return nil
+        case let .configured(stringProviding):
+            return stringProviding
+        }
+    }
+
+    func callAsFunction(_ key: String) -> String? {
+        getRemoteString?(key)
+    }
 }

--- a/GliaWidgetsTests/Resources/LocalizationTests.swift
+++ b/GliaWidgetsTests/Resources/LocalizationTests.swift
@@ -6,7 +6,7 @@ final class LocalizationTests: XCTestCase {
     let testString = "Glia"
 
     func test_stringProvider() {
-        let stringProviding = StringProviding(getRemoteString: { _ in self.testString })
+        let stringProviding = StringProvidingPhase.configured({ _ in self.testString })
 
         let localizationString = Localization.tr(
             "",
@@ -29,7 +29,7 @@ final class LocalizationTests: XCTestCase {
     }
 
     func test_fallbackWhenStringProvidingReturnsNil() {
-        let stringProviding = StringProviding(getRemoteString: { _ in nil })
+        let stringProviding = StringProvidingPhase.configured({ _ in nil })
 
         let localizationString = Localization.tr(
             "",
@@ -52,7 +52,7 @@ final class LocalizationTests: XCTestCase {
     }
 
     func test_fileFromStringWhenStringProvidingReturnsNil() {
-        let stringProviding = StringProviding(getRemoteString: { _ in nil })
+        let stringProviding = StringProvidingPhase.configured({ _ in nil })
 
         let localizationString = Localization.tr(
             "Localizable",

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
@@ -4,10 +4,6 @@ import XCTest
 @testable import GliaWidgets
 
 extension GliaTests {
-    override class func tearDown() {
-        Glia.sharedInstance.stringProviding = nil
-    }
-
     func testStartEngagementThrowsErrorWhenEngagementAlreadyExists() throws {
         var sdkEnv = Glia.Environment.failing
         sdkEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
@@ -110,7 +106,7 @@ extension GliaTests {
         theme.call.connect.queue.firstText = "Glia 1"
         theme.chat.connect.queue.firstText = "Glia 2"
 
-        try sdk.configure(with: .mock(), theme: theme) { _ in 
+        try sdk.configure(with: .mock(), theme: theme) { _ in
             do {
                 try sdk.startEngagement(engagementKind: .chat, in: ["queueId"])
             } catch {
@@ -242,6 +238,7 @@ extension GliaTests {
         let configuredSdkTheme = resultingViewFactory?.theme
         XCTAssertEqual(configuredSdkTheme?.call.connect.queue.firstText, "Company Name")
         XCTAssertEqual(configuredSdkTheme?.chat.connect.queue.firstText, "Company Name")
+        XCTAssertEqual(configuredSdkTheme?.alertConfiguration.liveObservationConfirmation.message?.contains("Company Name"), true)
     }
 
     func testCompanyNameIsReceivedFromThemeIfCustomLocalesIsEmpty() throws {
@@ -274,7 +271,6 @@ extension GliaTests {
         let theme = Theme()
         theme.call.connect.queue.firstText = "Glia 1"
         theme.chat.connect.queue.firstText = "Glia 2"
-        theme.alertConfiguration.liveObservationConfirmation.message = "Glia 3"
 
         try sdk.configure(with: .mock(), theme: theme) { _ in
             do {
@@ -287,7 +283,6 @@ extension GliaTests {
         let configuredSdkTheme = resultingViewFactory?.theme
         XCTAssertEqual(configuredSdkTheme?.call.connect.queue.firstText, "Glia 1")
         XCTAssertEqual(configuredSdkTheme?.chat.connect.queue.firstText, "Glia 2")
-        XCTAssertEqual(configuredSdkTheme?.alertConfiguration.liveObservationConfirmation.message?.contains("Glia 3"), true)
     }
 
     func testCompanyNameIsReceivedFromLocalFallbackIfCustomLocalesIsEmpty() throws {
@@ -311,10 +306,6 @@ extension GliaTests {
         environment.coreSdk.localeProvider.getRemoteString = { _ in "" }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
-            // Simulating what happens in the Widgets when the configuration gets done
-            Glia.sharedInstance.stringProviding = StringProviding(
-                getRemoteString: environment.coreSdk.localeProvider.getRemoteString
-            )
             completion(.success(()))
         }
         environment.coreSdk.getCurrentEngagement = { nil }

--- a/SnapshotTests/AlertViewControllerDynamicTypeFontTests.swift
+++ b/SnapshotTests/AlertViewControllerDynamicTypeFontTests.swift
@@ -55,6 +55,7 @@ final class AlertViewControllerDynamicTypeFontTests: SnapshotTestCase {
     func test_liveObservationConfirmationAlert() {
         let alert = alert(ofKind: .liveObservationConfirmation(
             .liveObservationMock(),
+            link: { _ in },
             accepted: {},
             declined: {}
         ))

--- a/SnapshotTests/AlertViewControllerLayoutTests.swift
+++ b/SnapshotTests/AlertViewControllerLayoutTests.swift
@@ -54,6 +54,7 @@ final class AlertViewControllerLayoutTests: SnapshotTestCase {
     func test_liveObservationConfirmationAlert() {
         let alert = alert(ofKind: .liveObservationConfirmation(
             .liveObservationMock(),
+            link: { _ in },
             accepted: {},
             declined: {}
         ))

--- a/SnapshotTests/AlertViewControllerVoiceOverTests.swift
+++ b/SnapshotTests/AlertViewControllerVoiceOverTests.swift
@@ -43,6 +43,7 @@ final class AlertViewControllerVoiceOverTests: SnapshotTestCase {
     func test_liveObservationConfirmationAlert() {
         let alert = alert(ofKind: .liveObservationConfirmation(
             .liveObservationMock(),
+            link: { _ in },
             accepted: {},
             declined: {}
         ))

--- a/TestingApp/ViewController/ViewController.swift
+++ b/TestingApp/ViewController/ViewController.swift
@@ -206,7 +206,8 @@ extension ViewController {
             self.catchingError {
                 try Glia.sharedInstance.startEngagement(
                     engagementKind: engagementKind,
-                    in: [self.queueId]
+                    in: [self.queueId],
+                    theme: self.theme
                 )
             }
         }


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-2861

**What was solved?**
Integrators want to be able to add links to their “terms and conditions” or/and “privacy policies” pages to the confirmation dialog. To allow this AlertConfiguration, AlertStyle, RemoteConfiguration were extended. Link buttons are optional. Also all localization keys with "live_observation.confirm.*" prefix were renamed to "engagement.confirm.*".

⚠️ All tests will be added in separate tasks.

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
![Simulator Screen Shot - iPhone 14 - 2023-11-22 at 14 46 44](https://github.com/salemove/ios-sdk-widgets/assets/70878708/f5fb87b4-da99-42d0-92fa-474fea872a97)