### PR TITLE
Add WebViewController for Confirmation Alert links

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -328,6 +328,12 @@
 		84265E6B29912E2100D65842 /* RemoteConfiguration+CallVisualizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84265E6A29912E2100D65842 /* RemoteConfiguration+CallVisualizer.swift */; };
 		84265E6E29914DDA00D65842 /* ViewController+CallVisualizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84265E6D29914DDA00D65842 /* ViewController+CallVisualizer.swift */; };
 		844D3C6C29142C17002887A9 /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844D3C6B29142C17002887A9 /* Optional+Extensions.swift */; };
+		84520BDB2B0FA15A00F97617 /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84520BDA2B0FA15A00F97617 /* WebViewController.swift */; };
+		84520BDD2B10C16E00F97617 /* WebViewController.Props.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84520BDC2B10C16E00F97617 /* WebViewController.Props.swift */; };
+		84520BE12B14B8F800F97617 /* WebViewStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84520BE02B14B8F800F97617 /* WebViewStyle.swift */; };
+		84520BE32B14B97A00F97617 /* Theme+WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84520BE22B14B97A00F97617 /* Theme+WebView.swift */; };
+		84520BE52B14BAA200F97617 /* RemoteConfiguration+WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84520BE42B14BAA200F97617 /* RemoteConfiguration+WebView.swift */; };
+		84520BEB2B1887DF00F97617 /* CallVisualizer.Presenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84520BEA2B1887DF00F97617 /* CallVisualizer.Presenter.swift */; };
 		8458769F2823FD18007AC3DF /* SurveyViewControllerVoiceOverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8458769E2823FD18007AC3DF /* SurveyViewControllerVoiceOverTests.swift */; };
 		845876A22823FF34007AC3DF /* Survey.ViewController.Props.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845876A12823FF34007AC3DF /* Survey.ViewController.Props.Mock.swift */; };
 		845876A5282A9015007AC3DF /* ScaleQuestionView.Props.Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845876A4282A9015007AC3DF /* ScaleQuestionView.Props.Accessibility.swift */; };
@@ -1084,6 +1090,12 @@
 		84265E6A29912E2100D65842 /* RemoteConfiguration+CallVisualizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteConfiguration+CallVisualizer.swift"; sourceTree = "<group>"; };
 		84265E6D29914DDA00D65842 /* ViewController+CallVisualizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+CallVisualizer.swift"; sourceTree = "<group>"; };
 		844D3C6B29142C17002887A9 /* Optional+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+Extensions.swift"; sourceTree = "<group>"; };
+		84520BDA2B0FA15A00F97617 /* WebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
+		84520BDC2B10C16E00F97617 /* WebViewController.Props.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewController.Props.swift; sourceTree = "<group>"; };
+		84520BE02B14B8F800F97617 /* WebViewStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewStyle.swift; sourceTree = "<group>"; };
+		84520BE22B14B97A00F97617 /* Theme+WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Theme+WebView.swift"; sourceTree = "<group>"; };
+		84520BE42B14BAA200F97617 /* RemoteConfiguration+WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteConfiguration+WebView.swift"; sourceTree = "<group>"; };
+		84520BEA2B1887DF00F97617 /* CallVisualizer.Presenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallVisualizer.Presenter.swift; sourceTree = "<group>"; };
 		8458769E2823FD18007AC3DF /* SurveyViewControllerVoiceOverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyViewControllerVoiceOverTests.swift; sourceTree = "<group>"; };
 		845876A12823FF34007AC3DF /* Survey.ViewController.Props.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Survey.ViewController.Props.Mock.swift; sourceTree = "<group>"; };
 		845876A4282A9015007AC3DF /* ScaleQuestionView.Props.Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScaleQuestionView.Props.Accessibility.swift; sourceTree = "<group>"; };
@@ -2090,6 +2102,7 @@
 				C06A7587296ECD75006B69A2 /* Theme+VisitorCode.swift */,
 				84265DEF2983E62100D65842 /* Theme+ScreenSharing.swift */,
 				C0175A2B2A67E2E9001FACDE /* Theme+Gva.swift */,
+				84520BE22B14B97A00F97617 /* Theme+WebView.swift */,
 			);
 			path = Theme;
 			sourceTree = "<group>";
@@ -2097,6 +2110,7 @@
 		1A60AFC12566857200E53F53 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				84520BD92B0FA14700F97617 /* WebViewController */,
 				C02248A82AD53DDF00CC4930 /* LiveObservation */,
 				84D5B95E2A14DEFD00807F92 /* QuickLookBased */,
 				C05E3EDC29C99DEE0013BC81 /* ProximityManager */,
@@ -2844,6 +2858,7 @@
 				7594093A298D376A008B173A /* RemoteConfiguration+AssetsBuilder.swift */,
 				84265E6A29912E2100D65842 /* RemoteConfiguration+CallVisualizer.swift */,
 				7594093C298D376A008B173A /* RemoteConfiguration+Chat.swift */,
+				84520BE42B14BAA200F97617 /* RemoteConfiguration+WebView.swift */,
 			);
 			path = RemoteConfiguration;
 			sourceTree = "<group>";
@@ -3045,6 +3060,7 @@
 				84265E49298D7B1900D65842 /* CallVisualizer.Coordinator.swift */,
 				84265E4A298D7B1900D65842 /* CallVisualizer.Coordinator.Environment.swift */,
 				846A5C3F29ED83C50049B29F /* CallVisualizer.Coordinator.DelegateEvent.swift */,
+				84520BEA2B1887DF00F97617 /* CallVisualizer.Presenter.swift */,
 			);
 			path = Coordinator;
 			sourceTree = "<group>";
@@ -3094,6 +3110,16 @@
 				84265E6D29914DDA00D65842 /* ViewController+CallVisualizer.swift */,
 			);
 			path = ViewController;
+			sourceTree = "<group>";
+		};
+		84520BD92B0FA14700F97617 /* WebViewController */ = {
+			isa = PBXGroup;
+			children = (
+				84520BDA2B0FA15A00F97617 /* WebViewController.swift */,
+				84520BDC2B10C16E00F97617 /* WebViewController.Props.swift */,
+				84520BE02B14B8F800F97617 /* WebViewStyle.swift */,
+			);
+			path = WebViewController;
 			sourceTree = "<group>";
 		};
 		845876A02823FF21007AC3DF /* Mocks */ = {
@@ -4491,6 +4517,7 @@
 				C07F627D2AC2F31F003EFC97 /* ScreenSharingViewModel.swift in Sources */,
 				1A0C9A9125C41AB900815406 /* CallButtonBar.swift in Sources */,
 				C0D2F0302991229F00803B47 /* VideoCallCoordinator.Environment.swift in Sources */,
+				84520BE52B14BAA200F97617 /* RemoteConfiguration+WebView.swift in Sources */,
 				1AE15E3B257A5CC900A642C0 /* AlertConfiguration.swift in Sources */,
 				C07F62792AC2D2E8003EFC97 /* BackgroundSwiftUI.swift in Sources */,
 				75AF8D1027DFF4B3009EEE2C /* Survey.ValidationErrorView.swift in Sources */,
@@ -4515,6 +4542,7 @@
 				C06A7588296ECD75006B69A2 /* Theme+VisitorCode.swift in Sources */,
 				C0857DED28D4831E008D171D /* Theme+Text.swift in Sources */,
 				845876A22823FF34007AC3DF /* Survey.ViewController.Props.Mock.swift in Sources */,
+				84520BDD2B10C16E00F97617 /* WebViewController.Props.swift in Sources */,
 				1A4674B625E907320078FA1C /* AttachmentSourceListStyle.swift in Sources */,
 				75940946298D378A008B173A /* CoreSDKClient.Live.swift in Sources */,
 				7594098F298D3929008B173A /* Glia.OpaqueAuthentication.swift in Sources */,
@@ -4716,6 +4744,7 @@
 				1A4AD3CA256E864800468BFB /* ThemeColorStyle.swift in Sources */,
 				AFA2FDF228907E9D00428E6D /* GliaViewController.Mock.swift in Sources */,
 				9AB196DE27C3FFF400FD60AB /* Call.Environment.Mock.swift in Sources */,
+				84520BE12B14B8F800F97617 /* WebViewStyle.swift in Sources */,
 				1A0C143125B8547200B00695 /* EngagementStyle.swift in Sources */,
 				7594098B298D38C2008B173A /* CallVisualizer+Presentation.swift in Sources */,
 				C06152DA2AB1BC4300063BF8 /* OrientationManager.swift in Sources */,
@@ -4769,6 +4798,7 @@
 				847956402ADED7A2004EF60C /* CallVisualizer+Action.swift in Sources */,
 				AF10ED8D29BA210500E85309 /* SecureConversations.MessagesWithUnreadCountLoader.swift in Sources */,
 				C0D2F04A2992765F00803B47 /* VideoCallView.OperatorImageView.swift in Sources */,
+				84520BDB2B0FA15A00F97617 /* WebViewController.swift in Sources */,
 				755D186F29A6A6160009F5E8 /* WelcomeStyle+MessageTextViewDisabledStyle.swift in Sources */,
 				1ABD6C8125B6E97400D56EFA /* MultipleMediaUpgradeAlertConfiguration.swift in Sources */,
 				845E2F6C2837EF2E00C04D56 /* FilePreviewStyle.Accessibility.swift in Sources */,
@@ -4834,6 +4864,7 @@
 				AF3D520F2983BC5600AD8E69 /* FileUploader.Environment.Mock.swift in Sources */,
 				C43D7A1125FF92680064B1DA /* ChoiceCardStyle.swift in Sources */,
 				9A186A4127F605B90055886D /* HeaderButtonStyle.Accessibility.swift in Sources */,
+				84520BEB2B1887DF00F97617 /* CallVisualizer.Presenter.swift in Sources */,
 				C02248AA2AD53E6100CC4930 /* LiveObservation.swift in Sources */,
 				9AB196D827C3E27300FD60AB /* ChatViewModel.Environment.Mock.swift in Sources */,
 				3100EEFF293F7E0900D57F71 /* Theme+SecureConversationsWelcome.swift in Sources */,
@@ -4895,6 +4926,7 @@
 				C0D2F03B299149D600803B47 /* VideoCallViewModel.swift in Sources */,
 				C0D2F02E2991221900803B47 /* VideoCallCoordinator.DelegateEvent.swift in Sources */,
 				1A2DA73125EFA77E00032611 /* FileUploader.swift in Sources */,
+				84520BE32B14B97A00F97617 /* Theme+WebView.swift in Sources */,
 				1A60B0272568070800E53F53 /* UIStackView+Extensions.swift in Sources */,
 				75940945298D378A008B173A /* CoreSDKClient.Mock.swift in Sources */,
 				C0175A192A5D3C56001FACDE /* ChatView.Accessibility.swift in Sources */,

--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -339,7 +339,14 @@ extension Glia {
             guard
                 let engagement = self?.environment.coreSdk.getCurrentEngagement(),
                 engagement.source == .callVisualizer
-            else { return }
+            else {
+                switch event {
+                case let .onEngagementRequest(action):
+                    self?.callVisualizer.handleEngagementRequestAccepted(action)
+                default: return
+                }
+                return
+            }
 
             switch event {
             case .screenShareOffer(answer: let answer):
@@ -371,7 +378,6 @@ extension Glia {
                     self?.callVisualizer.endSession()
                     self?.onEvent?(.ended)
                 } else if case .engaged = state {
-                    self?.callVisualizer.handleEngagementRequestAccepted()
                     self?.onEvent?(.started)
                 }
             default:

--- a/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
+++ b/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
@@ -118,8 +118,8 @@ extension CallVisualizer {
         coordinator.handleAcceptedUpgrade()
     }
 
-    func handleEngagementRequestAccepted() {
-        coordinator.handleEngagementRequestAccepted()
+    func handleEngagementRequestAccepted(_ answer: Command<Bool>) {
+        coordinator.handleEngagementRequestAccepted(answer)
     }
 
     func addVideoStream(stream: CoreSdkClient.VideoStreamable) {

--- a/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Presenter.swift
+++ b/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Presenter.swift
@@ -1,0 +1,24 @@
+import UIKit
+
+extension CallVisualizer {
+    public struct Presenter {
+        init(presenter: @escaping () -> UIViewController?) {
+            self.getInstance = presenter
+        }
+        let getInstance: () -> UIViewController?
+    }
+}
+
+extension CallVisualizer.Presenter {
+    static func topViewController(application: UIKitBased.UIApplication) -> Self {
+        .init {
+            if var topController = application.windows().first(where: { $0.isKeyWindow })?.rootViewController {
+                while let presentedViewController = topController.presentedViewController {
+                    topController = presentedViewController
+                }
+                return topController
+            }
+            return nil
+        }
+    }
+}

--- a/GliaWidgets/Sources/CallVisualizer/VideoCall/View/VideoCallView.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VideoCall/View/VideoCallView.swift
@@ -72,9 +72,9 @@ extension CallVisualizer {
         }
 
         private lazy var header = Header(props: props.headerProps).make { header in
-            header.endButton.isHidden = true
-            header.closeButton.isHidden = true
-            header.endScreenShareButton.isHidden = true
+            header.endButton?.isHidden = true
+            header.closeButton?.isHidden = true
+            header.endScreenShareButton?.isHidden = true
 
             if let backButton = props.style.header.backButton {
                 header.backButton?.accessibilityLabel = backButton.accessibility.label
@@ -287,7 +287,7 @@ private extension CallVisualizer.VideoCallView {
         renderRemoteVideoStream = props.remoteVideoStream
         renderLocalVideoStream = props.localVideoStream
         topLabel.isHidden = props.topLabelHidden
-        header.endScreenShareButton.isHidden = props.endScreenShareButtonHidden
+        header.endScreenShareButton?.isHidden = props.endScreenShareButtonHidden
         connectView.isHidden = props.connectViewHidden
         topStackView.alpha = props.topStackAlpha
         header.props = props.headerProps

--- a/GliaWidgets/Sources/Component/Header/Header.Props.swift
+++ b/GliaWidgets/Sources/Component/Header/Header.Props.swift
@@ -4,10 +4,10 @@ extension Header {
     struct Props: Equatable {
         let title: String
         let effect: Effect
-        let endButton: ActionButton.Props
+        let endButton: ActionButton.Props?
         let backButton: HeaderButton.Props?
-        let closeButton: HeaderButton.Props
-        let endScreenshareButton: HeaderButton.Props
+        let closeButton: HeaderButton.Props?
+        let endScreenshareButton: HeaderButton.Props?
         let style: HeaderStyle
     }
 }

--- a/GliaWidgets/Sources/Component/Header/Header.swift
+++ b/GliaWidgets/Sources/Component/Header/Header.swift
@@ -10,9 +10,9 @@ final class Header: BaseView {
     }
 
     var backButton: HeaderButton?
-    var closeButton: HeaderButton
-    var endButton: ActionButton
-    var endScreenShareButton: HeaderButton
+    var closeButton: HeaderButton?
+    var endButton: ActionButton?
+    var endScreenShareButton: HeaderButton?
 
     var props: Props {
         didSet {
@@ -35,10 +35,15 @@ final class Header: BaseView {
         }
 
         self.props = props
-        self.closeButton = HeaderButton(with: props.closeButton)
-        self.endButton = ActionButton(props: props.endButton)
-
-        self.endScreenShareButton = HeaderButton(with: props.endScreenshareButton)
+        if let closeButtonProps = props.closeButton {
+            self.closeButton = HeaderButton(with: closeButtonProps)
+        }
+        if let endButtonProps = props.endButton {
+            self.endButton = ActionButton(props: endButtonProps)
+        }
+        if let endScreenshareProps = props.endScreenshareButton {
+            self.endScreenShareButton = HeaderButton(with: endScreenshareProps)
+        }
         super.init()
         self.titleLabel.accessibilityTraits = .header
     }
@@ -63,9 +68,12 @@ final class Header: BaseView {
         if let backButtonProps = props.backButton {
             backButton?.props = backButtonProps
         }
-
-        closeButton.props = props.closeButton
-        endButton.props = props.endButton
+        if let closeButtonProps = props.closeButton {
+            closeButton?.props = closeButtonProps
+        }
+        if let endButtonProps = props.endButton {
+            endButton?.props = endButtonProps
+        }
 
         titleLabel.text = props.title
         titleLabel.accessibilityLabel = props.title
@@ -75,8 +83,8 @@ final class Header: BaseView {
         titleLabel.font = props.style.titleFont
         titleLabel.textColor = props.style.titleColor
 
-        closeButton.accessibilityLabel = props.style.closeButton.accessibility.label
-        endButton.accessibilityLabel = props.style.endButton.accessibility.label
+        closeButton?.accessibilityLabel = props.style.closeButton.accessibility.label
+        endButton?.accessibilityLabel = props.style.endButton.accessibility.label
         setFontScalingEnabled(
             props.style.accessibility.isFontScalingEnabled,
             for: titleLabel
@@ -88,21 +96,21 @@ final class Header: BaseView {
     }
 
     func showCloseButton() {
-        endButton.isHidden = true
-        endScreenShareButton.isHidden = true
-        closeButton.isHidden = false
+        endButton?.isHidden = true
+        endScreenShareButton?.isHidden = true
+        closeButton?.isHidden = false
     }
 
     func showEndButton() {
-        endButton.isHidden = false
-        closeButton.isHidden = true
-        endScreenShareButton.isHidden = true
+        endButton?.isHidden = false
+        closeButton?.isHidden = true
+        endScreenShareButton?.isHidden = true
     }
 
     func showEndScreenSharingButton() {
-        endButton.isHidden = false
-        endScreenShareButton.isHidden = false
-        closeButton.isHidden = true
+        endButton?.isHidden = false
+        endScreenShareButton?.isHidden = false
+        closeButton?.isHidden = true
     }
 
     override func setup() {
@@ -112,7 +120,7 @@ final class Header: BaseView {
         rightItemContainer.spacing = 16
         rightItemContainer.alignment = .center
         backButton?.accessibilityIdentifier = "header_back_button"
-        closeButton.accessibilityIdentifier = "header_close_button"
+        closeButton?.accessibilityIdentifier = "header_close_button"
     }
 
     override func defineLayout() {
@@ -145,7 +153,15 @@ final class Header: BaseView {
             constraints += backButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor)
         }
 
-        rightItemContainer.addArrangedSubviews([endScreenShareButton, endButton, closeButton])
+        if let endScreenShareButton {
+            rightItemContainer.addArrangedSubview(endScreenShareButton)
+        }
+        if let endButton {
+            rightItemContainer.addArrangedSubview(endButton)
+        }
+        if let closeButton {
+            rightItemContainer.addArrangedSubview(closeButton)
+        }
         contentView.addSubview(rightItemContainer)
         rightItemContainer.translatesAutoresizingMaskIntoConstraints = false
         constraints += rightItemContainer.layoutInSuperview(edges: .trailing)

--- a/GliaWidgets/Sources/Coordinators/Call/CallCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Call/CallCoordinator.swift
@@ -3,6 +3,7 @@ import UIKit
 class CallCoordinator: SubFlowCoordinator, FlowCoordinator {
     enum DelegateEvent {
         case back
+        case openLink(WebViewController.Link)
         case engaged(operatorImageUrl: String?)
         case visitorOnHoldUpdated(isOnHold: Bool)
         case chat
@@ -108,6 +109,8 @@ private extension CallCoordinator {
         switch event {
         case .back:
             delegate?(.back)
+        case let .openLink(link):
+            delegate?(.openLink(link))
         case .engaged(let url):
             delegate?(.engaged(operatorImageUrl: url))
         case .finished:

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
@@ -4,6 +4,7 @@ import UIKit
 class ChatCoordinator: SubFlowCoordinator, FlowCoordinator {
     enum DelegateEvent {
         case back
+        case openLink(WebViewController.Link)
         case engaged(operatorImageUrl: String?)
         case secureTranscriptUpgradedToLiveChat(ChatViewController)
         case mediaUpgradeAccepted(
@@ -159,6 +160,8 @@ extension ChatCoordinator {
             switch event {
             case .back:
                 self?.delegate?(.back)
+            case let .openLink(link):
+                self?.delegate?(.openLink(link))
             case .engaged(let url):
                 self?.delegate?(.engaged(operatorImageUrl: url))
             case .finished:

--- a/GliaWidgets/Sources/LiveObservation/LiveObservationConfirmation.swift
+++ b/GliaWidgets/Sources/LiveObservation/LiveObservationConfirmation.swift
@@ -3,7 +3,7 @@ import Foundation
 extension LiveObservation {
     struct Confirmation {
         let conf: ConfirmationAlertConfiguration
-        let link: (URL) -> Void
+        let link: (WebViewController.Link) -> Void
         let accepted: () -> Void
         let declined: () -> Void
     }

--- a/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration+SnackBar.swift
+++ b/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration+SnackBar.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension RemoteConfiguration {
-    public struct SnackBar: Codable {
+    struct SnackBar: Codable {
         let background: Color?
         let text: Color?
     }

--- a/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration+WebView.swift
+++ b/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration+WebView.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension RemoteConfiguration {
+    struct WebView: Codable {
+        let header: Header?
+    }
+}

--- a/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration.swift
+++ b/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration.swift
@@ -11,6 +11,7 @@ public struct RemoteConfiguration: Codable {
     let secureConversationsWelcomeScreen: SecureConversationsWelcomeScreen?
     let secureConversationsConfirmationScreen: SecureConversationsConfirmationScreen?
     let snackBar: SnackBar?
+    let webBrowserScreen: WebView?
 }
 
 extension RemoteConfiguration {

--- a/GliaWidgets/Sources/Theme/Theme+SnackBarStyle.swift
+++ b/GliaWidgets/Sources/Theme/Theme+SnackBarStyle.swift
@@ -3,6 +3,7 @@ import UIKit
 extension Theme {
     var snackBarStyle: SnackBarStyle {
         .init(
+            text: Localization.LiveObservation.Indicator.message,
             background: color.baseDark,
             textColor: color.baseLight,
             textFont: .font(weight: .regular, size: 17),
@@ -12,6 +13,7 @@ extension Theme {
 
     var invertedSnackBarStyle: SnackBarStyle {
         .init(
+            text: Localization.LiveObservation.Indicator.message,
             background: color.baseLight,
             textColor: color.baseDark,
             textFont: .font(weight: .regular, size: 17),
@@ -20,7 +22,9 @@ extension Theme {
     }
 
     public struct SnackBarStyle: Equatable {
-        /// View's background color
+        /// SnackBar message text.
+        public var text: String
+        /// View's background color.
         public var background: UIColor
         /// Snack message text color.
         public var textColor: UIColor

--- a/GliaWidgets/Sources/Theme/Theme+WebView.swift
+++ b/GliaWidgets/Sources/Theme/Theme+WebView.swift
@@ -1,0 +1,46 @@
+import UIKit
+
+extension Theme {
+    var webViewStyle: WebViewStyle {
+        let closeButton = HeaderButtonStyle(
+            image: Asset.close.image,
+            color: color.baseLight,
+            accessibility: .init(
+                label: Localization.General.close,
+                hint: ""
+            )
+        )
+        let endButton = ActionButtonStyle(
+            title: Localization.General.end,
+            titleFont: font.buttonLabel,
+            titleColor: color.baseLight,
+            backgroundColor: .fill(color: color.systemNegative),
+            accessibility: .init(
+                label: Localization.General.end,
+                isFontScalingEnabled: true
+            )
+        )
+        let endScreenShareButton = HeaderButtonStyle(
+            image: Asset.startScreenShare.image,
+            color: color.baseLight,
+            accessibility: .init(
+                label: Localization.ScreenSharing.VisitorScreen.End.title,
+                hint: ""
+            )
+        )
+
+        // endButton, endScreenShareButton and backButton
+        // are hidden and not used on WebView screen
+        let header = HeaderStyle(
+            titleFont: font.header2,
+            titleColor: color.baseLight,
+            backgroundColor: .fill(color: color.primary),
+            backButton: nil,
+            closeButton: closeButton,
+            endButton: endButton,
+            endScreenShareButton: endScreenShareButton,
+            accessibility: .init(isFontScalingEnabled: true)
+        )
+        return .init(header: header)
+    }
+}

--- a/GliaWidgets/Sources/Theme/Theme.swift
+++ b/GliaWidgets/Sources/Theme/Theme.swift
@@ -67,6 +67,9 @@ public class Theme {
     /// Inverted snack bar View style.
     public lazy var invertedSnackBar: SnackBarStyle = { invertedSnackBarStyle }()
 
+    /// Chat view style.
+    public lazy var webView: WebViewStyle = { webViewStyle }()
+
     /// Initilizes the theme with base color and font style.
     ///
     /// - Parameters:
@@ -143,6 +146,10 @@ public class Theme {
             configuration: config.snackBar,
             assetsBuilder: assetsBuilder
         )
+        webView.apply(
+            configuration: config.webBrowserScreen,
+            assetsBuilder: assetsBuilder
+        )
     }
 
     func apply(
@@ -187,6 +194,14 @@ public class Theme {
         )
         secureConversationsConfirmation.apply(
             configuration: configuration.secureConversationsConfirmationScreen,
+            assetsBuilder: assetsBuilder
+        )
+        snackBar.apply(
+            configuration: configuration.snackBar,
+            assetsBuilder: assetsBuilder
+        )
+        webView.apply(
+            configuration: configuration.webBrowserScreen,
             assetsBuilder: assetsBuilder
         )
     }

--- a/GliaWidgets/Sources/ViewController/Call/CallViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Call/CallViewController.swift
@@ -51,14 +51,18 @@ final class CallViewController: EngagementViewController {
         guard let view = view as? CallView else { return }
         view.checkBarsOrientation()
     }
+}
 
+// MARK: - Private
+
+private extension CallViewController {
     @objc
-    private func deviceDidRotate() {
+    func deviceDidRotate() {
         guard let view = view as? CallView else { return }
         view.didRotate()
     }
 
-    private func bind(viewModel: CallViewModel, to view: CallView) {
+    func bind(viewModel: CallViewModel, to view: CallView) {
         view.header.showBackButton()
         view.header.showCloseButton()
 
@@ -115,19 +119,13 @@ final class CallViewController: EngagementViewController {
                 view.isVisitrOnHold = isOnHold
             case .transferring:
                 view.setConnectState(.transferring, animated: true)
-            case .showSnackBarView(let text):
-                self.snackBar.present(
-                    text: text,
-                    style: self.viewFactory.theme.invertedSnackBar,
-                    for: self,
-                    bottomOffset: -100,
-                    timerProviding: self.environment.timerProviding
-                )
+            case .showSnackBarView:
+                self.showSnackBarView()
             }
         }
     }
 
-    private static func buildNewHeaderProps(newTitle: String, props: Header.Props) -> Header.Props {
+    static func buildNewHeaderProps(newTitle: String, props: Header.Props) -> Header.Props {
         Header.Props(
             title: newTitle,
             effect: props.effect,
@@ -136,6 +134,17 @@ final class CallViewController: EngagementViewController {
             closeButton: props.closeButton,
             endScreenshareButton: props.endScreenshareButton,
             style: props.style
+        )
+    }
+
+    func showSnackBarView() {
+        let style = viewFactory.theme.invertedSnackBar
+        snackBar.present(
+            text: style.text,
+            style: style,
+            for: self,
+            bottomOffset: -100,
+            timerProviding: environment.timerProviding
         )
     }
 }

--- a/GliaWidgets/Sources/ViewController/Common/Alert/AlertViewController+LiveObservationConfirmation.swift
+++ b/GliaWidgets/Sources/ViewController/Common/Alert/AlertViewController+LiveObservationConfirmation.swift
@@ -3,7 +3,7 @@ import UIKit
 extension AlertViewController {
     func makeLiveObservationAlertView(
         with conf: ConfirmationAlertConfiguration,
-        link: @escaping (URL) -> Void,
+        link: @escaping (WebViewController.Link) -> Void,
         accepted: @escaping () -> Void,
         declined: @escaping () -> Void
     ) -> AlertView {
@@ -58,16 +58,17 @@ extension AlertViewController {
     private func linkButton(
         for url: String?,
         style: ActionButtonStyle,
-        action: Command<URL>
+        action: Command<(WebViewController.Link)>
     ) -> ActionButton? {
-        guard let buttonUrlString = url,
+        guard !style.title.isEmpty,
+              let buttonUrlString = url,
               let buttonUrl = URL(string: buttonUrlString)
         else { return nil }
         return ActionButton(
             props: .init(
                 style: style,
                 height: 34,
-                tap: .init { action(buttonUrl) }
+                tap: .init { action((title: style.title, url: buttonUrl)) }
             )
         )
     }

--- a/GliaWidgets/Sources/ViewController/Common/Alert/AlertViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Common/Alert/AlertViewController.swift
@@ -30,7 +30,7 @@ class AlertViewController: UIViewController, Replaceable {
 
         case liveObservationConfirmation(
             ConfirmationAlertConfiguration,
-            link: (URL) -> Void,
+            link: (WebViewController.Link) -> Void,
             accepted: () -> Void,
             declined: () -> Void
         )

--- a/GliaWidgets/Sources/ViewModel/Call/CallViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Call/CallViewModel.swift
@@ -112,7 +112,7 @@ class CallViewModel: EngagementViewModel, ViewModel {
             showConnecting()
             let operatorName = interactor.engagedOperator?.firstName ?? Localization.Engagement.defaultOperator
             action?(.setOperatorName(operatorName))
-            action?(.showSnackBarView(text: Localization.LiveObservation.Indicator.message))
+            action?(.showSnackBarView)
         case .ended:
             call.end()
         default:
@@ -547,7 +547,7 @@ extension CallViewModel {
         case setRemoteVideo(CoreSdkClient.StreamView?)
         case setLocalVideo(CoreSdkClient.StreamView?)
         case setVisitorOnHold(isOnHold: Bool)
-        case showSnackBarView(text: String)
+        case showSnackBarView
     }
 
     enum DelegateEvent {

--- a/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
@@ -345,8 +345,8 @@ extension EngagementViewModel {
     ) -> LiveObservation.Confirmation {
         .init(
             conf: self.alertConfiguration.liveObservationConfirmation,
-            link: { _ in
-                // TODO: Add navigating to WebView controller
+            link: { [weak self] link in
+                self?.engagementDelegate?(.openLink(link))
             },
             accepted: { [weak self] in
                 self?.enqueue(mediaType: mediaType)
@@ -411,6 +411,7 @@ extension EngagementViewModel {
 
     enum DelegateEvent {
         case back
+        case openLink(WebViewController.Link)
         case engaged(operatorImageUrl: String?)
         case finished
     }

--- a/GliaWidgets/Sources/WebViewController/WebViewController.Props.swift
+++ b/GliaWidgets/Sources/WebViewController/WebViewController.Props.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension WebViewController {
+    struct Props {
+        let link: Link?
+        let header: Header.Props?
+        let externalOpen: Command<URL>
+
+        static var initial: Self {
+            .init(
+                link: nil,
+                header: nil,
+                externalOpen: .nop
+            )
+        }
+    }
+}
+
+extension WebViewController {
+    typealias Link = (title: String, url: URL)
+}

--- a/GliaWidgets/Sources/WebViewController/WebViewController.swift
+++ b/GliaWidgets/Sources/WebViewController/WebViewController.swift
@@ -1,0 +1,85 @@
+import WebKit
+
+final class WebViewController: UIViewController {
+    var props: Props {
+        didSet {
+            renderProps()
+        }
+    }
+    private lazy var header = Header()
+    private lazy var webView: WKWebView = {
+        let webView = WKWebView()
+        webView.navigationDelegate = self
+        return webView
+    }()
+
+    init(props: Props = .initial) {
+        self.props = props
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setup()
+        loadRequest()
+    }
+}
+
+// MARK: - Private
+
+private extension WebViewController {
+    @objc
+    func close() {
+        dismiss(animated: true)
+    }
+
+    func setup() {
+        view.addSubview(header)
+        var constraints = [NSLayoutConstraint](); defer { constraints.activate() }
+        constraints += header.layoutInSuperview(edges: .horizontal)
+        constraints += header.layoutInSuperview(edges: .top)
+
+        view.addSubview(webView)
+        constraints += webView.layoutInSuperview(edges: .horizontal)
+        constraints += webView.layoutInSuperview(edges: .bottom)
+        constraints += webView.topAnchor.constraint(equalTo: header.bottomAnchor)
+    }
+
+    func loadRequest() {
+        guard let url = props.link?.url else { return }
+        let request = URLRequest(url: url)
+        webView.load(request)
+    }
+
+    func renderProps() {
+        guard let headerProps = props.header else { return }
+        header.props = headerProps
+    }
+}
+
+// MARK: - WKNavigationDelegate
+
+extension WebViewController: WKNavigationDelegate {
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
+        guard let url = navigationAction.request.url else {
+            decisionHandler(.cancel)
+            return
+        }
+        // WKNavigationType.other is received when the navigation url is assigned programatically
+        // or server-side redirection occurred.
+        // All further user navigation should be redirected to external browser.
+        if navigationAction.navigationType == .other {
+            decisionHandler(.allow)
+        } else {
+            props.externalOpen(url)
+            decisionHandler(.cancel)
+        }
+    }
+}

--- a/GliaWidgets/Sources/WebViewController/WebViewStyle.swift
+++ b/GliaWidgets/Sources/WebViewController/WebViewStyle.swift
@@ -1,0 +1,22 @@
+import UIKit
+
+public struct WebViewStyle {
+    /// Style of the view's header (navigation bar area).
+    public var header: HeaderStyle
+
+    ///
+    /// - Parameter header: Style of the view's header (navigation bar area).
+    public init(header: HeaderStyle) {
+        self.header = header
+    }
+
+    mutating func apply(
+        configuration: RemoteConfiguration.WebView?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
+        header.apply(
+            configuration: configuration?.header,
+            assetsBuilder: assetsBuilder
+        )
+    }
+}

--- a/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar+View.swift
+++ b/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar+View.swift
@@ -71,6 +71,7 @@ struct SnackBarContentView_Previews: PreviewProvider {
 
 extension Theme.SnackBarStyle {
     static let defaultStyle: Self = .init(
+        text: Localization.LiveObservation.Indicator.message,
         background: .init(hex: "#2C0735"),
         textColor: .init(hex: "#FFFFFF"),
         textFont: UIFont.systemFont(ofSize: 17, weight: .regular),

--- a/GliaWidgetsTests/CallVisualizer/VideoCall/VideoCallTests.swift
+++ b/GliaWidgetsTests/CallVisualizer/VideoCall/VideoCallTests.swift
@@ -24,7 +24,7 @@ final class VideoCallTests: XCTestCase {
         let props = viewModel.makeProps()
 
         XCTAssertTrue(isRunning)
-        props.videoCallViewProps.headerProps.endScreenshareButton.tap()
+        props.videoCallViewProps.headerProps.endScreenshareButton?.tap()
         XCTAssertFalse(isRunning)
     }
 

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
@@ -238,7 +238,6 @@ extension GliaTests {
         let configuredSdkTheme = resultingViewFactory?.theme
         XCTAssertEqual(configuredSdkTheme?.call.connect.queue.firstText, "Company Name")
         XCTAssertEqual(configuredSdkTheme?.chat.connect.queue.firstText, "Company Name")
-        XCTAssertEqual(configuredSdkTheme?.alertConfiguration.liveObservationConfirmation.message?.contains("Company Name"), true)
     }
 
     func testCompanyNameIsReceivedFromThemeIfCustomLocalesIsEmpty() throws {

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -428,7 +428,8 @@ final class GliaTests: XCTestCase {
             callVisualizer: nil,
             secureConversationsWelcomeScreen: nil,
             secureConversationsConfirmationScreen: nil,
-            snackBar: nil
+            snackBar: nil,
+            webBrowserScreen: nil
         )
 
         let theme = Theme(colorStyle: .custom(themeColor))


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-2870

**What was solved?**
- WebViewController was added to open Confirmation alert links. It can load only passed link and its server-side redirection. Further user navigation will be redirected to external browser. 
- Extended Theme and RemoteConfiguration for adjusting WebViewController appearance. 
- Showing LO indication was fixed for CV flow.
- Logic for accepting CV engagement was extended according to Confirmation alert introduction.

⚠️ Tests will be added in separate ticket/PR

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
