### PR TITLE
Add snapshot tests for confirmation alert with links

### DIFF
--- a/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.Mock.swift
+++ b/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.Mock.swift
@@ -68,6 +68,18 @@ extension ConfirmationAlertConfiguration {
             showsPoweredBy: true
         )
     }
+
+    static func liveObservationWithLinksMock() -> Self {
+        .init(
+            title: "Live Observation Confirmation",
+            message: "This is mock message",
+            firstLinkButtonUrl: "https://www.google.com",
+            secondLinkButtonUrl: "https://www.google.ee",
+            negativeTitle: "Cancel",
+            positiveTitle: "Allow",
+            showsPoweredBy: true
+        )
+    }
 }
 
 extension SingleMediaUpgradeAlertConfiguration {

--- a/SnapshotTests/AlertViewControllerDynamicTypeFontTests.swift
+++ b/SnapshotTests/AlertViewControllerDynamicTypeFontTests.swift
@@ -62,4 +62,16 @@ final class AlertViewControllerDynamicTypeFontTests: SnapshotTestCase {
         alert.assertSnapshot(as: .extra3LargeFont, in: .portrait)
         alert.assertSnapshot(as: .extra3LargeFont, in: .landscape)
     }
+
+    func test_liveObservationConfirmationAlertWithLinks() {
+        let alert = alert(ofKind: .liveObservationConfirmation(
+            .liveObservationWithLinksMock(),
+            link: { _ in },
+            accepted: {},
+            declined: {}
+        ))
+
+        alert.assertSnapshot(as: .extra3LargeFont, in: .portrait)
+        alert.assertSnapshot(as: .extra3LargeFont, in: .landscape)
+    }
 }

--- a/SnapshotTests/AlertViewControllerLayoutTests.swift
+++ b/SnapshotTests/AlertViewControllerLayoutTests.swift
@@ -58,6 +58,19 @@ final class AlertViewControllerLayoutTests: SnapshotTestCase {
             accepted: {},
             declined: {}
         ))
+
+        alert.assertSnapshot(as: .image, in: .portrait)
+        alert.assertSnapshot(as: .image, in: .landscape)
+    }
+
+    func test_liveObservationConfirmationAlertWithLinks() {
+        let alert = alert(ofKind: .liveObservationConfirmation(
+            .liveObservationWithLinksMock(),
+            link: { _ in },
+            accepted: {},
+            declined: {}
+        ))
+
         alert.assertSnapshot(as: .image, in: .portrait)
         alert.assertSnapshot(as: .image, in: .landscape)
     }

--- a/SnapshotTests/AlertViewControllerVoiceOverTests.swift
+++ b/SnapshotTests/AlertViewControllerVoiceOverTests.swift
@@ -50,6 +50,17 @@ final class AlertViewControllerVoiceOverTests: SnapshotTestCase {
         alert.assertSnapshot(as: .accessibilityImage)
     }
 
+    func test_liveObservationConfirmationAlertWithLinks() {
+        let alert = alert(ofKind: .liveObservationConfirmation(
+            .liveObservationWithLinksMock(),
+            link: { _ in },
+            accepted: {},
+            declined: {}
+        ))
+
+        alert.assertSnapshot(as: .accessibilityImage)
+    }
+
     private func alert(ofKind kind: AlertViewController.Kind) -> AlertViewController {
         let viewController = AlertViewController(
             kind: kind,


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-2868

**What was solved?**
This PR adds snapshot tests for confirmation alert with links.

Widget PR reference: https://github.com/salemove/ios-widgets-snapshots/pull/64

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
