### PR TITLE
Fix error showing up in Xcode console as warning

### DIFF
--- a/GliaWidgets/Sources/Interactor/Interactor.swift
+++ b/GliaWidgets/Sources/Interactor/Interactor.swift
@@ -96,7 +96,7 @@ class Interactor {
             .forEach {
                 let handler = $0.1
 
-                environment.gcd.mainQueue.asyncIfNeeded {
+                environment.gcd.mainQueue.async {
                     handler(event)
                 }
             }

--- a/GliaWidgetsTests/CallVisualizer/CallVisualizerTests+LO.swift
+++ b/GliaWidgetsTests/CallVisualizer/CallVisualizerTests+LO.swift
@@ -18,7 +18,7 @@ extension CallVisualizerTests {
             completion(.success(site))
         }
         gliaEnv.callVisualizerPresenter = .init(presenter: { nil })
-        gliaEnv.gcd.mainQueue.asyncIfNeeded = { $0() }
+        gliaEnv.gcd.mainQueue.async = { $0() }
         var interactable: CoreSdkClient.Interactable?
         gliaEnv.coreSDKConfigurator.configureWithInteractor = { interactor in
             interactable = interactor

--- a/GliaWidgetsTests/Sources/CallViewControllerTests.swift
+++ b/GliaWidgetsTests/Sources/CallViewControllerTests.swift
@@ -43,7 +43,7 @@ class CallViewControllerTests: XCTestCase {
         viewModelEnv.proximityManager = .init(environment: proximityManagerEnv)
 
         let interactor = Interactor.failing
-        interactor.environment.gcd.mainQueue.asyncIfNeeded = { $0() }
+        interactor.environment.gcd.mainQueue.async = { $0() }
         let viewModel = CallViewModel.mock(interactor: interactor, environment: viewModelEnv)
 
         var snackBar = SnackBar.failing

--- a/GliaWidgetsTests/Sources/CallViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/CallViewModelTests.swift
@@ -248,7 +248,7 @@ class CallViewModelTests: XCTestCase {
         var calls: [Calls] = []
 
         var interactorEnv: Interactor.Environment = .failing
-        interactorEnv.gcd.mainQueue.asyncIfNeeded = { $0() }
+        interactorEnv.gcd.mainQueue.async = { $0() }
         let interactor: Interactor = .mock(environment: interactorEnv)
 
         call = .init(
@@ -290,7 +290,7 @@ class CallViewModelTests: XCTestCase {
     // swiftlint:disable function_body_length
     func test_engagementTransferringReleasesStreams() throws {
         var interactorEnv: Interactor.Environment = .failing
-        interactorEnv.gcd.mainQueue.asyncIfNeeded = { $0() }
+        interactorEnv.gcd.mainQueue.async = { $0() }
         let interactor: Interactor = .mock(environment: interactorEnv)
         let remoteAudioStream = CoreSdkClient.MockAudioStreamable.mock(
             muteFunc: {},
@@ -367,7 +367,7 @@ class CallViewModelTests: XCTestCase {
 
     func test_interactorEventUpdatesCallMediaState() throws {
         var interactorEnv: Interactor.Environment = .failing
-        interactorEnv.gcd.mainQueue.asyncIfNeeded = { $0() }
+        interactorEnv.gcd.mainQueue.async = { $0() }
         let interactor: Interactor = .mock(environment: interactorEnv)
 
         let offer = try CoreSdkClient.MediaUpgradeOffer(type: .audio, direction: .oneWay)

--- a/GliaWidgetsTests/Sources/ChatViewControllerTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewControllerTests.swift
@@ -61,7 +61,7 @@ class ChatViewControllerTests: XCTestCase {
             return .mock
         }
         let interactor = Interactor.failing
-        interactor.environment.gcd.mainQueue.asyncIfNeeded = { $0() }
+        interactor.environment.gcd.mainQueue.async = { $0() }
         let viewModel = ChatViewModel.mock(interactor: interactor, environment: viewModelEnv)
 
         var snackBar = SnackBar.failing

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Gva.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Gva.swift
@@ -73,7 +73,7 @@ extension ChatViewModelTests {
         interactorEnv.coreSdk.sendMessageWithMessagePayload = { _, _ in
             XCTFail("sendMessageWithMessagePayload should not be called")
         }
-        interactorEnv.gcd.mainQueue.asyncIfNeeded = { _ in }
+        interactorEnv.gcd.mainQueue.async = { _ in }
         interactorEnv.coreSdk.queueForEngagement = { _, _ in }
         interactorEnv.coreSdk.configureWithInteractor = { _ in }
         interactorEnv.log.infoClosure = { _, _, _, _ in }

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Transferring.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Transferring.swift
@@ -16,7 +16,7 @@ extension ChatViewModelTests {
         interactorEnv.coreSdk.sendMessageWithMessagePayload = { _, _ in
             XCTFail("createSendMessagePayload should not be called")
         }
-        interactorEnv.gcd.mainQueue.asyncIfNeeded = { $0() }
+        interactorEnv.gcd.mainQueue.async = { $0() }
         interactorEnv.coreSdk.queueForEngagement = { _, _ in }
         interactorEnv.coreSdk.configureWithInteractor = { _ in }
         var log = interactorEnv.log

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -136,7 +136,7 @@ class ChatViewModelTests: XCTestCase {
 
     func test_onEngagementTransferringAddsTransferringItemToTheEndOfChat() throws {
         var interactorEnv: Interactor.Environment = .failing
-        interactorEnv.gcd.mainQueue.asyncIfNeeded = { $0() }
+        interactorEnv.gcd.mainQueue.async = { $0() }
         interactorEnv.log.infoClosure = { _, _, _, _ in }
         interactorEnv.log.prefixedClosure = { _ in interactorEnv.log }
         var viewModelEnv = ChatViewModel.Environment.failing()
@@ -164,7 +164,7 @@ class ChatViewModelTests: XCTestCase {
 
     func test_onEngagementTransferRemovesTransferringItemFromChat() throws {
         var interactorEnv: Interactor.Environment = .failing
-        interactorEnv.gcd.mainQueue.asyncIfNeeded = { $0() }
+        interactorEnv.gcd.mainQueue.async = { $0() }
         interactorEnv.log.infoClosure = { _, _, _, _ in }
         interactorEnv.log.prefixedClosure = { _ in interactorEnv.log }
         var viewModelEnv = ChatViewModel.Environment.failing()
@@ -195,7 +195,7 @@ class ChatViewModelTests: XCTestCase {
 
     func test_onEngagementTransferAddsOperatorConnectedChatItemToTheEndOfChat() throws {
         var interactorEnv: Interactor.Environment = .failing
-        interactorEnv.gcd.mainQueue.asyncIfNeeded = { $0() }
+        interactorEnv.gcd.mainQueue.async = { $0() }
         var viewModelEnv = ChatViewModel.Environment.failing()
         viewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
         viewModelEnv.fileManager.createDirectoryAtUrlWithIntermediateDirectories = { _, _, _ in }
@@ -629,7 +629,7 @@ class ChatViewModelTests: XCTestCase {
         interactorLog.infoClosure = { _, _, _, _ in }
         interactorLog.prefixedClosure = { _ in interactorLog }
         interactor.environment.log = interactorLog
-        interactor.environment.gcd.mainQueue.asyncIfNeeded = { $0() }
+        interactor.environment.gcd.mainQueue.async = { $0() }
         interactor.environment.coreSdk.configureWithInteractor = { _ in }
         interactor.environment.coreSdk.configureWithConfiguration = { _, callback in callback(.success(())) }
         interactor.environment.coreSdk.sendMessagePreview = { _, _ in }
@@ -687,7 +687,7 @@ class ChatViewModelTests: XCTestCase {
         interactorLog.prefixedClosure = { _ in log }
         interactorLog.infoClosure = { _, _, _, _ in }
         interactor.environment.log = interactorLog
-        interactor.environment.gcd.mainQueue.asyncIfNeeded = { $0() }
+        interactor.environment.gcd.mainQueue.async = { $0() }
         interactor.environment.coreSdk.configureWithInteractor = { _ in }
         interactor.environment.coreSdk.configureWithConfiguration = { _, callback in callback(.success(())) }
         interactor.environment.coreSdk.sendMessagePreview = { _, _ in }

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -89,7 +89,7 @@ final class GliaTests: XCTestCase {
         gliaEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
         gliaEnv.coreSdk.fetchSiteConfigurations = { _ in }
         gliaEnv.uuid = { .mock }
-        gliaEnv.gcd.mainQueue.asyncIfNeeded = { callback in callback() }
+        gliaEnv.gcd.mainQueue.async = { callback in callback() }
 
         let expectedTheme = Theme.mock(
             colorStyle: .custom(.init()),
@@ -168,7 +168,7 @@ final class GliaTests: XCTestCase {
         logger.infoClosure = { _, _, _, _ in }
         logger.prefixedClosure = { _ in logger }
         gliaEnv.coreSdk.createLogger = { _ in logger }
-        gliaEnv.gcd.mainQueue.asyncIfNeeded = { callback in callback() }
+        gliaEnv.gcd.mainQueue.async = { callback in callback() }
         gliaEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
@@ -204,7 +204,7 @@ final class GliaTests: XCTestCase {
         gliaEnv.conditionalCompilation.isDebug = { true }
         gliaEnv.coreSdk.configureWithInteractor = { _ in }
         gliaEnv.coreSdk.configureWithConfiguration = { _, _ in }
-        gliaEnv.gcd.mainQueue.asyncIfNeeded = { callback in callback() }
+        gliaEnv.gcd.mainQueue.async = { callback in callback() }
         gliaEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
@@ -239,7 +239,7 @@ final class GliaTests: XCTestCase {
         gliaEnv.coreSdk.createLogger = { _ in logger }
         gliaEnv.conditionalCompilation.isDebug = { true }
         gliaEnv.callVisualizerPresenter = .init(presenter: { nil })
-        gliaEnv.gcd.mainQueue.asyncIfNeeded = { callback in callback() }
+        gliaEnv.gcd.mainQueue.async = { callback in callback() }
         gliaEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
@@ -280,7 +280,7 @@ final class GliaTests: XCTestCase {
         gliaEnv.uuid = { .mock }
         gliaEnv.uiApplication.windows = { [] }
         gliaEnv.callVisualizerPresenter = .init(presenter: { nil })
-        gliaEnv.gcd.mainQueue.asyncIfNeeded = { callback in callback() }
+        gliaEnv.gcd.mainQueue.async = { callback in callback() }
         gliaEnv.notificationCenter.addObserverClosure = { _, _, _, _ in }
         gliaEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
@@ -518,7 +518,7 @@ final class GliaTests: XCTestCase {
         let screenShareHandler: ScreenShareHandler = .mock
         screenShareHandler.status().value = .started
         gliaEnv.screenShareHandler = screenShareHandler
-        gliaEnv.gcd.mainQueue.asyncIfNeeded = { callback in callback() }
+        gliaEnv.gcd.mainQueue.async = { callback in callback() }
         gliaEnv.coreSDKConfigurator.configureWithConfiguration = { _, callback in
             callback(.success(()))
         }


### PR DESCRIPTION
The error was about a table view not being shown yet but trying to lay out
its visible cells. This was fixed by using `async` instead of `asyncIfNeeded`,
which allows enough time for the table view to be shown.

MOB-2971

**What was solved?**

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
