### PR TITLE
Fix Snackbar position to unblock message entry view

### DIFF
--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
@@ -292,7 +292,8 @@ extension SecureConversations.Coordinator {
                 proximityManager: environment.proximityManager,
                 log: environment.log,
                 timerProviding: environment.timerProviding,
-                snackBar: environment.snackBar
+                snackBar: environment.snackBar,
+                notificationCenter: environment.notificationCenter
             ),
             startWithSecureTranscriptFlow: true
         )

--- a/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
@@ -546,7 +546,8 @@ private extension CallVisualizer.Coordinator {
             style: style,
             for: topMostViewController,
             timerProviding: environment.timerProviding,
-            gcd: environment.gcd
+            gcd: environment.gcd,
+            notificationCenter: environment.notificationCenter
         )
     }
 

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
@@ -36,5 +36,6 @@ extension ChatCoordinator {
         var log: CoreSdkClient.Logger
         var timerProviding: FoundationBased.Timer.Providing
         var snackBar: SnackBar
+        var notificationCenter: FoundationBased.NotificationCenter
     }
 }

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
@@ -81,7 +81,8 @@ class ChatCoordinator: SubFlowCoordinator, FlowCoordinator {
                 timerProviding: environment.timerProviding,
                 viewFactory: viewFactory,
                 gcd: environment.gcd,
-                snackBar: environment.snackBar
+                snackBar: environment.snackBar,
+                notificationCenter: environment.notificationCenter
             )
         )
         self.controller = chatController

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
@@ -271,7 +271,8 @@ extension EngagementCoordinator {
                 proximityManager: environment.proximityManager,
                 log: environment.log,
                 timerProviding: environment.timerProviding,
-                snackBar: environment.snackBar
+                snackBar: environment.snackBar,
+                notificationCenter: environment.notificationCenter
             ),
             startWithSecureTranscriptFlow: false
         )

--- a/GliaWidgets/Sources/ViewController/Call/CallViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Call/CallViewController.swift
@@ -154,7 +154,8 @@ private extension CallViewController {
             for: self,
             bottomOffset: -100,
             timerProviding: environment.timerProviding,
-            gcd: environment.gcd
+            gcd: environment.gcd,
+            notificationCenter: environment.notificationCenter
         )
     }
 }

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Environment.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Environment.swift
@@ -6,5 +6,6 @@ extension ChatViewController {
         var viewFactory: ViewFactory
         var gcd: GCD
         var snackBar: SnackBar
+        var notificationCenter: FoundationBased.NotificationCenter
     }
 }

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
@@ -10,7 +10,8 @@ extension ChatViewController {
         timerProviding: FoundationBased.Timer.Providing = .mock,
         viewFactory: ViewFactory = .mock(),
         gcd: GCD = .mock,
-        snackBar: SnackBar = .mock
+        snackBar: SnackBar = .mock,
+        notificationCenter: FoundationBased.NotificationCenter = .mock
     ) -> ChatViewController {
         ChatViewController(
             viewModel: .chat(chatViewModel),
@@ -18,7 +19,8 @@ extension ChatViewController {
                 timerProviding: timerProviding,
                 viewFactory: viewFactory,
                 gcd: gcd,
-                snackBar: snackBar
+                snackBar: snackBar,
+                notificationCenter: notificationCenter
             )
         )
     }

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
@@ -185,9 +185,10 @@ final class ChatViewController: EngagementViewController, PopoverPresenter {
                     text: style.text,
                     style: style,
                     for: self,
-                    bottomOffset: 0,
+                    bottomOffset: -128,
                     timerProviding: self.environment.timerProviding,
-                    gcd: self.environment.gcd
+                    gcd: self.environment.gcd,
+                    notificationCenter: self.environment.notificationCenter
                 )
             }
             self.renderProps()

--- a/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar+Presenter.swift
+++ b/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar+Presenter.swift
@@ -28,6 +28,7 @@ extension SnackBar {
                 )
             )
             self.environment = environment
+            self.monitorKeyboard()
         }
 
         func add() {
@@ -43,7 +44,7 @@ extension SnackBar {
             hostingController.view.translatesAutoresizingMaskIntoConstraints = false
              NSLayoutConstraint.activate([
                 hostingController.view.topAnchor.constraint(greaterThanOrEqualTo: parent.view.topAnchor),
-                hostingController.view.bottomAnchor.constraint(equalTo: parent.view.bottomAnchor),
+                hostingController.view.bottomAnchor.constraint(equalTo: parent.view.bottomAnchor, constant: 64),
                 hostingController.view.leadingAnchor.constraint(equalTo: parent.view.leadingAnchor),
                 hostingController.view.trailingAnchor.constraint(equalTo: parent.view.trailingAnchor)
              ])
@@ -82,9 +83,33 @@ extension SnackBar {
     }
 }
 
+private extension SnackBar.Presenter {
+    func monitorKeyboard() {
+        subscribeToNotification(UIResponder.keyboardWillShowNotification, selector: #selector(keyboardWillShow))
+    }
+
+    func subscribeToNotification(
+        _ notification: NSNotification.Name,
+        selector: Selector
+    ) {
+        environment.notificationCenter.addObserver(
+            self,
+            selector: selector,
+            name: notification,
+            object: nil
+        )
+    }
+
+    @objc
+    func keyboardWillShow(notification: NSNotification) {
+        self.updatePublisher.send(.keyboardWillShow)
+    }
+}
+
 extension SnackBar.Presenter {
     struct Environment {
         let timerProviding: FoundationBased.Timer.Providing
+        let notificationCenter: FoundationBased.NotificationCenter
         let gcd: GCD
     }
 }

--- a/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar+View.swift
+++ b/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar+View.swift
@@ -1,9 +1,14 @@
 import Combine
 import SwiftUI
+import UIKit
 
 extension SnackBar {
     struct ContentView: View {
-        enum ViewState { case appear(String), disappear }
+        enum ViewState {
+            case appear(String)
+            case disappear
+            case keyboardWillShow
+        }
         let publisher: AnyPublisher<ViewState, Never>
 
         @State private var text = ""
@@ -30,7 +35,7 @@ extension SnackBar {
                 .cornerRadius(4)
                 .foregroundColor(SwiftUI.Color(style.textColor))
                 .font(.convert(style.textFont))
-                .padding()
+                .padding(.horizontal)
                 .offset(y: currentOffset)
                 .onReceive(publisher) { newState in
                     switch newState {
@@ -52,6 +57,11 @@ extension SnackBar {
                         } else {
                             self.currentOffset = 300
                         }
+                    case .keyboardWillShow:
+                        withAnimation(.linear(duration: 0.015)) {
+                            self.currentOffset = -60
+                        }
+
                     }
                 }
         }

--- a/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar.Interface.swift
+++ b/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar.Interface.swift
@@ -7,7 +7,8 @@ struct SnackBar {
         _ viewController: UIViewController,
         _ bottomOffset: CGFloat,
         _ timerProviding: FoundationBased.Timer.Providing,
-        _ gcd: GCD
+        _ gcd: GCD,
+        _ notificationCenter: FoundationBased.NotificationCenter
     ) -> Void
 
     func present(
@@ -16,7 +17,8 @@ struct SnackBar {
         for viewController: UIViewController,
         bottomOffset: CGFloat = 0,
         timerProviding: FoundationBased.Timer.Providing,
-        gcd: GCD
+        gcd: GCD,
+        notificationCenter: FoundationBased.NotificationCenter
     ) {
         present(
             text,
@@ -24,7 +26,8 @@ struct SnackBar {
             viewController,
             bottomOffset,
             timerProviding,
-            gcd
+            gcd,
+            notificationCenter
         )
     }
 }

--- a/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar.Live.swift
+++ b/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar.Live.swift
@@ -4,12 +4,15 @@ import UIKit
 
 extension SnackBar {
     static let live: Self = {
-        .init { text, style, viewController, bottomOffset, timerProviding, gcd in
+        .init { text, style, viewController, bottomOffset, timerProviding, gcd, notificationCenter in
             let existedPresenter = Self.presenters.first(where: { $0.parentViewController === viewController })
             let presenter = existedPresenter ?? Presenter(
                 parentViewController: viewController,
                 style: style,
-                environment: .init(timerProviding: timerProviding, gcd: gcd)
+                environment: .init(
+                    timerProviding: timerProviding,
+                    notificationCenter: notificationCenter,
+                    gcd: gcd)
             )
             if existedPresenter == nil {
                 Self.presenters.append(presenter)

--- a/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar.Mock.swift
+++ b/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar.Mock.swift
@@ -3,7 +3,7 @@ import Foundation
 
 extension SnackBar {
     static let mock: Self = {
-        .init { _, _, _, _, _, _ in }
+        .init { _, _, _, _, _, _, _ in }
     }()
 }
 #endif

--- a/GliaWidgetsTests/CallVisualizer/CallVisualizerTests+LO.swift
+++ b/GliaWidgetsTests/CallVisualizer/CallVisualizerTests+LO.swift
@@ -26,7 +26,7 @@ extension CallVisualizerTests {
         gliaEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
-        gliaEnv.snackBar.present = { _, _, _, _, _, _ in
+        gliaEnv.snackBar.present = { _, _, _, _, _, _, _ in
             calls.append(.presentSnackBar)
         }
         let sdk = Glia(environment: gliaEnv)
@@ -44,7 +44,7 @@ extension CallVisualizerTests {
 
         var gliaEnv = Glia.Environment.failing
         gliaEnv.conditionalCompilation.isDebug = { true }
-        gliaEnv.snackBar.present = { _, _, _, _, _, _ in
+        gliaEnv.snackBar.present = { _, _, _, _, _, _, _ in
             calls.append(.presentSnackBar)
         }
         gliaEnv.coreSdk.createLogger = { _ in .mock }

--- a/GliaWidgetsTests/LiveObservations/SnackBar.Failing.swift
+++ b/GliaWidgetsTests/LiveObservations/SnackBar.Failing.swift
@@ -2,7 +2,7 @@ import Foundation
 @testable import GliaWidgets
 
 extension SnackBar {
-    static let failing = Self { _, _, _, _, _, _ in
+    static let failing = Self { _, _, _, _, _, _, _ in
         fail("\(Self.self).present")
     }
 }

--- a/GliaWidgetsTests/Sources/CallViewControllerTests.swift
+++ b/GliaWidgetsTests/Sources/CallViewControllerTests.swift
@@ -47,7 +47,7 @@ class CallViewControllerTests: XCTestCase {
         let viewModel = CallViewModel.mock(interactor: interactor, environment: viewModelEnv)
 
         var snackBar = SnackBar.failing
-        snackBar.present = { _, _, _, _, _, _ in
+        snackBar.present = { _, _, _, _, _, _, _ in
             calls.append(.presentSnackBar)
         }
 

--- a/GliaWidgetsTests/Sources/ChatViewControllerTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewControllerTests.swift
@@ -29,7 +29,8 @@ class ChatViewControllerTests: XCTestCase {
                     timerProviding: .mock,
                     viewFactory: .mock(),
                     gcd: .mock,
-                    snackBar: .mock
+                    snackBar: .mock,
+                    notificationCenter: .mock
                 )
             )
             weakViewController = viewController
@@ -65,14 +66,15 @@ class ChatViewControllerTests: XCTestCase {
         let viewModel = ChatViewModel.mock(interactor: interactor, environment: viewModelEnv)
 
         var snackBar = SnackBar.failing
-        snackBar.present = { _, _, _, _, _, _ in
+        snackBar.present = { _, _, _, _, _, _, _ in
             calls.append(.presentSnackBar)
         }
         let env = ChatViewController.Environment(
             timerProviding: .failing,
             viewFactory: .mock(),
             gcd: .failing,
-            snackBar: snackBar
+            snackBar: snackBar,
+            notificationCenter: .failing
         )
         let viewController = ChatViewController(
             viewModel: .chat(viewModel),


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-2973

**What was solved?**
The snack bar blocked entering messages into the text entry field. This PR moves the snack bar upwards according to the official design. The implementation is not how usually such cases would be handled, because UIHostingViewController, which holds Snackabr(SwiftUI view), cannot be made 'invisible' to touch, and so offsetting the view back and forth was the only known way of getting the desired UX result.
**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
