### PR TITLE
Improve LO indicator showing logic

### DIFF
--- a/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
@@ -114,9 +114,9 @@ extension CallVisualizer {
         func handleEngagementRequestAccepted(_ answer: Command<Bool>) {
             fetchSiteConfigurations { [weak self] site in
                 let showSnackBarIfNeeded: () -> Void = {
-                    if site.mobileObservationIndicationEnabled == true {
-                        self?.showSnackBarMessage()
-                    }
+                    guard site.mobileObservationEnabled == true else { return }
+                    guard site.mobileObservationIndicationEnabled == true else { return }
+                    self?.showSnackBarMessage()
                 }
                 let completion: Command<Bool> = .init { isAccepted in
                     if isAccepted {
@@ -149,9 +149,9 @@ extension CallVisualizer {
 
         func showSnackBarIfNeeded() {
             fetchSiteConfigurations { [weak self] site in
-                if site.mobileObservationIndicationEnabled == true {
-                    self?.showSnackBarMessage()
-                }
+                guard site.mobileObservationEnabled == true else { return }
+                guard site.mobileObservationIndicationEnabled == true else { return }
+                self?.showSnackBarMessage()
             }
         }
 

--- a/GliaWidgets/Sources/ViewModel/Call/CallViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Call/CallViewModel.swift
@@ -239,7 +239,9 @@ class CallViewModel: EngagementViewModel, ViewModel {
     func showSnackBarIfNeeded() {
         environment.fetchSiteConfigurations { [weak self] result in
             switch result {
-            case let .success(site) where site.mobileObservationIndicationEnabled == true:
+            case let .success(site):
+                guard site.mobileObservationEnabled == true else { return }
+                guard site.mobileObservationIndicationEnabled == true else { return }
                 self?.action?(.showSnackBarView)
             default: return
             }

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+LiveObservation.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+LiveObservation.swift
@@ -2,8 +2,8 @@ import Foundation
 
 extension ChatViewModel {
     func showSnackBarIfNeeded() {
-        if siteConfiguration?.mobileObservationIndicationEnabled == true {
-            action?(.showSnackBarView)
-        }
+        guard siteConfiguration?.mobileObservationEnabled == true else { return }
+        guard siteConfiguration?.mobileObservationIndicationEnabled == true else { return }
+        action?(.showSnackBarView)
     }
 }

--- a/GliaWidgetsTests/CallVisualizer/CallVisualizerTests+LO.swift
+++ b/GliaWidgetsTests/CallVisualizer/CallVisualizerTests+LO.swift
@@ -11,6 +11,7 @@ extension CallVisualizerTests {
         gliaEnv.conditionalCompilation.isDebug = { true }
         gliaEnv.coreSdk.createLogger = { _ in .mock }
         let site = try CoreSdkClient.Site.mock(
+            mobileObservationEnabled: true,
             mobileConfirmDialogEnabled: false,
             mobileObservationIndicationEnabled: true
         )
@@ -38,6 +39,78 @@ extension CallVisualizerTests {
         XCTAssertEqual(calls, [.presentSnackBar])
     }
 
+    func testLiveObservationIndicationIsDisabledOnEngagementRequest() throws {
+        enum Call { case presentSnackBar }
+        var calls: [Call] = []
+
+        var gliaEnv = Glia.Environment.failing
+        gliaEnv.conditionalCompilation.isDebug = { true }
+        gliaEnv.coreSdk.createLogger = { _ in .mock }
+        let site = try CoreSdkClient.Site.mock(
+            mobileObservationEnabled: true,
+            mobileConfirmDialogEnabled: false,
+            mobileObservationIndicationEnabled: false
+        )
+        gliaEnv.coreSdk.fetchSiteConfigurations = { completion in
+            completion(.success(site))
+        }
+        gliaEnv.callVisualizerPresenter = .init(presenter: { nil })
+        gliaEnv.gcd.mainQueue.async = { $0() }
+        var interactable: CoreSdkClient.Interactable?
+        gliaEnv.coreSDKConfigurator.configureWithInteractor = { interactor in
+            interactable = interactor
+        }
+        gliaEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
+            completion(.success(()))
+        }
+        gliaEnv.snackBar.present = { _, _, _, _, _, _, _ in
+            calls.append(.presentSnackBar)
+        }
+        let sdk = Glia(environment: gliaEnv)
+        try sdk.configure(with: .mock(), theme: .mock(), completion: { _ in })
+        sdk.callVisualizer.delegate?(.visitorCodeIsRequested)
+
+        interactable?.onEngagementRequest({ _, _, _ in })
+
+        XCTAssertEqual(calls, [])
+    }
+
+    func testLiveObservationIsDisabledOnEngagementRequest() throws {
+        enum Call { case presentSnackBar }
+        var calls: [Call] = []
+
+        var gliaEnv = Glia.Environment.failing
+        gliaEnv.conditionalCompilation.isDebug = { true }
+        gliaEnv.coreSdk.createLogger = { _ in .mock }
+        let site = try CoreSdkClient.Site.mock(
+            mobileObservationEnabled: false,
+            mobileConfirmDialogEnabled: false,
+            mobileObservationIndicationEnabled: true
+        )
+        gliaEnv.coreSdk.fetchSiteConfigurations = { completion in
+            completion(.success(site))
+        }
+        gliaEnv.callVisualizerPresenter = .init(presenter: { nil })
+        gliaEnv.gcd.mainQueue.async = { $0() }
+        var interactable: CoreSdkClient.Interactable?
+        gliaEnv.coreSDKConfigurator.configureWithInteractor = { interactor in
+            interactable = interactor
+        }
+        gliaEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
+            completion(.success(()))
+        }
+        gliaEnv.snackBar.present = { _, _, _, _, _, _, _ in
+            calls.append(.presentSnackBar)
+        }
+        let sdk = Glia(environment: gliaEnv)
+        try sdk.configure(with: .mock(), theme: .mock(), completion: { _ in })
+        sdk.callVisualizer.delegate?(.visitorCodeIsRequested)
+
+        interactable?.onEngagementRequest({ _, _, _ in })
+
+        XCTAssertEqual(calls, [])
+    }
+
     func testLiveObservationIndicatorIsPresentedOnEngagementRestore() throws {
         enum Call { case presentSnackBar }
         var calls: [Call] = []
@@ -49,6 +122,7 @@ extension CallVisualizerTests {
         }
         gliaEnv.coreSdk.createLogger = { _ in .mock }
         let site = try CoreSdkClient.Site.mock(
+            mobileObservationEnabled: true,
             mobileConfirmDialogEnabled: false,
             mobileObservationIndicationEnabled: true
         )
@@ -68,5 +142,71 @@ extension CallVisualizerTests {
         try sdk.configure(with: .mock(), theme: .mock(), completion: { _ in })
 
         XCTAssertEqual(calls, [.presentSnackBar])
+    }
+
+    func testLiveObservationIndicationIsDisabledOnEngagementRestore() throws {
+        enum Call { case presentSnackBar }
+        var calls: [Call] = []
+
+        var gliaEnv = Glia.Environment.failing
+        gliaEnv.conditionalCompilation.isDebug = { true }
+        gliaEnv.snackBar.present = { _, _, _, _, _, _, _ in
+            calls.append(.presentSnackBar)
+        }
+        gliaEnv.coreSdk.createLogger = { _ in .mock }
+        let site = try CoreSdkClient.Site.mock(
+            mobileObservationEnabled: true,
+            mobileConfirmDialogEnabled: true,
+            mobileObservationIndicationEnabled: false
+        )
+        gliaEnv.coreSdk.fetchSiteConfigurations = { completion in
+            completion(.success(site))
+        }
+        gliaEnv.callVisualizerPresenter = .init(presenter: { nil })
+        gliaEnv.gcd.mainQueue.asyncIfNeeded = { $0() }
+        gliaEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
+        let sdk = Glia(environment: gliaEnv)
+        sdk.environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
+            sdk.environment.coreSdk.getCurrentEngagement = {
+                .mock(source: .callVisualizer)
+            }
+            completion(.success(()))
+        }
+        try sdk.configure(with: .mock(), theme: .mock(), completion: { _ in })
+
+        XCTAssertEqual(calls, [])
+    }
+
+    func testLiveObservationIsDisabledOnEngagementRestore() throws {
+        enum Call { case presentSnackBar }
+        var calls: [Call] = []
+
+        var gliaEnv = Glia.Environment.failing
+        gliaEnv.conditionalCompilation.isDebug = { true }
+        gliaEnv.snackBar.present = { _, _, _, _, _, _, _ in
+            calls.append(.presentSnackBar)
+        }
+        gliaEnv.coreSdk.createLogger = { _ in .mock }
+        let site = try CoreSdkClient.Site.mock(
+            mobileObservationEnabled: false,
+            mobileConfirmDialogEnabled: true,
+            mobileObservationIndicationEnabled: true
+        )
+        gliaEnv.coreSdk.fetchSiteConfigurations = { completion in
+            completion(.success(site))
+        }
+        gliaEnv.callVisualizerPresenter = .init(presenter: { nil })
+        gliaEnv.gcd.mainQueue.asyncIfNeeded = { $0() }
+        gliaEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
+        let sdk = Glia(environment: gliaEnv)
+        sdk.environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
+            sdk.environment.coreSdk.getCurrentEngagement = {
+                .mock(source: .callVisualizer)
+            }
+            completion(.success(()))
+        }
+        try sdk.configure(with: .mock(), theme: .mock(), completion: { _ in })
+
+        XCTAssertEqual(calls, [])
     }
 }

--- a/GliaWidgetsTests/Sources/CallViewControllerTests.swift
+++ b/GliaWidgetsTests/Sources/CallViewControllerTests.swift
@@ -30,7 +30,8 @@ class CallViewControllerTests: XCTestCase {
             completion(.success([]))
         }
         let site = try CoreSdkClient.Site.mock(
-            mobileConfirmDialogEnabled: false,
+            mobileObservationEnabled: true,
+            mobileConfirmDialogEnabled: true,
             mobileObservationIndicationEnabled: true
         )
         viewModelEnv.fetchSiteConfigurations = { completion in
@@ -73,5 +74,113 @@ class CallViewControllerTests: XCTestCase {
         interactor.state = .engaged(nil)
 
         XCTAssertEqual(calls, [.presentSnackBar])
+    }
+
+    func testLiveObservationIndicationIsDisabled() throws {
+        enum Call { case presentSnackBar }
+        var calls: [Call] = []
+
+        var viewModelEnv = ChatViewModel.Environment.failing { completion in
+            completion(.success([]))
+        }
+        let site = try CoreSdkClient.Site.mock(
+            mobileObservationEnabled: true,
+            mobileConfirmDialogEnabled: true,
+            mobileObservationIndicationEnabled: false
+        )
+        viewModelEnv.fetchSiteConfigurations = { completion in
+            completion(.success(site))
+        }
+
+        var proximityManagerEnv = ProximityManager.Environment.failing
+        proximityManagerEnv.uiDevice.isProximityMonitoringEnabled = { _ in }
+        proximityManagerEnv.uiApplication.isIdleTimerDisabled = { _ in }
+        viewModelEnv.proximityManager = .init(environment: proximityManagerEnv)
+
+        let interactor = Interactor.failing
+        interactor.environment.gcd.mainQueue.async = { $0() }
+        let viewModel = CallViewModel.mock(interactor: interactor, environment: viewModelEnv)
+
+        var snackBar = SnackBar.failing
+        snackBar.present = { _, _, _, _, _, _, _ in
+            calls.append(.presentSnackBar)
+        }
+
+        var notificationCenter = FoundationBased.NotificationCenter.failing
+        notificationCenter.removeObserverClosure = { _ in }
+        notificationCenter.removeObserverWithNameAndObject = { _, _, _ in }
+        notificationCenter.addObserverClosure = { _, _, _, _ in }
+        GliaCore.sharedInstance.liveObservation.pause()
+        let env = CallViewController.Environment(
+            viewFactory: .mock(),
+            notificationCenter: notificationCenter,
+            log: .mock,
+            timerProviding: .failing,
+            gcd: .failing,
+            snackBar: snackBar
+        )
+        let viewController = CallViewController(
+            viewModel: viewModel,
+            environment: env
+        )
+
+        viewController.loadView()
+        interactor.state = .engaged(nil)
+
+        XCTAssertEqual(calls, [])
+    }
+
+    func testLiveObservationIsDisabled() throws {
+        enum Call { case presentSnackBar }
+        var calls: [Call] = []
+
+        var viewModelEnv = ChatViewModel.Environment.failing { completion in
+            completion(.success([]))
+        }
+        let site = try CoreSdkClient.Site.mock(
+            mobileObservationEnabled: false,
+            mobileConfirmDialogEnabled: true,
+            mobileObservationIndicationEnabled: true
+        )
+        viewModelEnv.fetchSiteConfigurations = { completion in
+            completion(.success(site))
+        }
+
+        var proximityManagerEnv = ProximityManager.Environment.failing
+        proximityManagerEnv.uiDevice.isProximityMonitoringEnabled = { _ in }
+        proximityManagerEnv.uiApplication.isIdleTimerDisabled = { _ in }
+        viewModelEnv.proximityManager = .init(environment: proximityManagerEnv)
+
+        let interactor = Interactor.failing
+        interactor.environment.gcd.mainQueue.async = { $0() }
+        let viewModel = CallViewModel.mock(interactor: interactor, environment: viewModelEnv)
+
+        var snackBar = SnackBar.failing
+        snackBar.present = { _, _, _, _, _, _, _ in
+            calls.append(.presentSnackBar)
+        }
+
+        var notificationCenter = FoundationBased.NotificationCenter.failing
+        notificationCenter.removeObserverClosure = { _ in }
+        notificationCenter.removeObserverWithNameAndObject = { _, _, _ in }
+        notificationCenter.addObserverClosure = { _, _, _, _ in }
+        GliaCore.sharedInstance.liveObservation.pause()
+        let env = CallViewController.Environment(
+            viewFactory: .mock(),
+            notificationCenter: notificationCenter,
+            log: .mock,
+            timerProviding: .failing,
+            gcd: .failing,
+            snackBar: snackBar
+        )
+        let viewController = CallViewController(
+            viewModel: viewModel,
+            environment: env
+        )
+
+        viewController.loadView()
+        interactor.state = .engaged(nil)
+
+        XCTAssertEqual(calls, [])
     }
 }


### PR DESCRIPTION




**Jira issue:**
https://glia.atlassian.net/browse/MOB-2986

**What was solved?**
This PR improves the logic of showing the LO indicator. It now checks if both mobile observation and mobile observation indications are enabled.
**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
