### PR TITLE
Add sensitive info screen to Testing App

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -432,6 +432,7 @@
 		8491AF652AAB281500CC3E72 /* ChatViewModelTests+CustomCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF642AAB281500CC3E72 /* ChatViewModelTests+CustomCard.swift */; };
 		8491AF672AB8707600CC3E72 /* ChatViewModelTests+Transferring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF662AB8707600CC3E72 /* ChatViewModelTests+Transferring.swift */; };
 		84A318A12869ECFC00CA1DE5 /* Unavailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A318A02869ECFC00CA1DE5 /* Unavailable.swift */; };
+		84CD035F2B56DEE300E7A1DC /* SensitiveDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CD035E2B56DEE300E7A1DC /* SensitiveDataViewController.swift */; };
 		84CFB7732822700000167258 /* Theme.Button.Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CFB7722822700000167258 /* Theme.Button.Accessibility.swift */; };
 		84D2292B28C61C8D00F64FE7 /* WKNavigationPolicyProvider.CustomResponseCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D2292A28C61C8D00F64FE7 /* WKNavigationPolicyProvider.CustomResponseCard.swift */; };
 		84D2292E28C61DFA00F64FE7 /* WKNavigationPolicyProvider.Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D2292D28C61DFA00F64FE7 /* WKNavigationPolicyProvider.Interface.swift */; };
@@ -1213,6 +1214,7 @@
 		8491AF642AAB281500CC3E72 /* ChatViewModelTests+CustomCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatViewModelTests+CustomCard.swift"; sourceTree = "<group>"; };
 		8491AF662AB8707600CC3E72 /* ChatViewModelTests+Transferring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatViewModelTests+Transferring.swift"; sourceTree = "<group>"; };
 		84A318A02869ECFC00CA1DE5 /* Unavailable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Unavailable.swift; sourceTree = "<group>"; };
+		84CD035E2B56DEE300E7A1DC /* SensitiveDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensitiveDataViewController.swift; sourceTree = "<group>"; };
 		84CFB7722822700000167258 /* Theme.Button.Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.Button.Accessibility.swift; sourceTree = "<group>"; };
 		84D2292A28C61C8D00F64FE7 /* WKNavigationPolicyProvider.CustomResponseCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKNavigationPolicyProvider.CustomResponseCard.swift; sourceTree = "<group>"; };
 		84D2292D28C61DFA00F64FE7 /* WKNavigationPolicyProvider.Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKNavigationPolicyProvider.Interface.swift; sourceTree = "<group>"; };
@@ -1820,6 +1822,7 @@
 		1A205D7925655CEC003AA3CD /* TestingApp */ = {
 			isa = PBXGroup;
 			children = (
+				84CD035D2B56DECA00E7A1DC /* SensitiveData */,
 				8491AF282A9394AF00CC3E72 /* DeeplinkService */,
 				AFD3C52A2A472B1C00BC37A9 /* VisitorInfo */,
 				C0D2F05E299F93EC00803B47 /* Playbook */,
@@ -3472,6 +3475,14 @@
 				8491AF622AA20F9D00CC3E72 /* GliaViewControllerDelegateMock.swift */,
 			);
 			path = Mocks;
+			sourceTree = "<group>";
+		};
+		84CD035D2B56DECA00E7A1DC /* SensitiveData */ = {
+			isa = PBXGroup;
+			children = (
+				84CD035E2B56DEE300E7A1DC /* SensitiveDataViewController.swift */,
+			);
+			path = SensitiveData;
 			sourceTree = "<group>";
 		};
 		84D2292C28C61DE000F64FE7 /* WKNavigationPolicyProvider */ = {
@@ -5207,6 +5218,7 @@
 				AF11F30728BE6F0C002ACEB4 /* UIAlertController+Extensions.swift in Sources */,
 				7552DFA82A683A2C0093519B /* UIStackView.Extensions.swift in Sources */,
 				AF3BD1DF2A42026D00A7713E /* Command.swift in Sources */,
+				84CD035F2B56DEE300E7A1DC /* SensitiveDataViewController.swift in Sources */,
 				8491AF2E2A93975100CC3E72 /* ConfigurationDeeplinkHandler.swift in Sources */,
 				754313CD2870B1C400C9C1C6 /* UserDefaultsStored.swift in Sources */,
 				1A205D7B25655CEC003AA3CD /* AppDelegate.swift in Sources */,

--- a/TestingApp/Main.storyboard
+++ b/TestingApp/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -21,7 +21,7 @@
                                 <rect key="frame" x="0.0" y="48" width="414" height="814"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="A3Y-Xf-Ufg">
-                                        <rect key="frame" x="0.0" y="16" width="414" height="873.5"/>
+                                        <rect key="frame" x="0.0" y="16" width="414" height="918.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Configuration" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4l1-DH-Wkd">
                                                 <rect key="frame" x="155.5" y="0.0" width="103.5" height="20.5"/>
@@ -192,14 +192,24 @@
                                                     <action selector="showUpdateVisitorInfo" destination="Y6W-OH-hqX" eventType="touchUpInside" id="bQD-DE-a1m"/>
                                                 </connections>
                                             </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PbA-Oy-bDr">
+                                                <rect key="frame" x="113.5" y="512.5" width="187" height="30"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="main_sensitiveData_button"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                                <state key="normal" title="Show sensitive data screen"/>
+                                                <connections>
+                                                    <action selector="showSensitiveDataTapped" destination="Y6W-OH-hqX" eventType="touchUpInside" id="tkz-Bx-Fmk"/>
+                                                </connections>
+                                            </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="UI customization" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E1e-uA-HuC">
-                                                <rect key="frame" x="143.5" y="512.5" width="127.5" height="20.5"/>
+                                                <rect key="frame" x="143.5" y="557.5" width="127.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ezc-iY-PbB">
-                                                <rect key="frame" x="141" y="548" width="132" height="30"/>
+                                                <rect key="frame" x="141" y="593" width="132" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_endEngagement_button"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="Nef-0j-qW7"/>
@@ -210,13 +220,13 @@
                                                 </connections>
                                             </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VisitorCode" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tI8-TQ-jWA">
-                                                <rect key="frame" x="162.5" y="593" width="89" height="20.5"/>
+                                                <rect key="frame" x="162.5" y="638" width="89" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="1gR-qB-lno">
-                                                <rect key="frame" x="90.5" y="628.5" width="233" height="30"/>
+                                                <rect key="frame" x="90.5" y="673.5" width="233" height="30"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YnU-rR-gCc">
                                                         <rect key="frame" x="0.0" y="0.0" width="88" height="30"/>
@@ -245,7 +255,7 @@
                                                 </subviews>
                                             </stackView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7mi-et-ybT">
-                                                <rect key="frame" x="0.0" y="673.5" width="414" height="200"/>
+                                                <rect key="frame" x="0.0" y="718.5" width="414" height="200"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="200" id="GaG-7F-RUb"/>

--- a/TestingApp/SensitiveData/SensitiveDataViewController.swift
+++ b/TestingApp/SensitiveData/SensitiveDataViewController.swift
@@ -1,0 +1,53 @@
+import UIKit
+import GliaCoreSDK
+
+final class SensitiveDataViewController: UIViewController {
+    private lazy var message: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.text = """
+        This screen emulates the integrator application screen with sensitive data.
+
+        Be aware this screen should not be visible to the operator during Live Observation, but should be visible during screen sharing.
+        """
+        label.accessibilityIdentifier = "sensitiveData_message"
+        return label
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        setup()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        GliaCore.sharedInstance.liveObservation.pause()
+        super.viewWillAppear(animated)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        GliaCore.sharedInstance.liveObservation.resume()
+        super.viewWillDisappear(animated)
+    }
+
+    private func setup() {
+        view.addSubview(message)
+        message.translatesAutoresizingMaskIntoConstraints = false
+        [
+            message.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            message.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            message.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: 20),
+            message.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: 20)
+        ].forEach { $0.isActive = true }
+
+        let closeButton = UIBarButtonItem(barButtonSystemItem: .close, target: self, action: #selector(close))
+        closeButton.accessibilityIdentifier = "sensitiveData_close"
+        navigationItem.rightBarButtonItem = closeButton
+    }
+
+    @objc
+    private func close(_ sender: UIButton) {
+        dismiss(animated: true)
+    }
+}

--- a/TestingApp/ViewController/ViewController.swift
+++ b/TestingApp/ViewController/ViewController.swift
@@ -89,6 +89,12 @@ class ViewController: UIViewController {
         }
     }
 
+    @IBAction private func showSensitiveDataTapped() {
+        let controller = SensitiveDataViewController()
+        let navigation = UINavigationController(rootViewController: controller)
+        present(navigation, animated: true)
+    }
+
     private func showErrorAlert(using error: Error) {
         if let gliaError = error as? GliaError {
             switch gliaError {


### PR DESCRIPTION
**What was solved?**
Sensitive data screen was added to test pause/resume LO in acceptance tests

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
