### PR TITLE
Avoid muting visitor when one is put on hold

### DIFF
--- a/GliaWidgets/Sources/ViewModel/Call/CallViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Call/CallViewModel.swift
@@ -134,7 +134,6 @@ class CallViewModel: EngagementViewModel, ViewModel {
     private func setVisitorOnHold(_ isOnHold: Bool) {
         if isOnHold {
             call.video.stream.value.localStream?.pause()
-            call.audio.stream.value.localStream?.mute()
             action?(.setButtonState(.mute, state: .active))
         } else {
             if !call.hasVisitorMutedAudio {

--- a/GliaWidgetsTests/Sources/CallViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/CallViewModelTests.swift
@@ -99,7 +99,7 @@ class CallViewModelTests: XCTestCase {
         XCTAssertFalse(isVideoButtonEnabled)
         XCTAssertFalse(isMuteButtonEnabled)
         XCTAssertTrue(isLocalVideoStreamPaused)
-        XCTAssertTrue(isLocalAudioStreamMuted)
+        XCTAssertFalse(isLocalAudioStreamMuted)
     }
 
     func test_localVideoIsNotEnabledWhenUpgradingFromAudioToVideoWhileOnHold() throws {


### PR DESCRIPTION
MOB-2997

**Jira issue:**
https://glia.atlassian.net/browse/MOB-2997

**What was solved?**
To prevent keeping visitor muted once operator turns off visitor on-hold, we no longer mute visitor explicitly when one is put on hold. This avoids inconsistency between UI that shows that visitor is not muted, while visitor is actually muted.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**
Kudos to @kuldar-daniel for adding tests a while back that caught this change.

 - [x] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
