### PR TITLE
Add accessibilityIds for sent images

### DIFF
--- a/GliaWidgets/Sources/Download/FileDownload.swift
+++ b/GliaWidgets/Sources/Download/FileDownload.swift
@@ -25,6 +25,15 @@ class FileDownload {
         case downloading(progress: ObservableValue<Double>)
         case downloaded(LocalFile)
         case error(Error)
+
+        var accessibilityString: String {
+            switch self {
+            case .none: return "none"
+            case .downloading: return "downloading"
+            case .downloaded: return "downloaded"
+            case .error: return "error"
+            }
+        }
     }
 
     let state = ObservableValue<State>(with: .none)

--- a/GliaWidgets/Sources/View/Chat/Message/Content/File/Image/ChatImageFileContentView.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/Content/File/Image/ChatImageFileContentView.swift
@@ -74,6 +74,8 @@ class ChatImageFileContentView: ChatFileContentView {
         default:
             imageView.image = nil
         }
+
+        updateAccessibilityIdentifier(with: download)
     }
 
     private func setImage(from file: LocalFile) {
@@ -85,5 +87,11 @@ class ChatImageFileContentView: ChatFileContentView {
 
     private func setImage(_ image: UIImage?) {
         imageView.image = image
+    }
+
+    private func updateAccessibilityIdentifier(with download: FileDownload) {
+        accessibilityIdentifier = download.file.name.map {
+            "chat_message_image_\($0)_\(download.state.value.accessibilityString)"
+        }
     }
 }

--- a/GliaWidgetsTests/Sources/FileDownloadTests.swift
+++ b/GliaWidgetsTests/Sources/FileDownloadTests.swift
@@ -17,12 +17,12 @@ class FileDownloadTests: XCTestCase {
         let generalFileUrl = try XCTUnwrap(
             URL(string: "https://mock.mock.mock.moc")
         )
-        
+
         enum Fetch: Equatable {
             case engagement
             case secureMessaging
         }
-        
+
         let env = FetchFile.Environment(
             fetchFile: { _, _, _ in },
             downloadSecureFile: { _, _, _ in .mock }
@@ -40,5 +40,23 @@ class FileDownloadTests: XCTestCase {
         XCTAssertEqual(evaluateFile(.init(url: engagementFileUrl)), .engagement)
         XCTAssertEqual(evaluateFile(.init(url: secureMessagingFileUrl)), .secureMessaging)
         XCTAssertEqual(evaluateFile(.init(url: generalFileUrl)), .engagement)
+    }
+
+    func testAccessibilityStrings() {
+        let strings = [
+            "none",
+            "downloading",
+            "downloaded",
+            "error"
+        ]
+
+        let states: [FileDownload.State] = [
+            .none,
+            .downloading(progress: .init(with: 0)),
+            .downloaded(.mock()),
+            .error(.network)
+        ]
+
+        XCTAssertEqual(states.map(\.accessibilityString), strings)
     }
 }


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-2245

**What was solved?**
Accessibility identifiers were added for images sent in the chat. It's needed for Acceptance tests.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
