### PR TITLE
Enable LSSupportsOpeningDocumentsInPlace needed for acceptance tests

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -5681,6 +5681,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.glia.sdk.widgets-example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "Widgets Example App (Bitrise)";
+				SUPPORTS_OPENING_DOCUMENTS_IN_PLACE = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
@@ -5712,6 +5713,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "Widgets Example App (Bitrise)";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Widgets - TestingApp | AppStore";
+				SUPPORTS_OPENING_DOCUMENTS_IN_PLACE = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 			};

--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
@@ -233,7 +233,10 @@ extension SecureConversations {
                     self?.selectedPickerController = nil
                 }
             }
-            let controller = FilePickerController(viewModel: viewModel)
+            let controller = FilePickerController(
+                viewModel: viewModel,
+                environment: .init(fileManager: environment.fileManager)
+            )
             // Keep strong reference, otherwise
             // `controller` will be deallocted, resulting in
             // event not being sent.

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
@@ -125,7 +125,10 @@ class ChatCoordinator: SubFlowCoordinator, FlowCoordinator {
             }
         }
 
-        let controller = FilePickerController(viewModel: viewModel)
+        let controller = FilePickerController(
+            viewModel: viewModel,
+            environment: .init(fileManager: environment.fileManager)
+        )
         filePickerController = controller
         navigationPresenter.present(controller.viewController)
     }

--- a/GliaWidgets/Sources/ViewController/Common/FilePicker/FilePickerController.swift
+++ b/GliaWidgets/Sources/ViewController/Common/FilePicker/FilePickerController.swift
@@ -6,6 +6,8 @@ final class FilePickerController: NSObject {
         documentPicker.delegate = self
         documentPicker.allowsMultipleSelection = false
         documentPicker.modalPresentationStyle = .fullScreen
+        let urls = environment.fileManager.urlsForDirectoryInDomainMask(.documentDirectory, .userDomainMask)
+        documentPicker.directoryURL = urls.first
         viewModel.environment.log.prefixed(Self.self).info(
             "Create File Preview screen",
             function: "\(\FilePickerController.viewController)"
@@ -14,9 +16,14 @@ final class FilePickerController: NSObject {
     }
 
     private let viewModel: FilePickerViewModel
+    private let environment: Environment
 
-    init(viewModel: FilePickerViewModel) {
+    init(
+        viewModel: FilePickerViewModel,
+        environment: Environment
+    ) {
         self.viewModel = viewModel
+        self.environment = environment
     }
 
     deinit {
@@ -34,5 +41,11 @@ extension FilePickerController: UIDocumentPickerDelegate {
     func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
         controller.dismiss(animated: true)
         viewModel.event(.cancelled)
+    }
+}
+
+extension FilePickerController {
+    public struct Environment {
+        let fileManager: FoundationBased.FileManager
     }
 }

--- a/TestingApp/Info.plist
+++ b/TestingApp/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>UIFileSharingEnabled</key>
+    <true/>
+    <key>LSSupportsOpeningDocumentsInPlace</key>
+    <string>$(SUPPORTS_OPENING_DOCUMENTS_IN_PLACE)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>CFBundleDevelopmentRegion</key>


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-2246

**What was solved?**
Enabling this value allows:
- opening application Documents directory through UIDocumentPickerViewController
- pushing files to application Documents directory in Acceptance tests

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
