### PR TITLE
Add MAXIMUM_UPLOADS_PER_MESSAGE variable

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -437,6 +437,10 @@
 		8491AF652AAB281500CC3E72 /* ChatViewModelTests+CustomCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF642AAB281500CC3E72 /* ChatViewModelTests+CustomCard.swift */; };
 		8491AF672AB8707600CC3E72 /* ChatViewModelTests+Transferring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF662AB8707600CC3E72 /* ChatViewModelTests+Transferring.swift */; };
 		84A318A12869ECFC00CA1DE5 /* Unavailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A318A02869ECFC00CA1DE5 /* Unavailable.swift */; };
+		84C24CF82B8353A00089A388 /* ProcessInfoHandling.Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C24CF72B8353A00089A388 /* ProcessInfoHandling.Interface.swift */; };
+		84C24CFA2B83541F0089A388 /* ProcessInfoHandling.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C24CF92B83541F0089A388 /* ProcessInfoHandling.Mock.swift */; };
+		84C24CFC2B8354A80089A388 /* ProcessInfoHandling.Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C24CFB2B8354A80089A388 /* ProcessInfoHandling.Live.swift */; };
+		84C24CFF2B8357BB0089A388 /* ProcessInfoHandling.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C24CFE2B8357BB0089A388 /* ProcessInfoHandling.Failing.swift */; };
 		84CD035F2B56DEE300E7A1DC /* SensitiveDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CD035E2B56DEE300E7A1DC /* SensitiveDataViewController.swift */; };
 		84CFB7732822700000167258 /* Theme.Button.Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CFB7722822700000167258 /* Theme.Button.Accessibility.swift */; };
 		84D2292B28C61C8D00F64FE7 /* WKNavigationPolicyProvider.CustomResponseCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D2292A28C61C8D00F64FE7 /* WKNavigationPolicyProvider.CustomResponseCard.swift */; };
@@ -1226,6 +1230,10 @@
 		8491AF642AAB281500CC3E72 /* ChatViewModelTests+CustomCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatViewModelTests+CustomCard.swift"; sourceTree = "<group>"; };
 		8491AF662AB8707600CC3E72 /* ChatViewModelTests+Transferring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatViewModelTests+Transferring.swift"; sourceTree = "<group>"; };
 		84A318A02869ECFC00CA1DE5 /* Unavailable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Unavailable.swift; sourceTree = "<group>"; };
+		84C24CF72B8353A00089A388 /* ProcessInfoHandling.Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessInfoHandling.Interface.swift; sourceTree = "<group>"; };
+		84C24CF92B83541F0089A388 /* ProcessInfoHandling.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessInfoHandling.Mock.swift; sourceTree = "<group>"; };
+		84C24CFB2B8354A80089A388 /* ProcessInfoHandling.Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessInfoHandling.Live.swift; sourceTree = "<group>"; };
+		84C24CFE2B8357BB0089A388 /* ProcessInfoHandling.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessInfoHandling.Failing.swift; sourceTree = "<group>"; };
 		84CD035E2B56DEE300E7A1DC /* SensitiveDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensitiveDataViewController.swift; sourceTree = "<group>"; };
 		84CFB7722822700000167258 /* Theme.Button.Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.Button.Accessibility.swift; sourceTree = "<group>"; };
 		84D2292A28C61C8D00F64FE7 /* WKNavigationPolicyProvider.CustomResponseCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKNavigationPolicyProvider.CustomResponseCard.swift; sourceTree = "<group>"; };
@@ -2180,6 +2188,7 @@
 		1A60AFC12566857200E53F53 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				84C24CF62B8353840089A388 /* ProcessInfoHandling */,
 				C0ECC7902B70E9B5001F1EEF /* OperatorRequestHandlerService */,
 				84520BD92B0FA14700F97617 /* WebViewController */,
 				C02248A82AD53DDF00CC4930 /* LiveObservation */,
@@ -2848,6 +2857,7 @@
 		7512A57827BF9FB800319DF1 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				84C24CFD2B8357B00089A388 /* ProcessInfoHandling */,
 				C0ECC7952B7278C9001F1EEF /* OperatorRequestsHandlerService */,
 				31FF0DD22B5AB82000834AFB /* CallVisualizer */,
 				31FF0DC72B5907C600834AFB /* Coordinators */,
@@ -3536,6 +3546,24 @@
 				8491AF622AA20F9D00CC3E72 /* GliaViewControllerDelegateMock.swift */,
 			);
 			path = Mocks;
+			sourceTree = "<group>";
+		};
+		84C24CF62B8353840089A388 /* ProcessInfoHandling */ = {
+			isa = PBXGroup;
+			children = (
+				84C24CF72B8353A00089A388 /* ProcessInfoHandling.Interface.swift */,
+				84C24CFB2B8354A80089A388 /* ProcessInfoHandling.Live.swift */,
+				84C24CF92B83541F0089A388 /* ProcessInfoHandling.Mock.swift */,
+			);
+			path = ProcessInfoHandling;
+			sourceTree = "<group>";
+		};
+		84C24CFD2B8357B00089A388 /* ProcessInfoHandling */ = {
+			isa = PBXGroup;
+			children = (
+				84C24CFE2B8357BB0089A388 /* ProcessInfoHandling.Failing.swift */,
+			);
+			path = ProcessInfoHandling;
 			sourceTree = "<group>";
 		};
 		84CD035D2B56DECA00E7A1DC /* SensitiveData */ = {
@@ -4823,6 +4851,7 @@
 				AF6291132B0813B000D3D76B /* SwiftBased.Mock.swift in Sources */,
 				1AC7A74F2582571100567FF8 /* Interactor.swift in Sources */,
 				C0ECC7992B7506D0001F1EEF /* OperatorRequestHandlerService+Mock.swift in Sources */,
+				84C24CFC2B8354A80089A388 /* ProcessInfoHandling.Live.swift in Sources */,
 				845E2F72283D068000C04D56 /* HeaderStyle.Accessibility.swift in Sources */,
 				AFA1A9952AA9248400095BE8 /* ChatViewModel+ViewModel.swift in Sources */,
 				1A1E30CB25F9FDC400850E68 /* ChatImageFileContentStyle.swift in Sources */,
@@ -4952,6 +4981,7 @@
 				C4F176CD261D1543009D9F07 /* ChatFileDownloadContentView.swift in Sources */,
 				755D187129A6A6400009F5E8 /* WelcomeStyle+MessageTextViewNormalStyle.swift in Sources */,
 				845A28FC28AFF092008558EA /* URLScheme.swift in Sources */,
+				84C24CF82B8353A00089A388 /* ProcessInfoHandling.Interface.swift in Sources */,
 				75F58EE127E7D5300065BA2D /* Survey.ViewController.Props.swift in Sources */,
 				84602A742AE94DE50031E606 /* ProximityManager.Mock.swift in Sources */,
 				754CC61527E27C42005676E9 /* Survey.Checkbox.swift in Sources */,
@@ -5073,6 +5103,7 @@
 				9A1992ED27D6C19E00161AAE /* FileSystemStorage.Environment.Mock.swift in Sources */,
 				1AFB1E6825F7AE3C00CA460D /* ChatAttachment.swift in Sources */,
 				9A186A3527F5CF3C0055886D /* FileUploadStyle.Accessibility.swift in Sources */,
+				84C24CFA2B83541F0089A388 /* ProcessInfoHandling.Mock.swift in Sources */,
 				84A318A12869ECFC00CA1DE5 /* Unavailable.swift in Sources */,
 				1AE15E49257A6BD200A642C0 /* ConfirmationAlertConfiguration.swift in Sources */,
 				C0175A172A5D30D7001FACDE /* GvaResponseTextView.swift in Sources */,
@@ -5248,6 +5279,7 @@
 				EB7A1508286D98000035AC62 /* FileUploader.Environment.Failing.swift in Sources */,
 				AF2355A229C9EC7E007D9896 /* IdCollectionTests.swift in Sources */,
 				8491AF572AA0964800CC3E72 /* ChatItem.Kind.Mock.swift in Sources */,
+				84C24CFF2B8357BB0089A388 /* ProcessInfoHandling.Failing.swift in Sources */,
 				8491AF632AA20F9D00CC3E72 /* GliaViewControllerDelegateMock.swift in Sources */,
 				84681A952A61844000DD7406 /* ChatViewModelTests+Gva.swift in Sources */,
 				847A7643285A1914004044D1 /* FileUploadListViewModelTests.swift in Sources */,

--- a/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
+++ b/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
@@ -171,7 +171,8 @@ extension Glia {
                 proximityManager: environment.proximityManager,
                 log: loggerPhase.logger,
                 snackBar: environment.snackBar,
-                operatorRequestHandlerService: operatorRequestHandlerService
+                operatorRequestHandlerService: operatorRequestHandlerService,
+                maximumUploads: { self.maximumUploads }
             )
         )
         rootCoordinator?.delegate = { [weak self] event in

--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -48,6 +48,10 @@ public protocol SceneProvider: AnyObject {
     func windowScene() -> UIWindowScene?
 }
 
+private extension Glia {
+    static let maximumUploads = 25
+}
+
 /// Glia's engagement interface.
 public class Glia {
     /// A singleton to access the Glia's interface.
@@ -58,6 +62,18 @@ public class Glia {
     public var onEvent: ((GliaEvent) -> Void)?
 
     var stringProvidingPhase: StringProvidingPhase = .notConfigured
+
+    lazy var maximumUploads: Int = {
+        var value = Self.maximumUploads
+        /// `MAXIMUM_UPLOADS_PER_MESSAGE` is used in acceptance tests to decrease the time
+        /// for uploading maximum number of files in a single message.
+        if let stringValue = environment.processInfo.value(for: .maximumUploads) {
+            /// Round to 1, because the attachment button doesn't turns to disabled state
+            /// if the value is set to 0.
+            value = max(Int(stringValue) ?? 1, 1)
+        }
+        return value
+    }()
 
     public lazy var callVisualizer = CallVisualizer(
         environment: .init(

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.Environment.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.Environment.swift
@@ -31,5 +31,6 @@ extension SecureConversations.TranscriptModel {
         var stopSocketObservation: CoreSdkClient.StopSocketObservation
         var createSendMessagePayload: CoreSdkClient.CreateSendMessagePayload
         var log: CoreSdkClient.Logger
+        var maximumUploads: () -> Int
     }
 }

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
@@ -25,7 +25,6 @@ extension SecureConversations {
         typealias Event = ChatViewModel.Event
 
         static let messageTextLimit = WelcomeViewModel.messageTextLimit
-        static let maximumUploads = WelcomeViewModel.maximumUploads
 
         var action: ActionCallback?
         var delegate: DelegateCallback?
@@ -122,7 +121,7 @@ extension SecureConversations {
             self.alertConfiguration = alertConfiguration
             self.hasViewAppeared = false
             let uploader = FileUploader(
-                maximumUploads: Self.maximumUploads,
+                maximumUploads: environment.maximumUploads(),
                 environment: .init(
                     uploadFile: .toSecureMessaging(environment.secureUploadFile),
                     fileManager: environment.fileManager,

--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
@@ -45,7 +45,7 @@ extension SecureConversations {
                     sendSecureMessagePayload: environment.sendSecureMessagePayload,
                     alertConfiguration: viewFactory.theme.alertConfiguration,
                     fileUploader: environment.createFileUploader(
-                        SecureConversations.WelcomeViewModel.maximumUploads,
+                        environment.maximumUploads(),
                         .init(
                             uploadFile: .toSecureMessaging(environment.uploadSecureFile),
                             fileManager: environment.fileManager,
@@ -298,7 +298,8 @@ extension SecureConversations.Coordinator {
                 timerProviding: environment.timerProviding,
                 snackBar: environment.snackBar,
                 notificationCenter: environment.notificationCenter,
-                operatorRequestHandlerService: environment.operatorRequestHandlerService
+                operatorRequestHandlerService: environment.operatorRequestHandlerService,
+                maximumUploads: environment.maximumUploads
             ),
             startWithSecureTranscriptFlow: true
         )
@@ -370,6 +371,7 @@ extension SecureConversations.Coordinator {
         var timerProviding: FoundationBased.Timer.Providing
         var snackBar: SnackBar
         var operatorRequestHandlerService: OperatorRequestHandlerService
+        var maximumUploads: () -> Int
     }
 
     enum DelegateEvent {

--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.swift
@@ -15,7 +15,6 @@ extension SecureConversations {
         static let unavailableMessageCenterAlertAccIdentidier = "unavailable_message_center_alert_identifier"
 
         static let messageTextLimit = 10_000
-        static let maximumUploads = 25
 
         var action: ((Action) -> Void)?
         var delegate: ((DelegateEvent) -> Void)?

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
@@ -38,5 +38,6 @@ extension ChatCoordinator {
         var snackBar: SnackBar
         var notificationCenter: FoundationBased.NotificationCenter
         var operatorRequestHandlerService: OperatorRequestHandlerService
+        var maximumUploads: () -> Int
     }
 }

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
@@ -166,7 +166,8 @@ extension ChatCoordinator {
             startAction: startAction,
             deliveredStatusText: viewFactory.theme.chat.visitorMessageStyle.delivered,
             chatType: chatType,
-            environment: Self.enviromentForChatModel(environment: environment, viewFactory: viewFactory)
+            environment: Self.enviromentForChatModel(environment: environment, viewFactory: viewFactory),
+            maximumUploads: environment.maximumUploads
         )
         viewModel.isInteractableCard = viewFactory.messageRenderer?.isInteractable
         viewModel.shouldShowCard = viewFactory.messageRenderer?.shouldShowCard
@@ -353,7 +354,8 @@ extension ChatCoordinator {
            startSocketObservation: environment.startSocketObservation,
            stopSocketObservation: environment.stopSocketObservation,
            createSendMessagePayload: environment.createSendMessagePayload,
-           log: environment.log
+           log: environment.log,
+           maximumUploads: environment.maximumUploads
        )
     }
 }

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
@@ -38,7 +38,8 @@ extension EngagementCoordinator.Environment {
         proximityManager: .mock,
         log: .mock,
         snackBar: .mock,
-        operatorRequestHandlerService: .mock()
+        operatorRequestHandlerService: .mock(),
+        maximumUploads: { 2 }
     )
 }
 #endif

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
@@ -40,5 +40,6 @@ extension EngagementCoordinator {
         var log: CoreSdkClient.Logger
         var snackBar: SnackBar
         var operatorRequestHandlerService: OperatorRequestHandlerService
+        var maximumUploads: () -> Int
     }
 }

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
@@ -273,7 +273,8 @@ extension EngagementCoordinator {
                 timerProviding: environment.timerProviding,
                 snackBar: environment.snackBar,
                 notificationCenter: environment.notificationCenter,
-                operatorRequestHandlerService: environment.operatorRequestHandlerService
+                operatorRequestHandlerService: environment.operatorRequestHandlerService,
+                maximumUploads: environment.maximumUploads
             ),
             startWithSecureTranscriptFlow: false
         )
@@ -511,7 +512,8 @@ extension EngagementCoordinator {
                 log: environment.log,
                 timerProviding: environment.timerProviding,
                 snackBar: environment.snackBar,
-                operatorRequestHandlerService: environment.operatorRequestHandlerService
+                operatorRequestHandlerService: environment.operatorRequestHandlerService,
+                maximumUploads: environment.maximumUploads
             )
         )
 

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Interface.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Interface.swift
@@ -50,6 +50,7 @@ extension Glia {
         var print: SwiftBased.Print
         var conditionalCompilation: ConditionalCompilationClient
         var snackBar: SnackBar
+        var processInfo: ProcessInfoHandling
     }
 }
 

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Live.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Live.swift
@@ -40,7 +40,8 @@ extension Glia.Environment {
         )),
         print: .live,
         conditionalCompilation: .live,
-        snackBar: .live
+        snackBar: .live,
+        processInfo: .live
     )
 }
 

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Mock.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Mock.swift
@@ -31,7 +31,8 @@ extension Glia.Environment {
         proximityManager: .mock,
         print: .mock,
         conditionalCompilation: .mock,
-        snackBar: .mock
+        snackBar: .mock,
+        processInfo: .mock()
     )
 }
 

--- a/GliaWidgets/Sources/ProcessInfoHandling/ProcessInfoHandling.Interface.swift
+++ b/GliaWidgets/Sources/ProcessInfoHandling/ProcessInfoHandling.Interface.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+struct ProcessInfoHandling {
+    var info: () -> [String: String]
+}
+
+extension ProcessInfoHandling {
+    enum Key: String {
+        /// `MAXIMUM_UPLOADS_PER_MESSAGE` is used in acceptance tests to decrease the time
+        /// for uploading maximum number of files in a single message.
+        case maximumUploads = "MAXIMUM_UPLOADS_PER_MESSAGE"
+    }
+}
+
+extension ProcessInfoHandling {
+    func value(for key: Key) -> String? {
+        info()[key.rawValue]
+    }
+}

--- a/GliaWidgets/Sources/ProcessInfoHandling/ProcessInfoHandling.Live.swift
+++ b/GliaWidgets/Sources/ProcessInfoHandling/ProcessInfoHandling.Live.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension ProcessInfoHandling {
+    static let live = Self {
+        ProcessInfo.processInfo.environment
+    }
+}

--- a/GliaWidgets/Sources/ProcessInfoHandling/ProcessInfoHandling.Mock.swift
+++ b/GliaWidgets/Sources/ProcessInfoHandling/ProcessInfoHandling.Mock.swift
@@ -1,0 +1,9 @@
+#if DEBUG
+import Foundation
+
+extension ProcessInfoHandling {
+    static func mock(info: @escaping () -> [String: String] = { [:] }) -> Self {
+        .init(info: info)
+    }
+}
+#endif

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Mock.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Mock.swift
@@ -12,7 +12,8 @@ extension ChatViewModel {
         startAction: StartAction = .startEngagement,
         deliveredStatusText: String = "Delivered",
         chatType: ChatViewModel.ChatType = .nonAuthenticated,
-        environment: Environment = .mock
+        environment: Environment = .mock,
+        maximumUploads: () -> Int = { 2 }
     ) -> ChatViewModel {
         ChatViewModel(
             interactor: interactor,
@@ -26,7 +27,8 @@ extension ChatViewModel {
             startAction: startAction,
             deliveredStatusText: deliveredStatusText,
             chatType: chatType,
-            environment: environment
+            environment: environment,
+            maximumUploads: maximumUploads
         )
     }
 }

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -4,8 +4,6 @@ class ChatViewModel: EngagementViewModel {
     typealias ActionCallback = (Action) -> Void
     typealias DelegateCallback = (DelegateEvent) -> Void
 
-    static let maximumUploads = 25
-
     var action: ActionCallback?
     var delegate: DelegateCallback?
     // Used to check whether custom card contains interactable metadata.
@@ -76,8 +74,8 @@ class ChatViewModel: EngagementViewModel {
         startAction: StartAction,
         deliveredStatusText: String,
         chatType: ChatType,
-        environment: Environment
-
+        environment: Environment,
+        maximumUploads: () -> Int
     ) {
         self.call = call
         self.showsCallBubble = showsCallBubble
@@ -85,7 +83,7 @@ class ChatViewModel: EngagementViewModel {
         self.startAction = startAction
         self.chatType = chatType
         let uploader = FileUploader(
-            maximumUploads: Self.maximumUploads,
+            maximumUploads: maximumUploads(),
             environment: .init(
                 uploadFile: .toEngagement(environment.uploadFileToEngagement),
                 fileManager: environment.fileManager,

--- a/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
+++ b/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
@@ -89,6 +89,10 @@ extension EngagementCoordinator.Environment {
         proximityManager: .failing,
         log: .failing,
         snackBar: .failing,
-        operatorRequestHandlerService: .failing
+        operatorRequestHandlerService: .failing,
+        maximumUploads: {
+            fail("\(Self.self).maximumUploads")
+            return 2
+        }
     )
 }

--- a/GliaWidgetsTests/Glia.Environment.Failing.swift
+++ b/GliaWidgetsTests/Glia.Environment.Failing.swift
@@ -60,7 +60,8 @@ extension Glia.Environment {
         proximityManager: .failing,
         print: .failing,
         conditionalCompilation: .failing,
-        snackBar: .failing
+        snackBar: .failing,
+        processInfo: .failing
     )
 }
 

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModel.Environment.Failing.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModel.Environment.Failing.swift
@@ -73,6 +73,10 @@ extension SecureConversations.TranscriptModel.Environment {
             fail("\(Self.self).createSendMessagePayload")
             return .mock()
         },
-        log: .failing
+        log: .failing,
+        maximumUploads: {
+            fail("\(Self.self).maximumUploads")
+            return 2
+        }
     )
 }

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+GVA.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+GVA.swift
@@ -84,6 +84,7 @@ extension SecureConversationsTranscriptModelTests {
         modelEnv.createFileUploadListModel = { _ in .mock() }
         modelEnv.listQueues = { callback in callback([], nil) }
         modelEnv.uiApplication.canOpenURL = { _ in true }
+        modelEnv.maximumUploads = { 2 }
         var logger = CoreSdkClient.Logger.failing
         logger.prefixedClosure = { _ in logger }
         logger.infoClosure = { _, _, _, _ in }
@@ -149,6 +150,7 @@ private extension SecureConversationsTranscriptModelTests {
         modelEnv.createFileUploadListModel = { _ in .mock() }
         modelEnv.listQueues = { callback in callback([], nil) }
         modelEnv.uiApplication.canOpenURL = { _ in true }
+        modelEnv.maximumUploads = { 2 }
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
             queueIds: modelEnv.queueIds,

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+URLs.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+URLs.swift
@@ -85,6 +85,7 @@ private extension SecureConversationsTranscriptModelTests {
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in .mock() }
         modelEnv.listQueues = { callback in callback([], nil) }
+        modelEnv.maximumUploads = { 2 }
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
             queueIds: modelEnv.queueIds,

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests.swift
@@ -14,6 +14,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in .mock() }
         modelEnv.listQueues = { callback in callback([], nil) }
+        modelEnv.maximumUploads = { 2 }
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
             queueIds: modelEnv.queueIds,
@@ -42,6 +43,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in .mock() }
         modelEnv.listQueues = { callback in callback(nil, .mock()) }
+        modelEnv.maximumUploads = { 2 }
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
             queueIds: modelEnv.queueIds,
@@ -69,6 +71,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.getSecureUnreadMessageCount = { _ in }
         modelEnv.startSocketObservation = {}
+        modelEnv.maximumUploads = { 2 }
         let site = try CoreSdkClient.Site.mock(allowedFileSenders: .mock(visitor: true))
         modelEnv.fetchSiteConfigurations = { callback in
             callback(.success(site))
@@ -101,6 +104,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in .mock() }
         modelEnv.listQueues = { _ in }
+        modelEnv.maximumUploads = { 2 }
         enum Call: String, Equatable {
             case fetchChatHistory
             case loadSiteConfiguration
@@ -149,6 +153,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.fetchSiteConfigurations = { _ in }
         modelEnv.getSecureUnreadMessageCount = { _ in  }
         modelEnv.startSocketObservation = {}
+        modelEnv.maximumUploads = { 2 }
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
             queueIds: modelEnv.queueIds,
@@ -194,6 +199,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
         modelEnv.getSecureUnreadMessageCount = { _ in  }
+        modelEnv.maximumUploads = { 2 }
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
             queueIds: modelEnv.queueIds,
@@ -234,6 +240,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
         modelEnv.getSecureUnreadMessageCount = { _ in  }
+        modelEnv.maximumUploads = { 2 }
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
             queueIds: modelEnv.queueIds,
@@ -270,6 +277,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
         modelEnv.getSecureUnreadMessageCount = { _ in  }
+        modelEnv.maximumUploads = { 2 }
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
             queueIds: modelEnv.queueIds,
@@ -306,6 +314,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.createSendMessagePayload = {
             .mock(messageIdSuffix: "mock", content: $0, attachment: $1)
         }
+        modelEnv.maximumUploads = { 2 }
         enum Call: Equatable { case sendSecureMessagePayload }
         var calls: [Call] = []
         modelEnv.sendSecureMessagePayload = { _, _, _ in
@@ -344,6 +353,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
         modelEnv.startSocketObservation = {}
+        modelEnv.maximumUploads = { 2 }
         enum Call: Equatable { case getSecureUnreadMessageCount }
         var calls: [Call] = []
         modelEnv.getSecureUnreadMessageCount = { _ in
@@ -378,6 +388,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in fileUploadListModel }
         modelEnv.listQueues = { _ in }
+        modelEnv.maximumUploads = { 2 }
         modelEnv.fetchChatHistory = { callback in
             callback(.success([.mock(sender: .operator)]))
         }
@@ -430,6 +441,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.listQueues = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
         modelEnv.fetchChatHistory = { _ in }
+        modelEnv.maximumUploads = { 2 }
         modelEnv.getSecureUnreadMessageCount = { callback in
             callback(.success(0))
         }
@@ -494,6 +506,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.listQueues = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
         modelEnv.fetchChatHistory = { _ in }
+        modelEnv.maximumUploads = { 2 }
         modelEnv.getSecureUnreadMessageCount = { callback in
             callback(.success(0))
         }
@@ -552,6 +565,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
     func testIsSecureConversationsAvailableIsFalseIsDueToEmptyQueue() {
         var modelEnvironment = TranscriptModel.Environment.failing
         modelEnvironment.fileManager = .mock
+        modelEnvironment.maximumUploads = { 2 }
         modelEnvironment.createFileUploadListModel = {
             .mock(environment: $0)
         }
@@ -582,6 +596,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         logger.infoClosure = { _, _, _, _ in }
         modelEnvironment.log = logger
         modelEnvironment.fileManager = .mock
+        modelEnvironment.maximumUploads = { 2 }
         modelEnvironment.createFileUploadListModel = {
             .mock(environment: $0)
         }
@@ -608,6 +623,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         logger.infoClosure = { _, _, _, _ in }
         modelEnvironment.log = logger
         modelEnvironment.fileManager = .mock
+        modelEnvironment.maximumUploads = { 2 }
         modelEnvironment.createFileUploadListModel = {
             .mock(environment: $0)
         }
@@ -634,6 +650,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         logger.infoClosure = { _, _, _, _ in }
         modelEnvironment.log = logger
         modelEnvironment.fileManager = .mock
+        modelEnvironment.maximumUploads = { 2 }
         modelEnvironment.createFileUploadListModel = {
             .mock(environment: $0)
         }
@@ -660,6 +677,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         logger.infoClosure = { _, _, _, _ in }
         modelEnvironment.log = logger
         modelEnvironment.fileManager = .mock
+        modelEnvironment.maximumUploads = { 2 }
         modelEnvironment.createFileUploadListModel = {
             .mock(environment: $0)
         }

--- a/GliaWidgetsTests/SecureConversations/Coordinator/SecureConversations.Coordinator.Environment.Mock.swift
+++ b/GliaWidgetsTests/SecureConversations/Coordinator/SecureConversations.Coordinator.Environment.Mock.swift
@@ -49,6 +49,7 @@ extension SecureConversations.Coordinator.Environment {
             present: { text, style, viewController, bottomOffset, timerProviding, gcd, notificationCenter in
             }
         ),
-        operatorRequestHandlerService: .mock()
+        operatorRequestHandlerService: .mock(), 
+        maximumUploads: { 2 }
     )
 }

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -65,7 +65,8 @@ class ChatViewModelTests: XCTestCase {
                 proximityManager: .mock,
                 log: .mock,
                 operatorRequestHandlerService: .mock()
-            )
+            ),
+            maximumUploads: { 2 }
         )
 
         viewModel.sendChoiceCardResponse(choiceCardMock, to: "mocked-message-id")
@@ -430,6 +431,7 @@ class ChatViewModelTests: XCTestCase {
 
         var transcriptModelEnv = TranscriptModel.Environment.failing
         transcriptModelEnv.fileManager = fileManager
+        transcriptModelEnv.maximumUploads = { 2 }
         var uploaderEnv = FileUploader.Environment.failing
         uploaderEnv.fileManager = fileManager
         let transcriptFileUploadListModelEnv = FileUploadListViewModel.Environment.failing(
@@ -442,6 +444,7 @@ class ChatViewModelTests: XCTestCase {
         let transcriptFileUploadListModel = FileUploadListViewModel(environment: transcriptFileUploadListModelEnv)
         transcriptModelEnv.createFileUploadListModel = { _ in transcriptFileUploadListModel }
         transcriptModelEnv.listQueues = { callback in callback([], nil) }
+        transcriptModelEnv.maximumUploads = { 2 }
         var logger = CoreSdkClient.Logger.failing
         logger.prefixedClosure = { _ in logger }
         logger.infoClosure = { _, _, _, _ in }

--- a/GliaWidgetsTests/Sources/Coordinators/Chat/ChatCoordinator.Environment.Mock.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/Chat/ChatCoordinator.Environment.Mock.swift
@@ -38,6 +38,7 @@ extension ChatCoordinator.Environment {
         timerProviding: .mock,
         snackBar: .mock,
         notificationCenter: .mock,
-        operatorRequestHandlerService: .mock()
+        operatorRequestHandlerService: .mock(),
+        maximumUploads: { 2 }
     )
 }

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -65,6 +65,7 @@ final class GliaTests: XCTestCase {
         gliaEnv.coreSdk.createLogger = { _ in logger }
         gliaEnv.conditionalCompilation.isDebug = { true }
         gliaEnv.print = .mock
+        gliaEnv.processInfo.info = { [:] } 
         var proximityManagerEnv = ProximityManager.Environment.failing
         proximityManagerEnv.uiDevice.isProximityMonitoringEnabled = { _ in }
         proximityManagerEnv.uiApplication.isIdleTimerDisabled = { _ in }

--- a/GliaWidgetsTests/Sources/ProcessInfoHandling/ProcessInfoHandling.Failing.swift
+++ b/GliaWidgetsTests/Sources/ProcessInfoHandling/ProcessInfoHandling.Failing.swift
@@ -1,0 +1,9 @@
+import Foundation
+@testable import GliaWidgets
+
+extension ProcessInfoHandling {
+    static let failing = Self {
+        fail("\(Self.self).info")
+        return [:]
+    }
+}


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-2646

**What was solved?**
Adding this variable gives a way to adjust maximum amount of files that can be attached to a single message. This is needed to make the test checking whether the attachment button is disabled when maximum number of file is attached shorter. This variable will be passed through `processInfo` from acceptance test.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
