### PR TITLE
Snackbar is out of bounds when cv engagement is established

### DIFF
--- a/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
@@ -490,6 +490,7 @@ private extension CallVisualizer.Coordinator {
             text: style.text,
             style: style,
             for: topMostViewController,
+            bottomOffset: -60,
             timerProviding: environment.timerProviding,
             gcd: environment.gcd,
             notificationCenter: environment.notificationCenter


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-xxx

**What was solved?**
Snackbar is out of bounds after cv engagement is established. This happened because we tweaked the implementation for ChatView, where snackbar was covering text entry field.
**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
