### PR TITLE
CallVisualizer views do not close upon ending engagement

### DIFF
--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -104,7 +104,9 @@ public class Glia {
             proximityManager: environment.proximityManager,
             log: loggerPhase.logger,
             fetchSiteConfigurations: environment.coreSdk.fetchSiteConfigurations,
-            snackBar: environment.snackBar
+            snackBar: environment.snackBar,
+            coreSdk: environment.coreSdk,
+            operatorRequestHandlerService: operatorRequestHandlerService
         )
     )
     var rootCoordinator: EngagementCoordinator?
@@ -199,6 +201,10 @@ public class Glia {
             switch action {
             case .visitorCodeIsRequested:
                 self.setupInteractor(configuration: configuration)
+            case .engagementStarted:
+                self.onEvent?(.started)
+            case .engagementEnded:
+                self.onEvent?(.ended)
             }
         }
 
@@ -408,60 +414,6 @@ public class Glia {
 // MARK: - Internal
 
 extension Glia {
-    internal func startObservingInteractorEvents() {
-        interactor?.addObserver(self) { [weak self] event in
-            guard
-                let engagement = self?.environment.coreSdk.getCurrentEngagement(),
-                engagement.source == .callVisualizer
-            else {
-                switch event {
-                case let .onEngagementRequest(action):
-                    self?.callVisualizer.handleEngagementRequestAccepted(action)
-                default: return
-                }
-                return
-            }
-
-            switch event {
-            case .screenShareOffer(answer: let answer):
-                self?.environment.coreSdk.requestEngagedOperator { operators, _ in
-                    self?.operatorRequestHandlerService.offerScreenShare(
-                        from: operators?.compactMap { $0.name }.joined(separator: ", ") ?? "",
-                        accepted: { [weak self] in
-                            self?.callVisualizer.observeScreenSharingHandlerState()
-                        },
-                        answer: answer
-                    )
-                }
-            case let .upgradeOffer(offer, answer):
-                self?.environment.coreSdk.requestEngagedOperator { operators, _ in
-                    self?.operatorRequestHandlerService.offerMediaUpgrade(
-                        from: operators?.compactMap { $0.name }.joined(separator: ", ") ?? "",
-                        offer: offer,
-                        accepted: { [weak self] in
-                            self?.callVisualizer.handleAcceptedUpgrade()
-                        },
-                        answer: answer
-                    )
-                }
-            case let .videoStreamAdded(stream):
-                self?.callVisualizer.addVideoStream(stream: stream)
-            case let .stateChanged(state):
-                if case .ended = state {
-                    self?.callVisualizer.endSession()
-                    self?.onEvent?(.ended)
-                    self?.loggerPhase.logger.prefixed(Self.self).info("Engagement ended")
-                } else if case .engaged = state {
-                    self?.loggerPhase.logger.prefixed(Self.self).info("New Call visualizer engagement loaded")
-                    self?.onEvent?(.started)
-                    self?.loggerPhase.logger.prefixed(Self.self).info("Engagement started")
-                }
-            default:
-                break
-            }
-        }
-    }
-
     @discardableResult
     func setupInteractor(
         configuration: Configuration,
@@ -484,7 +436,7 @@ extension Glia {
         environment.coreSDKConfigurator.configureWithInteractor(interactor)
         self.interactor = interactor
 
-        startObservingInteractorEvents()
+        self.callVisualizer.startObservingInteractorEvents()
         return interactor
     }
 }

--- a/GliaWidgets/Sources/CallVisualizer/CallVisualizer+Action.swift
+++ b/GliaWidgets/Sources/CallVisualizer/CallVisualizer+Action.swift
@@ -3,5 +3,7 @@ import Foundation
 extension CallVisualizer {
     enum Action {
         case visitorCodeIsRequested
+        case engagementStarted
+        case engagementEnded
     }
 }

--- a/GliaWidgets/Sources/CallVisualizer/CallVisualizer+Environment.swift
+++ b/GliaWidgets/Sources/CallVisualizer/CallVisualizer+Environment.swift
@@ -28,5 +28,7 @@ extension CallVisualizer {
         var log: CoreSdkClient.Logger
         var fetchSiteConfigurations: CoreSdkClient.FetchSiteConfigurations
         var snackBar: SnackBar
+        var coreSdk: CoreSdkClient
+        var operatorRequestHandlerService: OperatorRequestHandlerService
     }
 }

--- a/GliaWidgetsTests/CallVisualizer/ScreenSharing/Mocks/CallVisualizer.Environment.Mock.swift
+++ b/GliaWidgetsTests/CallVisualizer/ScreenSharing/Mocks/CallVisualizer.Environment.Mock.swift
@@ -26,7 +26,9 @@ extension CallVisualizer.Environment {
         proximityManager: .mock,
         log: .mock,
         fetchSiteConfigurations: { _ in },
-        snackBar: .mock
+        snackBar: .mock,
+        coreSdk: .mock,
+        operatorRequestHandlerService: .mock()
     )
 }
 


### PR DESCRIPTION
MOB-3114

**Jira issue:**
https://glia.atlassian.net/browse/MOB-3114

**What was solved?**
CV was broken and the views didn't close when CV engagement had ended, leaving the views in a limbo where they didn't function but were present. This was caused by not observing interaction events, and checking if CV engagement was present before acting on specific interaction event. This was contradicting because if engagement had ended, current engagement couldn't be CV anymore.
**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
