### PR TITLE
Call visualizer views did not close on engagement ending

### DIFF
--- a/GliaWidgets/Sources/CallVisualizer/CallVisualizer+Action.swift
+++ b/GliaWidgets/Sources/CallVisualizer/CallVisualizer+Action.swift
@@ -3,5 +3,7 @@ import Foundation
 extension CallVisualizer {
     enum Action {
         case visitorCodeIsRequested
+        case engagementStarted
+        case engagementEnded
     }
 }

--- a/GliaWidgets/Sources/CallVisualizer/CallVisualizer+Environment.swift
+++ b/GliaWidgets/Sources/CallVisualizer/CallVisualizer+Environment.swift
@@ -28,5 +28,7 @@ extension CallVisualizer {
         var log: CoreSdkClient.Logger
         var fetchSiteConfigurations: CoreSdkClient.FetchSiteConfigurations
         var snackBar: SnackBar
+        var coreSdk: CoreSdkClient
+        var operatorRequestHandlerService: OperatorRequestHandlerService
     }
 }

--- a/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
+++ b/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
@@ -134,7 +134,7 @@ extension CallVisualizer {
 
     func endSession() {
         coordinator.end()
-        stopObservingInteractorEvents()
+        delegate?(.engagementEnded)
     }
 
     func handleRestoredEngagement() {
@@ -151,21 +151,58 @@ extension CallVisualizer {
 extension CallVisualizer {
     func startObservingInteractorEvents() {
         environment.interactorProviding()?.addObserver(self) { [weak self] event in
-            guard let engagement = self?.environment.getCurrentEngagement(), engagement.source == .callVisualizer else {
+            if case .stateChanged(.ended(.byOperator)) = event {
+                self?.endSession()
+                self?.environment.log.prefixed(Self.self).info("Call visualizer engagement ended")
+            }
+
+            guard
+                let engagement = self?.environment.getCurrentEngagement(),
+                engagement.source == .callVisualizer
+            else {
+                switch event {
+                case let .onEngagementRequest(action):
+                    self?.handleEngagementRequestAccepted(action)
+                default: return
+                }
                 return
             }
+
             switch event {
+            case .screenShareOffer(answer: let answer):
+                self?.environment.coreSdk.requestEngagedOperator { operators, _ in
+                    self?.environment.operatorRequestHandlerService.offerScreenShare(
+                        from: operators?.compactMap { $0.name }.joined(separator: ", ") ?? "",
+                        accepted: { [weak self] in
+                            self?.observeScreenSharingHandlerState()
+                        },
+                        answer: answer
+                    )
+                }
+            case let .upgradeOffer(offer, answer):
+                self?.environment.coreSdk.requestEngagedOperator { operators, _ in
+                    self?.environment.operatorRequestHandlerService.offerMediaUpgrade(
+                        from: operators?.compactMap { $0.name }.joined(separator: ", ") ?? "",
+                        offer: offer,
+                        accepted: { [weak self] in
+                            self?.handleAcceptedUpgrade()
+                        },
+                        answer: answer
+                    )
+                }
+            case let .videoStreamAdded(stream):
+                self?.addVideoStream(stream: stream)
+            case let .stateChanged(state):
+                if case .engaged = state {
+                    self?.environment.log.prefixed(Self.self).info("New Call visualizer engagement loaded")
+                    self?.delegate?(.engagementStarted)
+                    self?.environment.log.prefixed(Self.self).info("Engagement started")
+                }
             case let .screenSharingStateChanged(state):
                 self?.environment.screenShareHandler.updateState(state)
-            case .stateChanged(.ended):
-                self?.environment.log.prefixed(Self.self).info("Call visualizer engagement ended")
             default:
                 break
             }
         }
-    }
-
-    func stopObservingInteractorEvents() {
-        environment.interactorProviding()?.removeObserver(self)
     }
 }

--- a/GliaWidgetsTests/CallVisualizer/ScreenSharing/Mocks/CallVisualizer.Environment.Mock.swift
+++ b/GliaWidgetsTests/CallVisualizer/ScreenSharing/Mocks/CallVisualizer.Environment.Mock.swift
@@ -26,7 +26,9 @@ extension CallVisualizer.Environment {
         proximityManager: .mock,
         log: .mock,
         fetchSiteConfigurations: { _ in },
-        snackBar: .mock
+        snackBar: .mock,
+        coreSdk: .mock,
+        operatorRequestHandlerService: .mock()
     )
 }
 


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3114

**What was solved?**
CV was broken and the views didn't close when CV engagement had ended, leaving the views in limbo where they didn't function but were present. This was caused by not observing interaction events, and checking if CV engagement was present before acting on specific interaction events. This was contradicting because if the engagement had ended, the current engagement couldn't be CV anymore.

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
