### PR TITLE
Enable visitor video by default

### DIFF
--- a/GliaWidgets/Sources/ViewModel/Call/CallViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Call/CallViewModel.swift
@@ -323,18 +323,8 @@ extension CallViewModel {
     private func showLocalVideo(with stream: CoreSdkClient.VideoStreamable) {
         action?(.switchToVideoMode)
         action?(.setLocalVideo(stream.getStreamView()))
-        stream.onHold = { [weak stream, environment] isOnHold in
-            // onHold case is not handled deliberately because it
-            // is handled elsewhere. This logic may need some adjustments
-            // in future
-            if !isOnHold {
-                if let stream = stream {
-                    stream.playVideo()
-                } else {
-                    environment.log.warning("Video stream is not available to be resumed after on-hold.")
-                }
-            }
-        }
+        guard call.isVisitorOnHold.value == false else { return }
+        stream.playVideo()
     }
 
     private func hideRemoteVideo() {


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3146

**What was solved?**
This PR enables visitor video by default unless the visitor is on hold, in which case visitor video will be enabled only after the hold is lifted.
**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
