### PR TITLE
Add unit tests to EngagementCoordinator chat functionality

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -191,6 +191,8 @@
 		315BAB1E29ADFED800FF284B /* ConfirmationStyle+CheckMessagesButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 315BAB1D29ADFED800FF284B /* ConfirmationStyle+CheckMessagesButtonStyle.swift */; };
 		31758EC02B5E9E22007BBD9F /* VideoCallCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31758EBE2B5E9E22007BBD9F /* VideoCallCoordinatorTests.swift */; };
 		31758EC12B5E9E22007BBD9F /* CallVisualizer.VideoCallCoordinator.Environment.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31758EBF2B5E9E22007BBD9F /* CallVisualizer.VideoCallCoordinator.Environment.Mock.swift */; };
+		31758EC42B5FB192007BBD9F /* EngagementCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31758EC32B5FB192007BBD9F /* EngagementCoordinatorTests.swift */; };
+		31758EC62B5FC182007BBD9F /* SceneProvider.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31758EC52B5FC182007BBD9F /* SceneProvider.Mock.swift */; };
 		31882C9B2AA21B71009DE4BD /* Localization+Templates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31882C9A2AA21B71009DE4BD /* Localization+Templates.swift */; };
 		3189DD9429DEFAC600D68E9F /* SecureConversations.WelcomeViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3189DD9329DEFAC600D68E9F /* SecureConversations.WelcomeViewModelSpec.swift */; };
 		3189DD9629E4331200D68E9F /* SecureConversations.WelcomeViewModel.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3189DD9529E4331200D68E9F /* SecureConversations.WelcomeViewModel.Mock.swift */; };
@@ -992,6 +994,8 @@
 		315BAB1D29ADFED800FF284B /* ConfirmationStyle+CheckMessagesButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConfirmationStyle+CheckMessagesButtonStyle.swift"; sourceTree = "<group>"; };
 		31758EBE2B5E9E22007BBD9F /* VideoCallCoordinatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoCallCoordinatorTests.swift; sourceTree = "<group>"; };
 		31758EBF2B5E9E22007BBD9F /* CallVisualizer.VideoCallCoordinator.Environment.Mock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CallVisualizer.VideoCallCoordinator.Environment.Mock.swift; sourceTree = "<group>"; };
+		31758EC32B5FB192007BBD9F /* EngagementCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngagementCoordinatorTests.swift; sourceTree = "<group>"; };
+		31758EC52B5FC182007BBD9F /* SceneProvider.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneProvider.Mock.swift; sourceTree = "<group>"; };
 		31882C9A2AA21B71009DE4BD /* Localization+Templates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Localization+Templates.swift"; sourceTree = "<group>"; };
 		3189DD9329DEFAC600D68E9F /* SecureConversations.WelcomeViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.WelcomeViewModelSpec.swift; sourceTree = "<group>"; };
 		3189DD9529E4331200D68E9F /* SecureConversations.WelcomeViewModel.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.WelcomeViewModel.Mock.swift; sourceTree = "<group>"; };
@@ -2742,6 +2746,14 @@
 			path = ConfirmationStyle;
 			sourceTree = "<group>";
 		};
+		31758EC22B5FB155007BBD9F /* EngagementCoordinator */ = {
+			isa = PBXGroup;
+			children = (
+				31758EC32B5FB192007BBD9F /* EngagementCoordinatorTests.swift */,
+			);
+			path = EngagementCoordinator;
+			sourceTree = "<group>";
+		};
 		3189DD9229DEF62600D68E9F /* Welcome */ = {
 			isa = PBXGroup;
 			children = (
@@ -2789,6 +2801,7 @@
 		31FF0DC72B5907C600834AFB /* Coordinators */ = {
 			isa = PBXGroup;
 			children = (
+				31758EC22B5FB155007BBD9F /* EngagementCoordinator */,
 				31FF0DCD2B5A88E700834AFB /* Call */,
 				31FF0DC82B5907C600834AFB /* Chat */,
 			);
@@ -3544,6 +3557,7 @@
 			isa = PBXGroup;
 			children = (
 				8491AF622AA20F9D00CC3E72 /* GliaViewControllerDelegateMock.swift */,
+				31758EC52B5FC182007BBD9F /* SceneProvider.Mock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -5223,6 +5237,7 @@
 				C03A8049292BC8DB00DDECA6 /* CallViewControllerTests.swift in Sources */,
 				84D5B9662A15204400807F92 /* QuickLookBased.Failing.swift in Sources */,
 				84602A772AEA5BEA0031E606 /* ProximityManager.Failing.swift in Sources */,
+				31758EC62B5FC182007BBD9F /* SceneProvider.Mock.swift in Sources */,
 				753B05F82AFC1D750084611E /* SerialQueueTests.swift in Sources */,
 				31B278032B55BE670021DEC1 /* SecureConversations.WelcomeViewController.Mock.swift in Sources */,
 				84681A982A61853300DD7406 /* GvaOption.Mock.swift in Sources */,
@@ -5297,6 +5312,7 @@
 				8491AF672AB8707600CC3E72 /* ChatViewModelTests+Transferring.swift in Sources */,
 				AFEF5C7429929A8D005C3D8D /* SecureConversations.FileUploadListViewModel.Environment.Failing.swift in Sources */,
 				AFF9542C2ADDA10600C277E0 /* CoreSDKConfigurator.Failing.swift in Sources */,
+				31758EC42B5FB192007BBD9F /* EngagementCoordinatorTests.swift in Sources */,
 				9A3E1D9D27BA7741005634EB /* FoundationBased.Failing.swift in Sources */,
 				9A3E1D8427B67F1B005634EB /* Helper.swift in Sources */,
 				C0175A0F2A55A624001FACDE /* ChatMessagaEntryViewTests.swift in Sources */,

--- a/GliaWidgets.xcodeproj/xcshareddata/xcschemes/GliaWidgetsTests.xcscheme
+++ b/GliaWidgets.xcodeproj/xcshareddata/xcschemes/GliaWidgetsTests.xcscheme
@@ -10,7 +10,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/GliaWidgets/Sources/Coordinator/SubFlowCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinator/SubFlowCoordinator.swift
@@ -1,9 +1,11 @@
 import Foundation
 
 class SubFlowCoordinator {
-    private var subFlowCoordinators = [Any]()
+    private var subFlowCoordinators: [any FlowCoordinator] = []
 
-    func pushCoordinator<T: FlowCoordinator>(_ coordinator: T) {
+    var coordinators: [any FlowCoordinator] { subFlowCoordinators }
+
+    func pushCoordinator(_ coordinator: any FlowCoordinator) {
         subFlowCoordinators.append(coordinator)
     }
 

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
@@ -10,7 +10,7 @@ class EngagementCoordinator: SubFlowCoordinator, FlowCoordinator {
     }
 
     var gliaViewController: GliaViewController?
-    private let interactor: Interactor
+    let interactor: Interactor
     private let viewFactory: ViewFactory
     private weak var sceneProvider: SceneProvider?
     private var engagement: Engagement = .none
@@ -20,8 +20,8 @@ class EngagementCoordinator: SubFlowCoordinator, FlowCoordinator {
     private let screenShareHandler: ScreenShareHandler
 
     private let navigationController = NavigationController()
-    private let navigationPresenter: NavigationPresenter
-    private let gliaPresenter: GliaPresenter
+    let navigationPresenter: NavigationPresenter
+    let gliaPresenter: GliaPresenter
     private let kBubbleViewSize: CGFloat = 60.0
     private let features: Features
     private let environment: Environment
@@ -50,7 +50,6 @@ class EngagementCoordinator: SubFlowCoordinator, FlowCoordinator {
 
     // swiftlint:disable function_body_length
     func start() {
-
         switch engagementKind {
         case .none:
             break
@@ -699,7 +698,7 @@ extension EngagementKind {
 }
 
 extension EngagementCoordinator {
-    enum DelegateEvent {
+    enum DelegateEvent: Equatable {
         case started
         case engagementChanged(EngagementKind)
         case ended

--- a/GliaWidgets/Sources/Presenter/GliaPresenter.swift
+++ b/GliaWidgets/Sources/Presenter/GliaPresenter.swift
@@ -15,7 +15,7 @@ final class GliaPresenter {
         }
     }()
 
-    private var topMostViewController: UIViewController {
+    var topMostViewController: UIViewController {
         guard let window = window else {
             fatalError("Could not find key UIWindow to present on")
         }

--- a/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinatorTests.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinatorTests.swift
@@ -1,0 +1,312 @@
+import Foundation
+import XCTest
+@testable import GliaWidgets
+
+final class EngagementCoordinatorTests: XCTestCase {
+    var coordinator: EngagementCoordinator!
+    var closuresForTearDown: [() -> Void] = []
+
+    override func setUp() {
+        UIView.setAnimationsEnabled(false)
+        coordinator = createCoordinator()
+    }
+
+    override func tearDown() {
+        for closure in closuresForTearDown {
+            closure()
+        }
+
+        UIView.setAnimationsEnabled(true)
+    }
+
+    func createCoordinator(
+        withKind engagementKind: EngagementKind = .chat
+    ) -> EngagementCoordinator {
+        return EngagementCoordinator(
+            interactor: .mock(),
+            viewFactory: .mock(),
+            sceneProvider: MockedSceneProvider(),
+            engagementKind: engagementKind,
+            screenShareHandler: .mock,
+            features: [],
+            environment: .mock
+        )
+    }
+
+    // Start
+
+    func test_startText() throws {
+        var calledEvents: [EngagementCoordinator.DelegateEvent] = []
+
+        coordinator.delegate = { event in
+            calledEvents.append(event)
+        }
+
+        coordinator.start()
+
+        XCTAssertEqual(coordinator.interactor.state, .enqueueing(.text))
+        let viewController = coordinator.navigationPresenter.viewControllers.first as? ChatViewController
+        XCTAssertNotNil(viewController)
+        XCTAssertNotNil(coordinator.gliaViewController)
+
+        XCTAssertEqual(calledEvents.count, 1)
+        XCTAssertEqual(calledEvents.first, .started)
+    }
+
+    func test_startAudioCall() throws {
+        let coordinator = createCoordinator(withKind: .audioCall)
+        var calledEvents: [EngagementCoordinator.DelegateEvent] = []
+
+        coordinator.delegate = { event in
+            calledEvents.append(event)
+        }
+
+        coordinator.start()
+
+        XCTAssertEqual(coordinator.interactor.state, .enqueueing(.audio))
+        let viewController = coordinator.navigationPresenter.viewControllers.first as? CallViewController
+        XCTAssertNotNil(viewController)
+        XCTAssertNotNil(coordinator.gliaViewController)
+
+        XCTAssertEqual(calledEvents.count, 1)
+        XCTAssertEqual(calledEvents.first, .started)
+    }
+
+    func test_startVideoCall() throws {
+        let coordinator = createCoordinator(withKind: .videoCall)
+        var calledEvents: [EngagementCoordinator.DelegateEvent] = []
+
+        coordinator.delegate = { event in
+            calledEvents.append(event)
+        }
+
+        coordinator.start()
+
+        XCTAssertEqual(coordinator.interactor.state, .enqueueing(.video))
+        let viewController = coordinator.navigationPresenter.viewControllers.first as? CallViewController
+        XCTAssertNotNil(viewController)
+        XCTAssertNotNil(coordinator.gliaViewController)
+
+        XCTAssertEqual(calledEvents.count, 1)
+        XCTAssertEqual(calledEvents.first, .started)
+    }
+
+    func test_startMessagingWelcome() throws {
+        let coordinator = createCoordinator(withKind: .messaging(.welcome))
+        var calledEvents: [EngagementCoordinator.DelegateEvent] = []
+
+        coordinator.delegate = { event in
+            calledEvents.append(event)
+        }
+
+        coordinator.start()
+
+        XCTAssertEqual(coordinator.interactor.state, .none)
+        let viewController = coordinator.navigationPresenter.viewControllers.first as? SecureConversations.WelcomeViewController
+        XCTAssertNotNil(viewController)
+        XCTAssertNotNil(coordinator.gliaViewController)
+
+        XCTAssertEqual(calledEvents.count, 1)
+        XCTAssertEqual(calledEvents.first, .started)
+    }
+
+    func test_startMessagingChatTranscript() throws {
+        let coordinator = createCoordinator(withKind: .messaging(.chatTranscript))
+        var calledEvents: [EngagementCoordinator.DelegateEvent] = []
+
+        coordinator.delegate = { event in
+            calledEvents.append(event)
+        }
+
+        coordinator.start()
+
+        XCTAssertEqual(coordinator.interactor.state, .none)
+        let viewController = coordinator.navigationPresenter.viewControllers.first as? ChatViewController
+        XCTAssertNotNil(viewController)
+        XCTAssertNotNil(coordinator.gliaViewController)
+
+        XCTAssertEqual(calledEvents.count, 1)
+        XCTAssertEqual(calledEvents.first, .started)
+    }
+
+    // End
+
+    func test_endChatWithSurvey() throws {
+        let survey: CoreSdkClient.Survey = try .mock()
+        coordinator.interactor.currentEngagement = .mock(fetchSurvey: { _, completion in completion(.success(survey)) })
+        coordinator.end()
+
+        let surveyViewController = coordinator.gliaPresenter.topMostViewController as? Survey.ViewController
+        XCTAssertNotNil(surveyViewController)
+    }
+
+    func test_endChatWithoutSurvey() throws {
+        var calledEvents: [EngagementCoordinator.DelegateEvent] = []
+
+        coordinator.delegate = { event in
+            calledEvents.append(event)
+        }
+
+        let survey: CoreSdkClient.Survey = try .mock()
+        coordinator.start()
+
+        try showGliaViewController()
+
+        coordinator.interactor.currentEngagement = .mock(fetchSurvey: { _, completion in completion(.success(survey)) })
+        coordinator.end(surveyPresentation: .doNotPresentSurvey)
+
+        callAfterTimeout {
+            XCTAssertEqual(self.coordinator.navigationPresenter.viewControllers.count, 0)
+            XCTAssertEqual(self.coordinator.engagementKind, .none)
+            XCTAssertTrue(calledEvents.contains(.ended))
+        }
+    }
+
+    // Chat coordinator delegate events
+
+    func test_chatCoordinatorBackOnInteractorStateNone() {
+        coordinator.start()
+        coordinator.interactor.state = .none
+        
+        XCTAssertNotEqual(coordinator.coordinators.count, 0)
+
+        let chatCoordinator = coordinator.coordinators.last as? ChatCoordinator
+
+        chatCoordinator?.delegate?(.back)
+        let flowCoordinator = coordinator.coordinators.last
+
+        XCTAssertNil(flowCoordinator)
+    }
+
+    func test_chatCoordinatorBackOnInteractorStateAny() {
+        var calledEvents: [EngagementCoordinator.DelegateEvent] = []
+
+        coordinator.delegate = { event in
+            calledEvents.append(event)
+        }
+
+        coordinator.start()
+
+        let chatCoordinator = coordinator.coordinators.last as? ChatCoordinator
+        chatCoordinator?.delegate?(.back)
+        
+        callAfterTimeout {
+            XCTAssertEqual(calledEvents.last, .minimized)
+        }
+    }
+
+    func test_chatCoordinatorBackCall() {
+        coordinator = createCoordinator(withKind: .audioCall)
+
+        var calledEvents: [EngagementCoordinator.DelegateEvent] = []
+        coordinator.delegate = { event in
+            calledEvents.append(event)
+        }
+
+        coordinator.start()
+
+        let chatCoordinator = coordinator.coordinators.last as? ChatCoordinator
+        chatCoordinator?.delegate?(.back)
+
+        callAfterTimeout {
+            XCTAssertNotNil(coordinator.navigationPresenter.viewControllers.first as? EngagementViewController)
+        }
+    }
+
+    func test_chatCoordinatorBackCallFromChat() throws {
+        var calledEvents: [EngagementCoordinator.DelegateEvent] = []
+
+        coordinator.delegate = { event in
+            calledEvents.append(event)
+        }
+
+        coordinator.start()
+
+        let chatCoordinator = coordinator.coordinators.last as? ChatCoordinator
+
+        let mediaUpgradeOffer = try! CoreSdkClient.MediaUpgradeOffer(type: .audio, direction: .twoWay)
+        chatCoordinator?.delegate?(
+            .mediaUpgradeAccepted(
+                offer: mediaUpgradeOffer,
+                answer: { answer, success in success?(true, nil) }
+            )
+        )
+        chatCoordinator?.delegate?(.back)
+
+        callAfterTimeout {
+            XCTAssertEqual(calledEvents.last, .minimized)
+        }
+    }
+
+    func test_chatCoordinatorEngaged() throws {
+        var calledEvents: [EngagementCoordinator.DelegateEvent] = []
+
+        coordinator.delegate = { event in
+            calledEvents.append(event)
+        }
+
+        coordinator.start()
+
+        try showGliaViewController()
+        let chatCoordinator = coordinator.coordinators.last as? ChatCoordinator
+        chatCoordinator?.delegate?(.engaged(operatorImageUrl: URL.mock.absoluteString))
+
+        switch coordinator.gliaViewController!.bubbleKind {
+        case .userImage(let url):
+            XCTAssertEqual(url, URL.mock.absoluteString)
+        default: XCTFail()
+        }
+    }
+
+    func test_chatCoordinatorSecureTranscriptUpgradedToLiveChat() throws {
+        var calledEvents: [EngagementCoordinator.DelegateEvent] = []
+
+        coordinator.delegate = { event in
+            calledEvents.append(event)
+        }
+
+        coordinator.start()
+
+        try showGliaViewController()
+        let chatCoordinator = coordinator.coordinators.last as? ChatCoordinator
+        chatCoordinator?.delegate?(.finished)
+
+        let flowCoordinator = coordinator.coordinators.last
+
+        callAfterTimeout {
+            XCTAssertNil(flowCoordinator)
+        }
+    }
+}
+
+private extension EngagementCoordinatorTests {
+    var currentWindow: UIWindow? {
+        get throws {
+            let scene = try XCTUnwrap(UIApplication.shared.connectedScenes.first as? UIWindowScene)
+            return scene.windows.first { !($0 is BubbleWindow) }
+        }
+    }
+    // Some actions in the coordinator require the view controller to be
+    // present in the window hierarchy to work. Also restores the old
+    // view controller on tearDown.
+    func showGliaViewController() throws {
+        let window = try currentWindow
+        let oldRootViewController = window?.rootViewController
+        window?.rootViewController = coordinator.gliaViewController
+
+        closuresForTearDown.append {
+            window?.rootViewController = oldRootViewController
+        }
+    }
+
+    // Some of the actions in these tests include waiting for animations or dismissals
+    // of view controllers. These fail if the asserts are done right away.
+    func callAfterTimeout(_ callback: () -> Void) {
+        let expectation = expectation(description: "Wait")
+        let result = XCTWaiter.wait(for: [expectation], timeout: 0.5)
+
+        if result == .timedOut {
+            callback()
+        }
+    }
+}

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -101,12 +101,6 @@ final class GliaTests: XCTestCase {
         var receivedTheme: Theme?
         var receivedFeatures = Features.init()
 
-        class MockedSceneProvider: SceneProvider {
-            init () {}
-            func windowScene() -> UIWindowScene? {
-                UIWindow().windowScene
-            }
-        }
         let expectedSceneProvider = MockedSceneProvider()
         var receivedSceneProvider: SceneProvider?
         gliaEnv.createRootCoordinator = { interactor, viewFactory, sceneProvider, _, screenShareHandler, features, environment in

--- a/GliaWidgetsTests/Sources/Glia/Mocks/SceneProvider.Mock.swift
+++ b/GliaWidgetsTests/Sources/Glia/Mocks/SceneProvider.Mock.swift
@@ -1,0 +1,12 @@
+import UIKit
+@testable import GliaWidgets
+
+class MockedSceneProvider: SceneProvider {
+    private let window = UIWindow()
+
+    init () {}
+
+    func windowScene() -> UIWindowScene? {
+        window.windowScene
+    }
+}


### PR DESCRIPTION
The secure conversations functionality isn't tested yet because these tests proved to be very challenging to write and the commit was getting quite long. Secure conversations functionality will be tested in a future commit.

MOB-2919

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)
