### PR TITLE
Define accessibilityId for images sent by visitor

### DIFF
--- a/GliaWidgets/Sources/View/Chat/Message/Content/File/ChatFileContentView.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/Content/File/ChatFileContentView.swift
@@ -9,7 +9,7 @@ class ChatFileContentView: UIView {
     private let style: ChatFileContentStyle
     private let content: Content
     private let tap: () -> Void
-    private let accessibilityProperties: ChatFileContentView.AccessibilityProperties
+    let accessibilityProperties: ChatFileContentView.AccessibilityProperties
 
     init(
         with style: ChatFileContentStyle,

--- a/GliaWidgets/Sources/View/Chat/Message/Content/File/Image/ChatImageFileContentView.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/Content/File/Image/ChatImageFileContentView.swift
@@ -90,8 +90,13 @@ class ChatImageFileContentView: ChatFileContentView {
     }
 
     private func updateAccessibilityIdentifier(with download: FileDownload) {
-        accessibilityIdentifier = download.file.name.map {
-            "chat_message_image_\($0)_\(download.state.value.accessibilityString)"
+        switch accessibilityProperties.from {
+        case .operator:
+            accessibilityIdentifier = download.file.name.map {
+                "chat_message_image_\($0)_\(download.state.value.accessibilityString)"
+            }
+        case .visitor:
+            accessibilityIdentifier = "chat_message_image_visitor_\(download.state.value.accessibilityString)"
         }
     }
 }


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-2646

**What was solved?**
Because of inability to know the name of images selected from PhotoLibrary, which is used as part of attachment accessibilityId, predefined id was added for images sent by visitor, depending only on downloading state.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)