### PR TITLE
Update GliaCoreDependency to 1.3.5 in Package

### DIFF
--- a/GliaWidgets.podspec
+++ b/GliaWidgets.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   }
   s.exclude_files         = ['GliaWidgets/Window/**']
 
-  s.dependency 'GliaCoreSDK', '1.3.9'
+  s.dependency 'GliaCoreSDK', '1.3.10'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "GliaCoreDependency",
-            url: "https://github.com/salemove/ios-bundle/releases/download/0.35.0/GliaCoreDependency.xcframework.zip",
-            checksum: "8e1746da612dad8a130fd872b3058511121b7c6f29e3b0351ecbbffa96971489"
+            url: "https://github.com/salemove/ios-bundle/releases/download/1.3.5/GliaCoreDependency.xcframework.zip",
+            checksum: "a7ca12542bc8470af16632311e96a1925f102e0ee6d36f5c86e422aebe655af1"
         ),
         .binaryTarget(
             name: "TwilioVoice",

--- a/Package.swift
+++ b/Package.swift
@@ -31,8 +31,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "GliaCoreSDK",
-            url: "https://github.com/salemove/ios-bundle/releases/download/1.3.9/GliaCoreSDK.xcframework.zip",
-            checksum: "09f50106a19e0722c62d16f5c4b436999c6ef83617f126a5747e85be5cfece8d"
+            url: "https://github.com/salemove/ios-bundle/releases/download/1.3.10/GliaCoreSDK.xcframework.zip",
+            checksum: "f0ca1fbae1bbb4decdedc3fd929f10864b15adcb8196e959b8b14b0251c42582"
         ),
         .target(
             name: "GliaWidgets",

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
     - AccessibilitySnapshot/Core
     - SnapshotTesting (~> 1.0)
   - GliaCoreDependency (2.3.0)
-  - GliaCoreSDK (1.3.9):
+  - GliaCoreSDK (1.3.10):
     - GliaCoreDependency (= 2.3.0)
     - TwilioVoice (= 6.8.0)
     - WebRTC-lib (= 119.0.0)
@@ -34,7 +34,7 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   AccessibilitySnapshot: a91e4a69f870188b51f43863d9fc7269d07cdd93
   GliaCoreDependency: 37f48a5a32e2646617b87cbe9d4b30eedd123f6f
-  GliaCoreSDK: 79efcb1a3e8b8ee39d94a2ed586c944bb09a75fc
+  GliaCoreSDK: 088d9a33b1b96264bd713d7375005ca4939b390d
   SnapshotTesting: 6141c48b6aa76ead61431ca665c14ab9a066c53b
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
   TwilioVoice: 9563c9ad71b9ab7bbad0b59b67cfe4be96c75d23

--- a/templates/GliaWidgets.podspec
+++ b/templates/GliaWidgets.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   }
   s.exclude_files         = ['GliaWidgets/Window/**']
 
-  s.dependency 'GliaCoreSDK', '1.3.9'
+  s.dependency 'GliaCoreSDK', '1.3.10'
 end

--- a/templates/Package.swift
+++ b/templates/Package.swift
@@ -16,8 +16,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "GliaCoreDependency",
-            url: "https://github.com/salemove/ios-bundle/releases/download/0.35.0/GliaCoreDependency.xcframework.zip",
-            checksum: "8e1746da612dad8a130fd872b3058511121b7c6f29e3b0351ecbbffa96971489"
+            url: "https://github.com/salemove/ios-bundle/releases/download/1.3.5/GliaCoreDependency.xcframework.zip",
+            checksum: "a7ca12542bc8470af16632311e96a1925f102e0ee6d36f5c86e422aebe655af1"
         ),
         .binaryTarget(
             name: "TwilioVoice",


### PR DESCRIPTION
**What was solved?**
Updated GliaCoreDependency to 1.3.5 in Package, because previous version is outdated for current SDK.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
