### PR TITLE
Call minimize() before GVA deeplink is opened

### DIFF
--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.GVA.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.GVA.swift
@@ -63,13 +63,17 @@ private extension SecureConversations.TranscriptModel {
                 openUrl(url)
 
             default:
-                if urlTarget == .gvaOptionUrlTargetModal ||
-                    urlTarget == .gvaOptionUrlTargetSelf {
-                    // if GvaOption.urlTarget is "modal" or "self", then button url is deeplink
-                    // and should be opened by UIApplication, to provide integrator
-                    // an ability to handle deeplinks they configured.
+                // if GvaOption.urlTarget is "modal" or "self", then button url is deeplink
+                // and should be opened by UIApplication, to provide integrator
+                // an ability to handle deeplinks they configured.
+                switch urlTarget {
+                case String.gvaOptionUrlTargetSelf:
+                    // In case of urlTarget "self" we need to minimize Glia UI
+                    self.delegate?(.minimize)
                     openUrl(url)
-                } else {
+                case String.gvaOptionUrlTargetModal:
+                    openUrl(url)
+                default:
                     return
                 }
             }

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
@@ -20,6 +20,7 @@ extension SecureConversations {
             case takeMedia(ObservableValue<MediaPickerEvent>)
             case pickFile(ObservableValue<FilePickerEvent>)
             case upgradeToChatEngagement(TranscriptModel)
+            case minimize
         }
 
         typealias Event = ChatViewModel.Event

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
@@ -13,6 +13,7 @@ class ChatCoordinator: SubFlowCoordinator, FlowCoordinator {
         )
         case call
         case finished
+        case minimize
     }
 
     var delegate: ((DelegateEvent) -> Void)?
@@ -207,6 +208,8 @@ extension ChatCoordinator {
                 self?.presentQuickLookController(with: file)
             case .call:
                 self?.delegate?(.call)
+            case .minimize:
+                self?.delegate?(.minimize)
             }
         }
 
@@ -317,6 +320,8 @@ extension ChatCoordinator {
                 controller.swapAndBindViewModel(.chat(chatModel))
                 chatModel.migrate(from: transcriptModel)
                 self.delegate?(.secureTranscriptUpgradedToLiveChat(controller))
+            case .minimize:
+                self?.delegate?(.minimize)
             }
         }
     }

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
@@ -336,6 +336,8 @@ extension EngagementCoordinator {
         case .finished:
             popCoordinator()
             self.end()
+        case .minimize:
+            minimize()
         }
     }
 

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+GVA.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+GVA.swift
@@ -86,13 +86,17 @@ private extension ChatViewModel {
                 openUrl(url)
 
             default:
-                if urlTarget == .gvaOptionUrlTargetModal ||
-                    urlTarget == .gvaOptionUrlTargetSelf {
-                    // if GvaOption.urlTarget is "modal" or "self", then button url is deeplink
-                    // and should be opened by UIApplication, to provide integrator
-                    // an ability to handle deeplinks they configured.
+                // if GvaOption.urlTarget is "modal" or "self", then button url is deeplink
+                // and should be opened by UIApplication, to provide integrator
+                // an ability to handle deeplinks they configured.
+                switch urlTarget {
+                case String.gvaOptionUrlTargetSelf:
+                    // In case of urlTarget "self" we need to minimize Glia UI
+                    self.delegate?(.minimize)
                     openUrl(url)
-                } else {
+                case String.gvaOptionUrlTargetModal:
+                    openUrl(url)
+                default:
                     return
                 }
             }

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+ViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+ViewModel.swift
@@ -67,6 +67,7 @@ extension ChatViewModel: ViewModel {
         case secureTranscriptUpgradedToLiveChat(ChatViewController)
         case showFile(LocalFile)
         case call
+        case minimize
     }
 
     enum StartAction {

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+GVA.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+GVA.swift
@@ -2,6 +2,45 @@
 import XCTest
 
 extension SecureConversationsTranscriptModelTests {
+    func test_gvaDeepLinkActionCallsMinimize() {
+        let option: GvaOption = .mock(url: "mock://mock.self", urlTarget: "self")
+        var calls: [Call] = []
+        let viewModel = createViewModel()
+        viewModel.delegate = { event in
+            switch event {
+            case .minimize:
+                calls.append(.minimize)
+
+            default:
+                XCTFail("createSendMessagePayload should not be called")
+            }
+        }
+        viewModel.environment.uiApplication.open = { _ in }
+
+        viewModel.gvaOptionAction(for: option)()
+
+        XCTAssertEqual(calls, [.minimize])
+    }
+
+    func test_gvaDeepLinkActionDoesNotCallMinimize() {
+        let option: GvaOption = .mock(url: "mock://mock.modal", urlTarget: "modal")
+        var calls: [Call] = []
+        let viewModel = createViewModel()
+        viewModel.delegate = { event in
+            switch event {
+            case .minimize:
+                calls.append(.minimize)
+
+            default:
+                XCTFail("createSendMessagePayload should not be called")
+            }
+        }
+        viewModel.environment.uiApplication.open = { _ in }
+
+        viewModel.gvaOptionAction(for: option)()
+        XCTAssertTrue(calls.isEmpty)
+    }
+
     func test_gvaLinkButtonAction() {
         let options: [GvaOption] = [
             .mock(url: "http://mock.mock"),
@@ -138,6 +177,7 @@ private extension SecureConversationsTranscriptModelTests {
         case openUrl(String?)
         case sendOption(String?, String?)
         case showAlert
+        case minimize
     }
 
     func createViewModel() -> TranscriptModel {

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Gva.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Gva.swift
@@ -2,6 +2,43 @@
 import XCTest
 
 extension ChatViewModelTests {
+    func test_gvaDeepLinkActionCallsMinimize() {
+        let option: GvaOption = .mock(url: "mock://mock.self", urlTarget: "self")
+        var calls: [Call] = []
+        viewModel = .mock()
+        viewModel.delegate = { event in
+            switch event {
+            case .minimize:
+                calls.append(.minimize)
+
+            default:
+                XCTFail("createSendMessagePayload should not be called")
+            }
+        }
+
+        viewModel.gvaOptionAction(for: option)()
+
+        XCTAssertEqual(calls, [.minimize])
+    }
+
+    func test_gvaDeepLinkActionDoesNotCallMinimize() {
+        let option: GvaOption = .mock(url: "mock://mock.modal", urlTarget: "modal")
+        var calls: [Call] = []
+        viewModel = .mock()
+        viewModel.delegate = { event in
+            switch event {
+            case .minimize:
+                calls.append(.minimize)
+
+            default:
+                XCTFail("createSendMessagePayload should not be called")
+            }
+        }
+
+        viewModel.gvaOptionAction(for: option)()
+        XCTAssertTrue(calls.isEmpty)
+    }
+
     func test_gvaLinkButtonAction() {
         let options: [GvaOption] = [
             .mock(url: "http://mock.mock"),
@@ -162,5 +199,6 @@ private extension ChatViewModelTests {
         case openUrl(String?)
         case sendOption(String?, String?)
         case showAlert
+        case minimize
     }
 }

--- a/TestingApp/DeeplinkService/SettingsDeeplinkHandler.swift
+++ b/TestingApp/DeeplinkService/SettingsDeeplinkHandler.swift
@@ -19,7 +19,6 @@ struct SettingsDeeplinkHandler: DeeplinkHandler {
               let root = window?.rootViewController as? ViewController else {
             return false
         }
-        Glia.sharedInstance.minimize()
         root.presentSettings()
         return true
     }


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3201

**What was solved?**
In order to the client request for making Glia UI automatically minimized when deeplink is opened by pressing GVA button, these changes were made.
In case when `urlTarget` is `self` we need to minimize Glia UI and then open the link, if  `urlTarget` is `modal` - just open the link.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [x] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
