### PR TITLE
Use 'Unauthenticate' instead of 'De-authenticate' in logs

### DIFF
--- a/GliaWidgets/Public/Glia/Glia.OpaqueAuthentication.swift
+++ b/GliaWidgets/Public/Glia/Glia.OpaqueAuthentication.swift
@@ -137,7 +137,7 @@ extension Glia {
                 }
             },
             deauthenticateWithCallback: { [weak self] callback in
-                self?.loggerPhase.logger.prefixed(Self.self).info("De-authenticate")
+                self?.loggerPhase.logger.prefixed(Self.self).info("Unauthenticate")
                 auth.deauthenticate { result in
                     switch result {
                     case .success:


### PR DESCRIPTION
MOB-3197

**Jira issue:**
https://glia.atlassian.net/browse/MOB-3197

**What was solved?**
In order to match terminology with Web and Direct ID related documentation 'De-authenticate' is replaced with 'Unauthenticate'.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
