### PR TITLE
Address bubble disappearing when tapped during live engagement auth

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -606,6 +606,9 @@
 		AF7753122B19EC3200E523A2 /* Logger.Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7753112B19EC3200E523A2 /* Logger.Live.swift */; };
 		AF7753142B19ED4F00E523A2 /* Logger.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7753132B19ED4F00E523A2 /* Logger.Mock.swift */; };
 		AF7753172B1DBFE600E523A2 /* Glia.Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7753162B1DBFE600E523A2 /* Glia.Logging.swift */; };
+		AF9C0C382BC3F53A00C25E47 /* TaskSleep.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9C0C372BC3F53A00C25E47 /* TaskSleep.swift */; };
+		AF9C0C3A2BC3F6BC00C25E47 /* TaskSleep.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9C0C392BC3F6BC00C25E47 /* TaskSleep.Failing.swift */; };
+		AF9C0C3C2BC4739800C25E47 /* Transformable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9C0C3B2BC4739800C25E47 /* Transformable.swift */; };
 		AF9DB22E2890571A00A0C442 /* RootCoordinator.Environment.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9DB22D2890571A00A0C442 /* RootCoordinator.Environment.Failing.swift */; };
 		AF9DB23128905A1D00A0C442 /* ViewFactory.Environment.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9DB23028905A1D00A0C442 /* ViewFactory.Environment.Failing.swift */; };
 		AFA1A9952AA9248400095BE8 /* ChatViewModel+ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA1A9942AA9248400095BE8 /* ChatViewModel+ViewModel.swift */; };
@@ -1544,6 +1547,9 @@
 		AF7753112B19EC3200E523A2 /* Logger.Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.Live.swift; sourceTree = "<group>"; };
 		AF7753132B19ED4F00E523A2 /* Logger.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.Mock.swift; sourceTree = "<group>"; };
 		AF7753162B1DBFE600E523A2 /* Glia.Logging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Glia.Logging.swift; sourceTree = "<group>"; };
+		AF9C0C372BC3F53A00C25E47 /* TaskSleep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskSleep.swift; sourceTree = "<group>"; };
+		AF9C0C392BC3F6BC00C25E47 /* TaskSleep.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskSleep.Failing.swift; sourceTree = "<group>"; };
+		AF9C0C3B2BC4739800C25E47 /* Transformable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transformable.swift; sourceTree = "<group>"; };
 		AF9DB22D2890571A00A0C442 /* RootCoordinator.Environment.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootCoordinator.Environment.Failing.swift; sourceTree = "<group>"; };
 		AF9DB23028905A1D00A0C442 /* ViewFactory.Environment.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewFactory.Environment.Failing.swift; sourceTree = "<group>"; };
 		AFA1A9942AA9248400095BE8 /* ChatViewModel+ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatViewModel+ViewModel.swift"; sourceTree = "<group>"; };
@@ -2142,6 +2148,7 @@
 				AF6291142B0818DE00D3D76B /* SwiftBased.Failing.swift */,
 				AFF9542B2ADDA10600C277E0 /* CoreSDKConfigurator.Failing.swift */,
 				AF1C197F2B14FE9F00F8810F /* ConditionalCompilationClient.Failing.swift */,
+				AF9C0C392BC3F6BC00C25E47 /* TaskSleep.Failing.swift */,
 			);
 			path = GliaWidgetsTests;
 			sourceTree = "<group>";
@@ -2556,6 +2563,8 @@
 				1A60AFCC256694E300E53F53 /* ViewFactory */,
 				1A60AFC52566865600E53F53 /* ViewModel */,
 				84D2292C28C61DE000F64FE7 /* WKNavigationPolicyProvider */,
+				AF9C0C372BC3F53A00C25E47 /* TaskSleep.swift */,
+				AF9C0C3B2BC4739800C25E47 /* Transformable.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -5592,6 +5601,7 @@
 				1AC7A7AF258786CB00567FF8 /* EngagementViewModel.swift in Sources */,
 				9AE9E4B327E0E60F00BFE239 /* CallViewModel.Mock.swift in Sources */,
 				C09046DE2B7E0AB9003C437C /* ConnectStatusStyle.RemoteConfig.swift in Sources */,
+				AF9C0C3C2BC4739800C25E47 /* Transformable.swift in Sources */,
 				31882C9B2AA21B71009DE4BD /* Localization+Templates.swift in Sources */,
 				845876A8282A94CF007AC3DF /* BooleanQuestionView.Props.Accessibility.swift in Sources */,
 				C09046F82B7E109B003C437C /* Theme.ChoiceCardStyle.RemoteConfig.swift in Sources */,
@@ -5679,6 +5689,7 @@
 				1AA738AE2578E0D500E1120F /* ConnectAnimationView.swift in Sources */,
 				754CC61627E2816F005676E9 /* Survey.InputQuestionView.swift in Sources */,
 				3146C9492AB18AC70047D8CC /* Localization+StringProviding.swift in Sources */,
+				AF9C0C382BC3F53A00C25E47 /* TaskSleep.swift in Sources */,
 				9A1992DF27D62C2E00161AAE /* ImageView.Cache.Mock.swift in Sources */,
 				8491AF0D2A7A9CB900CC3E72 /* Theme.VisitorChatMessageStyle.swift in Sources */,
 				1A2DA72D25EF9DD900032611 /* FileUpload.swift in Sources */,
@@ -5974,6 +5985,7 @@
 				9ACC25D227B4727500BC5335 /* CoreSDKClient.Failing.swift in Sources */,
 				84265E07298AE96B00D65842 /* ScreenSharingViewModelTests.swift in Sources */,
 				EB9ADB51280EBD4E00FAE8A4 /* InteractorStateTests.swift in Sources */,
+				AF9C0C3A2BC3F6BC00C25E47 /* TaskSleep.Failing.swift in Sources */,
 				8491AF652AAB281500CC3E72 /* ChatViewModelTests+CustomCard.swift in Sources */,
 				EB7A1508286D98000035AC62 /* FileUploader.Environment.Failing.swift in Sources */,
 				AF2355A229C9EC7E007D9896 /* IdCollectionTests.swift in Sources */,

--- a/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
+++ b/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
@@ -183,12 +183,11 @@ extension Glia {
                 log: loggerPhase.logger,
                 snackBar: environment.snackBar,
                 operatorRequestHandlerService: operatorRequestHandlerService,
-                maximumUploads: { self.maximumUploads }
+                maximumUploads: { self.maximumUploads },
+                taskSleep: environment.taskSleep
             )
         )
-        rootCoordinator?.delegate = { [weak self] event in
-            self?.handleCoordinatorEvent(event)
-        }
+        rootCoordinator?.delegate = { [weak self] event in self?.handleCoordinatorEvent(event) }
         rootCoordinator?.start(maximize: maximize)
     }
 

--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -59,7 +59,6 @@ public enum GliaEvent: Equatable {
 
 /// Used to provide `UIWindowScene` to the framework.
 public protocol SceneProvider: AnyObject {
-    @available(iOS 13.0, *)
     func windowScene() -> UIWindowScene?
 }
 

--- a/GliaWidgets/Sources/Component/Bubble/BubbleWindow.swift
+++ b/GliaWidgets/Sources/Component/Bubble/BubbleWindow.swift
@@ -79,7 +79,7 @@ class BubbleWindow: UIWindow {
     }
 }
 
-private class BubbleViewController: UIViewController {
+class BubbleViewController: UIViewController {
     private let bubbleView: BubbleView
     private let edgeInset: CGFloat
 

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
@@ -39,7 +39,8 @@ extension EngagementCoordinator.Environment {
         log: .mock,
         snackBar: .mock,
         operatorRequestHandlerService: .mock(),
-        maximumUploads: { 2 }
+        maximumUploads: { 2 },
+        taskSleep: .mock
     )
 }
 #endif

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
@@ -41,5 +41,6 @@ extension EngagementCoordinator {
         var snackBar: SnackBar
         var operatorRequestHandlerService: OperatorRequestHandlerService
         var maximumUploads: () -> Int
+        var taskSleep: TaskSleep
     }
 }

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
@@ -39,7 +39,16 @@ class EngagementCoordinator: SubFlowCoordinator, FlowCoordinator {
         self.viewFactory = viewFactory
         self.sceneProvider = sceneProvider
         self.engagementKind = engagementKind
-        self.gliaPresenter = GliaPresenter(sceneProvider: sceneProvider)
+        self.gliaPresenter = GliaPresenter(
+            environment: .init(
+                appWindowsProvider: .init(
+                    uiApplication: environment.uiApplication,
+                    sceneProvider: sceneProvider
+                ),
+                log: environment.log,
+                taskSleep: environment.taskSleep
+            )
+        )
         self.navigationPresenter = NavigationPresenter(with: navigationController)
         self.screenShareHandler = screenShareHandler
         self.features = features

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Interface.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Interface.swift
@@ -51,6 +51,7 @@ extension Glia {
         var conditionalCompilation: ConditionalCompilationClient
         var snackBar: SnackBar
         var processInfo: ProcessInfoHandling
+        var taskSleep: TaskSleep
     }
 }
 

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Live.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Live.swift
@@ -41,7 +41,8 @@ extension Glia.Environment {
         print: .live,
         conditionalCompilation: .live,
         snackBar: .live,
-        processInfo: .live
+        processInfo: .live,
+        taskSleep: .live
     )
 }
 

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Mock.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Mock.swift
@@ -32,7 +32,8 @@ extension Glia.Environment {
         print: .mock,
         conditionalCompilation: .mock,
         snackBar: .mock,
-        processInfo: .mock()
+        processInfo: .mock(),
+        taskSleep: .mock
     )
 }
 

--- a/GliaWidgets/Sources/Presenter/GliaPresenter.swift
+++ b/GliaWidgets/Sources/Presenter/GliaPresenter.swift
@@ -1,19 +1,39 @@
 import UIKit
 
 final class GliaPresenter {
-    private let sceneProvider: SceneProvider?
+    var environment: Environment
+    var delayedTask: Task<Void, Error>?
 
-    private lazy var window: UIWindow? = {
-        if #available(iOS 13, *) {
-            if let sceneProvider = sceneProvider {
-                return sceneProvider.windowScene()?.windows.first { $0.isKeyWindow }
-            } else {
-                return UIApplication.shared.windows.first { $0.isKeyWindow }
-            }
+    private var window: UIWindow? {
+        // Retrieve all available windows.
+        let allWindows = environment.appWindowsProvider.windows()
+        // It is likely that there is one more window except BubbleWindow,
+        // so we filter out `BubbleWindow` based windows.
+        let nonBubbleWindows = allWindows.filter { !($0 is BubbleWindow) }
+        // In case if there are no windows except `BubbleWindow`, we return
+        // the one that is the key window, even if it is `BubbleWindow`.
+        // There's still a chance to get proper window via `present(_:animated:completion:)`
+        // method by using waiting strategy.
+        if nonBubbleWindows.isEmpty {
+            return allWindows.first(where: \.isKeyWindow)
+        // If there's one or more non-BubbleWindow(s), we can search for one key
+        // or one with non `nil` `rootViewController`,
+        // but allow fallback to waiting strategy, just in case.
         } else {
-            return UIApplication.shared.keyWindow
+            // First try to get non-bubble key window.
+            let nonBubbleKeyWindow = nonBubbleWindows.first(where: \.isKeyWindow)
+            // In case non-bubble key window is not found, substitute it with the one that has non-nil
+            // root view controller, if there's one.
+            let nonBubbleWindowWithRootViewController = nonBubbleWindows.first { $0.rootViewController != nil }
+            // In case non-bubble window with root view controller is not found, fallback to any key window,
+            // including bubble window. In such case, later during presentation this search
+            // for non-bubble window will be repeated using waiting strategy.
+            let fallbackKeyWindow = allWindows.first(where: \.isKeyWindow)
+            return nonBubbleKeyWindow ??
+                 nonBubbleWindowWithRootViewController ??
+                 fallbackKeyWindow
         }
-    }()
+    }
 
     var topMostViewController: UIViewController {
         guard let window = window else {
@@ -31,8 +51,8 @@ final class GliaPresenter {
         return presenter
     }
 
-    init(sceneProvider: SceneProvider?) {
-        self.sceneProvider = sceneProvider
+    init(environment: Environment) {
+        self.environment = environment
     }
 
     func present(
@@ -40,11 +60,53 @@ final class GliaPresenter {
         animated: Bool,
         completion: (() -> Void)? = nil
     ) {
-        topMostViewController.present(
-            viewController,
-            animated: animated,
-            completion: completion
-        )
+        if topMostViewController is BubbleViewController {
+            environment.log.warning(
+                """
+                Attempt to present \(type(of: viewController)) on \(BubbleViewController.self).
+                Falling back to waiting non-\(BubbleViewController.self) strategy.
+                """
+            )
+
+            self.delayedTask?.cancel()
+            self.delayedTask = Task { @MainActor in
+                var timeWaited: UInt64 = 0
+                // Attempt to wait until top most view controller (BubbleViewController)
+                // is replaced with something else.
+                while topMostViewController is BubbleViewController {
+                    defer {
+                        timeWaited += Self.waitingAttemptTimeNanoSeconds
+                    }
+                    // If task takes too much time, we return from the cycle,
+                    // thus completing the work on the task.
+                    guard timeWaited < Self.maxWaitingTimeNanoseconds else {
+                        environment.log.error(
+                            """
+                            Waiting for non-\(BubbleViewController.self) has timed out after \(timeWaited) nanoseconds.
+                            Unable to present \(type(of: viewController)) on \(BubbleViewController.self)
+                            """)
+                        return
+                    }
+                    // Suspend current task to try again later. This will not block main thread.
+                    try await environment.taskSleep(Self.waitingAttemptTimeNanoSeconds)
+                    // Let other processes to be worked on.
+                    await Task.yield()
+                }
+
+                topMostViewController.present(
+                    viewController,
+                    animated: animated,
+                    completion: completion
+                )
+            }
+
+        } else {
+            topMostViewController.present(
+                viewController,
+                animated: animated,
+                completion: completion
+            )
+        }
     }
 
     func dismiss(
@@ -60,5 +122,30 @@ final class GliaPresenter {
             animated: animated,
             completion: completion
         )
+    }
+}
+
+extension GliaPresenter {
+    // Time to wait before making another attempt to reach non-BubbleViewController.
+    static let waitingAttemptTimeNanoSeconds: UInt64 = 100_000_000  // 0.1 sec.
+    // Maximum time allowed to wait in total, reaching which will result in timeout.
+    static let maxWaitingTimeNanoseconds = 3_000_000_000 // 3 seconds.
+
+    struct Environment {
+        var appWindowsProvider: AppWindowsProvider
+        var log: CoreSdkClient.Logger
+        var taskSleep: TaskSleep
+    }
+}
+
+extension GliaPresenter {
+    struct AppWindowsProvider {
+        var windows: () -> [UIWindow]
+    }
+}
+
+extension GliaPresenter.AppWindowsProvider {
+    init(uiApplication: UIKitBased.UIApplication, sceneProvider: SceneProvider?) {
+        self.windows = { sceneProvider?.windowScene()?.windows ?? uiApplication.windows() }
     }
 }

--- a/GliaWidgets/Sources/TaskSleep.swift
+++ b/GliaWidgets/Sources/TaskSleep.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+struct TaskSleep {
+    var taskSleep: (_ delay: UInt64) async throws -> Void
+
+    func callAsFunction(_ delay: UInt64) async throws {
+        try await taskSleep(delay)
+    }
+}
+
+extension TaskSleep {
+    static let live = Self(
+        taskSleep: { timeToWait in
+            try await Task.sleep(nanoseconds: timeToWait)
+        }
+    )
+}
+
+#if DEBUG
+extension TaskSleep {
+    static let mock = Self(taskSleep: { _ in })
+}
+#endif

--- a/GliaWidgets/Sources/Transformable.swift
+++ b/GliaWidgets/Sources/Transformable.swift
@@ -1,0 +1,20 @@
+/// Helper for chaining in-place mutations on value types. Useful in unit tests when changing dependencies
+/// passed by `Environment`, for example:
+/// ```
+/// extension EngagementCoordinator.Environment: Transformable {}
+/// extension UIKitBased.UIApplication: Transformable {}
+///
+/// let environment = EngagementCoordinator.Environment.mock.transform {
+///   $0.uiApplication = .failing.transform { $0.windows = { [ .mock() ] } }
+/// }
+protocol Transformable {
+    func transform(_ rewrite: (inout  Self) -> Void) -> Self
+}
+
+extension Transformable {
+    func transform(_ rewrite: (inout  Self) -> Void) -> Self {
+        var value = self
+        rewrite(&value)
+        return value
+    }
+}

--- a/GliaWidgets/Sources/UIKitBased/UIKitBased.Interface.swift
+++ b/GliaWidgets/Sources/UIKitBased/UIKitBased.Interface.swift
@@ -24,4 +24,8 @@ enum UIKitBased {
         var bounds: () -> CGRect
         var scale: () -> CGFloat
     }
+
+    typealias UIWindow = UIKit.UIWindow
 }
+
+extension UIKitBased.UIApplication: Transformable {}

--- a/GliaWidgets/Sources/UIKitBased/UIKitBased.Mock.swift
+++ b/GliaWidgets/Sources/UIKitBased/UIKitBased.Mock.swift
@@ -40,4 +40,12 @@ extension UIKitBased.UIScreen {
         scale: { .init() }
     )
 }
+
+extension UIKitBased.UIWindow {
+    static func mock(rootViewController: UIKit.UIViewController = . init()) -> UIKitBased.UIWindow {
+        let window = UIKit.UIWindow()
+        window.rootViewController = rootViewController
+        return window
+    }
+}
 #endif

--- a/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
+++ b/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
@@ -93,6 +93,7 @@ extension EngagementCoordinator.Environment {
         maximumUploads: {
             fail("\(Self.self).maximumUploads")
             return 2
-        }
+        },
+        taskSleep: .failing
     )
 }

--- a/GliaWidgetsTests/Glia.Environment.Failing.swift
+++ b/GliaWidgetsTests/Glia.Environment.Failing.swift
@@ -61,7 +61,8 @@ extension Glia.Environment {
         print: .failing,
         conditionalCompilation: .failing,
         snackBar: .failing,
-        processInfo: .failing
+        processInfo: .failing,
+        taskSleep: .failing
     )
 }
 

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
@@ -102,7 +102,7 @@ extension GliaTests {
         }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
         environment.createRootCoordinator = { _, _, _, _, _, _, _ in
-            .mock()
+            .mock(environment: .engagementCoordEnvironmentWithKeyWindow)
         }
         let sdk = Glia(environment: environment)
         try sdk.start(.chat, configuration: .mock(), queueID: "queueId", theme: .mock())
@@ -124,6 +124,7 @@ extension GliaTests {
         environment.coreSdk.createLogger = { _ in logger }
         environment.conditionalCompilation.isDebug = { true }
         var resultingViewFactory: ViewFactory?
+
         environment.createRootCoordinator = { _, viewFactory, _, _, _, _, _ in
             resultingViewFactory = viewFactory
 
@@ -134,7 +135,7 @@ extension GliaTests {
                 engagementKind: .none,
                 screenShareHandler: .mock,
                 features: [],
-                environment: .failing
+                environment: .engagementCoordEnvironmentWithKeyWindow
             )
         }
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
@@ -176,7 +177,7 @@ extension GliaTests {
                 engagementKind: .none,
                 screenShareHandler: .mock,
                 features: [],
-                environment: .failing
+                environment: .engagementCoordEnvironmentWithKeyWindow
             )
         }
         environment.conditionalCompilation.isDebug = { true }
@@ -236,7 +237,7 @@ extension GliaTests {
                 engagementKind: .none,
                 screenShareHandler: .mock,
                 features: [],
-                environment: .failing
+                environment: .engagementCoordEnvironmentWithKeyWindow
             )
         }
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
@@ -283,7 +284,7 @@ extension GliaTests {
                 engagementKind: .none,
                 screenShareHandler: .mock,
                 features: [],
-                environment: .failing
+                environment: .engagementCoordEnvironmentWithKeyWindow
             )
         }
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
@@ -330,7 +331,7 @@ extension GliaTests {
                 engagementKind: .none,
                 screenShareHandler: .mock,
                 features: [],
-                environment: .failing
+                environment: .engagementCoordEnvironmentWithKeyWindow
             )
         }
 
@@ -383,7 +384,7 @@ extension GliaTests {
                 engagementKind: .none,
                 screenShareHandler: .mock,
                 features: [],
-                environment: .failing
+                environment: .engagementCoordEnvironmentWithKeyWindow
             )
         }
 
@@ -402,5 +403,13 @@ extension GliaTests {
         let localFallbackCompanyName = "Company Name"
         XCTAssertEqual(configuredSdkTheme?.call.connect.queue.firstText, localFallbackCompanyName)
         XCTAssertEqual(configuredSdkTheme?.chat.connect.queue.firstText, localFallbackCompanyName)
+    }
+}
+
+extension EngagementCoordinator.Environment: Transformable {
+    static var engagementCoordEnvironmentWithKeyWindow: Self {
+        EngagementCoordinator.Environment.mock.transform {
+            $0.uiApplication = .failing.transform { $0.windows = { [ .mock() ] } }
+        }
     }
 }

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -517,7 +517,9 @@ final class GliaTests: XCTestCase {
         environment.conditionalCompilation.isDebug = { true }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
-        environment.createRootCoordinator = { _, _, _, _, _, _, _ in  .mock() }
+        var engCoordEnvironment = EngagementCoordinator.Environment.engagementCoordEnvironmentWithKeyWindow
+        engCoordEnvironment.fileManager = .mock
+        environment.createRootCoordinator = { _, _, _, _, _, _, _ in EngagementCoordinator.mock(environment: engCoordEnvironment) }
 
         let sdk = Glia(environment: environment)
         enum Call {

--- a/GliaWidgetsTests/TaskSleep.Failing.swift
+++ b/GliaWidgetsTests/TaskSleep.Failing.swift
@@ -1,0 +1,9 @@
+@testable import GliaWidgets
+
+extension TaskSleep {
+    static let failing = Self(
+        taskSleep: { _ in
+            fail("\(Self.self).taskSleep")
+        }
+    )
+}


### PR DESCRIPTION
MOB-3226

**Jira issue:**
https://glia.atlassian.net/browse/MOB-3226

**What was solved?**
Make sure that right after Direct ID authentication, the 'maximize' navigation happens when bubble is tapped. The issue was with attempt to present 'GliaViewController' on 'BubbleViewController', which resulted in hidden 'BubbleView'. Now we try to filter out 'BubbleWindow' to avoid presenting on its `topMostController`. In case if this BubbleWindow is the only window, we use 'waiting with timeout' strategy for non-BubbleViewController to become top most and continue navigation with it.

Tests are to be added in separate PR.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
