### PR TITLE
Fix catalog-info.yaml owner name

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -11,4 +11,4 @@ metadata:
 spec:
   type: library
   lifecycle: production
-  owner: tm-mobile
+  owner: mobile


### PR DESCRIPTION
Backstage now requires the name to be without 'tm-' prefix

**Jira issue:**
https://glia.atlassian.net/browse/MOB-xxx

**What was solved?**

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

 - [ ] Tests fixed, added? Unit, acceptance, snapshots?
 - [ ] Logging necessary for future troubleshooting of customer issues added?

**Screenshots:**
