### PR TITLE
Generate and upload docs web page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 gem "fastlane"
+gem 'jazzy'
 gem 'cocoapods'
 gem 'cocoapods-no-autoimports'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,26 +213,41 @@ GEM
     httpclient (2.8.3)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
+    jazzy (0.14.4)
+      cocoapods (~> 1.5)
+      mustache (~> 1.1)
+      open4 (~> 1.3)
+      redcarpet (~> 3.4)
+      rexml (~> 3.2)
+      rouge (>= 2.0.6, < 5.0)
+      sassc (~> 2.1)
+      sqlite3 (~> 1.3)
+      xcinvoke (~> 0.3.0)
     jmespath (1.6.2)
     json (2.7.1)
     jwt (2.7.1)
+    liferaft (0.0.6)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.6)
     minitest (5.22.3)
     molinillo (0.8.0)
     multi_json (1.15.0)
     multipart-post (2.3.0)
+    mustache (1.1.1)
     mutex_m (0.2.0)
     nanaimo (0.3.0)
     nap (1.1.0)
     naturally (2.2.1)
     netrc (0.11.0)
     nkf (0.2.0)
+    open4 (1.3.4)
     optparse (0.1.1)
     os (1.1.4)
     plist (3.7.0)
     public_suffix (4.0.7)
     rake (13.1.0)
+    redcarpet (3.6.0)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
@@ -243,6 +258,8 @@ GEM
     ruby-macho (2.5.1)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
+    sassc (2.4.0)
+      ffi (~> 1.9)
     security (0.1.3)
     signet (0.18.0)
       addressable (~> 2.8)
@@ -252,6 +269,8 @@ GEM
     simctl (1.6.10)
       CFPropertyList
       naturally
+    sqlite3 (1.7.3)
+      mini_portile2 (~> 2.8.0)
     terminal-notifier (2.0.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -268,6 +287,8 @@ GEM
     unicode-display_width (2.5.0)
     webrick (1.8.1)
     word_wrap (1.0.0)
+    xcinvoke (0.3.0)
+      liferaft (~> 0.0.6)
     xcodeproj (1.24.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
@@ -288,6 +309,7 @@ DEPENDENCIES
   cocoapods
   cocoapods-no-autoimports
   fastlane
+  jazzy
 
 BUNDLED WITH
-   2.3.14
+   2.3.11

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -96,6 +96,7 @@ workflows:
         - content: pod trunk push GliaWidgets.podspec --verbose --allow-warnings
     - cache-push@2: {}
     after_run:
+    - documentation
     - _increment_project_version
     - increment_widgets_version_in_cortex_financial
   development-build:
@@ -283,6 +284,22 @@ workflows:
     - opts:
         is_expand: false
       BITRISE_EXPORT_METHOD: app-store
+  documentation:
+    description: Generates documentation using jazzy and uploads to AWS. This workflow
+      doesn't checkout git repository and prepare xcproj/xcworkspace.
+    steps:
+    - fastlane@3:
+        inputs:
+        - work_dir: "$BITRISE_SOURCE_DIR"
+        - lane: ios sdk_documentation
+    - amazon-s3-upload@3:
+        inputs:
+        - upload_bucket: "$AWS_BUCKET/widgets"
+        - access_key_id: "$AWS_KEY"
+        - secret_access_key: "$AWS_PASSWORD"
+        - acl_control: public-read
+        - upload_local_path: "$BITRISE_SOURCE_DIR/$SDK_SCHEME/docs/"
+
 app:
   envs:
   - opts:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -75,30 +75,8 @@ workflows:
         - content: |-
             bundle install
     - cocoapods-install@2: {}
-    - xcode-test@4:
-        inputs:
-        - scheme: $TEST_SCHEME
-    - git-tag@1:
-        inputs:
-        - tag: $NEW_VERSION
-    - generate-changelog@0: {}
-    - github-release@0:
-        inputs:
-        - username: $GITHUB_USERNAME
-        - name: Glia iOS Widgets SDK $NEW_VERSION
-        - body: $BITRISE_CHANGELOG
-        - api_token: $GITHUB_API_TOKEN
-        - draft: "no"
-        - tag: $NEW_VERSION
-        - commit: $GIT_CLONE_COMMIT_HASH
-    - script@1:
-        inputs:
-        - content: pod trunk push GliaWidgets.podspec --verbose --allow-warnings
-    - cache-push@2: {}
     after_run:
     - documentation
-    - _increment_project_version
-    - increment_widgets_version_in_cortex_financial
   development-build:
     steps:
     - activate-ssh-key@4:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -118,4 +118,9 @@ platform :ios do
     sh("sed -i '' 's/\${CORE_SDK_VERSION}/#{core_sdk_version}/' ../Package.swift")
     sh("sed -i '' 's/\${CORE_SDK_CHECKSUM}/#{core_sdk_checksum}/' ../Package.swift")
   end
+
+  desc "Generate SDK documentation web page using jazzy"
+  lane :sdk_documentation do
+    jazzy
+  end
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -53,6 +53,14 @@ Creates a pull request in the repository with whatever changes have been made. U
 
 Creates a pull request in the repository with updates to Core SDK version. 
 
+### ios sdk_documentation
+
+```sh
+[bundle exec] fastlane ios sdk_documentation
+```
+
+Generate SDK documentation web page using jazzy
+
 ----
 
 This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.

--- a/jazzy.yaml
+++ b/jazzy.yaml
@@ -1,0 +1,8 @@
+clean: true
+author: Glia Technologies, Inc
+author_url: https://glia.com
+github_url: https://github.com/salemove/ios-sdk-widgets
+root_url: https://docs.glia.com/glia-mobile/docs/ios-widgets-sdk
+output: docs
+theme: apple
+xcodebuild_arguments: [-workspace, 'GliaWidgets.xcworkspace', -scheme, 'GliaWidgets', -destination, "platform=iOS Simulator,name=iPhone 14"]


### PR DESCRIPTION
**Jira issue:**
No ticket

**What was solved?**
Now API docs wen page should be generated based on in-code docs and uploaded to the Amazon S3 bucket

**Release notes:**

 - [x] Feature: Now Widgets SDK API docs should be available to public through web page
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from iOS SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3589734507/Logging+from+iOS+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
