### PR TITLE
Update base device for snapshot tests to iOS 15.5

### DIFF
--- a/SnapshotTests/SnapshotTestCase.swift
+++ b/SnapshotTests/SnapshotTestCase.swift
@@ -27,9 +27,9 @@ extension SnapshotTestCase {
     }
 
     private static let testedDevices = [
-        // iPhone 13, iOS 15.2
+        // iPhone 13, iOS 15.5
         TestDeviceConfig(
-            systemVersion: "15.2",
+            systemVersion: "15.5",
             screenSize: CGSize(
                 width: 390,
                 height: 844

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -193,16 +193,18 @@ workflows:
     - recreate-user-schemes@1:
         inputs:
         - project_path: $BITRISE_PROJECT_PATH
-    - xcode-test@4:
+    - xcode-test:
         inputs:
         - scheme: $TEST_SCHEME
-    - xcode-test@4:
+        - destination: platform=iOS Simulator,name=iPhone 13,OS=15.5
+    - xcode-test:
         inputs:
         - scheme: $SNAPSHOTS_SCHEME
-        - destination: platform=iOS Simulator,name=iPhone 13,OS=15.2
-    - xcode-test@4:
+        - destination: platform=iOS Simulator,name=iPhone 13,OS=15.5
+    - xcode-test:
         inputs:
         - scheme: $TESTING_APP_TESTS_SCHEME
+        - destination: platform=iOS Simulator,name=iPhone 13,OS=15.5
     - xcode-archive@4:
         inputs:
         - scheme: $APP_SCHEME


### PR DESCRIPTION
**What was solved?**
Update base device for snapshot tests to iOS 15.5 because of CI requirements.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from iOS SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3589734507/Logging+from+iOS+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
