### PR TITLE
Fix response card handling

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -417,6 +417,8 @@
 		847956362AD96AD7004EF60C /* CoreSDKConfigurator.Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847956352AD96AD7004EF60C /* CoreSDKConfigurator.Interface.swift */; };
 		847956402ADED7A2004EF60C /* CallVisualizer.Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8479563F2ADED7A2004EF60C /* CallVisualizer.Action.swift */; };
 		847A7643285A1914004044D1 /* FileUploadListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847A7642285A1914004044D1 /* FileUploadListViewModelTests.swift */; };
+		8485704F2BEE3A0800CEBCC5 /* ChatViewTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8485704E2BEE3A0800CEBCC5 /* ChatViewTest.swift */; };
+		848570512BEE3CCC00CEBCC5 /* ChatStyle.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848570502BEE3CCC00CEBCC5 /* ChatStyle.Mock.swift */; };
 		8491AF002A6FB44200CC3E72 /* GvaGalleryCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AEFF2A6FB44200CC3E72 /* GvaGalleryCardCell.swift */; };
 		8491AF022A6FBBBA00CC3E72 /* GvaGalleryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF012A6FBBBA00CC3E72 /* GvaGalleryListView.swift */; };
 		8491AF062A77F16D00CC3E72 /* GvaGalleryCardStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF052A77F16D00CC3E72 /* GvaGalleryCardStyle.swift */; };
@@ -1357,6 +1359,8 @@
 		847956352AD96AD7004EF60C /* CoreSDKConfigurator.Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSDKConfigurator.Interface.swift; sourceTree = "<group>"; };
 		8479563F2ADED7A2004EF60C /* CallVisualizer.Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallVisualizer.Action.swift; sourceTree = "<group>"; };
 		847A7642285A1914004044D1 /* FileUploadListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadListViewModelTests.swift; sourceTree = "<group>"; };
+		8485704E2BEE3A0800CEBCC5 /* ChatViewTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewTest.swift; sourceTree = "<group>"; };
+		848570502BEE3CCC00CEBCC5 /* ChatStyle.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStyle.Mock.swift; sourceTree = "<group>"; };
 		8491AEFF2A6FB44200CC3E72 /* GvaGalleryCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GvaGalleryCardCell.swift; sourceTree = "<group>"; };
 		8491AF012A6FBBBA00CC3E72 /* GvaGalleryListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GvaGalleryListView.swift; sourceTree = "<group>"; };
 		8491AF052A77F16D00CC3E72 /* GvaGalleryCardStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GvaGalleryCardStyle.swift; sourceTree = "<group>"; };
@@ -3278,6 +3282,7 @@
 		7512A57827BF9FB800319DF1 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				8485704D2BEE39EB00CEBCC5 /* ChatView */,
 				AF9C0C432BC5A22800C25E47 /* GliaPresenter */,
 				84C24CFD2B8357B00089A388 /* ProcessInfoHandling */,
 				C0ECC7952B7278C9001F1EEF /* OperatorRequestsHandlerService */,
@@ -3889,6 +3894,15 @@
 				AFF954292ADD8DB600C277E0 /* CoreSDKConfigurator.Mock.swift */,
 			);
 			path = CoreSDKConfigurator;
+			sourceTree = "<group>";
+		};
+		8485704D2BEE39EB00CEBCC5 /* ChatView */ = {
+			isa = PBXGroup;
+			children = (
+				8485704E2BEE3A0800CEBCC5 /* ChatViewTest.swift */,
+				848570502BEE3CCC00CEBCC5 /* ChatStyle.Mock.swift */,
+			);
+			path = ChatView;
 			sourceTree = "<group>";
 		};
 		8491AEFE2A6FB40B00CC3E72 /* Gallery */ = {
@@ -6024,6 +6038,7 @@
 				84520BED2B19FD3000F97617 /* CallVisualizerTests+LO.swift in Sources */,
 				9A19927027D3BCAE00161AAE /* GCD.Failing.swift in Sources */,
 				3142696A29FFB712003DF62E /* Interactor.Failing.swift in Sources */,
+				8485704F2BEE3A0800CEBCC5 /* ChatViewTest.swift in Sources */,
 				8491AF602AA1EBB600CC3E72 /* TranscriptModelTests+URLs.swift in Sources */,
 				9A8130C427D9099F00220BBD /* FileDownload.Environment.Failing.swift in Sources */,
 				3117EBA22B9B041100F520D8 /* (null) in Sources */,
@@ -6050,6 +6065,7 @@
 				AF9DB22E2890571A00A0C442 /* RootCoordinator.Environment.Failing.swift in Sources */,
 				AF9DB23128905A1D00A0C442 /* ViewFactory.Environment.Failing.swift in Sources */,
 				3117EBA42B9B426200F520D8 /* (null) in Sources */,
+				848570512BEE3CCC00CEBCC5 /* ChatStyle.Mock.swift in Sources */,
 				9A3E1DA027BA7B9F005634EB /* FileSystemStorageTests.swift in Sources */,
 				EB9ADB5A2829089F00FAE8A4 /* ChatItem+Equatable.swift in Sources */,
 				EB7A150A286D98270035AC62 /* FileUploaderTests.swift in Sources */,

--- a/GliaWidgets/Sources/View/Chat/ChatView.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatView.swift
@@ -788,7 +788,10 @@ extension ChatView {
         }
 
         guard let contentView = messageRenderer?.render(message) else {
-            if chatMessage.cardType == .choiceCard {
+            // if metadata can't be handled and
+            // the message has single_choice attachment type
+            // then handle it as Response card
+            if chatMessage.attachment?.type == .singleChoice {
                 return choiceCardMessageContent(
                     chatMessage,
                     showsImage: showsImage,
@@ -796,6 +799,7 @@ extension ChatView {
                     isActive: isActive
                 )
             }
+            // otherwise handle as regular operator message
             return operatorMessageContent(
                 chatMessage,
                 showsImage: showsImage,

--- a/GliaWidgetsTests/Sources/ChatView/ChatStyle.Mock.swift
+++ b/GliaWidgetsTests/Sources/ChatView/ChatStyle.Mock.swift
@@ -1,0 +1,535 @@
+import UIKit
+@testable import GliaWidgets
+
+extension ChatStyle {
+    static func mock(
+        header: HeaderStyle = .mock(),
+        connect: ConnectStyle = .mock(),
+        backgroundColor: ColorType = .fill(color: .clear),
+        preferredStatusBarStyle: UIStatusBarStyle = .default,
+        title: String = "",
+        visitorMessageStyle: Theme.VisitorMessageStyle = .mock(),
+        operatorMessageStyle: Theme.OperatorMessageStyle = .mock(),
+        choiceCardStyle: Theme.ChoiceCardStyle = .mock(),
+        messageEntry: ChatMessageEntryStyle = .mock(),
+        audioUpgrade: ChatCallUpgradeStyle = .mock(),
+        videoUpgrade: ChatCallUpgradeStyle = .mock(),
+        callBubble: BubbleStyle = .mock(),
+        pickMedia: AttachmentSourceListStyle = .mock(),
+        unreadMessageIndicator: UnreadMessageIndicatorStyle = .mock(),
+        operatorTypingIndicator: OperatorTypingIndicatorStyle = .mock(),
+        secureTranscriptTitle: String = "",
+        secureTranscriptHeader: HeaderStyle = .mock(),
+        unreadMessageDivider: UnreadMessageDividerStyle = .mock(),
+        systemMessageStyle: Theme.SystemMessageStyle = .mock(),
+        gliaVirtualAssistant: GliaVirtualAssistantStyle = .mock()
+    ) -> ChatStyle {
+        ChatStyle.init(
+            header: header,
+            connect: connect,
+            backgroundColor: backgroundColor,
+            preferredStatusBarStyle: preferredStatusBarStyle,
+            title: title,
+            visitorMessageStyle: visitorMessageStyle,
+            operatorMessageStyle: operatorMessageStyle,
+            choiceCardStyle: choiceCardStyle,
+            messageEntry: messageEntry,
+            audioUpgrade: audioUpgrade,
+            videoUpgrade: videoUpgrade,
+            callBubble: callBubble,
+            pickMedia: pickMedia,
+            unreadMessageIndicator: unreadMessageIndicator,
+            operatorTypingIndicator: operatorTypingIndicator,
+            secureTranscriptTitle: secureTranscriptTitle,
+            secureTranscriptHeader: secureTranscriptHeader,
+            unreadMessageDivider: unreadMessageDivider,
+            systemMessageStyle: systemMessageStyle,
+            gliaVirtualAssistant: gliaVirtualAssistant
+        )
+    }
+}
+extension ConnectStyle {
+    static func mock(
+        queueOperator: ConnectOperatorStyle = .mock,
+        queue: ConnectStatusStyle = .mock(),
+        connecting: ConnectStatusStyle = .mock(),
+        connected: ConnectStatusStyle = .mock(),
+        transferring: ConnectStatusStyle = .mock(),
+        onHold: ConnectStatusStyle = .mock()
+    ) -> ConnectStyle {
+        return .init(
+            queueOperator: queueOperator,
+            queue: queue,
+            connecting: connecting,
+            connected: connected,
+            transferring: transferring,
+            onHold: onHold
+        )
+    }
+}
+
+extension ConnectStatusStyle {
+    static func mock(
+        firstText: String? = nil,
+        firstTextFont: UIFont = .systemFont(ofSize: 16),
+        firstTextFontColor: UIColor = .black,
+        firstTextStyle: UIFont.TextStyle = .body,
+        secondText: String? = nil,
+        secondTextFont: UIFont = .systemFont(ofSize: 16),
+        secondTextFontColor: UIColor = .black,
+        secondTextStyle: UIFont.TextStyle = .body
+    ) -> ConnectStatusStyle {
+        return .init(
+            firstText: firstText,
+            firstTextFont: firstTextFont,
+            firstTextFontColor: firstTextFontColor,
+            firstTextStyle: firstTextStyle,
+            secondText: secondText,
+            secondTextFont: secondTextFont,
+            secondTextFontColor: secondTextFontColor,
+            secondTextStyle: secondTextStyle
+        )
+    }
+}
+
+extension Theme.VisitorMessageStyle {
+    static func mock(
+        text: Theme.Text = .mock(),
+        background: Theme.Layer = .mock(),
+        imageFile: ChatImageFileContentStyle = .mock(),
+        fileDownload: ChatFileDownloadStyle = .mock(),
+        status: Theme.Text = .mock(),
+        delivered: String = ""
+    ) -> Theme.VisitorMessageStyle {
+        return .init(
+            text: text,
+            background: background,
+            imageFile: imageFile,
+            fileDownload: fileDownload,
+            status: status,
+            delivered: delivered
+        )
+    }
+}
+
+extension Theme.Text {
+    static func mock(
+        color: String = "",
+        font: UIFont = .systemFont(ofSize: 16),
+        textStyle: UIFont.TextStyle = .body,
+        accessibility: Accessibility = .unsupported
+    ) -> Theme.Text {
+        return .init(
+            color: color,
+            font: font,
+            textStyle: textStyle,
+            accessibility: accessibility
+        )
+    }
+}
+
+extension Theme.Layer {
+    static func mock(
+        background: ColorType? = nil,
+        borderColor: CGColor = .clear,
+        borderWidth: CGFloat = 0,
+        cornerRadius: CGFloat = 0
+    ) -> Theme.Layer {
+        return .init(
+            background: background,
+            borderColor: borderColor,
+            borderWidth: borderWidth,
+            cornerRadius: cornerRadius
+        )
+    }
+}
+
+extension ChatImageFileContentStyle {
+    static func mock(
+        backgroundColor: UIColor = .white
+    ) -> ChatImageFileContentStyle {
+        return .init(backgroundColor: backgroundColor)
+    }
+}
+
+extension ChatFileDownloadStyle {
+    static func mock(
+        filePreview: FilePreviewStyle = .mock,
+        download: ChatFileDownloadStateStyle = .mock(),
+        downloading: ChatFileDownloadStateStyle = .mock(),
+        open: ChatFileDownloadStateStyle = .mock(),
+        error: ChatFileDownloadErrorStateStyle = .mock(),
+        progressColor: UIColor = .red,
+        errorProgressColor: UIColor = .red,
+        progressBackgroundColor: UIColor = .red,
+        backgroundColor: UIColor = .white,
+        borderColor: UIColor = .clear
+    ) -> ChatFileDownloadStyle {
+        return .init(
+            filePreview: filePreview,
+            download: download,
+            downloading: downloading,
+            open: open,
+            error: error,
+            progressColor: progressColor,
+            errorProgressColor: errorProgressColor,
+            progressBackgroundColor: progressBackgroundColor,
+            backgroundColor: backgroundColor,
+            borderColor: borderColor
+        )
+    }
+}
+
+extension ChatFileDownloadStateStyle {
+    static func mock(
+        text: String = "",
+        font: UIFont = .systemFont(ofSize: 16),
+        textColor: UIColor = .black,
+        textStyle: UIFont.TextStyle = .body,
+        infoFont: UIFont = .systemFont(ofSize: 16),
+        infoColor: UIColor = .red,
+        infoTextStyle: UIFont.TextStyle = .body
+    ) -> ChatFileDownloadStateStyle {
+        return .init(
+            text: text,
+            font: font,
+            textColor: textColor,
+            textStyle: textStyle,
+            infoFont: infoFont,
+            infoColor: infoColor,
+            infoTextStyle: infoTextStyle
+        )
+    }
+}
+
+extension ChatFileDownloadErrorStateStyle {
+    static func mock(
+        text: String = "",
+        font: UIFont = .systemFont(ofSize: 16),
+        textColor: UIColor = .black,
+        textStyle: UIFont.TextStyle = .body,
+        infoFont: UIFont = .systemFont(ofSize: 16),
+        infoColor: UIColor = .black,
+        infoTextStyle: UIFont.TextStyle = .body,
+        separatorText: String = "",
+        separatorFont: UIFont = .systemFont(ofSize: 16),
+        separatorTextColor: UIColor = .black,
+        separatorTextStyle: UIFont.TextStyle = .body,
+        retryText: String = "",
+        retryFont: UIFont = .systemFont(ofSize: 16),
+        retryTextColor: UIColor = .black,
+        retryTextStyle: UIFont.TextStyle = .body
+    ) -> ChatFileDownloadErrorStateStyle {
+        return .init(
+            text: text,
+            font: font,
+            textColor: textColor,
+            textStyle: textStyle,
+            infoFont: infoFont,
+            infoColor: infoColor,
+            infoTextStyle: infoTextStyle,
+            separatorText: separatorText,
+            separatorFont: separatorFont,
+            separatorTextColor: separatorTextColor,
+            separatorTextStyle: separatorTextStyle,
+            retryText: retryText,
+            retryFont: retryFont,
+            retryTextColor: retryTextColor,
+            retryTextStyle: retryTextStyle
+        )
+    }
+}
+
+extension Theme.OperatorMessageStyle {
+    static func mock(
+        text: Theme.Text = .mock(),
+        background: Theme.Layer = .mock(),
+        imageFile: ChatImageFileContentStyle = .mock(),
+        fileDownload: ChatFileDownloadStyle = .mock(),
+        operatorImage: UserImageStyle = .mock()
+    ) -> Theme.OperatorMessageStyle {
+        return .init(
+            text: text,
+            background: background,
+            imageFile: imageFile,
+            fileDownload: fileDownload,
+            operatorImage: operatorImage
+        )
+    }
+}
+
+extension Theme.ChoiceCardStyle {
+    static func mock(
+        text: Theme.Text = .mock(),
+        background: Theme.Layer = .mock(),
+        imageFile: ChatImageFileContentStyle = .mock(),
+        fileDownload: ChatFileDownloadStyle = .mock(),
+        operatorImage: UserImageStyle = .mock(),
+        choiceOption: Option = .mock()
+    ) -> Theme.ChoiceCardStyle {
+        return .init(
+            text: text,
+            background: background,
+            imageFile: imageFile,
+            fileDownload: fileDownload,
+            operatorImage: operatorImage,
+            choiceOption: choiceOption
+        )
+    }
+}
+
+extension Theme.ChoiceCardStyle.Option {
+    static func mock(
+        normal: Theme.Button = .mock(),
+        selected: Theme.Button = .mock(),
+        disabled: Theme.Button = .mock()
+    ) -> Theme.ChoiceCardStyle.Option {
+        return .init(
+            normal: normal,
+            selected: selected,
+            disabled: disabled
+        )
+    }
+}
+
+extension Theme.Button {
+    static func mock(
+        background: ColorType = .fill(color: .white),
+        title: Theme.Text = .mock(),
+        cornerRadius: CGFloat = 0,
+        borderWidth: CGFloat = 0,
+        borderColor: String? = nil,
+        shadow: Theme.Shadow = .standard,
+        accessibility: Accessibility = .unsupported
+    ) -> Theme.Button {
+        return .init(
+            background: background,
+            title: title,
+            cornerRadius: cornerRadius,
+            borderWidth: borderWidth,
+            borderColor: borderColor,
+            shadow: shadow,
+            accessibility: accessibility
+        )
+    }
+}
+
+extension ChatMessageEntryStyle {
+    static func mock(
+        messageFont: UIFont = .systemFont(ofSize: 16),
+        messageColor: UIColor = .black,
+        enterMessagePlaceholder: String = "",
+        startEngagementPlaceholder: String = "",
+        choiceCardPlaceholder: String = "",
+        placeholderFont: UIFont = .systemFont(ofSize: 16),
+        placeholderColor: UIColor = .black,
+        separatorColor: UIColor = .black,
+        backgroundColor: UIColor = .white,
+        mediaButton: MessageButtonStyle = .mock(),
+        sendButton: MessageButtonStyle = .mock(),
+        uploadList: FileUploadListStyle = .mock
+    ) -> ChatMessageEntryStyle {
+        return .init(
+            messageFont: messageFont,
+            messageColor: messageColor,
+            enterMessagePlaceholder: enterMessagePlaceholder,
+            startEngagementPlaceholder: startEngagementPlaceholder,
+            choiceCardPlaceholder: choiceCardPlaceholder,
+            placeholderFont: placeholderFont,
+            placeholderColor: placeholderColor,
+            separatorColor: separatorColor,
+            backgroundColor: backgroundColor,
+            mediaButton: mediaButton,
+            sendButton: sendButton,
+            uploadList: uploadList
+        )
+    }
+}
+
+extension MessageButtonStyle {
+    static func mock(
+        image: UIImage = .mock,
+        color: UIColor = .black
+    ) -> MessageButtonStyle {
+        return .init(
+            image: image,
+            color: color
+        )
+    }
+}
+
+extension ChatCallUpgradeStyle {
+    static func mock(
+        icon: UIImage = .mock,
+        iconColor: UIColor = .black,
+        text: String = "",
+        textFont: UIFont = .systemFont(ofSize: 16),
+        textColor: UIColor = .black,
+        durationFont: UIFont = .systemFont(ofSize: 16),
+        durationColor: UIColor = .black,
+        borderColor: UIColor = .clear
+    ) -> ChatCallUpgradeStyle {
+        return .init(
+            icon: icon,
+            iconColor: iconColor,
+            text: text,
+            textFont: textFont,
+            textColor: textColor,
+            durationFont: durationFont,
+            durationColor: durationColor,
+            borderColor: borderColor
+        )
+    }
+}
+
+extension UnreadMessageIndicatorStyle {
+    static func mock(
+        badgeFont: UIFont = .systemFont(ofSize: 16),
+        badgeTextColor: UIColor = .white,
+        badgeColor: ColorType = .fill(color: .black),
+        placeholderImage: UIImage? = nil,
+        placeholderColor: UIColor = .black,
+        placeholderBackgroundColor: ColorType = .fill(color: .black),
+        imageBackgroundColor: ColorType = .fill(color: .black),
+        transferringImage: UIImage = .mock
+    ) -> UnreadMessageIndicatorStyle {
+        return .init(
+            badgeFont: badgeFont,
+            badgeTextColor: badgeTextColor,
+            badgeColor: badgeColor,
+            placeholderImage: placeholderImage,
+            placeholderColor: placeholderColor,
+            placeholderBackgroundColor: placeholderBackgroundColor,
+            imageBackgroundColor: imageBackgroundColor,
+            transferringImage: transferringImage
+        )
+    }
+}
+
+extension OperatorTypingIndicatorStyle {
+    static func mock(
+        color: UIColor = .red
+    ) -> OperatorTypingIndicatorStyle {
+        return .init(color: color)
+    }
+}
+
+extension UnreadMessageDividerStyle {
+    static func mock(
+        title: String = "",
+        titleColor: UIColor = .black,
+        titleFont: UIFont = .systemFont(ofSize: 16),
+        lineColor: UIColor = .black,
+        accessibility: Accessibility = .unsupported
+    ) -> UnreadMessageDividerStyle {
+        return .init(
+            title: title,
+            titleColor: titleColor,
+            titleFont: titleFont,
+            lineColor: lineColor,
+            accessibility: accessibility
+        )
+    }
+}
+
+extension Theme.SystemMessageStyle {
+    static func mock(
+        text: Theme.Text = .mock(),
+        background: Theme.Layer = .mock(),
+        imageFile: ChatImageFileContentStyle = .mock(),
+        fileDownload: ChatFileDownloadStyle = .mock()
+    ) -> Theme.SystemMessageStyle {
+        return .init(
+            text: text,
+            background: background,
+            imageFile: imageFile,
+            fileDownload: fileDownload
+        )
+    }
+}
+
+extension GliaVirtualAssistantStyle {
+    static func mock(
+        persistentButton: GvaPersistentButtonStyle = .mock(),
+        quickReplyButton: GvaQuickReplyButtonStyle = .mock(),
+        galleryList: GvaGalleryListViewStyle = .initial
+    ) -> GliaVirtualAssistantStyle {
+        return .init(
+            persistentButton: persistentButton,
+            quickReplyButton: quickReplyButton,
+            galleryList: galleryList
+        )
+    }
+}
+
+extension GvaPersistentButtonStyle {
+    static func mock(
+        title: Theme.ChatTextContentStyle = .mock(),
+        backgroundColor: ColorType = .fill(color: .white),
+        cornerRadius: CGFloat = 0,
+        borderWidth: CGFloat = 0,
+        borderColor: UIColor = .clear,
+        button: ButtonStyle = .mock()
+    ) -> GvaPersistentButtonStyle {
+        return .init(
+            title: title,
+            backgroundColor: backgroundColor,
+            cornerRadius: cornerRadius,
+            borderWidth: borderWidth,
+            borderColor: borderColor,
+            button: button
+        )
+    }
+}
+
+extension GvaQuickReplyButtonStyle {
+    static func mock(
+        textFont: UIFont = .systemFont(ofSize: 16),
+        textColor: UIColor = .black,
+        backgroundColor: ColorType = .fill(color: .white),
+        cornerRadius: CGFloat = 0,
+        borderColor: UIColor = .clear,
+        borderWidth: CGFloat = 0
+    ) -> GvaQuickReplyButtonStyle {
+        return .init(
+            textFont: textFont,
+            textColor: textColor,
+            backgroundColor: backgroundColor,
+            cornerRadius: cornerRadius,
+            borderColor: borderColor,
+            borderWidth: borderWidth
+        )
+    }
+}
+
+extension GvaPersistentButtonStyle.ButtonStyle {
+    static func mock(
+        textFont: UIFont = .systemFont(ofSize: 16),
+        textColor: UIColor = .black,
+        backgroundColor: ColorType = .fill(color: .white),
+        cornerRadius: CGFloat = 0,
+        borderColor: UIColor = .clear,
+        borderWidth: CGFloat = 0
+    ) -> GvaPersistentButtonStyle.ButtonStyle {
+        return .init(
+            textFont: textFont,
+            textColor: textColor,
+            backgroundColor: backgroundColor,
+            cornerRadius: cornerRadius,
+            borderColor: borderColor,
+            borderWidth: borderWidth
+        )
+    }
+}
+
+extension Theme.ChatTextContentStyle {
+    static func mock(
+        text: Theme.Text = .mock(),
+        background: Theme.Layer = .mock()
+    ) -> Theme.ChatTextContentStyle {
+        return .init(
+            text: text,
+            background: background
+        )
+    }
+}

--- a/GliaWidgetsTests/Sources/ChatView/ChatViewTest.swift
+++ b/GliaWidgetsTests/Sources/ChatView/ChatViewTest.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import GliaWidgets
+
+final class ChatViewTest: XCTestCase {
+
+    var view: ChatView!
+
+    func test_contentForChatItemIsChoiceCardIfThereIsBrokenMetadata() throws {
+        let env = EngagementView.Environment(
+            data: .failing,
+            uuid: { .mock },
+            gcd: .failing,
+            imageViewCache: .failing,
+            timerProviding: .failing,
+            uiApplication: .failing,
+            uiScreen: .failing
+        )
+        view = ChatView(
+            with: .mock(),
+            messageRenderer: .webRenderer,
+            environment: env,
+            props: .init(header: .mock())
+        )
+        let metadataDecodingContainer = try CoreSdkMessageMetadataContainer(
+            jsonData: "{ }".data(using: .utf8)!
+        ).container
+        let message = ChatMessage.mock(
+            sender: .operator,
+            attachment: ChatAttachment.mock(
+                type: .singleChoice,
+                files: nil,
+                imageUrl: nil,
+                options: nil
+            ),
+            metadata: MessageMetadata(container: metadataDecodingContainer)
+        )
+        let item = try XCTUnwrap(ChatItem(
+            with: message,
+            isCustomCardSupported: true
+        ))
+        switch view.content(for: item) {
+        case .choiceCard:
+            break
+        default:
+            XCTFail("Content should be .choiceCard")
+        }
+    }
+}


### PR DESCRIPTION
There was a bug when custom response card message payload has empty metadata object and the SDK can not decode it, the fallback to response card never happens. This commit fixes it.

MOB-3314

**Jira issue:**
https://glia.atlassian.net/browse/MOB-xxx

**What was solved?**

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from iOS SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3589734507/Logging+from+iOS+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
