### PR TITLE
Show error snackbar when access token expired

### DIFF
--- a/GliaWidgets/Sources/ViewController/Call/CallViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Call/CallViewController.swift
@@ -14,7 +14,10 @@ final class CallViewController: EngagementViewController {
             viewModel: viewModel,
             environment: .init(
                 viewFactory: environment.viewFactory,
-                snackBar: environment.snackBar
+                snackBar: environment.snackBar,
+                timerProviding: environment.timerProviding,
+                gcd: environment.gcd,
+                notificationCenter: environment.notificationCenter
             )
         )
     }

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
@@ -21,7 +21,10 @@ final class ChatViewController: EngagementViewController, PopoverPresenter {
             viewModel: viewModel.engagementModel,
             environment: .init(
                 viewFactory: environment.viewFactory,
-                snackBar: environment.snackBar
+                snackBar: environment.snackBar,
+                timerProviding: environment.timerProviding,
+                gcd: environment.gcd,
+                notificationCenter: environment.notificationCenter
             )
         )
     }

--- a/GliaWidgets/Sources/ViewController/EngagementViewController.swift
+++ b/GliaWidgets/Sources/ViewController/EngagementViewController.swift
@@ -75,6 +75,8 @@ class EngagementViewController: UIViewController, AlertPresenter {
                 view?.header.showEndScreenSharingButton()
             case let .showLiveObservationConfirmation(configuration):
                 self.showLiveObservationConfirmation(with: configuration)
+            case let .showSnackbar(text):
+                self.showSnackbar(text: text)
             }
         }
     }
@@ -82,6 +84,18 @@ class EngagementViewController: UIViewController, AlertPresenter {
     func swapAndBindEgagementViewModel(_ engagementModel: CommonEngagementModel) {
         self.viewModel = engagementModel
         bind(engagementViewModel: engagementModel)
+    }
+
+    private func showSnackbar(text: String) {
+        let style = environment.viewFactory.theme.snackBarStyle
+        environment.snackBar.present(
+            text: text,
+            style: style,
+            for: self,
+            timerProviding: environment.timerProviding,
+            gcd: environment.gcd,
+            notificationCenter: environment.notificationCenter
+        )
     }
 
     private func showLiveObservationConfirmation(
@@ -112,5 +126,8 @@ extension EngagementViewController {
     struct Environment {
         var viewFactory: ViewFactory
         var snackBar: SnackBar
+        var timerProviding: FoundationBased.Timer.Providing
+        var gcd: GCD
+        var notificationCenter: FoundationBased.NotificationCenter
     }
 }

--- a/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
@@ -321,6 +321,18 @@ private extension EngagementViewModel {
                     dismissed: { self.endSession() }
                 )
             }
+        case let authenticationError as CoreSdkClient.Authentication.Error:
+            switch authenticationError {
+            case let .expiredAccessToken(message):
+                environment.log.prefixed(Self.self).info("Show authentication error snackbar")
+                engagementAction?(.showSnackbar(text: message))
+            default:
+                environment.log.prefixed(Self.self).info("Show Unexpected error Dialog")
+                showAlert(
+                    with: alertConfiguration.unexpectedError,
+                    dismissed: { self.endSession() }
+                )
+            }
         default:
             environment.log.prefixed(Self.self).info("Show Unexpected error Dialog")
             showAlert(
@@ -410,6 +422,7 @@ extension EngagementViewModel {
         case showEndButton
         case showEndScreenShareButton
         case showLiveObservationConfirmation(LiveObservation.Confirmation)
+        case showSnackbar(text: String)
     }
 
     enum DelegateEvent {


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3261

**What was solved?**
When a visitor's access token is expired, CoreSDK sends a specific error message to WidgetSDK, which is then displayed on a snack bar.

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [X] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from iOS SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3589734507/Logging+from+iOS+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
