### PR TITLE
Destination for deployment workflow into master

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -78,6 +78,7 @@ workflows:
     - xcode-test@4:
         inputs:
         - scheme: $TEST_SCHEME
+        - destination: platform=iOS Simulator,name=iPhone 13,OS=15.5
     - git-tag@1:
         inputs:
         - tag: $NEW_VERSION


### PR DESCRIPTION
**This PR duplicates changes into master branch made in [PR](https://github.com/salemove/ios-sdk-widgets/pull/942)**

Bitrise deployment workflow fails due to incompatible device type with latest iOS used by default. This commit defined newer device version to align it with other workflows, like pull-request one.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)