### PR TITLE
Add unit tests for camera flip related API

### DIFF
--- a/GliaWidgets/Sources/View/Call/Video/FlipCameraButtonStyle.Accessibility.swift
+++ b/GliaWidgets/Sources/View/Call/Video/FlipCameraButtonStyle.Accessibility.swift
@@ -70,3 +70,14 @@ extension FlipCameraButtonStyle.Accessibility {
         }
     }
 }
+
+#if DEBUG
+extension FlipCameraButtonStyle.Accessibility {
+    static let mock = Self(
+        switchToBackCameraAccessibilityLabel: "",
+        switchToBackCameraAccessibilityHint: "",
+        switchToFrontCameraAccessibilityLabel: "",
+        switchToFrontCameraAccessibilityHint: ""
+    )
+}
+#endif

--- a/GliaWidgets/Sources/View/Call/Video/FlipCameraButtonStyle.swift
+++ b/GliaWidgets/Sources/View/Call/Video/FlipCameraButtonStyle.swift
@@ -43,3 +43,13 @@ extension FlipCameraButtonStyle {
         accessibility: .nop
     )
 }
+
+#if DEBUG
+extension FlipCameraButtonStyle {
+    static let mock = Self(
+        backgroundColor: .fill(color: .clear),
+        imageColor: .fill(color: .clear),
+        accessibility: .mock
+    )
+}
+#endif


### PR DESCRIPTION
MOB-3315

**Jira issue:**
https://glia.atlassian.net/browse/MOB-3315

**What was solved?**
Add unit tests for camera flip related API, specifically 'CallViewModel.setFlipCameraButtonVisible' static method, since it is reused between regular video call engagement and call visualizer.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from iOS SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3589734507/Logging+from+iOS+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
