### PR TITLE
Add refresh access token capability to testing app

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -861,6 +861,7 @@
 		C0D2F08B29A4E95700803B47 /* ConnectView.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F08929A4E92D00803B47 /* ConnectView.Mock.swift */; };
 		C0D2F08C29A4EBA900803B47 /* VIdeoCallView.Environment.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F06F29A4DB5C00803B47 /* VIdeoCallView.Environment.Mock.swift */; };
 		C0D2F08F29A61A8D00803B47 /* VideoCallViewController.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F08D29A61A7800803B47 /* VideoCallViewController.Mock.swift */; };
+		C0D6C9E62BFB695E00D4709B /* ViewController+AuthTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6C9E52BFB695E00D4709B /* ViewController+AuthTimer.swift */; };
 		C0E948042AB1D5D200890026 /* ActionButtonSwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E948032AB1D5D200890026 /* ActionButtonSwiftUI.swift */; };
 		C0E948062AB1D64700890026 /* HeaderButtonSwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E948052AB1D64700890026 /* HeaderButtonSwiftUI.swift */; };
 		C0E948092AB1D6AB00890026 /* HeaderSwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E948082AB1D6AB00890026 /* HeaderSwiftUI.swift */; };
@@ -1813,6 +1814,7 @@
 		C0D2F08629A4E8AE00803B47 /* CallButtonBar.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallButtonBar.Mock.swift; sourceTree = "<group>"; };
 		C0D2F08929A4E92D00803B47 /* ConnectView.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectView.Mock.swift; sourceTree = "<group>"; };
 		C0D2F08D29A61A7800803B47 /* VideoCallViewController.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCallViewController.Mock.swift; sourceTree = "<group>"; };
+		C0D6C9E52BFB695E00D4709B /* ViewController+AuthTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+AuthTimer.swift"; sourceTree = "<group>"; };
 		C0E948032AB1D5D200890026 /* ActionButtonSwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionButtonSwiftUI.swift; sourceTree = "<group>"; };
 		C0E948052AB1D64700890026 /* HeaderButtonSwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderButtonSwiftUI.swift; sourceTree = "<group>"; };
 		C0E948082AB1D6AB00890026 /* HeaderSwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderSwiftUI.swift; sourceTree = "<group>"; };
@@ -3696,6 +3698,7 @@
 			isa = PBXGroup;
 			children = (
 				1A205D7E25655CEC003AA3CD /* ViewController.swift */,
+				C0D6C9E52BFB695E00D4709B /* ViewController+AuthTimer.swift */,
 				84265E6D29914DDA00D65842 /* ViewController+CallVisualizer.swift */,
 			);
 			path = ViewController;
@@ -6144,6 +6147,7 @@
 				1A4AD3D6256FE7F800468BFB /* UIColor+Extensions.swift in Sources */,
 				AF11F30728BE6F0C002ACEB4 /* UIAlertController+Extensions.swift in Sources */,
 				7552DFA82A683A2C0093519B /* UIStackView.Extensions.swift in Sources */,
+				C0D6C9E62BFB695E00D4709B /* ViewController+AuthTimer.swift in Sources */,
 				AF3BD1DF2A42026D00A7713E /* Command.swift in Sources */,
 				84CD035F2B56DEE300E7A1DC /* SensitiveDataViewController.swift in Sources */,
 				8491AF2E2A93975100CC3E72 /* ConfigurationDeeplinkHandler.swift in Sources */,

--- a/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.Mock.swift
+++ b/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.Mock.swift
@@ -21,7 +21,8 @@ extension AlertConfiguration {
             unavailableMessageCenter: .mock(),
             unavailableMessageCenterForBeingUnauthenticated: .mock(),
             unsupportedGvaBroadcastError: .mock(),
-            liveObservationConfirmation: .mock()
+            liveObservationConfirmation: .mock(),
+            expiredAccessTokenError: .mock()
         )
     }
 }

--- a/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.swift
+++ b/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.swift
@@ -57,6 +57,9 @@ public struct AlertConfiguration {
     /// Configuration of the live observation aknwoledgement
     public var liveObservationConfirmation: ConfirmationAlertConfiguration
 
+    /// Configuration of expired access token error
+    public var expiredAccessTokenError: MessageAlertConfiguration
+
     /// - Parameters:
     ///   - leaveQueue: Configuration of the queue leaving confirmation alert.
     ///   - endEngagement: Configuration of the engagement ending confirmation alert.
@@ -98,7 +101,8 @@ public struct AlertConfiguration {
         unavailableMessageCenter: MessageAlertConfiguration,
         unavailableMessageCenterForBeingUnauthenticated: MessageAlertConfiguration,
         unsupportedGvaBroadcastError: MessageAlertConfiguration,
-        liveObservationConfirmation: ConfirmationAlertConfiguration
+        liveObservationConfirmation: ConfirmationAlertConfiguration,
+        expiredAccessTokenError: MessageAlertConfiguration
     ) {
         self.leaveQueue = leaveQueue
         self.endEngagement = endEngagement
@@ -119,5 +123,6 @@ public struct AlertConfiguration {
         self.unavailableMessageCenterForBeingUnauthenticated = unavailableMessageCenterForBeingUnauthenticated
         self.unsupportedGvaBroadcastError = unsupportedGvaBroadcastError
         self.liveObservationConfirmation = liveObservationConfirmation
+        self.expiredAccessTokenError = expiredAccessTokenError
     }
 }

--- a/GliaWidgets/Sources/Theme/Theme+AlertConfiguration.swift
+++ b/GliaWidgets/Sources/Theme/Theme+AlertConfiguration.swift
@@ -133,6 +133,12 @@ extension Theme {
             message: nil
         )
 
+        // TO DO - Localization values will be added in MOB-3343
+        let expiredAccessTokenError = MessageAlertConfiguration(
+            title: "Authentication issue",
+            message: "Please restart the app and log in again."
+        )
+
         let liveObservationConfirmation = ConfirmationAlertConfiguration(
             title: Localization.Engagement.Confirm.title,
             message: Localization.Engagement.Confirm.message,
@@ -163,7 +169,8 @@ extension Theme {
             unavailableMessageCenter: unavailableMessageCenter,
             unavailableMessageCenterForBeingUnauthenticated: unavailableMessageCenterForBeingUnauthenticated,
             unsupportedGvaBroadcastError: unsupportedGvaBroadcastError,
-            liveObservationConfirmation: liveObservationConfirmation
+            liveObservationConfirmation: liveObservationConfirmation,
+            expiredAccessTokenError: expiredAccessTokenError
         )
     }
 }

--- a/GliaWidgets/Sources/ViewController/Common/Alert/AlertPresenter.swift
+++ b/GliaWidgets/Sources/ViewController/Common/Alert/AlertPresenter.swift
@@ -30,6 +30,21 @@ protocol AlertPresenter: DismissalAndPresentationController where Self: UIViewCo
 }
 
 extension AlertPresenter {
+    func presentCriticalErrorAlert(
+        with conf: MessageAlertConfiguration,
+        accessibilityIdentifier: String? = nil,
+        dismissed: (() -> Void)? = nil
+    ) {
+        let alert: AlertViewController = .init(
+            kind: .criticalError(
+                conf,
+                accessibilityIdentifier: accessibilityIdentifier,
+                dismissed: dismissed
+            ),
+            viewFactory: viewFactory
+        )
+        replacePresentedOfferIfPossible(with: alert)
+    }
     func presentAlert(
         with conf: MessageAlertConfiguration,
         accessibilityIdentifier: String? = nil,

--- a/GliaWidgets/Sources/ViewController/Common/Alert/AlertViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Common/Alert/AlertViewController.swift
@@ -35,13 +35,19 @@ class AlertViewController: UIViewController, Replaceable {
             declined: () -> Void
         )
 
+        case criticalError(
+            MessageAlertConfiguration,
+            accessibilityIdentifier: String?,
+            dismissed: (() -> Void)?
+        )
+
         /// Indicating presentation priority of an alert.
         /// Based on comparing values we can decide whether an alert can be replaced with another alert.
         fileprivate var presentationPriority: PresentationPriority {
             switch self {
-            case .singleAction, .liveObservationConfirmation:
+            case .singleAction, .criticalError:
                 return .highest
-            case .confirmation:
+            case .confirmation, .liveObservationConfirmation:
                 return .high
             case .message, .singleMediaUpgrade, .screenShareOffer:
                 return .regular
@@ -173,6 +179,12 @@ class AlertViewController: UIViewController, Replaceable {
                 link: link,
                 accepted: accepted,
                 declined: declined
+            )
+        case let .criticalError(conf, accessibilityIdentifier, dismissed):
+            return makeMessageAlertView(
+                with: conf,
+                accessibilityIdentifier: accessibilityIdentifier,
+                dismissed: dismissed
             )
         }
     }

--- a/GliaWidgets/Sources/ViewController/EngagementViewController.swift
+++ b/GliaWidgets/Sources/ViewController/EngagementViewController.swift
@@ -75,8 +75,12 @@ class EngagementViewController: UIViewController, AlertPresenter {
                 view?.header.showEndScreenSharingButton()
             case let .showLiveObservationConfirmation(configuration):
                 self.showLiveObservationConfirmation(with: configuration)
-            case let .showSnackbar(text):
-                self.showSnackbar(text: text)
+            case let .showCriticalErrorAlert(conf, accessibilityIdentifier, dismissed):
+                self.presentCriticalErrorAlert(
+                    with: conf,
+                    accessibilityIdentifier: accessibilityIdentifier,
+                    dismissed: dismissed
+                )
             }
         }
     }
@@ -84,18 +88,6 @@ class EngagementViewController: UIViewController, AlertPresenter {
     func swapAndBindEgagementViewModel(_ engagementModel: CommonEngagementModel) {
         self.viewModel = engagementModel
         bind(engagementViewModel: engagementModel)
-    }
-
-    private func showSnackbar(text: String) {
-        let style = environment.viewFactory.theme.snackBarStyle
-        environment.snackBar.present(
-            text: text,
-            style: style,
-            for: self,
-            timerProviding: environment.timerProviding,
-            gcd: environment.gcd,
-            notificationCenter: environment.notificationCenter
-        )
     }
 
     private func showLiveObservationConfirmation(

--- a/TestingApp/Main.storyboard
+++ b/TestingApp/Main.storyboard
@@ -166,17 +166,33 @@
                                                         </segments>
                                                         <color key="selectedSegmentTintColor" systemColor="systemBlueColor"/>
                                                     </segmentedControl>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pHy-59-v7T">
+                                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="aOj-gT-Fab">
                                                         <rect key="frame" x="0.0" y="65" width="237.5" height="30"/>
-                                                        <accessibility key="accessibilityConfiguration" identifier="main_authenticate_button"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="30" id="ezp-dJ-Nup"/>
-                                                        </constraints>
-                                                        <state key="normal" title="Authenticate"/>
-                                                        <connections>
-                                                            <action selector="toggleAuthentication" destination="Y6W-OH-hqX" eventType="touchUpInside" id="ilH-Ar-YKu"/>
-                                                        </connections>
-                                                    </button>
+                                                        <subviews>
+                                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pHy-59-v7T">
+                                                                <rect key="frame" x="0.0" y="0.0" width="118.5" height="30"/>
+                                                                <accessibility key="accessibilityConfiguration" identifier="main_authenticate_button"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="30" id="ezp-dJ-Nup"/>
+                                                                </constraints>
+                                                                <state key="normal" title="Authenticate"/>
+                                                                <connections>
+                                                                    <action selector="toggleAuthentication" destination="Y6W-OH-hqX" eventType="touchUpInside" id="ilH-Ar-YKu"/>
+                                                                </connections>
+                                                            </button>
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5zf-Ur-3od">
+                                                                <rect key="frame" x="118.5" y="0.0" width="119" height="30"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="30" id="LPc-hG-dHW"/>
+                                                                </constraints>
+                                                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                                                <state key="normal" title="Refresh"/>
+                                                                <connections>
+                                                                    <action selector="refreshAccessToken" destination="Y6W-OH-hqX" eventType="touchUpInside" id="UPk-Bw-NuW"/>
+                                                                </connections>
+                                                            </button>
+                                                        </subviews>
+                                                    </stackView>
                                                 </subviews>
                                             </stackView>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ojd-PF-wje">
@@ -314,6 +330,7 @@
                         <outlet property="authenticationBehaviorSegmentedControl" destination="kH0-DZ-F2e" id="m54-z8-Emh"/>
                         <outlet property="autoConfigureSdkToggle" destination="rZ7-2H-jwc" id="nAr-zX-vTy"/>
                         <outlet property="configureButton" destination="4yC-lN-tH2" id="sAf-jg-YTC"/>
+                        <outlet property="refreshAccessTokenButton" destination="5zf-Ur-3od" id="O5Q-56-XDi"/>
                         <outlet property="secureConversationsButton" destination="ojd-PF-wje" id="kN8-zY-QYl"/>
                         <outlet property="toggleAuthenticateButton" destination="pHy-59-v7T" id="9rO-74-dfE"/>
                     </connections>
@@ -328,7 +345,7 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemBlueColor">
-            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/TestingApp/ViewController/ViewController+AuthTimer.swift
+++ b/TestingApp/ViewController/ViewController+AuthTimer.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+extension ViewController {
+    /// We don't have a way to report back to viewController,
+    /// about deauthentication because of an error. We need to
+    /// check it manually so that UI renders properly.
+    func startAuthTimer() {
+        authTimer = Timer.scheduledTimer(
+            timeInterval: 3.0,
+            target: self,
+            selector: #selector(checkAuthState),
+            userInfo: nil,
+            repeats: true
+        )
+    }
+
+    func stopAuthTimer() {
+        authTimer?.invalidate()
+        authTimer = nil
+    }
+
+    @objc func checkAuthState() {
+        guard let authentication, authentication.isAuthenticated else {
+            authentication = nil
+            stopAuthTimer()
+            renderAuthenticatedState(isAuthenticated: false)
+            return
+        }
+        renderAuthenticatedState(isAuthenticated: true)
+    }
+}


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3267

**What was solved?**
In addition to access token refreshing, snackbar was replaced with alert to overcome UI issues, such as conflicting alerts. LO confirmation alert priority was reduced to override it with 401 error. In testing app a timer was added to guarantee proper UI when 401 occurs and visitor is de-authenticated by CoreSDK.
**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [X] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from iOS SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3589734507/Logging+from+iOS+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
