### PR TITLE
Fix crash occurring on onHold event during LO

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -337,6 +337,7 @@
 		75FF151727F4E13900FE7BE2 /* Theme.Survey.BooleanQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FF151627F4E13900FE7BE2 /* Theme.Survey.BooleanQuestion.swift */; };
 		75FF151B27F4F52D00FE7BE2 /* Theme.Survey.SingleQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FF151A27F4F52D00FE7BE2 /* Theme.Survey.SingleQuestion.swift */; };
 		75FF151D27F4F8E000FE7BE2 /* Theme.Survey.InputQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FF151C27F4F8E000FE7BE2 /* Theme.Survey.InputQuestion.swift */; };
+		8418AD7B2BFB69BC007DE207 /* OnHoldOverlayVisualEffectViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8418AD7A2BFB69BC007DE207 /* OnHoldOverlayVisualEffectViewTests.swift */; };
 		84265DF02983E62100D65842 /* Theme+ScreenSharing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84265DEF2983E62100D65842 /* Theme+ScreenSharing.swift */; };
 		84265E07298AE96B00D65842 /* ScreenSharingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84265E06298AE96B00D65842 /* ScreenSharingViewModelTests.swift */; };
 		84265E4B298D7B1900D65842 /* CallVisualizer.Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84265E49298D7B1900D65842 /* CallVisualizer.Coordinator.swift */; };
@@ -1278,6 +1279,7 @@
 		75FF151A27F4F52D00FE7BE2 /* Theme.Survey.SingleQuestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.Survey.SingleQuestion.swift; sourceTree = "<group>"; };
 		75FF151C27F4F8E000FE7BE2 /* Theme.Survey.InputQuestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.Survey.InputQuestion.swift; sourceTree = "<group>"; };
 		7BF80688D6DD761AADD4A046 /* Pods_SnapshotTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SnapshotTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8418AD7A2BFB69BC007DE207 /* OnHoldOverlayVisualEffectViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnHoldOverlayVisualEffectViewTests.swift; sourceTree = "<group>"; };
 		84265DEF2983E62100D65842 /* Theme+ScreenSharing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Theme+ScreenSharing.swift"; sourceTree = "<group>"; };
 		84265E06298AE96B00D65842 /* ScreenSharingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenSharingViewModelTests.swift; sourceTree = "<group>"; };
 		84265E0B298AECBA00D65842 /* ScreenSharingViewStyle+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ScreenSharingViewStyle+Mock.swift"; sourceTree = "<group>"; };
@@ -3282,6 +3284,7 @@
 		7512A57827BF9FB800319DF1 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				8418AD792BFB68C9007DE207 /* OnHoldOverlayVisualEffectView */,
 				8485704D2BEE39EB00CEBCC5 /* ChatView */,
 				AF9C0C432BC5A22800C25E47 /* GliaPresenter */,
 				84C24CFD2B8357B00089A388 /* ProcessInfoHandling */,
@@ -3609,6 +3612,14 @@
 				845E2F7E283F99F200C04D56 /* Theme.Survey.ValidationError.swift */,
 			);
 			path = Survey;
+			sourceTree = "<group>";
+		};
+		8418AD792BFB68C9007DE207 /* OnHoldOverlayVisualEffectView */ = {
+			isa = PBXGroup;
+			children = (
+				8418AD7A2BFB69BC007DE207 /* OnHoldOverlayVisualEffectViewTests.swift */,
+			);
+			path = OnHoldOverlayVisualEffectView;
 			sourceTree = "<group>";
 		};
 		84265E05298AE93700D65842 /* ScreenSharing */ = {
@@ -6098,6 +6109,7 @@
 				9AE05CB32805C9D900871321 /* ChatViewModel.Environment.Failing.swift in Sources */,
 				7552DFB12A6FB7DF0093519B /* ChatMessageTests.swift in Sources */,
 				31CCE3E82BCE8F3A00F92535 /* VideoCallCoordinatorTests.swift in Sources */,
+				8418AD7B2BFB69BC007DE207 /* OnHoldOverlayVisualEffectViewTests.swift in Sources */,
 				8491AF672AB8707600CC3E72 /* ChatViewModelTests+Transferring.swift in Sources */,
 				AFEF5C7429929A8D005C3D8D /* SecureConversations.FileUploadListViewModel.Environment.Failing.swift in Sources */,
 				AFF9542C2ADDA10600C277E0 /* CoreSDKConfigurator.Failing.swift in Sources */,

--- a/GliaWidgets/Sources/Component/Bubble/BubbleView.swift
+++ b/GliaWidgets/Sources/Component/Bubble/BubbleView.swift
@@ -37,7 +37,10 @@ class BubbleView: BaseView {
     ) {
         self.style = style
         self.environment = environment
-        self.onHoldView = OnHoldOverlayView(style: style.onHoldOverlay)
+        self.onHoldView = OnHoldOverlayView(
+            environment: .init(gcd: environment.gcd),
+            style: style.onHoldOverlay
+        )
         self.onHoldView.clipsToBounds = true
 
         super.init()

--- a/GliaWidgets/Sources/Component/Connect/Operator/ConnectOperatorView.swift
+++ b/GliaWidgets/Sources/Component/Connect/Operator/ConnectOperatorView.swift
@@ -129,7 +129,10 @@ final class ConnectOperatorView: BaseView {
     func showOnHoldView() {
         onHoldView?.removeFromSuperview()
 
-        let onHoldView = OnHoldOverlayView(style: style.onHoldOverlay)
+        let onHoldView = OnHoldOverlayView(
+            environment: .init(gcd: environment.gcd),
+            style: style.onHoldOverlay
+        )
         self.onHoldView = onHoldView
 
         imageView.addSubview(onHoldView)

--- a/GliaWidgets/Sources/Component/OnHoldOverlay/OnHoldOverlayView.swift
+++ b/GliaWidgets/Sources/Component/OnHoldOverlay/OnHoldOverlayView.swift
@@ -2,13 +2,17 @@ import UIKit
 
 final class OnHoldOverlayView: UIView {
     private let style: OnHoldOverlayStyle
-    private let blurEffectView = OnHoldOverlayVisualEffectView()
+    private let blurEffectView: OnHoldOverlayVisualEffectView
     private let imageView = UIImageView()
 
     private var gradientLayer: CAGradientLayer?
 
-    init(style: OnHoldOverlayStyle) {
+    init(
+        environment: Environment,
+        style: OnHoldOverlayStyle
+    ) {
         self.style = style
+        self.blurEffectView = OnHoldOverlayVisualEffectView(environment: .init(gcd: environment.gcd))
 
         super.init(frame: .zero)
 
@@ -55,5 +59,11 @@ final class OnHoldOverlayView: UIView {
         constraints += imageView.layoutInSuperviewCenter()
         constraints += imageView.match(.width, value: style.imageSize.width)
         constraints += imageView.match(.height, value: style.imageSize.height)
+    }
+}
+
+extension OnHoldOverlayView {
+    struct Environment {
+        let gcd: GCD
     }
 }

--- a/GliaWidgets/Sources/Component/OnHoldOverlay/OnHoldOverlayVisualEffectView.swift
+++ b/GliaWidgets/Sources/Component/OnHoldOverlay/OnHoldOverlayVisualEffectView.swift
@@ -5,19 +5,36 @@ final class OnHoldOverlayVisualEffectView: UIVisualEffectView {
         duration: 1,
         curve: .linear
     )
+    private let environment: Environment
+
+    init(environment: Environment) {
+        self.environment = environment
+        super.init(effect: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
     override func draw(_ rect: CGRect) {
         super.draw(rect)
 
-        effect = nil
-        animator.stopAnimation(true)
-        animator.addAnimations { [weak self] in
-            self?.effect = UIBlurEffect(style: .regular)
+        environment.gcd.mainQueue.async {
+            self.effect = nil
+            self.animator.stopAnimation(true)
+            self.animator.addAnimations { [weak self] in
+                self?.effect = UIBlurEffect(style: .regular)
+            }
+            self.animator.fractionComplete = 0.1
         }
-        animator.fractionComplete = 0.1
     }
 
     deinit {
         animator.stopAnimation(true)
+    }
+}
+
+extension OnHoldOverlayVisualEffectView {
+    struct Environment {
+        let gcd: GCD
     }
 }

--- a/GliaWidgetsTests/Sources/OnHoldOverlayVisualEffectView/OnHoldOverlayVisualEffectViewTests.swift
+++ b/GliaWidgetsTests/Sources/OnHoldOverlayVisualEffectView/OnHoldOverlayVisualEffectViewTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import GliaWidgets
+
+final class OnHoldOverlayVisualEffectViewTests: XCTestCase {
+
+    func test_overlayViewDrawIsExecutedOnMainQueue() {
+        enum Call { case mainQueueAsync }
+        var calls: [Call] = []
+        var gcd = GCD.failing
+        gcd.mainQueue.async = { _ in
+            calls.append(.mainQueueAsync)
+        }
+        let environment = OnHoldOverlayVisualEffectView.Environment(gcd: gcd)
+        let view = OnHoldOverlayVisualEffectView(environment: environment)
+
+        view.draw(.zero)
+
+        XCTAssertEqual(calls, [.mainQueueAsync])
+    }
+}


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3332

**What was solved?**
When the visitor is put on-hold during LO, the crash occurs, because `OnHoldOverlayVisualEffectView.draw` method is called on background thread by `layer?.render(in:)` in `WindowCapturer.native`. Since we need to keep screen capturing on background thread, `draw` method execution was wrapped into main queue. This issue is related only to native implementation for WindowCapturer, and is not reproducible for flutter side.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from iOS SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3589734507/Logging+from+iOS+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.