### PR TITLE
Add subset of new SwiftLint rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -15,6 +15,10 @@ opt_in_rules:
   - closure_spacing
   - closure_end_indentation
   - force_unwrapping
+  - comma_inheritance
+  - convenience_type
+  - empty_xctest_method
+  - let_var_whitespace
 excluded: # paths to ignore during linting. Takes precedence over `included`.
   - Carthage
   - Pods

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.CommonEngagementModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.CommonEngagementModel.swift
@@ -4,6 +4,7 @@ protocol CommonEngagementModel: AnyObject {
     var engagementAction: EngagementViewModel.ActionCallback? { get set }
     var engagementDelegate: EngagementViewModel.DelegateCallback? { get set }
     var hasViewAppeared: Bool { get }
+
     func event(_ event: EngagementViewModel.Event)
     func setViewAppeared()
 }

--- a/GliaWidgets/SecureConversations/FileUploadListView/SecureConversations.FileUploadView.swift
+++ b/GliaWidgets/SecureConversations/FileUploadListView/SecureConversations.FileUploadView.swift
@@ -6,6 +6,7 @@ extension SecureConversations {
 
         struct Props: Equatable, Identifiying {
             typealias Identifier = String
+
             let id: Identifier
             let style: Style
             let state: State

--- a/GliaWidgets/SecureConversations/SecureConversations.Availability.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Availability.swift
@@ -3,6 +3,7 @@ import Foundation
 extension SecureConversations {
     struct Availability {
         typealias CompletionResult = (Result<Status, CoreSdkClient.SalemoveError>) -> Void
+
         var environment: Environment
 
         func checkSecureConversationsAvailability(completion: @escaping CompletionResult) {

--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeView.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeView.swift
@@ -10,6 +10,7 @@ extension SecureConversations {
             let uiScreen: UIKitBased.UIScreen
             let notificationCenter: FoundationBased.NotificationCenter
         }
+
         static let sideMargin = 24.0
         static let filePickerButtonSize = 44.0
 

--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewController.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewController.swift
@@ -9,6 +9,7 @@ extension SecureConversations {
             let notificationCenter: FoundationBased.NotificationCenter
             var log: CoreSdkClient.Logger
         }
+
         var props: Props {
             didSet {
                 renderProps()

--- a/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Presenter.swift
+++ b/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Presenter.swift
@@ -5,6 +5,7 @@ extension CallVisualizer {
         init(presenter: @escaping () -> UIViewController?) {
             self.getInstance = presenter
         }
+
         let getInstance: () -> UIViewController?
     }
 }

--- a/GliaWidgets/Sources/CallVisualizer/ScreenSharing/Coordinator/ScreenSharingCoordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/ScreenSharing/Coordinator/ScreenSharingCoordinator.swift
@@ -3,6 +3,7 @@ import UIKit
 extension CallVisualizer {
     final class ScreenSharingCoordinator: FlowCoordinator {
         typealias ViewController = UIViewController
+
         var delegate: ((DelegateEvent) -> Void)?
 
         private let environment: Environment

--- a/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeCoordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeCoordinator.swift
@@ -3,8 +3,8 @@ import UIKit
 extension CallVisualizer {
     class VisitorCodeCoordinator: FlowCoordinator {
         typealias ViewController = UIViewController
-        let theme: Theme
 
+        let theme: Theme
         var delegate: ((DelegateEvent) -> Void)?
         var environment: Environment
         let presentation: CallVisualizer.Presentation

--- a/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeView.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeView.swift
@@ -12,6 +12,7 @@ extension CallVisualizer {
                 case loading
                 case success(visitorCode: String)
             }
+
             let viewState: ViewState
             let viewType: ViewType
             let style: VisitorCodeStyle

--- a/GliaWidgets/Sources/Component/Button/Action/ActionButton.swift
+++ b/GliaWidgets/Sources/Component/Button/Action/ActionButton.swift
@@ -21,6 +21,7 @@ class ActionButton: UIButton {
     }
 
     var isLayoutDefined = false
+
     override func updateConstraints() {
         super.updateConstraints()
 

--- a/GliaWidgets/Sources/Coordinator/FlowCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinator/FlowCoordinator.swift
@@ -4,6 +4,7 @@ protocol FlowCoordinator: AnyObject {
     associatedtype ViewController
     associatedtype DelegateEvent
 
-    func start() -> ViewController
     var delegate: ((DelegateEvent) -> Void)? { get set }
+
+    func start() -> ViewController
 }

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -9,44 +9,52 @@ struct CoreSdkClient {
     var localeProvider: LocaleProvider
 
     typealias FetchVisitorInfo = (_ completion: @escaping (Result<Self.Salemove.VisitorInfo, Error>) -> Void) -> Void
+
     var fetchVisitorInfo: FetchVisitorInfo
 
     typealias UpdateVisitorInfo = (
         _ info: Self.VisitorInfoUpdate,
         _ completion: @escaping (Result<Bool, Error>) -> Void
     ) -> Void
+
     var updateVisitorInfo: UpdateVisitorInfo
 
     typealias ConfigureWithConfiguration = (
         _ sdkConfiguration: Self.Salemove.Configuration,
         _ completion: @escaping Self.ConfigureCompletion
     ) -> Void
+
     var configureWithConfiguration: ConfigureWithConfiguration
 
     typealias ConfigureWithInteractor = (_ interactor: Self.Interactable) -> Void
+
     var configureWithInteractor: ConfigureWithInteractor
 
     typealias ListQueues = (
         _ completion: @escaping Self.QueueRequestBlock
     ) -> Void
+
     var listQueues: ListQueues
 
     typealias QueueForEngagement = (
         _ options: GliaCoreSDK.QueueForEngagementOptions,
         _ completion: @escaping (Result<GliaCoreSDK.QueueTicket, GliaCoreSDK.GliaCoreError>) -> Void
     ) -> Void
+
     var queueForEngagement: QueueForEngagement
 
     typealias RequestMediaUpgradeWithOffer = (
         _ offer: Self.MediaUpgradeOffer,
         _ completion: @escaping Self.SuccessBlock
     ) -> Void
+
     var requestMediaUpgradeWithOffer: RequestMediaUpgradeWithOffer
 
     typealias SendMessagePreview = (
         _ message: String,
         _ completion: @escaping Self.SuccessBlock
     ) -> Void
+
     var sendMessagePreview: SendMessagePreview
 
     typealias SendMessageWithMessagePayloadCallback = (Result<CoreSdkClient.Message, CoreSdkClient.GliaCoreError>) -> Void
@@ -54,18 +62,22 @@ struct CoreSdkClient {
             _ sendMessagePayload: Self.SendMessagePayload,
             _ completion: @escaping SendMessageWithMessagePayloadCallback
         ) -> Void
+
     var sendMessageWithMessagePayload: SendMessageWithMessagePayload
 
     typealias CancelQueueTicket = (
         _ queueTicket: Self.QueueTicket,
         _ completion: @escaping GliaCoreSDK.SuccessBlock
     ) -> Void
+
     var cancelQueueTicket: CancelQueueTicket
 
     typealias EndEngagement = (_ completion: @escaping Self.SuccessBlock) -> Void
+
     var endEngagement: EndEngagement
 
     typealias RequestEngagedOperator = (_ completion: @escaping Self.OperatorBlock) -> Void
+
     var requestEngagedOperator: RequestEngagedOperator
 
     typealias UploadFileToEngagement = (
@@ -73,6 +85,7 @@ struct CoreSdkClient {
         _ progress: Self.EngagementFileProgressBlock?,
         _ completion: @escaping Self.EngagementFileCompletionBlock
     ) -> Void
+
     var uploadFileToEngagement: UploadFileToEngagement
 
     typealias FetchFile = (
@@ -80,12 +93,15 @@ struct CoreSdkClient {
         _ progress: Self.EngagementFileProgressBlock?,
         _ completion: @escaping Self.EngagementFileFetchCompletionBlock
     ) -> Void
+
     var fetchFile: FetchFile
 
     typealias GetCurrentEngagement = () -> Self.Engagement?
+
     var getCurrentEngagement: GetCurrentEngagement
 
     typealias FetchSiteConfigurations = (_ completion: @escaping (Result<Self.Site, Error>) -> Void) -> Void
+
     var fetchSiteConfigurations: FetchSiteConfigurations
 
     typealias SubmitSurveyAnswer = (
@@ -96,14 +112,19 @@ struct CoreSdkClient {
             _ completion: @escaping (Result<Void, GliaCoreSDK.GliaCoreError>) -> Void
         ) -> Void
     )
+
     var submitSurveyAnswer: SubmitSurveyAnswer
+
     typealias CreateAuthentication = (_ behaviour: AuthenticationBehavior) throws -> Authentication
+
     var authentication: CreateAuthentication
 
     typealias FetchChatHistory = (_ completion: @escaping (Result<[ChatMessage], GliaCoreSDK.GliaCoreError>) -> Void) -> Void
+
     var fetchChatHistory: FetchChatHistory
 
     typealias RequestVisitorCode = (_ completion: @escaping (VisitorCodeBlock) -> Void) -> GliaCore.Cancellable
+
     var requestVisitorCode: RequestVisitorCode
 
     typealias SendSecureMessagePayload = (
@@ -111,6 +132,7 @@ struct CoreSdkClient {
         _ queueIds: [String],
         _ completion: @escaping (Result<Self.Message, Error>) -> Void
     ) -> Self.Cancellable
+
     var sendSecureMessagePayload: SendSecureMessagePayload
 
     typealias SecureConversationsUploadFile = (
@@ -118,12 +140,15 @@ struct CoreSdkClient {
         _ progress: EngagementFileProgressBlock?,
         _ completion: @escaping (Result<EngagementFileInformation, Swift.Error>) -> Void
     ) -> Self.Cancellable
+
     var uploadSecureFile: SecureConversationsUploadFile
 
     typealias GetSecureUnreadMessageCount = (_ callback: @escaping (Result<Int, Error>) -> Void) -> Void
+
     var getSecureUnreadMessageCount: GetSecureUnreadMessageCount
 
     typealias SecureMarkMessagesAsRead = (_ callback: @escaping (Result<Void, Error>) -> Void) -> Cancellable
+
     var secureMarkMessagesAsRead: SecureMarkMessagesAsRead
 
     typealias DownloadSecureFile = (
@@ -135,15 +160,19 @@ struct CoreSdkClient {
     var downloadSecureFile: DownloadSecureFile
 
     typealias StartSocketObservation = () -> Void
+
     var startSocketObservation: StartSocketObservation
 
     typealias StopSocketObservation = () -> Void
+
     var stopSocketObservation: StopSocketObservation
 
     typealias CreateSendMessagePayload = (_ content: String, _ attachment: Attachment?) -> SendMessagePayload
+
     var createSendMessagePayload: CreateSendMessagePayload
 
     typealias CreateLogger = ([String: String]) throws -> Logger
+
     var createLogger: CreateLogger
 }
 
@@ -178,6 +207,7 @@ extension CoreSdkClient {
 extension CoreSdkClient {
     struct LocaleProvider {
         typealias CustomLocaleGetRemoteString = (String) -> String?
+
         var getRemoteString: CustomLocaleGetRemoteString
     }
 }

--- a/GliaWidgets/Sources/CoreSDKClient/Logger/Logger.Implementation.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/Logger/Logger.Implementation.swift
@@ -6,11 +6,13 @@ extension CoreSdkClient.Logger {
         func warning(_ object: @autoclosure () -> Any, file: String, function: String, line: Int) {}
         func info(_ object: @autoclosure () -> Any, file: String, function: String, line: Int) {}
         func debug(_ object: @autoclosure () -> Any, file: String, function: String, line: Int) {}
+        func prefixed(_ prefix: String) -> CoreSdkClient.Logging { self }
+        func prefixed<TypeAsPrefix>(_ prefix: TypeAsPrefix.Type) -> CoreSdkClient.Logging { self }
+
         var localLogger: (CoreSdkClient.Logging)? { nil }
         var remoteLogger: (CoreSdkClient.Logging)? { nil }
         var oneTime: CoreSdkClient.Logging { self }
-        func prefixed(_ prefix: String) -> CoreSdkClient.Logging { self }
-        func prefixed<TypeAsPrefix>(_ prefix: TypeAsPrefix.Type) -> CoreSdkClient.Logging { self }
     }
+
     static let notConfigured = Self(NotConfiguredLogger())
 }

--- a/GliaWidgets/Sources/CoreSDKClient/Logger/Logger.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/Logger/Logger.Interface.swift
@@ -78,5 +78,6 @@ extension CoreSdkClient.Logger {
     enum ParameterKey {
         static let widgetsSDKVersion = "client_app.widgets.version"
     }
+
     static let loggerParameters = [ParameterKey.widgetsSDKVersion: StaticValues.sdkVersion]
 }

--- a/GliaWidgets/Sources/CoreSDKClient/Logger/Logger.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/Logger/Logger.Mock.swift
@@ -3,16 +3,18 @@ import Foundation
 #if DEBUG
 extension CoreSdkClient.Logger {
     struct Mock: CoreSdkClient.Logging {
-        var oneTime: CoreSdkClient.Logging { self }
         func error(_ object: @autoclosure () -> Any, file: String, function: String, line: Int) {}
         func warning(_ object: @autoclosure () -> Any, file: String, function: String, line: Int) {}
         func info(_ object: @autoclosure () -> Any, file: String, function: String, line: Int) {}
         func debug(_ object: @autoclosure () -> Any, file: String, function: String, line: Int) {}
-        var localLogger: CoreSdkClient.Logging?
-        var remoteLogger: CoreSdkClient.Logging?
         func prefixed(_ prefix: String) -> CoreSdkClient.Logging { self }
         func prefixed<TypeAsPrefix>(_ prefix: TypeAsPrefix.Type) -> CoreSdkClient.Logging { self }
+
+        var oneTime: CoreSdkClient.Logging { self }
+        var localLogger: CoreSdkClient.Logging?
+        var remoteLogger: CoreSdkClient.Logging?
     }
+
     static let mock = Self(
         oneTimeClosure: { Self(Mock()) },
         prefixedClosure: { _ in Self(Mock()) },

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Interface.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Interface.swift
@@ -21,6 +21,7 @@ extension Glia {
             _ features: Features,
             _ environment: EngagementCoordinator.Environment
         ) -> EngagementCoordinator
+
         var coreSdk: CoreSdkClient
         var audioSession: AudioSession
         var uuid: () -> UUID

--- a/GliaWidgets/Sources/IdCollection/IdCollection.swift
+++ b/GliaWidgets/Sources/IdCollection/IdCollection.swift
@@ -1,8 +1,9 @@
 /// Collection that allows easier access by element identifier.
-struct IdCollection<Identifier: Hashable, Item: Equatable>: Equatable & Collection {
+struct IdCollection<Identifier: Hashable, Item: Equatable>: Equatable, Collection {
 
     typealias DictionaryType = [Identifier: Item]
     typealias ArrayType = [Identifier]
+
     private var items = [Identifier: Item]()
     private var list = [Identifier]()
 

--- a/GliaWidgets/Sources/QuickLookBased/QuickLookBased.Interface.swift
+++ b/GliaWidgets/Sources/QuickLookBased/QuickLookBased.Interface.swift
@@ -2,7 +2,7 @@ import Foundation
 import QuickLook
 import UIKit
 
-struct QuickLookBased {
+enum QuickLookBased {
     struct ThumbnailGenerator {
         var generateBestRepresentation: (QLThumbnailGenerator.Request, @escaping (QuickLookBased.ThumbnailRepresentation?, Error?) -> Void) -> Void
     }

--- a/GliaWidgets/Sources/ViewController/Common/Replaceble/UIViewController+Replaceble.swift
+++ b/GliaWidgets/Sources/ViewController/Common/Replaceble/UIViewController+Replaceble.swift
@@ -12,8 +12,9 @@ enum PresentationPriority: Int {
 }
 
 protocol Replaceable where Self: UIViewController {
-    var presentationPriority: PresentationPriority { get }
     func isReplaceable(with replaceable: Replaceable) -> Bool
+
+    var presentationPriority: PresentationPriority { get }
 }
 
 extension Replaceable {

--- a/GliaWidgets/Sources/ViewController/Survey/SurveyViewController.View.swift
+++ b/GliaWidgets/Sources/ViewController/Survey/SurveyViewController.View.swift
@@ -126,6 +126,7 @@ extension Survey {
         }
 
         var _updateUi: (() -> Void)?
+
         func updateUi(theme: Theme) {
 
             _updateUi = { [weak self] in

--- a/GliaWidgets/Sources/ViewModel/Chat/Data/ChatMessage.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/Data/ChatMessage.swift
@@ -26,6 +26,7 @@ enum ChatMessageSender: Int, Codable {
 
 class ChatMessage: Codable {
     typealias MessageId = String
+
     let id: MessageId
     let `operator`: ChatOperator?
     let sender: ChatMessageSender

--- a/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
@@ -3,6 +3,7 @@ import Foundation
 class EngagementViewModel: CommonEngagementModel {
     typealias ActionCallback = (Action) -> Void
     typealias DelegateCallback = (DelegateEvent) -> Void
+
     static let alertSingleActionAccessibilityIdentifier = "alert_close_engagementEnded"
     var engagementAction: ActionCallback?
     var engagementDelegate: DelegateCallback?

--- a/GliaWidgets/Sources/ViewModel/ViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/ViewModel.swift
@@ -6,6 +6,7 @@ protocol ViewModel {
     associatedtype DelegateEvent
 
     func event(_ event: Event)
+
     var action: ((Action) -> Void)? { get set }
     var delegate: ((DelegateEvent) -> Void)? { get set }
 }

--- a/GliaWidgets/StaticValues.swift
+++ b/GliaWidgets/StaticValues.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-final class StaticValues {
+enum StaticValues {
     /// Current SDK version. This version gets synced with the Info.plist version
     /// when incrementing the version through Fastlane. Unlike the Info.plist, this
     /// version cannot be changed by integrators, so this ensures that our code will

--- a/GliaWidgets/SwiftUI/Components/BackgroundSwiftUI.swift
+++ b/GliaWidgets/SwiftUI/Components/BackgroundSwiftUI.swift
@@ -6,6 +6,7 @@ struct Background: View {
     init(_ colorType: ColorType) {
         self.colorType = colorType
     }
+
     var body: some View {
         switch colorType {
         case .fill(let color):

--- a/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar+View.swift
+++ b/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar+View.swift
@@ -9,6 +9,7 @@ extension SnackBar {
             case disappear
             case keyboardWillShow
         }
+
         let publisher: AnyPublisher<ViewState, Never>
 
         @State private var text = ""


### PR DESCRIPTION
Add the following rules to the codebase:

- comma_inheritance
- convenience_type
- empty_xctest_method
- let_var_whitespace

The two that make the most changes are `convenience_type`, in which we should declare as `enum` the types that are used only for keeping static vars/methods, and `let_var_whitespace` which require a space before/after a var, but not inside `func` in order to improve readability.

MOB-3175

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from iOS SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3589734507/Logging+from+iOS+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
