### PR TITLE
Fix local video shape after device orientation change

### DIFF
--- a/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
+++ b/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
@@ -59,7 +59,8 @@ extension Glia {
                 timerProviding: environment.timerProviding,
                 uiApplication: environment.uiApplication,
                 uiScreen: environment.uiScreen,
-                log: loggerPhase.logger
+                log: loggerPhase.logger,
+                uiDevice: environment.uiDevice
             )
         )
 

--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -169,7 +169,8 @@ public class Glia {
                 timerProviding: environment.timerProviding,
                 uiApplication: environment.uiApplication,
                 uiScreen: environment.uiScreen,
-                log: loggerPhase.logger
+                log: loggerPhase.logger,
+                uiDevice: environment.uiDevice
             )
         )
 

--- a/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
+++ b/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
@@ -26,7 +26,8 @@ public final class CallVisualizer {
                 timerProviding: environment.timerProviding,
                 uiApplication: environment.uiApplication,
                 uiScreen: environment.uiScreen,
-                log: environment.log
+                log: environment.log,
+                uiDevice: environment.uiDevice
             )
         )
         return Coordinator(

--- a/GliaWidgets/Sources/UIKitBased/UIKitBased.Interface.swift
+++ b/GliaWidgets/Sources/UIKitBased/UIKitBased.Interface.swift
@@ -18,6 +18,7 @@ enum UIKitBased {
         var proximityState: () -> Bool
         var isProximityMonitoringEnabled: (Bool) -> Void
         var orientationDidChangeNotification: () -> NSNotification.Name
+        var orientation: () -> UIDeviceOrientation
     }
 
     struct UIScreen {

--- a/GliaWidgets/Sources/UIKitBased/UIKitBased.Live.swift
+++ b/GliaWidgets/Sources/UIKitBased/UIKitBased.Live.swift
@@ -19,7 +19,8 @@ extension UIKitBased.UIDevice {
     static let live = Self.init(
         proximityState: { UIDevice.current.proximityState },
         isProximityMonitoringEnabled: { UIDevice.current.isProximityMonitoringEnabled = $0 },
-        orientationDidChangeNotification: { UIDevice.orientationDidChangeNotification }
+        orientationDidChangeNotification: { UIDevice.orientationDidChangeNotification },
+        orientation: { UIDevice.current.orientation }
     )
 }
 

--- a/GliaWidgets/Sources/UIKitBased/UIKitBased.Mock.swift
+++ b/GliaWidgets/Sources/UIKitBased/UIKitBased.Mock.swift
@@ -30,7 +30,8 @@ extension UIKitBased.UIDevice {
     static let mock = Self.init(
         proximityState: { .init() },
         isProximityMonitoringEnabled: { _ in },
-        orientationDidChangeNotification: { .init("") }
+        orientationDidChangeNotification: { .init("") },
+        orientation: { .unknown }
     )
 }
 

--- a/GliaWidgets/Sources/View/Call/CallView.swift
+++ b/GliaWidgets/Sources/View/Call/CallView.swift
@@ -418,13 +418,15 @@ class CallView: EngagementView {
 // MARK: Local Video
 
 extension CallView {
+    static let localVideoSideMultiplier = 0.3
+
     private func setLocalVideoFrame(isVisible: Bool) {
         if isVisible {
-            let screenSize: CGRect = environment.uiScreen.bounds()
+            let screenBounds = environment.uiScreen.bounds()
 
-            let size = CGSize(
-                width: screenSize.width * 0.3,
-                height: screenSize.height * 0.3
+            let size = Self.localVideoSize(
+                for: environment.uiDevice.orientation(),
+                from: screenBounds.size
             )
 
             localVideoView.frame = CGRect(
@@ -438,19 +440,19 @@ extension CallView {
     }
 
     private func adjustLocalVideoFrameAfterOrientationChange() {
-        let screenSize: CGRect = environment.uiScreen.bounds()
+        let screenBounds = environment.uiScreen.bounds()
 
-        let size = CGSize(
-            width: screenSize.width * 0.3,
-            height: screenSize.height * 0.3
+        let newSize = Self.localVideoSize(
+            for: environment.uiDevice.orientation(),
+            from: screenBounds.size
         )
 
         localVideoView.frame = CGRect(
             origin: CGPoint(
-                x: localVideoBounds.maxX - size.width,
-                y: localVideoBounds.maxY - size.height
+                x: localVideoBounds.maxX - newSize.width,
+                y: localVideoBounds.maxY - newSize.height
             ),
-            size: size
+            size: newSize
         )
     }
 
@@ -488,6 +490,27 @@ extension CallView {
 
         localVideoView.frame = frame
     }
+
+    static func localVideoSize(
+        for orientation: UIDeviceOrientation,
+        from screenSize: CGSize
+    ) -> CGSize {
+        let width: CGFloat
+        let height: CGFloat
+
+        if orientation.isLandscape {
+            width = max(screenSize.width, screenSize.height)
+            height = min(screenSize.width, screenSize.height)
+        } else {
+            width = min(screenSize.width, screenSize.height)
+            height = max(screenSize.width, screenSize.height)
+        }
+
+        return CGSize(
+            width: width * Self.localVideoSideMultiplier,
+            height: height * Self.localVideoSideMultiplier
+        )
+    }
 }
 
 extension CallView {
@@ -499,5 +522,6 @@ extension CallView {
         var timerProviding: FoundationBased.Timer.Providing
         var uiApplication: UIKitBased.UIApplication
         var uiScreen: UIKitBased.UIScreen
+        var uiDevice: UIKitBased.UIDevice
     }
 }

--- a/GliaWidgets/Sources/ViewFactory/ViewFactory.Environment.Interface.swift
+++ b/GliaWidgets/Sources/ViewFactory/ViewFactory.Environment.Interface.swift
@@ -10,5 +10,6 @@ extension ViewFactory {
         var uiApplication: UIKitBased.UIApplication
         var uiScreen: UIKitBased.UIScreen
         var log: CoreSdkClient.Logger
+        var uiDevice: UIKitBased.UIDevice
     }
 }

--- a/GliaWidgets/Sources/ViewFactory/ViewFactory.Environment.Mock.swift
+++ b/GliaWidgets/Sources/ViewFactory/ViewFactory.Environment.Mock.swift
@@ -8,7 +8,8 @@ extension ViewFactory.Environment {
         timerProviding: .mock,
         uiApplication: .mock,
         uiScreen: .mock,
-        log: .mock
+        log: .mock,
+        uiDevice: .mock
     )
 }
 #endif

--- a/GliaWidgets/Sources/ViewFactory/ViewFactory.swift
+++ b/GliaWidgets/Sources/ViewFactory/ViewFactory.swift
@@ -84,7 +84,8 @@ class ViewFactory {
                 imageViewCache: environment.imageViewCache,
                 timerProviding: environment.timerProviding,
                 uiApplication: environment.uiApplication,
-                uiScreen: environment.uiScreen
+                uiScreen: environment.uiScreen,
+                uiDevice: environment.uiDevice
             ),
             props: Self.callHeaderProps(
                 theme: theme,

--- a/GliaWidgetsTests/Factory/ViewFactory.Environment.Failing.swift
+++ b/GliaWidgetsTests/Factory/ViewFactory.Environment.Failing.swift
@@ -12,6 +12,7 @@ extension ViewFactory.Environment {
         timerProviding: .failing,
         uiApplication: .failing,
         uiScreen: .failing,
-        log: .failing
+        log: .failing,
+        uiDevice: .failing
     )
 }

--- a/GliaWidgetsTests/Sources/CallViewTests.swift
+++ b/GliaWidgetsTests/Sources/CallViewTests.swift
@@ -69,4 +69,17 @@ class CallViewTests: XCTestCase {
         view.isVisitrOnHold = false
         XCTAssertTrue(view.bottomLabel.isHidden)
     }
+
+    func test_localVideoSizeReturnsExpectedSizeBasedOnDeviceOrientation() {
+        let sideA = 100.0
+        let sideB = 50.0
+        let screenSize = CGSize(width: sideA, height: sideB)
+        let multiplier = CallView.localVideoSideMultiplier
+        let sizeForPortrait = CallView.localVideoSize(for: .portrait, from: screenSize)
+        XCTAssertEqual(sizeForPortrait, CGSize(width: sideB * multiplier, height: sideA * multiplier))
+        let sizeForLandscapeLeft = CallView.localVideoSize(for: .landscapeLeft, from: screenSize)
+        XCTAssertEqual(sizeForLandscapeLeft, CGSize(width: sideA * multiplier, height: sideB * multiplier))
+        let sizeForLandscapeRight = CallView.localVideoSize(for: .landscapeRight, from: screenSize)
+        XCTAssertEqual(sizeForLandscapeRight, CGSize(width: sideA * multiplier, height: sideB * multiplier))
+    }
 }

--- a/GliaWidgetsTests/UIKitBased.Failing.swift
+++ b/GliaWidgetsTests/UIKitBased.Failing.swift
@@ -61,6 +61,10 @@ extension UIKitBased.UIDevice {
         orientationDidChangeNotification: {
             fail("\(Self.self).orientationDidChangeNotification")
             return NSNotification.Name(rawValue: "")
+        },
+        orientation: {
+            fail("\(Self.self).orientation")
+            return .unknown
         }
     )
 }


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3338

**What was solved?**
Fix local video shape after device orientation change by evaluating current device orientation and deriving width and height for the video.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from iOS SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3589734507/Logging+from+iOS+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
