### PR TITLE
Add subset of new SwiftLint rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -19,6 +19,10 @@ opt_in_rules:
   - convenience_type
   - empty_xctest_method
   - let_var_whitespace
+  - multiline_arguments_brackets
+  - multiline_literal_brackets
+  - multiline_parameters
+  - multiline_parameters_brackets
 excluded: # paths to ignore during linting. Takes precedence over `included`.
   - Carthage
   - Pods

--- a/GliaWidgets/SecureConversations/Confirmation/Theme+SecureConversationsConfirmation.swift
+++ b/GliaWidgets/SecureConversations/Confirmation/Theme+SecureConversationsConfirmation.swift
@@ -41,6 +41,8 @@ extension Theme {
             confirmationImageTint: color.primary,
             titleStyle: titleStyle,
             subtitleStyle: subtitleStyle,
-            checkMessagesButtonStyle: checkMessagesButtonStyle, backgroundColor: color.baseLight)
+            checkMessagesButtonStyle: checkMessagesButtonStyle,
+            backgroundColor: color.baseLight
+        )
     }
 }

--- a/GliaWidgets/SecureConversations/FileUploadListView/SecureConversations.FileUploadView.swift
+++ b/GliaWidgets/SecureConversations/FileUploadListView/SecureConversations.FileUploadView.swift
@@ -250,7 +250,8 @@ extension SecureConversations {
 extension SecureConversations.FileUploadView.Props.State {
     init(
         state: GliaWidgets.FileUpload.State,
-        localFile: GliaWidgets.LocalFile) {
+        localFile: GliaWidgets.LocalFile
+    ) {
         switch state {
         case .none:
             self = .none

--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
@@ -179,7 +179,8 @@ extension SecureConversations {
                     case .chatTranscriptScreenRequested:
                         self?.navigateToTranscript()
                     }
-                })
+                }
+            )
 
             let controller = SecureConversations.ConfirmationViewController(model: model)
 

--- a/GliaWidgets/SecureConversations/SecureConversations.MessagesWithUnreadCountLoader.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.MessagesWithUnreadCountLoader.swift
@@ -60,7 +60,8 @@ extension SecureConversations {
 
         static func messageWithUnreadCountResult(
             messageResult: Result<[ChatMessage], Error>,
-            unreadCountResult: Result<Int, Error>) -> Result<MessagesWithUnreadCount, Error> {
+            unreadCountResult: Result<Int, Error>
+        ) -> Result<MessagesWithUnreadCount, Error> {
                 // Without messages unread count does not make much sense,
                 // that is why we prefer to report error for messages in case
                 // of failure for both requests. Same for success - ignore

--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeView.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeView.swift
@@ -115,14 +115,15 @@ extension SecureConversations {
 
         lazy var messageWarningStackView = UIStackView(
             arrangedSubviews: [
-            messageWarningImageView,
-            messageWarningLabel
-            ])
-            .make { stackView in
-                stackView.alignment = .center
-                stackView.axis = .horizontal
-                stackView.spacing = 5
-            }
+                messageWarningImageView,
+                messageWarningLabel
+            ]
+        )
+        .make { stackView in
+            stackView.alignment = .center
+            stackView.axis = .horizontal
+            stackView.spacing = 5
+        }
 
         let fileUploadListView: FileUploadListView
         let environment: Environemnt

--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.swift
@@ -235,8 +235,7 @@ extension SecureConversations.WelcomeViewModel {
 
         return filePickerButton
     }
-    static func textViewState(for instance: SecureConversations.WelcomeViewModel
-    ) -> TextViewProps? {
+    static func textViewState(for instance: SecureConversations.WelcomeViewModel) -> TextViewProps? {
         guard instance.availabilityStatus == .available else {
             return nil
         }

--- a/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeCoordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeCoordinator.swift
@@ -31,7 +31,8 @@ extension CallVisualizer {
                 presentation: presentation,
                 environment: .init(
                     timerProviding: environment.timerProviding,
-                    requestVisitorCode: environment.requestVisitorCode),
+                    requestVisitorCode: environment.requestVisitorCode
+                ),
                 theme: theme,
                 delegate: { [weak self] action in
                     switch action {

--- a/GliaWidgets/Sources/Component/AttachmentList/Item/AttachmentSourceItemView.swift
+++ b/GliaWidgets/Sources/Component/AttachmentList/Item/AttachmentSourceItemView.swift
@@ -49,8 +49,11 @@ class AttachmentSourceItemView: UIView {
             stackView.addArrangedSubview(imageView)
         }
 
-        let tapRecognizer = UITapGestureRecognizer(target: self,
-                                                   action: #selector(tapped))
+        let tapRecognizer = UITapGestureRecognizer(
+            target: self,
+            action: #selector(tapped)
+        )
+
         addGestureRecognizer(tapRecognizer)
     }
 

--- a/GliaWidgets/Sources/Component/Bubble/BubbleWindow.swift
+++ b/GliaWidgets/Sources/Component/Bubble/BubbleWindow.swift
@@ -15,8 +15,11 @@ class BubbleWindow: UIWindow {
     private var initialFrame: CGRect {
         let bounds = environment.uiApplication.windows().first?.frame ?? environment.uiScreen.bounds()
         let safeAreaInsets = environment.uiApplication.windows().first?.safeAreaInsets ?? .zero
-        let origin = CGPoint(x: bounds.width - kSize.width - safeAreaInsets.right - kEdgeInset,
-                             y: bounds.height - kSize.height - safeAreaInsets.bottom - kEdgeInset)
+        let origin = CGPoint(
+            x: bounds.width - kSize.width - safeAreaInsets.right - kEdgeInset,
+            y: bounds.height - kSize.height - safeAreaInsets.bottom - kEdgeInset
+        )
+
         return CGRect(origin: origin, size: kSize)
     }
 
@@ -49,8 +52,10 @@ class BubbleWindow: UIWindow {
     private func setup() {
         windowLevel = .statusBar
         clipsToBounds = true
-        rootViewController = BubbleViewController(bubbleView: bubbleView,
-                                                  edgeInset: kBubbleInset)
+        rootViewController = BubbleViewController(
+            bubbleView: bubbleView,
+            edgeInset: kBubbleInset
+        )
 
         bubbleView.tap = { [weak self] in self?.tap?() }
         bubbleView.pan = { [weak self] in self?.pan($0) }
@@ -65,10 +70,12 @@ class BubbleWindow: UIWindow {
         frame.origin.x += translation.x
         frame.origin.y += translation.y
 
-        let insets = UIEdgeInsets(top: -kEdgeInset,
-                                  left: -kEdgeInset,
-                                  bottom: -kEdgeInset,
-                                  right: -kEdgeInset)
+        let insets = UIEdgeInsets(
+            top: -kEdgeInset,
+            left: -kEdgeInset,
+            bottom: -kEdgeInset,
+            right: -kEdgeInset
+        )
         let insetFrame = frame.inset(by: insets)
         let boundsInsets = environment.uiApplication.windows().first?.safeAreaInsets ?? .zero
         let bounds = environment.uiScreen.bounds().inset(by: boundsInsets)

--- a/GliaWidgets/Sources/Component/CallButtonBar/Button/CallButton.swift
+++ b/GliaWidgets/Sources/Component/CallButtonBar/Button/CallButton.swift
@@ -79,8 +79,10 @@ class CallButton: UIView {
             for: titleLabel
         )
 
-        let tapRecognizer = UITapGestureRecognizer(target: self,
-                                                   action: #selector(tapped))
+        let tapRecognizer = UITapGestureRecognizer(
+            target: self,
+            action: #selector(tapped)
+        )
         addGestureRecognizer(tapRecognizer)
 
         isAccessibilityElement = true

--- a/GliaWidgets/Sources/Component/Connect/ConnectView.swift
+++ b/GliaWidgets/Sources/Component/Connect/ConnectView.swift
@@ -155,7 +155,9 @@ final class ConnectView: BaseView {
             options: .curveEaseInOut,
             animations: {
                 self.transform = .identity
-            }, completion: nil)
+            },
+            completion: nil
+        )
         isShowing = true
     }
 
@@ -168,7 +170,8 @@ final class ConnectView: BaseView {
             options: .curveEaseInOut,
             animations: {
                 self.transform = CGAffineTransform(scaleX: 0, y: 0)
-            }, completion: nil)
+            }, completion: nil
+        )
         isShowing = false
     }
 }

--- a/GliaWidgets/Sources/Component/MediaUpgrade/MediaUpgradeActionView.swift
+++ b/GliaWidgets/Sources/Component/MediaUpgrade/MediaUpgradeActionView.swift
@@ -40,8 +40,10 @@ class MediaUpgradeActionView: UIView {
         infoLabel.textColor = style.infoColor
         infoLabel.numberOfLines = 0
 
-        let tapRecognizer = UITapGestureRecognizer(target: self,
-                                                   action: #selector(tapped))
+        let tapRecognizer = UITapGestureRecognizer(
+            target: self,
+            action: #selector(tapped)
+        )
         addGestureRecognizer(tapRecognizer)
     }
 

--- a/GliaWidgets/Sources/Download/FileDownload.Environment.Interface.swift
+++ b/GliaWidgets/Sources/Download/FileDownload.Environment.Interface.swift
@@ -22,7 +22,8 @@ extension FileDownload.Environment.FetchFile {
     func startWithFile(
         _ file: CoreSdkClient.EngagementFile,
         progress: @escaping CoreSdkClient.EngagementFileProgressBlock,
-        completion: @escaping (Result<CoreSdkClient.EngagementFileData, Error>) -> Void) -> CoreSdkClient.Salemove.Cancellable? {
+        completion: @escaping (Result<CoreSdkClient.EngagementFileData, Error>) -> Void
+    ) -> CoreSdkClient.Salemove.Cancellable? {
             switch self {
             case let .fromSecureMessaging(fetch):
                 return fetch(file, progress, completion)

--- a/GliaWidgets/Sources/Download/FileDownload.swift
+++ b/GliaWidgets/Sources/Download/FileDownload.swift
@@ -77,9 +77,12 @@ class FileDownload {
             return
         }
 
-        let fetchFile = Environment.FetchFile.fetchForEngagementFile(CoreSdkClient.EngagementFile(url: fileUrl), environment: .init(
-            fetchFile: environment.fetchFile,
-            downloadSecureFile: environment.downloadSecureFile)
+        let fetchFile = Environment.FetchFile.fetchForEngagementFile(
+            CoreSdkClient.EngagementFile(url: fileUrl),
+            environment: .init(
+                fetchFile: environment.fetchFile,
+                downloadSecureFile: environment.downloadSecureFile
+            )
         )
 
         let engagementFile: CoreSdkClient.EngagementFile

--- a/GliaWidgets/Sources/Download/FileDownloader.swift
+++ b/GliaWidgets/Sources/Download/FileDownloader.swift
@@ -22,8 +22,10 @@ class FileDownloader {
         )
     }
 
-    func downloads(for files: [ChatEngagementFile]?,
-                   autoDownload: AutoDownload = .nothing) -> [FileDownload] {
+    func downloads(
+        for files: [ChatEngagementFile]?,
+        autoDownload: AutoDownload = .nothing
+    ) -> [FileDownload] {
         guard let files = files else { return [] }
 
         let downloads = files.compactMap { download(for: $0) }

--- a/GliaWidgets/Sources/FoundationBased/FoundationBased.Interface.swift
+++ b/GliaWidgets/Sources/FoundationBased/FoundationBased.Interface.swift
@@ -108,7 +108,8 @@ extension FoundationBased.Timer.Providing {
         target aTarget: Any,
         selector aSelector: Selector,
         userInfo: Any?,
-        repeats yesOrNo: Bool) -> FoundationBased.Timer {
+        repeats yesOrNo: Bool
+    ) -> FoundationBased.Timer {
             scheduledTimerWithTimeIntervalAndTarget(
                 ti,
                 aTarget,
@@ -118,7 +119,11 @@ extension FoundationBased.Timer.Providing {
             )
     }
 
-    func scheduledTimer(withTimeInterval interval: TimeInterval, repeats: Bool, block: @escaping (FoundationBased.Timer) -> Void) -> FoundationBased.Timer {
+    func scheduledTimer(
+        withTimeInterval interval: TimeInterval,
+        repeats: Bool,
+        block: @escaping (FoundationBased.Timer) -> Void
+    ) -> FoundationBased.Timer {
         scheduledTimerWithTimeIntervalAndRepeats(
             interval,
             repeats,

--- a/GliaWidgets/Sources/Screensharing/ScreenShareHandler.Implementation.swift
+++ b/GliaWidgets/Sources/Screensharing/ScreenShareHandler.Implementation.swift
@@ -30,6 +30,7 @@ extension ScreenShareHandler {
             },
             cleanUp: {
                 visitorState = nil
-            })
+            }
+        )
     }
 }

--- a/GliaWidgets/Sources/Theme/Survey/Theme.Survey.SingleQuestion.swift
+++ b/GliaWidgets/Sources/Theme/Survey/Theme.Survey.SingleQuestion.swift
@@ -37,7 +37,8 @@ public extension Theme.SurveyStyle {
                         textStyle: .body,
                         accessibility: .init(isFontScalingEnabled: true)
                     ),
-                    accessibility: .init(isFontScalingEnabled: true)),
+                    accessibility: .init(isFontScalingEnabled: true)
+                ),
                 error: .default(color: color, font: font),
                 accessibility: .init(isFontScalingEnabled: true)
             )

--- a/GliaWidgets/Sources/View/Chat/ChatView.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatView.swift
@@ -652,7 +652,10 @@ extension ChatView {
         view.appendContent(
             .downloads(
                 message.downloads,
-                accessibility: .init(from: .operator(message.operator?.name ?? style.accessibility.operator))),
+                accessibility: .init(
+                    from: .operator(message.operator?.name ?? style.accessibility.operator)
+                )
+            ),
             animated: false
         )
         view.downloadTapped = { [weak self] in self?.downloadTapped?($0) }
@@ -849,7 +852,8 @@ extension ChatView {
                 uuid: environment.uuid,
                 gcd: environment.gcd,
                 imageViewCache: environment.imageViewCache,
-                timerProviding: environment.timerProviding)
+                timerProviding: environment.timerProviding
+            )
         )
         connectView.setState(
             .connected(name: name, imageUrl: imageUrl),
@@ -867,7 +871,8 @@ extension ChatView {
                 uuid: environment.uuid,
                 gcd: environment.gcd,
                 imageViewCache: environment.imageViewCache,
-                timerProviding: environment.timerProviding)
+                timerProviding: environment.timerProviding
+            )
         )
         connectView.setState(
             .transferring,
@@ -912,7 +917,8 @@ extension ChatView {
         view.appendContent(
             .downloads(
                 message.downloads,
-                accessibility: .init(from: .operator(message.operator?.name ?? style.accessibility.operator))),
+                accessibility: .init(from: .operator(message.operator?.name ?? style.accessibility.operator))
+            ),
             animated: false
         )
         view.downloadTapped = { [weak self] in self?.downloadTapped?($0) }
@@ -947,7 +953,8 @@ extension ChatView {
         view.appendContent(
             .downloads(
                 message.downloads,
-                accessibility: .init(from: .operator(message.operator?.name ?? style.accessibility.operator))),
+                accessibility: .init(from: .operator(message.operator?.name ?? style.accessibility.operator))
+            ),
             animated: false
         )
         view.onOptionTapped = { [weak self] in self?.gvaButtonTapped?($0) }

--- a/GliaWidgets/Sources/View/Chat/Message/Content/File/ChatFileContentView.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/Content/File/ChatFileContentView.swift
@@ -45,8 +45,10 @@ class ChatFileContentView: UIView {
             }
         }
 
-        let tapRecognizer = UITapGestureRecognizer(target: self,
-                                                   action: #selector(tapped))
+        let tapRecognizer = UITapGestureRecognizer(
+            target: self,
+            action: #selector(tapped)
+        )
         addGestureRecognizer(tapRecognizer)
 
         isAccessibilityElement = true

--- a/GliaWidgets/Sources/View/Chat/Message/Content/File/Image/ChatImageFileContentView.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/Content/File/Image/ChatImageFileContentView.swift
@@ -8,11 +8,13 @@ class ChatImageFileContentView: ChatFileContentView {
     private let kInsets = UIEdgeInsets.zero
     private let kHeight: CGFloat = 155
 
-    init(with style: ChatImageFileContentStyle,
-         content: Content,
-         contentAlignment: ChatMessageContentAlignment,
-         accessibilityProperties: ChatFileContentView.AccessibilityProperties,
-         tap: @escaping () -> Void) {
+    init(
+        with style: ChatImageFileContentStyle,
+        content: Content,
+        contentAlignment: ChatMessageContentAlignment,
+        accessibilityProperties: ChatFileContentView.AccessibilityProperties,
+        tap: @escaping () -> Void
+    ) {
         self.style = style
         self.contentAlignment = contentAlignment
         super.init(

--- a/GliaWidgets/Sources/View/Common/Alert/AlertView.swift
+++ b/GliaWidgets/Sources/View/Common/Alert/AlertView.swift
@@ -182,8 +182,11 @@ class AlertView: BaseView {
     private func addCloseButton() {
         guard closeButton == nil else { return }
 
-        let closeButton = Button(kind: .alertClose,
-                                 tap: { [weak self] in self?.closeTapped?() })
+        let closeButton = Button(
+            kind: .alertClose,
+            tap: { [weak self] in self?.closeTapped?() }
+        )
+
         switch style.closeButtonColor {
         case .fill(let color):
             closeButton.tintColor = color

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
@@ -312,22 +312,23 @@ extension ChatViewController {
             ChatChoiceCardOption(with: try .mock(text: "One", value: "eno"))
         ]
         let messages: [ChatMessage] = [
-            .mock(id: messageId(),
-                  operator: .mock(
+            .mock(
+                id: messageId(),
+                operator: .mock(
                     name: "Blob",
                     pictureUrl: "https://mock.mock/operator/234/image.png"
-                  ),
-                  sender: .operator,
-                  content: "What is 2 + 2?",
-                  attachment: .init(
+                ),
+                sender: .operator,
+                content: "What is 2 + 2?",
+                attachment: .init(
                     type: .singleChoice,
                     files: nil,
                     imageUrl: "https://mock.mock/single_choice/567/image.png",
                     options: options,
                     selectedOption: .some("ruof")
-                  ),
-                  downloads: []
-                 )
+                ),
+                downloads: []
+            )
         ]
         chatViewModelEnv.fetchChatHistory = { $0(.success(messages)) }
 

--- a/GliaWidgets/Sources/ViewController/Common/Alert/AlertViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Common/Alert/AlertViewController.swift
@@ -118,27 +118,32 @@ class AlertViewController: UIViewController, Replaceable {
          ).activate()
 
         alertView.transform = CGAffineTransform(scaleX: 0.1, y: 0.1)
-        UIView.animate(withDuration: animated ? 0.4 : 0.0,
-                       delay: 0.0,
-                       usingSpringWithDamping: 0.8,
-                       initialSpringVelocity: 0.7,
-                       options: .curveEaseInOut,
-                       animations: {
-                        alertView.transform = .identity
-                       }, completion: nil)
+        UIView.animate(
+            withDuration: animated ? 0.4 : 0.0,
+            delay: 0.0,
+            usingSpringWithDamping: 0.8,
+            initialSpringVelocity: 0.7,
+            options: .curveEaseInOut,
+            animations: {
+                alertView.transform = .identity
+            },
+            completion: nil
+        )
     }
 
     private func hideAlertView(animated: Bool) {
-        UIView.animate(withDuration: animated ? 0.4 : 0.0,
-                       delay: 0.0,
-                       usingSpringWithDamping: 0.8,
-                       initialSpringVelocity: 0.7,
-                       options: .curveEaseInOut,
-                       animations: {
-                        self.alertView?.transform = CGAffineTransform(scaleX: 0.1, y: 0.1)
-                       }, completion: { _ in
-                        self.alertView = nil
-                       })
+        UIView.animate(
+            withDuration: animated ? 0.4 : 0.0,
+            delay: 0.0,
+            usingSpringWithDamping: 0.8,
+            initialSpringVelocity: 0.7,
+            options: .curveEaseInOut,
+            animations: {
+                self.alertView?.transform = CGAffineTransform(scaleX: 0.1, y: 0.1)
+            }, completion: { _ in
+                self.alertView = nil
+            }
+        )
     }
 
     private func makeAlertView() -> AlertView {

--- a/GliaWidgets/Sources/ViewController/Common/FilePicker/FilePickerController.swift
+++ b/GliaWidgets/Sources/ViewController/Common/FilePicker/FilePickerController.swift
@@ -32,8 +32,10 @@ final class FilePickerController: NSObject {
 }
 
 extension FilePickerController: UIDocumentPickerDelegate {
-    func documentPicker(_ controller: UIDocumentPickerViewController,
-                        didPickDocumentsAt urls: [URL]) {
+    func documentPicker(
+        _ controller: UIDocumentPickerViewController,
+        didPickDocumentsAt urls: [URL]
+    ) {
         guard let url = urls.first else { return }
         viewModel.event(.pickedFile(url))
     }

--- a/GliaWidgets/Sources/ViewController/Common/MediaPicker/MediaPickerController.swift
+++ b/GliaWidgets/Sources/ViewController/Common/MediaPicker/MediaPickerController.swift
@@ -37,8 +37,10 @@ final class MediaPickerController: NSObject {
         }
     }
 
-    private func mediaTypes(_ mediaTypes: [MediaPickerViewModel.MediaType],
-                            for sourceType: UIImagePickerController.SourceType) -> [String] {
+    private func mediaTypes(
+        _ mediaTypes: [MediaPickerViewModel.MediaType],
+        for sourceType: UIImagePickerController.SourceType
+    ) -> [String] {
         let types: [String] = mediaTypes.map {
             switch $0 {
             case .image:

--- a/GliaWidgets/Sources/ViewController/Common/Popover/PopoverViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Common/Popover/PopoverViewController.swift
@@ -6,10 +6,12 @@ final class PopoverViewController: UIViewController, Replaceable {
     private let contentInsets: UIEdgeInsets
     private let minimumWidth: CGFloat
 
-    init(with contentView: UIView,
-         presentFrom sourceView: UIView,
-         contentInsets: UIEdgeInsets = .zero,
-         minimumWidth: CGFloat = 250) {
+    init(
+        with contentView: UIView,
+        presentFrom sourceView: UIView,
+        contentInsets: UIEdgeInsets = .zero,
+        minimumWidth: CGFloat = 250
+    ) {
         self.contentView = contentView
         self.sourceView = sourceView
         self.contentInsets = contentInsets

--- a/GliaWidgets/Sources/ViewModel/Call/Data/Call.swift
+++ b/GliaWidgets/Sources/ViewModel/Call/Data/Call.swift
@@ -134,9 +134,11 @@ class Call {
     }
 
     func updateAudioStream(with stream: CoreSdkClient.AudioStreamable) {
-        updateMediaStream(audio.stream,
-                          with: stream,
-                          isRemote: stream.isRemote)
+        updateMediaStream(
+            audio.stream,
+            with: stream,
+            isRemote: stream.isRemote
+        )
 
         if stream.isRemote {
             stream.onHold = { [weak self] in
@@ -146,9 +148,11 @@ class Call {
     }
 
     func updateVideoStream(with stream: CoreSdkClient.VideoStreamable) {
-        updateMediaStream(video.stream,
-                          with: stream,
-                          isRemote: stream.isRemote)
+        updateMediaStream(
+            video.stream,
+            with: stream,
+            isRemote: stream.isRemote
+        )
 
         if stream.isRemote {
             stream.onHold = { [weak self] in
@@ -231,9 +235,11 @@ class Call {
         }
     }
 
-    private func updateMediaStream<Streamable>(_ mediaStream: ObservableValue<MediaStream<Streamable>>,
-                                               with stream: Streamable,
-                                               isRemote: Bool) {
+    private func updateMediaStream<Streamable>(
+        _ mediaStream: ObservableValue<MediaStream<Streamable>>,
+        with stream: Streamable,
+        isRemote: Bool
+    ) {
         let mediaStreamValue: MediaStream<Streamable>
         defer {
             mediaStream.value = mediaStreamValue

--- a/GliaWidgets/Sources/ViewModel/Chat/Data/ChatMessage.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/Data/ChatMessage.swift
@@ -68,9 +68,11 @@ class ChatMessage: Codable {
         case metadata
     }
 
-    init(with message: CoreSdkClient.Message,
-         queueID: String? = nil,
-         operator salemoveOperator: CoreSdkClient.Operator? = nil) {
+    init(
+        with message: CoreSdkClient.Message,
+        queueID: String? = nil,
+        operator salemoveOperator: CoreSdkClient.Operator? = nil
+    ) {
         id = message.id
 
         if let salemoveOperator = salemoveOperator {

--- a/GliaWidgets/Sources/ViewModel/Common/FilePicker/FilePickerViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Common/FilePicker/FilePickerViewModel.swift
@@ -47,9 +47,10 @@ class FilePickerViewModel: ViewModel {
     private let pickerEvent: ObservableValue<FilePickerEvent>
     var environment: Environment
 
-    init(pickerEvent: ObservableValue<FilePickerEvent>,
-         allowedFiles: FileTypes = .default,
-         environment: Environment
+    init(
+        pickerEvent: ObservableValue<FilePickerEvent>,
+        allowedFiles: FileTypes = .default,
+        environment: Environment
     ) {
         self.pickerEvent = pickerEvent
         self.allowedFiles = allowedFiles

--- a/GliaWidgets/Sources/ViewModel/Common/MediaPicker/MediaPickerViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Common/MediaPicker/MediaPickerViewModel.swift
@@ -62,9 +62,11 @@ class MediaPickerViewModel: ViewModel {
     private let mediaSource: MediaSource
     private let mediaTypes: [MediaType]
 
-    init(pickerEvent: ObservableValue<MediaPickerEvent>,
-         mediaSource: MediaSource,
-         mediaTypes: [MediaType] = [.image]) {
+    init(
+        pickerEvent: ObservableValue<MediaPickerEvent>,
+        mediaSource: MediaSource,
+        mediaTypes: [MediaType] = [.image]
+    ) {
         self.pickerEvent = pickerEvent
         self.mediaSource = mediaSource
         self.mediaTypes = mediaTypes

--- a/GliaWidgets/SwiftUI/Components/Buttons/ActionButtonSwiftUI.swift
+++ b/GliaWidgets/SwiftUI/Components/Buttons/ActionButtonSwiftUI.swift
@@ -12,12 +12,11 @@ struct ActionButtonSwiftUI: View {
             .background(SwiftUI.Color(model.style.backgroundColor.color))
             .cornerRadius(model.style.cornerRaidus ?? 0)
             .overlay(
-                RoundedRectangle(
-                    cornerRadius: model.style.cornerRaidus ?? 0)
-                        .stroke(
-                            SwiftUI.Color(model.style.borderColor ?? .clear),
-                            lineWidth: model.style.borderWidth ?? 0
-                        )
+                RoundedRectangle(cornerRadius: model.style.cornerRaidus ?? 0)
+                .stroke(
+                    SwiftUI.Color(model.style.borderColor ?? .clear),
+                    lineWidth: model.style.borderWidth ?? 0
+                )
             )
             .shadow(
                 color: SwiftUI.Color(model.style.shadowColor ?? .clear),

--- a/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar.Live.swift
+++ b/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar.Live.swift
@@ -12,7 +12,8 @@ extension SnackBar {
                 environment: .init(
                     timerProviding: timerProviding,
                     notificationCenter: notificationCenter,
-                    gcd: gcd)
+                    gcd: gcd
+                )
             )
             if existedPresenter == nil {
                 Self.presenters.append(presenter)


### PR DESCRIPTION
Add the following rules to the codebase:

- multiline_arguments_brackets
- multiline_literal_brackets
- multiline_parameters
- multiline_parameters_brackets

The main point is that sometimes it comes up in our PRs where should parenthesis start, end, how to delimit parameters of a method, etc. These rules in essence say that if you decide to put parameters in different lines, then the starting delimiter should be with the name of the method, and then also the end one should be on its own line. Also in this case, all parameters should go in their own lines. These rules do NOT mandate that you must put parameters into their own lines always, however. You are free to put them all in the same line if you want.

As you see with the changes, they all make the code look more like the structure and the readability we strive for, so I hope that adding these rules will make sense to you. Otherwise, you can comment in the PR.

MOB-3175

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from iOS SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3589734507/Logging+from+iOS+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
