### PR TITLE
Add subset of new SwiftLint rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -23,6 +23,9 @@ opt_in_rules:
   - multiline_literal_brackets
   - multiline_parameters
   - multiline_parameters_brackets
+  - unowned_variable_capture
+  - vertical_whitespace_opening_braces
+  - vertical_whitespace_closing_braces
 excluded: # paths to ignore during linting. Takes precedence over `included`.
   - Carthage
   - Pods

--- a/GliaWidgets/Public/Configuration/Configuration.Mock.swift
+++ b/GliaWidgets/Public/Configuration/Configuration.Mock.swift
@@ -3,7 +3,6 @@
 import Foundation
 
 extension Configuration {
-
     static func mock(
         authMethod: AuthorizationMethod = .siteApiKey(id: "site-api-key-id", secret: "site-api-key-secret"),
         environment: Environment = .beta,

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
@@ -751,7 +751,6 @@ extension SecureConversations.TranscriptModel {
                 in: self.pendingSection
             )
         }
-
     }
 }
 

--- a/GliaWidgets/SecureConversations/FileUploadListView/SecureConversations.FileUploadListViewModel.swift
+++ b/GliaWidgets/SecureConversations/FileUploadListView/SecureConversations.FileUploadListViewModel.swift
@@ -178,7 +178,6 @@ extension SecureConversations.FileUploadListViewModel {
             return nil
         }
         return handleAddedUpload(upload)
-
     }
 
     @discardableResult

--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeView.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeView.swift
@@ -379,7 +379,6 @@ extension SecureConversations.WelcomeView {
             )
         ])
         rootStackView.setCustomSpacing(16, after: titleLabel)
-
     }
 
     func defineSubtitleLabelLayout() {
@@ -390,7 +389,6 @@ extension SecureConversations.WelcomeView {
             )
         ])
         rootStackView.setCustomSpacing(16, after: subtitleLabel)
-
     }
 
     func defineCheckMessagesButtonLayout() {
@@ -824,7 +822,6 @@ extension SecureConversations.WelcomeView {
                 bottomOffset,
                 animated: true
             )
-
         }
     }
 }

--- a/GliaWidgets/Sources/CallVisualizer/VideoCall/View/ButtonBar/VideoCallView.CallButtonBar.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VideoCall/View/ButtonBar/VideoCallView.CallButtonBar.swift
@@ -2,7 +2,6 @@ import UIKit
 
 extension CallVisualizer.VideoCallView {
     final class CallButtonBar: BaseView {
-
         // MARK: - Properties
 
         var props: Props {

--- a/GliaWidgets/Sources/CallVisualizer/VideoCall/View/ConnectView/VideoCallView.ConnectOperatorView.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VideoCall/View/ConnectView/VideoCallView.ConnectOperatorView.swift
@@ -2,7 +2,6 @@ import UIKit
 
 extension CallVisualizer.VideoCallView {
     final class ConnectOperatorView: BaseView {
-
         // MARK: - Properties
 
         var props: Props {

--- a/GliaWidgets/Sources/CallVisualizer/VideoCall/View/ConnectView/VideoCallView.ConnectStatusView.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VideoCall/View/ConnectView/VideoCallView.ConnectStatusView.swift
@@ -2,7 +2,6 @@ import UIKit
 
 extension CallVisualizer.VideoCallView {
     final class ConnectStatusView: BaseView {
-
         // MARK: - Properties
 
         var props: Props = Props() {

--- a/GliaWidgets/Sources/CallVisualizer/VideoCall/View/ConnectView/VideoCallView.ConnectView.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VideoCall/View/ConnectView/VideoCallView.ConnectView.swift
@@ -2,7 +2,6 @@ import UIKit
 
 extension CallVisualizer.VideoCallView {
     final class ConnectView: BaseView {
-
         // MARK: - Properties
 
         private let operatorView: ConnectOperatorView
@@ -111,7 +110,6 @@ private extension CallVisualizer.VideoCallView.ConnectView {
         topPadding(for: props.state)
         renderShowing = props.transition
         updateConstraints()
-
     }
 
     func show(animated: Bool) {

--- a/GliaWidgets/Sources/CallVisualizer/VideoCall/View/ConnectView/VideoCallView.UserImageView.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VideoCall/View/ConnectView/VideoCallView.UserImageView.swift
@@ -2,7 +2,6 @@ import UIKit
 
 extension CallVisualizer.VideoCallView {
     final class UserImageView: BaseView {
-
         // MARK: - Properties
 
         var props: Props {

--- a/GliaWidgets/Sources/CallVisualizer/VideoCall/View/VideoCallView.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VideoCall/View/VideoCallView.swift
@@ -2,7 +2,6 @@ import UIKit
 
 extension CallVisualizer {
     final class VideoCallView: BaseView {
-
         // MARK: - Properties
 
         var props: Props {

--- a/GliaWidgets/Sources/CallVisualizer/VideoCall/ViewModel/VideoCallViewModel.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VideoCall/ViewModel/VideoCallViewModel.swift
@@ -2,7 +2,6 @@ import UIKit
 
 extension CallVisualizer {
     final class VideoCallViewModel {
-
         // MARK: - Properties
 
         var delegate: ((DelegateEvent) -> Void)?

--- a/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeView.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeView.swift
@@ -58,7 +58,6 @@ extension CallVisualizer {
                 viewState: ViewState = .loading,
                 style: VisitorCodeStyle = Theme().visitorCode,
                 isPoweredByShown: Bool = true
-
             ) {
                 self.viewType = viewType
                 self.style = style

--- a/GliaWidgets/Sources/Component/Bubble/BubbleView.swift
+++ b/GliaWidgets/Sources/Component/Bubble/BubbleView.swift
@@ -74,7 +74,6 @@ class BubbleView: BaseView {
         } else {
             addSubview(onHoldView)
         }
-
     }
 
     func hideOnHoldView() {

--- a/GliaWidgets/Sources/Component/CallButtonBar/Button/CallButton.swift
+++ b/GliaWidgets/Sources/Component/CallButtonBar/Button/CallButton.swift
@@ -131,7 +131,6 @@ class CallButton: UIView {
             imageView.tintColor = color
         case .gradient(let colors):
             imageView.makeGradientBackground(colors: colors)
-
         }
         titleLabel.text = style.title
         titleLabel.font = style.titleFont
@@ -180,7 +179,6 @@ class CallButton: UIView {
         stateStyle: CallButtonStyle.StateStyle,
         badgeItemCount: Int?
     ) -> (label: String?, value: String) {
-
         let badgeValue: String
 
         switch badgeItemCount {

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -95,7 +95,6 @@ extension CoreSdkClient.Salemove.Configuration {
 
 extension CoreSdkClient.Salemove.AuthorizationMethod {
     static let mock = Self.siteApiKey(id: "mockSiteApiKeyId", secret: "mockSiteApiKeySecret")
-
 }
 
 extension CoreSdkClient.VisitorContext {
@@ -114,7 +113,6 @@ extension CoreSdkClient.EngagementFileInformation {
         isSecurityScanningRequired: Bool = false,
         url: String? = "https://mock.mock/file.mock"
     ) throws -> CoreSdkClient.EngagementFileInformation {
-
         let jsonString = jsonFields(
             [
                 url.map { jsonField("url", value: $0) },
@@ -401,7 +399,6 @@ extension CoreSdkClient.Site.AllowedFileSenders.Mock {
             visitor: visitor
         )
     }
-
 }
 
 extension CoreSdkClient.Site.AllowedFileSenders {

--- a/GliaWidgets/Sources/Extensions/Array+Extensions.swift
+++ b/GliaWidgets/Sources/Extensions/Array+Extensions.swift
@@ -8,7 +8,6 @@ extension Array where Element == UIColor {
 }
 
 extension Array where Element == String {
-
     func convertToCgColors() -> [CGColor] {
         return map { UIColor(hex: $0).cgColor }
     }

--- a/GliaWidgets/Sources/Extensions/UIColor+Hex.swift
+++ b/GliaWidgets/Sources/Extensions/UIColor+Hex.swift
@@ -1,7 +1,6 @@
 import UIKit
 
 extension UIColor {
-
     convenience init(hex: String) {
         let trimHex = hex.trimmingCharacters(in: .whitespacesAndNewlines)
         let dropHash = String(trimHex.dropFirst()).trimmingCharacters(in: .whitespacesAndNewlines)

--- a/GliaWidgets/Sources/Extensions/UIFont+Extensions.swift
+++ b/GliaWidgets/Sources/Extensions/UIFont+Extensions.swift
@@ -2,7 +2,6 @@ import Foundation
 import UIKit
 
 extension UIFont {
-
     static func convertToFont(
         uiFont: UIFont?,
         textStyle: UIFont.TextStyle

--- a/GliaWidgets/Sources/IdCollection/IdCollection.swift
+++ b/GliaWidgets/Sources/IdCollection/IdCollection.swift
@@ -1,6 +1,5 @@
 /// Collection that allows easier access by element identifier.
 struct IdCollection<Identifier: Hashable, Item: Equatable>: Equatable, Collection {
-
     typealias DictionaryType = [Identifier: Item]
     typealias ArrayType = [Identifier]
 

--- a/GliaWidgets/Sources/Interactor/Interactor.swift
+++ b/GliaWidgets/Sources/Interactor/Interactor.swift
@@ -340,7 +340,6 @@ extension Interactor: CoreSdkClient.Interactable {
     }
 
     func start(engagement: CoreSdkClient.Engagement) {
-
         switch engagement.source {
         case .coreEngagement:
             start()

--- a/GliaWidgets/Sources/Layout/Layoutable.swift
+++ b/GliaWidgets/Sources/Layout/Layoutable.swift
@@ -4,7 +4,6 @@ import UIKit
 ///  flexible mechanism for defining UI and avoid make strict relations
 ///  with UIView.
 public protocol Layoutable {
-
     var leadingAnchor: NSLayoutXAxisAnchor { get }
     var trailingAnchor: NSLayoutXAxisAnchor { get }
     var leftAnchor: NSLayoutXAxisAnchor { get }

--- a/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.Mock.swift
+++ b/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.Mock.swift
@@ -1,6 +1,5 @@
 #if DEBUG
 extension AlertConfiguration {
-
     static func mock(showsPoweredBy: Bool = true) -> Self {
         .init(
             leaveQueue: .init(showsPoweredBy: showsPoweredBy),
@@ -28,7 +27,6 @@ extension AlertConfiguration {
 }
 
 extension SingleActionAlertConfiguration {
-
     static func mock(
         title: String? = "mocked-title",
         message: String? = "mocked-message",
@@ -84,7 +82,6 @@ extension ConfirmationAlertConfiguration {
 }
 
 extension SingleMediaUpgradeAlertConfiguration {
-
     static func mock() -> Self {
         .init(
             title: "mocked-title",
@@ -97,7 +94,6 @@ extension SingleMediaUpgradeAlertConfiguration {
 }
 
 extension MessageAlertConfiguration {
-
     static func mock(
         title: String? = "mocked-title",
         message: String? = "mocked-message"
@@ -110,7 +106,6 @@ extension MessageAlertConfiguration {
 }
 
 extension MediaUpgradeActionStyle {
-
     static func mock() -> Self {
         .init(
             title: "",
@@ -128,7 +123,6 @@ extension MediaUpgradeActionStyle {
 }
 
 extension MultipleMediaUpgradeAlertConfiguration {
-
     static func mock(
         title: String = "mocked-title",
         audioUpgradeAction: MediaUpgradeActionStyle = .mock(),
@@ -145,7 +139,6 @@ extension MultipleMediaUpgradeAlertConfiguration {
 }
 
 extension SettingsAlertConfiguration {
-
     static func mock() -> Self {
         .init(
             title: "mocked-title",

--- a/GliaWidgets/Sources/View/BaseView/BaseView.swift
+++ b/GliaWidgets/Sources/View/BaseView/BaseView.swift
@@ -1,7 +1,6 @@
 import UIKit
 
 class BaseView: UIView {
-
     var currentOrientation: UIInterfaceOrientation {
         guard let windowScene = UIApplication.shared.windows.first?.windowScene else {
             return .portrait

--- a/GliaWidgets/Sources/View/Call/CallStyle.RemoteConfig.swift
+++ b/GliaWidgets/Sources/View/Call/CallStyle.RemoteConfig.swift
@@ -44,7 +44,6 @@ extension CallStyle {
         _ bottomText: RemoteConfiguration.Text?,
         assetsBuilder: RemoteConfiguration.AssetsBuilder
     ) {
-
         bottomText?.alignment.unwrap { _ in
             // The logic for bottomText alignment has not been implemented
         }
@@ -65,7 +64,6 @@ extension CallStyle {
         _ topText: RemoteConfiguration.Text?,
         assetsBuilder: RemoteConfiguration.AssetsBuilder
     ) {
-
         topText?.alignment.unwrap { _ in
             // The logic for topText alignment has not been implemented
         }
@@ -90,7 +88,6 @@ extension CallStyle {
         _ duration: RemoteConfiguration.Text?,
         assetsBuilder: RemoteConfiguration.AssetsBuilder
     ) {
-
         duration?.alignment.unwrap { _ in
             // The logic for duration alignment has not been implemented
         }

--- a/GliaWidgets/Sources/View/Call/CallStyle.swift
+++ b/GliaWidgets/Sources/View/Call/CallStyle.swift
@@ -2,7 +2,6 @@ import UIKit
 
 /// Style of the call view.
 public class CallStyle: EngagementStyle {
-
     /// Title for the audio call.
     public var audioTitle: String
 

--- a/GliaWidgets/Sources/View/Chat/GVA/PersistentButton/GvaPersistentButtonView.swift
+++ b/GliaWidgets/Sources/View/Chat/GVA/PersistentButton/GvaPersistentButtonView.swift
@@ -96,7 +96,6 @@ extension GvaPersistentButtonView {
 
 extension GvaPersistentButtonView {
     final class ContainerView: BaseView {
-
         let style: GvaPersistentButtonStyle
 
         init(style: GvaPersistentButtonStyle) {

--- a/GliaWidgets/Sources/View/Chat/Message/Content/CustomCard/WebMessageCardView.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/Content/CustomCard/WebMessageCardView.swift
@@ -52,7 +52,6 @@ protocol WebMessageCardViewDelegate: AnyObject {
 }
 
 final class WebMessageCardView: UIView {
-
     private enum ActionType: Int {
         case mobileAction = 1
         case cardOption

--- a/GliaWidgets/Sources/View/Chat/Message/Content/File/ChatFileContentView.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/Content/File/ChatFileContentView.swift
@@ -79,7 +79,6 @@ extension ChatFileContentView {
             fileValue = file.accessibilityProperties.value
         case .download(let download):
             fileValue = download.accessibilityProperties.value
-
         }
 
         let sender: String

--- a/GliaWidgets/Sources/View/EngagementStyle.swift
+++ b/GliaWidgets/Sources/View/EngagementStyle.swift
@@ -2,7 +2,6 @@ import UIKit
 
 /// Base style for engagement views.
 public class EngagementStyle: Equatable {
-
     /// Style of the view's header (navigation bar area).
     public var header: HeaderStyle
 

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
@@ -522,7 +522,6 @@ extension ChatViewController {
                 ),
                 downloads: []
             )
-
         }
         chatViewModelEnv.fetchChatHistory = { $0(.success(messages)) }
         var interEnv = Interactor.Environment.mock

--- a/GliaWidgets/Sources/ViewController/Common/OfferPresenter/OfferPresenter.swift
+++ b/GliaWidgets/Sources/ViewController/Common/OfferPresenter/OfferPresenter.swift
@@ -6,8 +6,8 @@ protocol DismissalAndPresentationController where Self: UIViewController {
 
 extension DismissalAndPresentationController {
     func replacePresentedOfferIfPossible(with offer: Replaceable) {
-        let completion = { [unowned self] in
-            self.present(offer, animated: true)
+        let completion: () -> Void = { [weak self] in
+            self?.present(offer, animated: true)
         }
         guard let presented = self.presentedViewController as? Replaceable else {
             completion()

--- a/GliaWidgets/Sources/ViewController/Survey/Components/ButtonView/Survey.ButtonView.swift
+++ b/GliaWidgets/Sources/ViewController/Survey/Components/ButtonView/Survey.ButtonView.swift
@@ -2,7 +2,6 @@ import UIKit
 
 extension Survey {
     final class ButtonView: BaseView {
-
         enum State {
             case active, highlighted, selected
         }

--- a/GliaWidgets/Sources/ViewController/Survey/Components/CheckboxView/Survey.Checkbox.swift
+++ b/GliaWidgets/Sources/ViewController/Survey/Components/CheckboxView/Survey.Checkbox.swift
@@ -2,7 +2,6 @@ import UIKit
 
 extension Survey {
     final class CheckboxView: BaseView {
-
         enum State {
             case active, highlighted, selected
         }

--- a/GliaWidgets/Sources/ViewController/Survey/Components/ScaleQuestionView/Survey.ScaleQuestionView.swift
+++ b/GliaWidgets/Sources/ViewController/Survey/Components/ScaleQuestionView/Survey.ScaleQuestionView.swift
@@ -3,7 +3,6 @@ import UIKit
 
 extension Survey {
     final class ScaleQuestionView: BaseView {
-
         var props: Props {
             didSet { render() }
         }

--- a/GliaWidgets/Sources/ViewController/Survey/Mocks/Survey.ViewController.Props.Mock.swift
+++ b/GliaWidgets/Sources/ViewController/Survey/Mocks/Survey.ViewController.Props.Mock.swift
@@ -72,7 +72,6 @@ extension Survey.ViewController.Props {
 }
 
 private extension Survey.ViewController.Props {
-
     static func makeScalePropsMock(
         selectedOption: Survey.Option<Int>? = nil,
         showValidationError: Bool = false

--- a/GliaWidgets/Sources/ViewController/Survey/Survey.ViewController.Props.swift
+++ b/GliaWidgets/Sources/ViewController/Survey/Survey.ViewController.Props.swift
@@ -121,7 +121,6 @@ extension Survey.ViewController.Props {
         setQuestion: @escaping (String, SurveyQuestionPropsProtocol) -> Void,
         updateProps: @escaping (Self) -> Void
     ) -> Survey.ScaleQuestionView.Props {
-
         let accessibilityValue = sdkQuestion.required
         ? Localization.Survey.Question.Required.Accessibility.label
         : nil
@@ -161,7 +160,6 @@ extension Survey.ViewController.Props {
         setQuestion: @escaping (String, SurveyQuestionPropsProtocol) -> Void,
         updateProps: @escaping (Self) -> Void
     ) -> Survey.BooleanQuestionView.Props {
-
         let accessibilityValue = sdkQuestion.required
         ? Localization.Survey.Question.Required.Accessibility.label
         : nil
@@ -198,7 +196,6 @@ extension Survey.ViewController.Props {
         setQuestion: @escaping (String, SurveyQuestionPropsProtocol) -> Void,
         updateProps: @escaping (Self) -> Void
     ) -> Survey.SingleChoiceQuestionView.Props {
-
         let accessibilityValue = sdkQuestion.required
         ? Localization.Survey.Question.Required.Accessibility.label
         : nil
@@ -253,7 +250,6 @@ extension Survey.ViewController.Props {
         setQuestion: @escaping (String, SurveyQuestionPropsProtocol) -> Void,
         updateProps: @escaping (Self) -> Void
     ) -> Survey.InputQuestionView.Props {
-
         let accessibilityValue = sdkQuestion.required
         ? Localization.Survey.Question.Required.Accessibility.label
         : nil

--- a/GliaWidgets/Sources/ViewController/Survey/SurveyViewController.View.swift
+++ b/GliaWidgets/Sources/ViewController/Survey/SurveyViewController.View.swift
@@ -2,7 +2,6 @@ import UIKit
 
 extension Survey {
     final class ContentView: BaseView {
-
         // MARK: - Survey questions container
 
         lazy var header = UILabel().make {
@@ -128,7 +127,6 @@ extension Survey {
         var _updateUi: (() -> Void)?
 
         func updateUi(theme: Theme) {
-
             _updateUi = { [weak self] in
                 guard let this = self else { return }
                 this.header.font = theme.survey.title.font

--- a/GliaWidgets/Sources/ViewController/Survey/SurveyViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Survey/SurveyViewController.swift
@@ -2,7 +2,6 @@ import UIKit
 
 extension Survey {
     final class ViewController: UIViewController, AlertPresenter {
-
         struct Props {
             let header: String
             var questionsProps: [QuestionPropsProtocol]

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -571,7 +571,6 @@ extension ChatViewModel {
                     isMatchingOutgoingMessage = true
                 default:
                     break
-
                 }
                 // Early out if match was found.
                 if isMatchingOutgoingMessage {

--- a/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
@@ -141,7 +141,6 @@ class EngagementViewModel: CommonEngagementModel {
 
         case .ended(let reason) where reason == .byOperator:
             interactor.currentEngagement?.getSurvey(completion: { [weak self] result in
-
                 guard let self = self else { return }
                 guard case .success(let survey) = result, survey == nil else {
                     self.endSession()
@@ -347,7 +346,7 @@ private extension EngagementViewModel {
             }
         case let authenticationError as CoreSdkClient.Authentication.Error:
             switch authenticationError {
-            case let .expiredAccessToken(message):
+            case .expiredAccessToken:
                 environment.log.prefixed(Self.self).info("Show authentication error Dialog")
                 showCriticalErrorAlert(
                     with: alertConfiguration.expiredAccessTokenError,
@@ -416,7 +415,6 @@ extension EngagementViewModel: Hashable {
 }
 
 extension EngagementViewModel {
-
     enum Event {
         case viewWillAppear
         case viewDidAppear
@@ -454,7 +452,6 @@ extension EngagementViewModel {
         case showEndButton
         case showEndScreenShareButton
         case showLiveObservationConfirmation(LiveObservation.Confirmation)
-
     }
 
     enum DelegateEvent {

--- a/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar+View.swift
+++ b/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar+View.swift
@@ -62,7 +62,6 @@ extension SnackBar {
                         withAnimation(.linear(duration: 0.015)) {
                             self.currentOffset = -60
                         }
-
                     }
                 }
         }


### PR DESCRIPTION
Add the following rules to the codebase:

- unowned_variable_capture
- vertical_whitespace_opening_braces
- vertical_whitespace_closing_braces

These are mostly to end the inconsistency we have where some parts have spaces after opening braces, and some don't. We decided some time ago that we wouldn't but nothing was enforcing it other than PRs.

This is the last set of rules that are going to be added.

MOB-3175

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from iOS SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3589734507/Logging+from+iOS+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
