### PR TITLE
Remove `singleChoice` check for Custom Card

### DIFF
--- a/GliaWidgets/Sources/ViewModel/Chat/Data/ChatMessage.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/Data/ChatMessage.swift
@@ -52,8 +52,12 @@ class ChatMessage: Codable {
             return .gvaGallery(response)
         }
 
+        if metadata != nil {
+            return .customCard
+        }
+
         if attachment?.type == .singleChoice {
-            return metadata != nil ? .customCard : .choiceCard
+            return .choiceCard
         }
 
         return .none

--- a/GliaWidgetsTests/ChatMessage/ChatMessageTests.swift
+++ b/GliaWidgetsTests/ChatMessage/ChatMessageTests.swift
@@ -23,4 +23,15 @@ final class ChatMessageTests: XCTestCase {
         )
         XCTAssertEqual(msg.cardType, .customCard)
     }
+
+    func testCardType__metadataWithoutSingleChoice() throws {
+        let metadataDecodingContainer = try CoreSdkMessageMetadataContainer(
+            jsonData: "{\"html\": \"Hello\"}".data(using: .utf8)!
+        ).container
+        let msg = ChatMessage.mock(
+            attachment: .mock(type: nil, files: nil, imageUrl: nil, options: nil),
+            metadata: MessageMetadata(container: metadataDecodingContainer)
+        )
+        XCTAssertEqual(msg.cardType, .customCard)
+    }
 }


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3359

**What was solved?**
Since `attachment.type == .singleChoice` check for Custom Cards does not exist on Android side, that was decided to align the platform and remove it from iOS side. So now, evaluation of cardType does not take into account `attachment.type` if metadata exists.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from iOS SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3589734507/Logging+from+iOS+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.