### PR TITLE
Filter out 401 error when sending a message failed

### DIFF
--- a/GliaWidgetsTests/Sources/ChatViewControllerTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewControllerTests.swift
@@ -69,7 +69,7 @@ class ChatViewControllerTests: XCTestCase {
 
         viewModel.engagementAction = { action in
             switch action {
-            case let .showCriticalErrorAlert(conf, accessibilityIdentifier, dismissed):
+            case .showCriticalErrorAlert:
                 calls.append(.presentCriticalErrorAlert)
             default:
                 break
@@ -77,7 +77,7 @@ class ChatViewControllerTests: XCTestCase {
         }
 
         let error: CoreSdkClient.SalemoveError = .init(
-            reason: "Authentication issue",
+            reason: "Expired Access Token",
             error: CoreSdkClient.Authentication.Error.expiredAccessToken
         )
         interactor.fail(error: error)


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3357

**What was solved?**
When sending a message failed, Internal Error was always returned, making it impossible to determine the cause and, if needed, skip any action. Since 401 errors are handled from elsewhere, 401 case needs to be skipped.
**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from iOS SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3589734507/Logging+from+iOS+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
