### PR TITLE
GitHub action for building xcframework

### DIFF
--- a/.github/workflows/prepare-xcframework-release.yml
+++ b/.github/workflows/prepare-xcframework-release.yml
@@ -1,0 +1,119 @@
+name: prepare-xcframework-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      product_name: 
+        description: 'The Xcode product name'
+        required: true
+        default: 'GliaWidgets'
+      xcode_scheme: 
+        description: 'Xcode workspace scheme. It will be used for archieving project.'
+        required: true
+        default: 'GliaWidgets'
+
+jobs:
+  build:
+    name: Create PR, draft release, and build xcframework
+    runs-on: macos-latest
+    permissions:
+      contents: write
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        run: |
+          pod install --repo-update
+
+      - name: Archieve iphoneos
+        run: |
+          xcodebuild archive \
+            -workspace "${{ github.event.inputs.product_name }}.xcworkspace" \
+            -scheme "${{ github.event.inputs.xcode_scheme }}" \
+            -sdk iphoneos \
+            -archivePath "xcf/${{ github.event.inputs.product_name }}-iphoneos.xcarchive" \
+            SKIP_INSTALL=NO \
+            BUILD_LIBRARY_FOR_DISTRIBUTION=YES | xcpretty
+        shell: bash
+
+      - name: Archieve iphonesimulator
+        run: |
+          xcodebuild archive \
+            -workspace "${{ github.event.inputs.product_name }}.xcworkspace" \
+            -scheme "${{ github.event.inputs.xcode_scheme }}" \
+            -sdk iphonesimulator \
+            -archivePath "xcf/${{ github.event.inputs.product_name }}-iossimulator.xcarchive" \
+            SKIP_INSTALL=NO \
+            BUILD_LIBRARY_FOR_DISTRIBUTION=YES | xcpretty
+        shell: bash
+
+      - name: Create xcframework
+        run: |
+          xcodebuild -create-xcframework \
+          -framework "xcf/${{ github.event.inputs.product_name }}-iphoneos.xcarchive/Products/Library/Frameworks/${{ github.event.inputs.product_name }}.framework" \
+          -framework "xcf/${{ github.event.inputs.product_name }}-iossimulator.xcarchive/Products/Library/Frameworks/${{ github.event.inputs.product_name }}.framework" \
+          -output "xcf/${{ github.event.inputs.product_name }}.xcframework"
+        shell: bash
+
+      - name: Zip xcframework
+        run: |
+          cd xcf
+          zip -r GliaWidgetsXcf.xcframework.zip GliaWidgets.xcframework
+        shell: bash
+      
+      - name: Calculate checksum
+        id: calculate_xcf_checksum
+        run: |
+          cd xcf
+          echo "checksum=$(swift package compute-checksum GliaWidgetsXcf.xcframework.zip | tail -1 | tr -d '\n')" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Fetch semver
+        id: fetch_semver
+        run: |
+          cd GliaWidgets
+          filename=StaticValues.swift
+          echo "semver=$(grep 'sdkVersion\s*=\s*"' "$filename" | awk -F'"' '{print $2}')" >> "$GITHUB_OUTPUT"
+          
+        shell: bash
+      
+      - name: Update Package.swift
+        run: |
+          filename=Package.swift
+          semver=${{ steps.fetch_semver.outputs.semver}}
+          checksum=${{ steps.calculate_xcf_checksum.outputs.checksum}}
+          sed -i.bak "s/\${WIDGETS_SDK_SEMVER}/$semver/g" "$filename"
+          sed -i.bak "s/\${WIDGETS_SDK_CHECKSUM}/$checksum/g" "$filename"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: "release/${{ steps.fetch_semver.outputs.semver}}"
+          title: 'GliaWidgets SDK Release ${{ steps.fetch_semver.outputs.semver}}'
+          commit-message: |
+            GliaWidgets SDK Release ${{ steps.fetch_semver.outputs.semver}}
+
+      - uses: actions/create-release@v1
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.fetch_semver.outputs.semver}}
+          release_name: "GliaWidgetsSDK Release ${{ steps.fetch_semver.outputs.semver}}"
+          draft: true
+          prerelease: false
+          body: |
+            GliaWidgetsSDK Release
+            xcframework checksum: `${{ steps.calculate_xcf_checksum.outputs.checksum }}`
+
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: "xcf/GliaWidgetsXcf.xcframework.zip"
+          asset_name: "GliaWidgetsXcf.xcframework.zip"
+          asset_content_type: "application/zip"

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,5 @@ iOSInjectionProject/
 # with it.
 SnapshotTests/__Snapshots__/
 .vscode
+xcf
+*.bak

--- a/Package.swift
+++ b/Package.swift
@@ -34,6 +34,11 @@ let package = Package(
             url: "https://github.com/salemove/ios-bundle/releases/download/1.5.0/GliaCoreSDK.xcframework.zip",
             checksum: "f9d7d528e124169887a62bf713533395948e8e3ccf28e85ddf597f4a8b01beff"
         ),
+        .binaryTarget(
+            name: "GliaWidgetsSDKXcf",
+            url: "https://github.com/salemove/ios-sdk-widgets/releases/download/${WIDGETS_SDK_SEMVER}/GliaWidgetsXcf.xcframework.zip",
+            checksum: "${WIDGETS_SDK_CHECKSUM}"
+        ),
         .target(
             name: "GliaWidgets",
             dependencies: [
@@ -50,6 +55,16 @@ let package = Package(
             ],
             resources: [
                 .process("Resources")
+            ]
+        ),
+        .target(
+            name: "GliaWidgetsXcf",
+            dependencies: [
+                "GliaCoreSDK",
+                "GliaCoreDependency",
+                "TwilioVoice",
+                "WebRTC",
+                "GliaWidgetsSDKXcf"
             ]
         )
     ]

--- a/templates/Package.swift
+++ b/templates/Package.swift
@@ -10,7 +10,11 @@ let package = Package(
     products: [
         .library(
             name: "GliaWidgets",
-            targets: ["GliaWidgetsSDK"]
+            targets: ["GliaWidgets"]
+        ),
+        .library(
+            name: "GliaWidgetsXcf",
+            targets: ["GliaWidgetsXcf"]
         )
     ],
     targets: [
@@ -31,11 +35,22 @@ let package = Package(
         ),
         .binaryTarget(
             name: "GliaCoreSDK",
-            url: "https://github.com/salemove/ios-bundle/releases/download/${CORE_SDK_VERSION}/GliaCoreSDK.xcframework.zip",
+            url: "https://github.com/salemove/ios-bundle/releases/download/${CORE_SDK_SEMVER}/GliaCoreSDK.xcframework.zip",
             checksum: "${CORE_SDK_CHECKSUM}"
+        ),
+        .binaryTarget(
+            name: "GliaWidgetsSDKXcf",
+            url: "https://github.com/salemove/ios-sdk-widgets/releases/download/${WIDGETS_SDK_SEMVER}/GliaWidgetsXcf.xcframework.zip",
+            checksum: "${WIDGETS_SDK_CHECKSUM}"
         ),
         .target(
             name: "GliaWidgets",
+            dependencies: [
+                .target(name: "GliaCoreDependency"),
+                .target(name: "TwilioVoice"),
+                .target(name: "WebRTC"),
+                .target(name: "GliaCoreSDK"),
+            ],
             path: "GliaWidgets",
             exclude: [
                 "Cartfile.resolved",
@@ -47,13 +62,13 @@ let package = Package(
             ]
         ),
         .target(
-            name: "GliaWidgetsSDK",
+            name: "GliaWidgetsXcf",
             dependencies: [
                 "GliaCoreSDK",
                 "GliaCoreDependency",
                 "TwilioVoice",
                 "WebRTC",
-                "GliaWidgets"
+                "GliaWidgetsSDKXcf"
             ]
         )
     ]


### PR DESCRIPTION
Create separate GitHub action and
update Package.swift & templates/Package.swift

**Jira issue:**
https://glia.atlassian.net/browse/MOB-3362

**What was solved?**
Introduced a new GitHub Action that builds xcframework, zips archieves, calculates checksum, creates PR, and draft release.

A new action may be triggered only manually and supports params.

![image](https://github.com/salemove/ios-sdk-widgets/assets/125041274/169f078e-b0b7-48a5-9abd-d67d129c3069)


**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from iOS SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3589734507/Logging+from+iOS+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
