### PR TITLE
Add operator image displaying for Custom Cards

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -420,6 +420,8 @@
 		847A7643285A1914004044D1 /* FileUploadListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847A7642285A1914004044D1 /* FileUploadListViewModelTests.swift */; };
 		8485704F2BEE3A0800CEBCC5 /* ChatViewTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8485704E2BEE3A0800CEBCC5 /* ChatViewTest.swift */; };
 		848570512BEE3CCC00CEBCC5 /* ChatStyle.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848570502BEE3CCC00CEBCC5 /* ChatStyle.Mock.swift */; };
+		848B8ADC2C0759C500E990E6 /* Theme.CustomCardContainerStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848B8ADB2C0759C500E990E6 /* Theme.CustomCardContainerStyle.swift */; };
+		848B8ADE2C0870DC00E990E6 /* CustomCardContainerViewLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848B8ADD2C0870DC00E990E6 /* CustomCardContainerViewLayoutTests.swift */; };
 		8491AF002A6FB44200CC3E72 /* GvaGalleryCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AEFF2A6FB44200CC3E72 /* GvaGalleryCardCell.swift */; };
 		8491AF022A6FBBBA00CC3E72 /* GvaGalleryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF012A6FBBBA00CC3E72 /* GvaGalleryListView.swift */; };
 		8491AF062A77F16D00CC3E72 /* GvaGalleryCardStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF052A77F16D00CC3E72 /* GvaGalleryCardStyle.swift */; };
@@ -1364,6 +1366,8 @@
 		847A7642285A1914004044D1 /* FileUploadListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadListViewModelTests.swift; sourceTree = "<group>"; };
 		8485704E2BEE3A0800CEBCC5 /* ChatViewTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewTest.swift; sourceTree = "<group>"; };
 		848570502BEE3CCC00CEBCC5 /* ChatStyle.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStyle.Mock.swift; sourceTree = "<group>"; };
+		848B8ADB2C0759C500E990E6 /* Theme.CustomCardContainerStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.CustomCardContainerStyle.swift; sourceTree = "<group>"; };
+		848B8ADD2C0870DC00E990E6 /* CustomCardContainerViewLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCardContainerViewLayoutTests.swift; sourceTree = "<group>"; };
 		8491AEFF2A6FB44200CC3E72 /* GvaGalleryCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GvaGalleryCardCell.swift; sourceTree = "<group>"; };
 		8491AF012A6FBBBA00CC3E72 /* GvaGalleryListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GvaGalleryListView.swift; sourceTree = "<group>"; };
 		8491AF052A77F16D00CC3E72 /* GvaGalleryCardStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GvaGalleryCardStyle.swift; sourceTree = "<group>"; };
@@ -3948,6 +3952,7 @@
 				C09046F52B7E1050003C437C /* Theme.ChoiceCardStyle.Accessibility.swift */,
 				8491AF1E2A7D027D00CC3E72 /* Theme.ChatTextContentStyle.swift */,
 				C09046FD2B7E131B003C437C /* Theme.ChatTextContentStyle.Accessibility.swift */,
+				848B8ADB2C0759C500E990E6 /* Theme.CustomCardContainerStyle.swift */,
 			);
 			path = Chat;
 			sourceTree = "<group>";
@@ -4134,6 +4139,7 @@
 				C039FA7E2B19EB6E00DFD0E0 /* MediaPickerLayoutTests.swift */,
 				C039FA802B19ECBA00DFD0E0 /* MediaPickerDynamicFontTests.swift */,
 				C039FA822B19ED7D00DFD0E0 /* MediaPickerVoiceOverTests.swift */,
+				848B8ADD2C0870DC00E990E6 /* CustomCardContainerViewLayoutTests.swift */,
 			);
 			path = SnapshotTests;
 			sourceTree = "<group>";
@@ -5476,6 +5482,7 @@
 				C06A7588296ECD75006B69A2 /* Theme+VisitorCode.swift in Sources */,
 				C090476C2B7E24A8003C437C /* ChoiceCardOptionStateStyle.RemoteConfig.swift in Sources */,
 				C0857DED28D4831E008D171D /* Theme.Text.swift in Sources */,
+				848B8ADC2C0759C500E990E6 /* Theme.CustomCardContainerStyle.swift in Sources */,
 				845876A22823FF34007AC3DF /* Survey.ViewController.Props.Mock.swift in Sources */,
 				C090471D2B7E1AFF003C437C /* GvaGalleryCardStyle.ButtonStyle.swift in Sources */,
 				84520BDD2B10C16E00F97617 /* WebViewController.Props.swift in Sources */,
@@ -6205,6 +6212,7 @@
 				C07FA05029B0E41A00E9FB7F /* VideoCallViewControllerVoiceOverTests.swift in Sources */,
 				C039FA832B19ED7D00DFD0E0 /* MediaPickerVoiceOverTests.swift in Sources */,
 				C07FA05029B0E41A00E9FB7F /* VideoCallViewControllerVoiceOverTests.swift in Sources */,
+				848B8ADE2C0870DC00E990E6 /* CustomCardContainerViewLayoutTests.swift in Sources */,
 				AF755FDA2A71583900871E36 /* BubbleWindowLayoutTests.swift in Sources */,
 				AF22C88D2A6188EF0004BF3C /* ChatViewControllerLayoutTests.swift in Sources */,
 				AF03A7B12A6E96870081887D /* BubbleViewDynamicTypeFontTests.swift in Sources */,

--- a/GliaWidgets/Sources/Theme/Chat/Theme.CustomCardContainerStyle.swift
+++ b/GliaWidgets/Sources/Theme/Chat/Theme.CustomCardContainerStyle.swift
@@ -1,0 +1,15 @@
+import UIKit
+
+public extension Theme {
+    /// Style of a Custom Card container.
+    struct CustomCardContainerStyle {
+        /// Style of the operator's image.
+        public var operatorImage: UserImageStyle
+
+        ///
+        /// - Parameter operatorImage: Style of the operator's image.
+        public init(operatorImage: UserImageStyle) {
+            self.operatorImage = operatorImage
+        }
+    }
+}

--- a/GliaWidgets/Sources/View/Chat/ChatView.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatView.swift
@@ -205,55 +205,38 @@ extension ChatView {
                let item = itemForRow?($0.row, $0.section) {
                 switch cell.content {
                 case .operatorMessage(let view):
-                    switch item.kind {
-                    case .operatorMessage(let message, let showsImage, let imageUrl):
-                        // forward operator name to typing indicator's accessibility
-                        if let operatorName = message.operator?.name {
-                            typingIndicatorView.accessibilityProperties.operatorName = operatorName
-                        }
-
-                        view.showsOperatorImage = showsImage
-                        view.setOperatorImage(fromUrl: imageUrl, animated: animated)
-                    default:
-                        break
+                    guard case let .operatorMessage(message, showsImage, imageUrl) = item.kind else { return }
+                    // forward operator name to typing indicator's accessibility
+                    if let operatorName = message.operator?.name {
+                        typingIndicatorView.accessibilityProperties.operatorName = operatorName
                     }
+
+                    view.showsOperatorImage = showsImage
+                    view.setOperatorImage(fromUrl: imageUrl, animated: animated)
                 case .choiceCard(let view):
-                    switch item.kind {
-                    case .choiceCard(_, let showsImage, let imageUrl, _):
-                        view.showsOperatorImage = showsImage
-                        view.setOperatorImage(fromUrl: imageUrl, animated: animated)
-                    default:
-                        break
-                    }
-
+                    guard case let .choiceCard(_, showsImage, imageUrl, _) = item.kind else { return }
+                    view.showsOperatorImage = showsImage
+                    view.setOperatorImage(fromUrl: imageUrl, animated: animated)
                 case let .gvaGallery(view, _):
-                    switch item.kind {
-                    case let .gvaGallery(_, _, showsImage, imageUrl):
-                        view.showsOperatorImage = showsImage
-                        view.setOperatorImage(fromUrl: imageUrl, animated: animated)
-                    default: break
-                    }
+                    guard case let .gvaGallery(_, _, showsImage, imageUrl) = item.kind else { return }
+                    view.showsOperatorImage = showsImage
+                    view.setOperatorImage(fromUrl: imageUrl, animated: animated)
                 case let .gvaQuickReply(view):
-                    switch item.kind {
-                    case let .gvaGallery(_, _, showsImage, imageUrl):
-                        view.showsOperatorImage = showsImage
-                        view.setOperatorImage(fromUrl: imageUrl, animated: animated)
-                    default: break
-                    }
+                    guard case let .gvaQuickReply(_, _, showsImage, imageUrl) = item.kind else { return }
+                    view.showsOperatorImage = showsImage
+                    view.setOperatorImage(fromUrl: imageUrl, animated: animated)
                 case let .gvaResponseText(view):
-                    switch item.kind {
-                    case let .gvaResponseText(_, _, showsImage, imageUrl):
-                        view.showsOperatorImage = showsImage
-                        view.setOperatorImage(fromUrl: imageUrl, animated: animated)
-                    default: break
-                    }
+                    guard case let .gvaResponseText(_, _, showsImage, imageUrl) = item.kind else { return }
+                    view.showsOperatorImage = showsImage
+                    view.setOperatorImage(fromUrl: imageUrl, animated: animated)
                 case let .gvaPersistentButton(view):
-                    switch item.kind {
-                    case let .gvaPersistentButton(_, _, showsImage, imageUrl):
-                        view.showsOperatorImage = showsImage
-                        view.setOperatorImage(fromUrl: imageUrl, animated: animated)
-                    default: break
-                    }
+                    guard case let .gvaPersistentButton(_, _, showsImage, imageUrl) = item.kind else { return }
+                    view.showsOperatorImage = showsImage
+                    view.setOperatorImage(fromUrl: imageUrl, animated: animated)
+                case let .customCard(view):
+                    guard case let .customCard(_, showsImage, imageUrl, _) = item.kind else { return }
+                    view.showsOperatorImage = showsImage
+                    view.setOperatorImage(fromUrl: imageUrl, animated: animated)
                 default:
                     break
                 }
@@ -810,7 +793,16 @@ extension ChatView {
             )
         }
 
-        let container = CustomCardContainerView()
+        let container = CustomCardContainerView(
+            style: style.operatorMessageStyle.operatorImage,
+            environment: .init(
+                data: environment.data,
+                uuid: environment.uuid,
+                gcd: environment.gcd,
+                imageViewCache: environment.imageViewCache,
+                uiScreen: environment.uiScreen
+            )
+        )
         if let webCardView = contentView as? WebMessageCardView {
             webCardView.isUserInteractionEnabled = isActive
             webCardView.delegate = self
@@ -819,6 +811,8 @@ extension ChatView {
         }
 
         container.addContentView(contentView)
+        container.showsOperatorImage = showsImage
+        container.setOperatorImage(fromUrl: imageUrl, animated: false)
         return .customCard(container)
     }
 

--- a/GliaWidgets/Sources/View/Chat/Message/Content/CustomCard/CustomCardContainerView.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/Content/CustomCard/CustomCardContainerView.swift
@@ -1,13 +1,98 @@
 import UIKit
 
-final class CustomCardContainerView: UIView {
-    private let edgeInsets = UIEdgeInsets(top: 2, left: 10, bottom: 2, right: 60)
+private extension CGFloat {
+    static let operatorImageSide: CGFloat = 28
+}
 
+final class CustomCardContainerView: BaseView {
+    var showsOperatorImage: Bool = false {
+        didSet {
+            operatorImageView.isHidden = !showsOperatorImage
+        }
+    }
     var willDisplayView: (() -> Void)?
+
+    private let edgeInsets = UIEdgeInsets(top: 2, left: 44, bottom: 2, right: 60)
+    private let operatorImageInsets = UIEdgeInsets(top: 0, left: 8, bottom: 8, right: 0)
+    private let environment: Environment
+    private let style: UserImageStyle
+    private lazy var operatorImageView = UserImageView(
+        with: style,
+        environment: .init(
+            data: environment.data,
+            uuid: environment.uuid,
+            gcd: environment.gcd,
+            imageViewCache: environment.imageViewCache
+        )
+    )
+
+    init(
+        style: UserImageStyle,
+        environment: Environment
+    ) {
+        self.style = style
+        self.environment = environment
+        super.init()
+    }
+
+    @available(*, unavailable)
+    required init() { fatalError("init() has not been implemented") }
+
+    override func setup() {
+        super.setup()
+
+        addSubview(operatorImageView)
+        operatorImageView.layoutInSuperview(
+            edges: [.bottom, .leading],
+            insets: operatorImageInsets
+        ).activate()
+        operatorImageView.match(
+            [.width, .height],
+            value: .operatorImageSide
+        ).activate()
+    }
+
+    // MARK: - Internal
 
     func addContentView(_ contentView: UIView) {
         addSubview(contentView)
         contentView.translatesAutoresizingMaskIntoConstraints = false
         contentView.layoutInSuperview(insets: edgeInsets).activate()
     }
+
+    func setOperatorImage(fromUrl url: String?, animated: Bool) {
+        operatorImageView.setOperatorImage(fromUrl: url, animated: animated)
+    }
 }
+
+// MARK: - Environment
+
+extension CustomCardContainerView {
+    struct Environment {
+        var data: FoundationBased.Data
+        var uuid: () -> UUID
+        var gcd: GCD
+        var imageViewCache: ImageView.Cache
+        var uiScreen: UIKitBased.UIScreen
+    }
+}
+
+#if DEBUG
+extension CustomCardContainerView.Environment {
+    static func mock(
+        data: FoundationBased.Data = .mock,
+        uuid: @escaping () -> UUID = { .mock },
+        gcd: GCD = .mock,
+        imageViewCache: ImageView.Cache = .mock,
+        uiScreen: UIKitBased.UIScreen = .mock
+    ) -> CustomCardContainerView.Environment {
+        .init(
+            data: data,
+            uuid: uuid,
+            gcd: gcd,
+            imageViewCache: imageViewCache,
+            uiScreen: uiScreen
+        )
+    }
+}
+#endif

--- a/SnapshotTests/CustomCardContainerViewLayoutTests.swift
+++ b/SnapshotTests/CustomCardContainerViewLayoutTests.swift
@@ -1,0 +1,28 @@
+@testable import GliaWidgets
+import SnapshotTesting
+import XCTest
+
+final class CustomCardContainerViewLayoutTests: SnapshotTestCase {
+    func test_customCardContainer() {
+        let containerView = CustomCardContainerView(
+            style: .mock(
+                placeholderImage: .mock,
+                placeholderBackgroundColor: .fill(color: .lightGray),
+                imageBackgroundColor: .fill(color: .lightGray)
+            ),
+            environment: .mock(imageViewCache: .mock)
+        )
+        containerView.backgroundColor = .white
+        containerView.frame = .init(
+            origin: .zero,
+            size: .init(
+                width: 300,
+                height: 100
+            )
+        )
+        let contentView = UIView()
+        contentView.backgroundColor = .cyan
+        containerView.addContentView(contentView)
+        containerView.assertSnapshot(as: .image)
+    }
+}


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3366

**What was solved?**
Previously sender image was not displayed at all for Custom Card messages. This commit fixes that and adds snapshot test for CustomCardContainerView.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from iOS SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3589734507/Logging+from+iOS+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
![Simulator Screenshot - iPhone 15 - 2024-05-30 at 15 18 34](https://github.com/salemove/ios-sdk-widgets/assets/70878708/9c9db8aa-2e78-4ba3-9414-2c35caa2224c)