### PR TITLE
Update GliaCoreSDK to 1.5.0 and fix unit test compilation

### DIFF
--- a/GliaWidgets.podspec
+++ b/GliaWidgets.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   }
   s.exclude_files         = ['GliaWidgets/Window/**']
 
-  s.dependency 'GliaCoreSDK', '1.4.4'
+  s.dependency 'GliaCoreSDK', '1.5.0'
 end

--- a/GliaWidgetsTests/Sources/ChatViewControllerTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewControllerTests.swift
@@ -75,13 +75,13 @@ class ChatViewControllerTests: XCTestCase {
                 break
             }
         }
-        
-        let errorMessage = "Please restart the app and log in again"
+
         let error: CoreSdkClient.SalemoveError = .init(
             reason: "Authentication issue",
-            error: CoreSdkClient.Authentication.Error.expiredAccessToken(message: errorMessage))
+            error: CoreSdkClient.Authentication.Error.expiredAccessToken
+        )
         interactor.fail(error: error)
-        
+
         XCTAssertEqual(calls, [.presentCriticalErrorAlert])
     }
 

--- a/Package.swift
+++ b/Package.swift
@@ -31,8 +31,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "GliaCoreSDK",
-            url: "https://github.com/salemove/ios-bundle/releases/download/1.4.4/GliaCoreSDK.xcframework.zip",
-            checksum: "4c3172b6e2b746e941b965e173e146d2bf654b67c9e470cbe698dc6e2b7317c5"
+            url: "https://github.com/salemove/ios-bundle/releases/download/1.5.0/GliaCoreSDK.xcframework.zip",
+            checksum: "f9d7d528e124169887a62bf713533395948e8e3ccf28e85ddf597f4a8b01beff"
         ),
         .target(
             name: "GliaWidgets",

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
     - AccessibilitySnapshot/Core
     - SnapshotTesting (~> 1.0)
   - GliaCoreDependency (2.3.0)
-  - GliaCoreSDK (1.4.4):
+  - GliaCoreSDK (1.5.0):
     - GliaCoreDependency (= 2.3.0)
     - TwilioVoice (= 6.8.0)
     - WebRTC-lib (= 119.0.0)
@@ -35,7 +35,7 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   AccessibilitySnapshot: a91e4a69f870188b51f43863d9fc7269d07cdd93
   GliaCoreDependency: 37f48a5a32e2646617b87cbe9d4b30eedd123f6f
-  GliaCoreSDK: 6b9daa9eb34a962165cf1216f447e049d6faba5e
+  GliaCoreSDK: a5088474c24d1956b647a40062ffb243b0fa8eb3
   SnapshotTesting: 6141c48b6aa76ead61431ca665c14ab9a066c53b
   SwiftLint: c5b49076d727b772434318c236548f0a1110c299
   TwilioVoice: 9563c9ad71b9ab7bbad0b59b67cfe4be96c75d23

--- a/templates/GliaWidgets.podspec
+++ b/templates/GliaWidgets.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   }
   s.exclude_files         = ['GliaWidgets/Window/**']
 
-  s.dependency 'GliaCoreSDK', '1.4.4'
+  s.dependency 'GliaCoreSDK', '1.5.0'
 end


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3352

**What was solved?**
With upgrade to 1.5.0 Authentication.Error.expiredAccessToken signature has changed, so it had to be fixed in unit tests alongside Core SDK version change.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from iOS SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3589734507/Logging+from+iOS+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
