### PR TITLE
Extend accessibility for refresh token testing

### DIFF
--- a/TestingApp/Main.storyboard
+++ b/TestingApp/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -182,6 +182,7 @@
                                                             </button>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5zf-Ur-3od">
                                                                 <rect key="frame" x="118.5" y="0.0" width="119" height="30"/>
+                                                                <accessibility key="accessibilityConfiguration" identifier="main_refresh_token_button"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="30" id="LPc-hG-dHW"/>
                                                                 </constraints>

--- a/TestingApp/ViewController/ViewController.swift
+++ b/TestingApp/ViewController/ViewController.swift
@@ -603,7 +603,7 @@ extension ViewController {
         let isEmptyJwt = { enteredJwt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
 
         createAuthorizationAction.isEnabled = !isEmptyJwt()
-        createAuthorizationAction.accessibilityIdentifier = "create_authentication_alert_button"
+        createAuthorizationAction.accessibilityIdentifier = "refresh_token_alert_refresh_button"
 
         let jwtTextFieldDelegate = TextFieldDelegate(
             textChanged: { [weak createAuthorizationAction] text in
@@ -620,7 +620,7 @@ extension ViewController {
 
         alertController.addTextField(
             configurationHandler: { textField in
-                textField.accessibilityIdentifier = "authentication_id_token_textfield"
+                textField.accessibilityIdentifier = "authentication_refresh_token_textfield"
                 textField.addTarget(
                     jwtTextFieldDelegate,
                     action: #selector(jwtTextFieldDelegate.handleTextChanged(textField:)),


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3266

**What was solved?**
The changes extends testing app accessibility for testing refresh token

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from iOS SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3589734507/Logging+from+iOS+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
