### PR TITLE
Fix for "Engagement is ended" dialog

### DIFF
--- a/GliaWidgets/Sources/AlertManager/AlertTypeComposer.swift
+++ b/GliaWidgets/Sources/AlertManager/AlertTypeComposer.swift
@@ -63,7 +63,7 @@ extension AlertManager.AlertTypeComposer {
         case let .leaveQueue(confirmed):
             return leaveQueueAlertType(confirmed: confirmed)
         case let .endEngagement(confirmed):
-            return endEngagemtAlertType(confirmed: confirmed)
+            return endEngagementAlertType(confirmed: confirmed)
         case let .mediaUpgrade(operators, offer, accepted, declined, answer):
             return mediaUpgradeOfferAlertType(
                 operators: operators,
@@ -235,7 +235,8 @@ private extension AlertManager.AlertTypeComposer {
     }
 
     func operatorEndedEngagementAlertType(action: @escaping () -> Void) -> AlertType {
-        .singleAction(
+        environment.log.prefixed(Self.self).info("Show Engagement Ended Dialog")
+        return .singleAction(
             conf: theme.alertConfiguration.operatorEndedEngagement,
             accessibilityIdentifier: "alert_close_engagementEnded",
             actionTapped: action
@@ -251,8 +252,8 @@ private extension AlertManager.AlertTypeComposer {
         )
     }
 
-    func endEngagemtAlertType(confirmed: @escaping () -> Void) -> AlertType {
-        environment.log.prefixed(Self.self).info("Show Engagement Ended Dialog")
+    func endEngagementAlertType(confirmed: @escaping () -> Void) -> AlertType {
+        environment.log.prefixed(Self.self).info("Show End Engagement Dialog")
         return .confirmation(
             conf: theme.alertConfiguration.endEngagement,
             accessibilityIdentifier: "alert_confirmation_endEngagement",

--- a/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
@@ -130,7 +130,7 @@ class EngagementViewModel: CommonEngagementModel {
                     self.endSession()
                     return
                 }
-                self.engagementAction?(.showAlert(.endEngagement(confirmed: { [weak self] in
+                self.engagementAction?(.showAlert(.operatorEndedEngagement(action: { [weak self] in
                     self?.endSession()
                     self?.engagementDelegate?(
                           .engaged(

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -853,6 +853,41 @@ class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(interactor.state, .ended(.byVisitor))
         XCTAssertTrue(calls.isEmpty)
     }
+
+    func test_alertInputTypeWhenEngagementIsEndedByOperator() {
+        var alertInputType: AlertInputType?
+
+        let delegate: (EngagementViewModel.Action) -> Void = { action in
+            switch action {
+            case let .showAlert(type):
+                alertInputType = type
+            default: break
+            }
+        }
+
+        var interactorEnv = Interactor.Environment.failing
+        interactorEnv.gcd = .mock
+        interactorEnv.coreSdk.getCurrentEngagement = {
+            .mock(fetchSurvey: { _, completion in
+                completion(.success(nil))
+            })
+        }
+
+        let interactor = Interactor.mock(environment: interactorEnv)
+
+        viewModel = .mock(interactor: interactor)
+        viewModel.engagementAction = delegate
+
+        interactor.end(with: .operatorHungUp)
+
+        let isValidInput: Bool
+        if case .operatorEndedEngagement = alertInputType {
+            isValidInput = true
+        } else {
+            isValidInput = false
+        }
+        XCTAssertTrue(isValidInput)
+    }
 }
 
 extension ChatChoiceCardOption {


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3397

**What was solved?**
After adding AlertManager class into the WidgetsSDK handling all the alert presenting, presenting of singleAction dialog on visitor side after ending engagement by operator was broken. Instead of “Engagement is ended by operator” dialog the SDK shows “Are you sure you want to end engagement?” confirmation dialog. 

Logging is also fixed.
Unit test was added.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from iOS SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3589734507/Logging+from+iOS+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
