### PR TITLE
Implement CallVisualizer environment initialization methods

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -875,6 +875,8 @@
 		C0D6C9F72C0D2F6D00D4709B /* AlertPlacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6C9F62C0D2F6D00D4709B /* AlertPlacement.swift */; };
 		C0D6C9FB2C0D2F9A00D4709B /* AlertInputType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6C9FA2C0D2F9A00D4709B /* AlertInputType.swift */; };
 		C0D6CA002C106A1F00D4709B /* AlertManager.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6C9FF2C106A1F00D4709B /* AlertManager.Failing.swift */; };
+		C0D6CA232C1861F400D4709B /* VideoCallView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA222C1861F400D4709B /* VideoCallView.Environment.swift */; };
+		C0D6CA3D2C19A82100D4709B /* VideoCallViewController.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA3C2C19A82100D4709B /* VideoCallViewController.Environment.swift */; };
 		C0E948042AB1D5D200890026 /* ActionButtonSwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E948032AB1D5D200890026 /* ActionButtonSwiftUI.swift */; };
 		C0E948062AB1D64700890026 /* HeaderButtonSwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E948052AB1D64700890026 /* HeaderButtonSwiftUI.swift */; };
 		C0E948092AB1D6AB00890026 /* HeaderSwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E948082AB1D6AB00890026 /* HeaderSwiftUI.swift */; };
@@ -1837,6 +1839,8 @@
 		C0D6C9F62C0D2F6D00D4709B /* AlertPlacement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertPlacement.swift; sourceTree = "<group>"; };
 		C0D6C9FA2C0D2F9A00D4709B /* AlertInputType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertInputType.swift; sourceTree = "<group>"; };
 		C0D6C9FF2C106A1F00D4709B /* AlertManager.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertManager.Failing.swift; sourceTree = "<group>"; };
+		C0D6CA222C1861F400D4709B /* VideoCallView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCallView.Environment.swift; sourceTree = "<group>"; };
+		C0D6CA3C2C19A82100D4709B /* VideoCallViewController.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCallViewController.Environment.swift; sourceTree = "<group>"; };
 		C0E948032AB1D5D200890026 /* ActionButtonSwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionButtonSwiftUI.swift; sourceTree = "<group>"; };
 		C0E948052AB1D64700890026 /* HeaderButtonSwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderButtonSwiftUI.swift; sourceTree = "<group>"; };
 		C0E948082AB1D6AB00890026 /* HeaderSwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderSwiftUI.swift; sourceTree = "<group>"; };
@@ -4636,6 +4640,7 @@
 			isa = PBXGroup;
 			children = (
 				C0D2F0322991377C00803B47 /* VideoCallViewController.swift */,
+				C0D6CA3C2C19A82100D4709B /* VideoCallViewController.Environment.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -4644,6 +4649,7 @@
 			isa = PBXGroup;
 			children = (
 				C0D2F0372991394400803B47 /* VideoCallView.swift */,
+				C0D6CA222C1861F400D4709B /* VideoCallView.Environment.swift */,
 				C0D2F0522993CCC400803B47 /* ButtonBar */,
 				C0D2F04429925C3A00803B47 /* ConnectView */,
 			);
@@ -5477,6 +5483,7 @@
 				1A60AFCE2566958900E53F53 /* ViewFactory.swift in Sources */,
 				C06A7586296ECC57006B69A2 /* VisitorCodeStyle.Accessibility.swift in Sources */,
 				C09046C62B7E04BE003C437C /* AttachmentSourceItemStyle.Mock.swift in Sources */,
+				C0D6CA232C1861F400D4709B /* VideoCallView.Environment.swift in Sources */,
 				C09046D02B7E074B003C437C /* OperatorTypingIndicatorStyle.RemoteConfig.swift in Sources */,
 				9A186A3B27F5E6B50055886D /* ChatFileContentStyle.Accessibility.swift in Sources */,
 				C09046FA2B7E10C7003C437C /* Theme.ChoiceCardStyle.Options.swift in Sources */,
@@ -5918,6 +5925,7 @@
 				C02248AA2AD53E6100CC4930 /* LiveObservation.swift in Sources */,
 				9AB196D827C3E27300FD60AB /* ChatViewModel.Environment.Mock.swift in Sources */,
 				C09047072B7E158E003C437C /* Theme.SnackBarStyle.Accessibility.swift in Sources */,
+				C0D6CA3D2C19A82100D4709B /* VideoCallViewController.Environment.swift in Sources */,
 				AF1C197C2B14FD0900F8810F /* ConditionalCompilationClient.Live.swift in Sources */,
 				3100EEFF293F7E0900D57F71 /* Theme+SecureConversationsWelcome.swift in Sources */,
 				9A8130BF27D7AEF700220BBD /* FileUpload.Mock.swift in Sources */,

--- a/GliaWidgets/Sources/CallVisualizer/CallVisualizer.Environment.swift
+++ b/GliaWidgets/Sources/CallVisualizer/CallVisualizer.Environment.swift
@@ -33,3 +33,48 @@ extension CallVisualizer {
         var alertManager: AlertManager
     }
 }
+
+extension CallVisualizer.Environment {
+    static func create(
+        with environment: Glia.Environment,
+        interactorProviding: @escaping () -> Interactor?,
+        engagedOperator: @escaping () -> CoreSdkClient.Operator?,
+        theme: Theme,
+        assetBuilder: @escaping () -> RemoteConfiguration.AssetsBuilder,
+        onEvent: ((GliaEvent) -> Void)?,
+        loggerPhase: Glia.LoggerPhase,
+        alertManager: AlertManager
+    ) -> Self {
+        .init(
+            data: environment.data,
+            uuid: environment.uuid,
+            gcd: environment.gcd,
+            imageViewCache: environment.imageViewCache,
+            timerProviding: environment.timerProviding,
+            uiApplication: environment.uiApplication,
+            uiScreen: environment.uiScreen,
+            uiDevice: environment.uiDevice,
+            notificationCenter: environment.notificationCenter,
+            requestVisitorCode: environment.coreSdk.requestVisitorCode,
+            interactorProviding: interactorProviding,
+            callVisualizerPresenter: environment.callVisualizerPresenter,
+            bundleManaging: environment.bundleManaging,
+            screenShareHandler: environment.screenShareHandler,
+            audioSession: environment.audioSession,
+            date: environment.date,
+            engagedOperator: engagedOperator,
+            theme: theme,
+            assetsBuilder: assetBuilder,
+            getCurrentEngagement: environment.coreSdk.getCurrentEngagement,
+            eventHandler: onEvent,
+            orientationManager: environment.orientationManager,
+            proximityManager: environment.proximityManager,
+            log: loggerPhase.logger,
+            fetchSiteConfigurations: environment.coreSdk.fetchSiteConfigurations,
+            snackBar: environment.snackBar,
+            coreSdk: environment.coreSdk,
+            cameraDeviceManager: environment.cameraDeviceManager,
+            alertManager: alertManager
+        )
+    }
+}

--- a/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.Environment.swift
+++ b/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.Environment.swift
@@ -30,3 +30,40 @@ extension CallVisualizer.Coordinator {
         var alertManager: AlertManager
     }
 }
+
+extension CallVisualizer.Coordinator.Environment {
+    static func create(
+        with environment: CallVisualizer.Environment,
+        viewFactory: ViewFactory,
+        eventHandler: @escaping (CallVisualizer.Coordinator.DelegateEvent) -> Void
+    ) -> Self {
+        .init(
+            data: environment.data,
+            uuid: environment.uuid,
+            gcd: environment.gcd,
+            imageViewCache: environment.imageViewCache,
+            uiApplication: environment.uiApplication,
+            uiScreen: environment.uiScreen,
+            uiDevice: environment.uiDevice,
+            notificationCenter: environment.notificationCenter,
+            viewFactory: viewFactory,
+            presenter: environment.callVisualizerPresenter,
+            bundleManaging: environment.bundleManaging,
+            screenShareHandler: environment.screenShareHandler,
+            timerProviding: environment.timerProviding,
+            requestVisitorCode: environment.requestVisitorCode,
+            audioSession: environment.audioSession,
+            date: environment.date,
+            engagedOperator: environment.engagedOperator,
+            eventHandler: eventHandler,
+            orientationManager: environment.orientationManager,
+            proximityManager: environment.proximityManager,
+            log: environment.log,
+            interactorProviding: environment.interactorProviding(),
+            fetchSiteConfigurations: environment.fetchSiteConfigurations,
+            snackBar: environment.snackBar,
+            cameraDeviceManager: environment.cameraDeviceManager,
+            alertManager: environment.alertManager
+        )
+    }
+}

--- a/GliaWidgets/Sources/CallVisualizer/ScreenSharing/Coordinator/ScreenSharingCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/CallVisualizer/ScreenSharing/Coordinator/ScreenSharingCoordinator.Environment.swift
@@ -8,3 +8,14 @@ extension CallVisualizer.ScreenSharingCoordinator {
         var log: CoreSdkClient.Logger
     }
 }
+
+extension CallVisualizer.ScreenSharingCoordinator.Environment {
+    static func create(with environment: CallVisualizer.Coordinator.Environment) -> Self {
+        .init(
+            theme: environment.viewFactory.theme,
+            screenShareHandler: environment.screenShareHandler,
+            orientationManager: environment.orientationManager,
+            log: environment.log
+        )
+    }
+}

--- a/GliaWidgets/Sources/CallVisualizer/VideoCall/Coordinator/VideoCallCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VideoCall/Coordinator/VideoCallCoordinator.Environment.swift
@@ -20,3 +20,26 @@ extension CallVisualizer.VideoCallCoordinator {
         var flipCameraButtonStyle: FlipCameraButtonStyle
     }
 }
+
+extension CallVisualizer.VideoCallCoordinator.Environment {
+    static func create(with environment: CallVisualizer.Coordinator.Environment) -> Self {
+        .init(
+            data: environment.data,
+            uuid: environment.uuid,
+            gcd: environment.gcd,
+            imageViewCache: environment.imageViewCache,
+            timerProviding: environment.timerProviding,
+            uiApplication: environment.uiApplication,
+            uiScreen: environment.uiScreen,
+            uiDevice: environment.uiDevice,
+            notificationCenter: environment.notificationCenter,
+            date: environment.date,
+            engagedOperator: environment.engagedOperator,
+            screenShareHandler: environment.screenShareHandler,
+            proximityManager: environment.proximityManager,
+            log: environment.log,
+            cameraDeviceManager: environment.cameraDeviceManager,
+            flipCameraButtonStyle: environment.viewFactory.theme.call.flipCameraButtonStyle
+        )
+    }
+}

--- a/GliaWidgets/Sources/CallVisualizer/VideoCall/View/VideoCallView.Environment.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VideoCall/View/VideoCallView.Environment.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension CallVisualizer.VideoCallView {
+    struct Environment {
+        let gcd: GCD
+        let uiScreen: UIKitBased.UIScreen
+    }
+}
+
+extension CallVisualizer.VideoCallView.Environment {
+    static func create(with environment: CallVisualizer.VideoCallCoordinator.Environment) -> Self {
+        .init(
+            gcd: environment.gcd,
+            uiScreen: environment.uiScreen
+        )
+    }
+}

--- a/GliaWidgets/Sources/CallVisualizer/VideoCall/View/VideoCallView.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VideoCall/View/VideoCallView.swift
@@ -423,10 +423,3 @@ private extension CallVisualizer.VideoCallView {
         localVideoView.frame = frame
     }
 }
-
-extension CallVisualizer.VideoCallView {
-    struct Environment {
-        let gcd: GCD
-        let uiScreen: UIKitBased.UIScreen
-    }
-}

--- a/GliaWidgets/Sources/CallVisualizer/VideoCall/ViewController/VideoCallViewController.Environment.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VideoCall/ViewController/VideoCallViewController.Environment.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension CallVisualizer.VideoCallViewController {
+    struct Environment {
+        var videoCallView: CallVisualizer.VideoCallView.Environment
+        var notificationCenter: FoundationBased.NotificationCenter
+    }
+}
+
+extension CallVisualizer.VideoCallViewController.Environment {
+    static func create(with environment: CallVisualizer.VideoCallCoordinator.Environment) -> Self {
+        .init(
+            videoCallView: .create(with: environment),
+            notificationCenter: environment.notificationCenter
+        )
+    }
+}

--- a/GliaWidgets/Sources/CallVisualizer/VideoCall/ViewController/VideoCallViewController.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VideoCall/ViewController/VideoCallViewController.swift
@@ -51,15 +51,6 @@ extension CallVisualizer.VideoCallViewController {
     }
 }
 
-// MARK: - Environment
-
-extension CallVisualizer.VideoCallViewController {
-    struct Environment {
-        var videoCallView: CallVisualizer.VideoCallView.Environment
-        var notificationCenter: FoundationBased.NotificationCenter
-    }
-}
-
 // MARK: - Private
 
 private extension CallVisualizer.VideoCallViewController {

--- a/GliaWidgets/Sources/CallVisualizer/VideoCall/ViewModel/VideoCallViewModel.Environment.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VideoCall/ViewModel/VideoCallViewModel.Environment.swift
@@ -18,3 +18,24 @@ extension CallVisualizer.VideoCallViewModel {
         var flipCameraButtonStyle: FlipCameraButtonStyle
     }
 }
+
+extension CallVisualizer.VideoCallViewModel.Environment {
+    static func create(with environment: CallVisualizer.VideoCallCoordinator.Environment) -> Self {
+        .init(
+            data: environment.data,
+            uuid: environment.uuid,
+            gcd: environment.gcd,
+            imageViewCache: environment.imageViewCache,
+            timerProviding: environment.timerProviding,
+            uiApplication: environment.uiApplication,
+            notificationCenter: environment.notificationCenter,
+            date: environment.date,
+            engagedOperator: environment.engagedOperator,
+            screenShareHandler: environment.screenShareHandler,
+            proximityManager: environment.proximityManager,
+            log: environment.log,
+            cameraDeviceManager: environment.cameraDeviceManager,
+            flipCameraButtonStyle: environment.flipCameraButtonStyle
+        )
+    }
+}

--- a/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeCoordinator+Environment.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeCoordinator+Environment.swift
@@ -4,3 +4,12 @@ extension CallVisualizer.VisitorCodeCoordinator {
         var requestVisitorCode: CoreSdkClient.RequestVisitorCode
     }
 }
+
+extension CallVisualizer.VisitorCodeCoordinator.Environment {
+    static func create(with environment: CallVisualizer.Coordinator.Environment) -> Self {
+        .init(
+            timerProviding: environment.timerProviding,
+            requestVisitorCode: environment.requestVisitorCode
+        )
+    }
+}

--- a/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeViewModel+Environment.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeViewModel+Environment.swift
@@ -6,3 +6,12 @@ extension CallVisualizer.VisitorCodeViewModel {
         var requestVisitorCode: CoreSdkClient.RequestVisitorCode
     }
 }
+
+extension CallVisualizer.VisitorCodeViewModel.Environment {
+    static func create(with environment: CallVisualizer.VisitorCodeCoordinator.Environment) -> Self {
+        .init(
+            timerProviding: environment.timerProviding,
+            requestVisitorCode: environment.requestVisitorCode
+        )
+    }
+}


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3395

**What was solved?**
Create static methods for call visualizer-related environments' initialization.
**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from iOS SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3589734507/Logging+from+iOS+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
