### PR TITLE
Address autolayout warnings in ChatView

### DIFF
--- a/GliaWidgets/Sources/View/Chat/ChatView.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatView.swift
@@ -200,6 +200,10 @@ extension ChatView {
     }
 
     func updateItemsUserImage(animated: Bool) {
+        // Prevent breaking autolayout.
+        guard self.frame != .zero else {
+            return
+        }
         tableView.indexPathsForVisibleRows?.forEach {
             if let cell = tableView.cellForRow(at: $0) as? ChatItemCell,
                let item = itemForRow?($0.row, $0.section) {
@@ -275,6 +279,10 @@ extension ChatView {
     }
 
     func scrollToBottom(animated: Bool) {
+        // Prevent breaking autolayout.
+        guard self.frame != .zero else {
+            return
+        }
         tableView.scrollToBottom(animated: animated)
     }
 


### PR DESCRIPTION
MOB-2629

**Jira issue:**
https://glia.atlassian.net/browse/MOB-2629

**What was solved?**
Address autolayout warnings in `ChatView` by avoiding interactions with table view when view frame is equal to zero.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from iOS SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3589734507/Logging+from+iOS+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
