### PR TITLE
Remove queueIds validation

### DIFF
--- a/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
+++ b/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
@@ -22,14 +22,10 @@ extension Glia {
     ///
     public func startEngagement(
         engagementKind: EngagementKind,
-        in queueIds: [String],
+        in queueIds: [String] = [],
         features: Features = .all,
         sceneProvider: SceneProvider? = nil
     ) throws {
-        let trimmedQueueIds = queueIds
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-        guard !trimmedQueueIds.isEmpty else { throw GliaError.startingEngagementWithNoQueueIdsIsNotAllowed }
         // It checks if ongoing engagement exists on WidgetsSDK side, if it doesn't but ongoing engagement exists
         // on CoreSDK side, it will be restored.
         guard engagement == .none else { throw GliaError.engagementExists }
@@ -42,7 +38,7 @@ extension Glia {
         // Creates interactor instance
         let createdInteractor = setupInteractor(
             configuration: configuration,
-            queueIds: trimmedQueueIds
+            queueIds: queueIds
         )
 
         // Apply company name to theme and get the modified theme

--- a/GliaWidgets/Public/GliaError.swift
+++ b/GliaWidgets/Public/GliaError.swift
@@ -19,6 +19,7 @@ public enum GliaError: Error {
     case clearingVisitorSessionDuringEngagementIsNotAllowed
 
     /// Starting engagement with no queue ids is not allowed.
+    @available(*, deprecated, message: "Starting engagement with no queue ids is allowed")
     case startingEngagementWithNoQueueIdsIsNotAllowed
 
     /// The site API key credentials are invalid.


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3402

**What was solved?**
Because of adding a logic for automatic connection to default queues in case of passed empty queueIds array, a validation on WidgetsSDK side is no longer needed. 
`startingEngagementWithNoQueueIdsIsNotAllowed` error is marked as deprecated.

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from iOS SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3589734507/Logging+from+iOS+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.