### PR TITLE
Set features via configure method for toggling bubble visibility

### DIFF
--- a/GliaWidgets/Public/Glia/Glia+RestoreEngagement.swift
+++ b/GliaWidgets/Public/Glia/Glia+RestoreEngagement.swift
@@ -4,6 +4,7 @@ extension Glia {
     func restoreOngoingEngagement(
         configuration: Configuration,
         currentEngagement: CoreSdkClient.Engagement,
+        features: Features,
         maximize: Bool
     ) {
         // Creates interactor instance
@@ -22,16 +23,9 @@ extension Glia {
         let viewFactory = ViewFactory(
             with: modifiedTheme,
             messageRenderer: messageRenderer,
-            environment: .init(
-                data: environment.data,
-                uuid: environment.uuid,
-                gcd: environment.gcd,
-                imageViewCache: environment.imageViewCache,
-                timerProviding: environment.timerProviding,
-                uiApplication: environment.uiApplication,
-                uiScreen: environment.uiScreen,
-                log: loggerPhase.logger,
-                uiDevice: environment.uiDevice
+            environment: .create(
+                with: self.environment,
+                loggerPhase: self.loggerPhase
             )
         )
 
@@ -48,8 +42,7 @@ extension Glia {
             viewFactory: viewFactory,
             sceneProvider: nil,
             engagementKind: EngagementKind(media: ongoingEngagementMediaStreams),
-            // TODO: figure out if we can get features from somewhere, because bubble may explicitly removed as feature, and in such case bubble should not show up.
-            features: .all,
+            features: features,
             maximize: maximize
         )
 

--- a/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
+++ b/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
@@ -7,7 +7,6 @@ extension Glia {
     /// - Parameters:
     ///   - engagementKind: Engagement media type.
     ///   - in: Queue identifiers
-    ///   - features: Set of features to be enabled in the SDK.
     ///   - sceneProvider: Used to provide `UIWindowScene` to the framework. Defaults to
     ///     the first active foreground scene.
     ///
@@ -21,15 +20,17 @@ extension Glia {
     ///   initially prior to this method, because `GliaError.sdkIsNotConfigured` will occur otherwise.
     ///
     public func startEngagement(
-        engagementKind: EngagementKind,
+        of engagementKind: EngagementKind, // To help compiler to avoid ambiguity, change signature of `engagementKind` parameter.
         in queueIds: [String] = [],
-        features: Features = .all,
         sceneProvider: SceneProvider? = nil
     ) throws {
         // In order to align behaviour between platforms,
         // `GliaError.engagementExists` is no longer thrown,
         // instead engagement is getting restored.
         guard let configuration = self.configuration else { throw GliaError.sdkIsNotConfigured }
+
+        // It is assumed that `features` to be provided from `configure` or via deprecated `startEngagement` method.
+        let features = self.features ?? []
 
         if let engagement = environment.coreSdk.getCurrentEngagement() {
             if engagement.source == .callVisualizer {
@@ -41,6 +42,7 @@ extension Glia {
                     self.restoreOngoingEngagement(
                         configuration: configuration,
                         currentEngagement: engagement,
+                        features: features,
                         maximize: true
                     )
                 }

--- a/GliaWidgets/Public/Glia/Glia.Deprecated.swift
+++ b/GliaWidgets/Public/Glia/Glia.Deprecated.swift
@@ -181,8 +181,8 @@ extension Glia {
         )
     }
 
-    /// Deprecated, use ``Glia.startEngagement(engagementKind:in queueIds:features:sceneProvider:)`` instead.
-    /// Use ``configure(with configuration:uiConfig:theme:assetsBuilder:completion:)`` to pass in ``RemoteConfiguration``.
+    /// Deprecated, use ``Glia.startEngagement(engagementKind:in queueIds:sceneProvider:)`` instead.
+    /// Use ``configure(with configuration:uiConfig:theme:assetsBuilder:features:completion:)`` to pass in ``RemoteConfiguration``.
     @available(*, deprecated, message: """
             Deprecated, use ``Glia.startEngagement(engagementKind:in queueIds:features:sceneProvider:)`` instead.
             Use ``configure(with configuration:uiConfig:theme:assetsBuilder:completion:)`` to pass in ``RemoteConfiguration``.
@@ -203,6 +203,27 @@ extension Glia {
             features: features,
             sceneProvider: sceneProvider
         )
+    }
+
+    /// Deprecated, use ``Glia.startEngagement(engagementKind:in queueIds:sceneProvider:)`` instead.
+    /// Use ``configure(with configuration:uiConfig:theme:assetsBuilder:features:completion:)`` to pass in ``Features``.
+    public func startEngagement(
+        engagementKind: EngagementKind,
+        in queueIds: [String] = [],
+        features: Features = .all,
+        sceneProvider: SceneProvider? = nil
+    ) throws {
+        // Even though `configuration` is validated via non-deprecated
+        // `Glia.startEngagement(engagementKind:in queueIds:sceneProvider:)`,
+        // we need to validate it also here to make sure that `features` are assigned
+        // only if `configuration` passes validation.
+        guard self.configuration != nil else { throw GliaError.sdkIsNotConfigured }
+        // We need to assign features to be used for restored engagement
+        // during Direct ID authenticated flow.
+        // Here we overwrite value that was set via `configure` method,
+        // to preserve initial behaviour, when `configure` was not providing `features`.
+        self.features = features
+        try startEngagement(of: engagementKind, in: queueIds, sceneProvider: sceneProvider)
     }
 
     /// Deprecated, use ``configure(with configuration:theme:uiConfig:assetsBuilder:completion:)`` instead.

--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -113,6 +113,9 @@ public class Glia {
     var assetsBuilder: RemoteConfiguration.AssetsBuilder = .standard
     var loggerPhase: LoggerPhase
     var alertManager: AlertManager
+    // We need to store `features` via `configure` or deprecated `startEngagement` methods
+    // to use it when engagement gets restored for Direct ID authentication flow.
+    var features: Features?
 
     private(set) var configuration: Configuration?
 
@@ -162,6 +165,7 @@ public class Glia {
     ///   - theme: A custom theme to use with the engagement.
     ///   - uiConfig: Remote UI configuration.
     ///   - assetsBuilder: Provides assets for remote configuration.
+    ///   - features: Set of features to be enabled in the SDK.
     ///   - completion: Completion handler that will be fired once configuration is
     ///     complete.
     ///
@@ -174,6 +178,7 @@ public class Glia {
         theme: Theme = Theme(),
         uiConfig: RemoteConfiguration? = nil,
         assetsBuilder: RemoteConfiguration.AssetsBuilder = .standard,
+        features: Features = .all,
         completion: @escaping (Result<Void, Error>) -> Void
     ) throws {
         guard environment.coreSdk.getCurrentEngagement() == nil else {
@@ -185,6 +190,9 @@ public class Glia {
         }
         self.theme = theme
         self.assetsBuilder = assetsBuilder
+        // We need to store features to be used for restored engagement
+        // during Direct ID authenticated flow.
+        self.features = features
         // `configuration` should be erased to avoid cases when integrators
         // call `configure` and `startEngagement` asynchronously, and
         // second-time configuration has not been complete, but `startEngagement`
@@ -236,6 +244,7 @@ public class Glia {
                     self.restoreOngoingEngagement(
                         configuration: configuration,
                         currentEngagement: currentEngagement,
+                        features: features,
                         maximize: false
                     )
                 }

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -357,6 +357,27 @@ final class GliaTests: XCTestCase {
         }
     }
 
+    func testConfigureSetsFeaturesFieldPassedAsParameter() throws {
+        var environment = Glia.Environment.failing
+        var logger = CoreSdkClient.Logger.failing
+        logger.infoClosure = { _, _, _, _ in }
+        logger.prefixedClosure = { _ in logger }
+        logger.configureLocalLogLevelClosure = { _ in }
+        logger.configureRemoteLogLevelClosure = { _ in }
+        environment.coreSdk.createLogger = { _ in logger }
+        environment.conditionalCompilation.isDebug = { false }
+        environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
+            completion(.success(()))
+        }
+        let sdk = Glia(environment: environment)
+        try sdk.configure(with: .mock(), features: .bubbleView) { _ in }
+        XCTAssertEqual(sdk.features, .bubbleView)
+        try sdk.configure(with: .mock(), features: []) { _ in }
+        XCTAssertEqual(sdk.features, [])
+        try sdk.configure(with: .mock(), features: .all) { _ in }
+        XCTAssertEqual(sdk.features, .all)
+    }
+
     func testClearVisitorSessionThrowsErrorDuringActiveEngagement() throws {
         var environment = Glia.Environment.failing
         var logger = CoreSdkClient.Logger.failing


### PR DESCRIPTION
MOB-3422

**Jira issue:**
https://glia.atlassian.net/browse/MOB-3422

**What was solved?**

- Set features via configure method for toggling bubble visibility for restored engagement.
- Deprecate `startEngagement` to omit `features` parameter and add such parameter to `configure` method.


**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from iOS SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3589734507/Logging+from+iOS+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
