### PR TITLE
Fixed Operator ended engagement dialog showing

### DIFF
--- a/GliaWidgets/Sources/AlertManager/AlertInputType.swift
+++ b/GliaWidgets/Sources/AlertManager/AlertInputType.swift
@@ -51,7 +51,8 @@ enum AlertInputType: Equatable {
         case (.microphoneSettings, .microphoneSettings):
             return true
         case (.operatorEndedEngagement, .operatorEndedEngagement):
-            return true
+            // temporarily considered as unequal to fix presenting `operatorEndedEngagement` alert
+            return false
         case (.unsupportedGvaBroadcastError, .unsupportedGvaBroadcastError):
             return true
         case (.unavailableMessageCenter, .unavailableMessageCenter):


### PR DESCRIPTION
**Jira issue:**
https://glia.atlassian.net/browse/MOB-3423

**What was solved?**
Operator ended engagement dialog was not shown after audio/video call, once an operator ends an engagement. This happened because of race condition when the SDK tries to show the dialog from chat screen, which is not in view hierarchy.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from iOS SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3589734507/Logging+from+iOS+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
