### PR TITLE
Secure Conversations with default queues

### DIFF
--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
@@ -132,10 +132,11 @@ extension SecureConversations {
         }
 
         private func checkSecureConversationsAvailability() {
-            availability.checkSecureConversationsAvailability { [weak self] result in
+            availability.checkSecureConversationsAvailability(for: environment.queueIds) { [weak self] result in
                 guard let self else { return }
                 switch result {
-                case .success(.available):
+                case let .success(.available(queueIds)):
+                    self.environment.queueIds = queueIds
                     self.isSecureConversationsAvailable = true
                 case .failure, .success(.unavailable(.emptyQueue)):
                     self.isSecureConversationsAvailable = false

--- a/GliaWidgetsTests/SecureConversations/Availability.Environment.Failing.swift
+++ b/GliaWidgetsTests/SecureConversations/Availability.Environment.Failing.swift
@@ -5,10 +5,10 @@ extension SecureConversations.Availability.Environment {
         listQueues: { _ in
             fail("\(Self.self).listQueues")
         },
-        queueIds: [],
         isAuthenticated: {
             fail("\(Self.self).isAuthenticated")
             return false
-        }
+        },
+        log: .failing
     )
 }

--- a/GliaWidgetsTests/SecureConversations/AvailabilityTests.swift
+++ b/GliaWidgetsTests/SecureConversations/AvailabilityTests.swift
@@ -4,16 +4,36 @@ import XCTest
 final class AvailabilityTests: XCTestCase {
     typealias Availability = SecureConversations.Availability
 
+    func testListQueuesErrorPassedToResult() throws {
+        var env = Availability.Environment.failing
+        let error = CoreSdkClient.SalemoveError.mock()
+        env.listQueues = { callback in
+            callback(nil, error)
+        }
+        env.isAuthenticated = { true }
+        let queueIds = [UUID.mock.uuidString]
+        let availability = Availability(environment: env)
+        var receivedResult: Result<Availability.Status, CoreSdkClient.SalemoveError>?
+        availability.checkSecureConversationsAvailability(for: queueIds) { result in
+            receivedResult = result
+        }
+        try XCTAssertEqual(XCTUnwrap(receivedResult), .failure(error))
+    }
+
     func testEmptyQueueStatus() throws {
         var env = Availability.Environment.failing
         env.listQueues = { callback in
             callback([], nil)
         }
+        var logger = CoreSdkClient.Logger.failing
+        logger.prefixedClosure = { _ in logger }
+        logger.warningClosure = { _, _, _, _ in }
+        env.log = logger
         env.isAuthenticated = { true }
-        env.queueIds = [UUID.mock.uuidString]
+        let queueIds = [UUID.mock.uuidString]
         let availability = Availability(environment: env)
         var receivedResult: Result<Availability.Status, CoreSdkClient.SalemoveError>?
-        availability.checkSecureConversationsAvailability { result in
+        availability.checkSecureConversationsAvailability(for: queueIds) { result in
             receivedResult = result
         }
         try XCTAssertEqual(XCTUnwrap(receivedResult), .success(.unavailable(.emptyQueue)))
@@ -24,11 +44,15 @@ final class AvailabilityTests: XCTestCase {
         env.listQueues = { callback in
             callback([], nil)
         }
+        var logger = CoreSdkClient.Logger.failing
+        logger.prefixedClosure = { _ in logger }
+        logger.warningClosure = { _, _, _, _ in }
+        env.log = logger
         env.isAuthenticated = { false }
-        env.queueIds = [UUID.mock.uuidString]
+        let queueIds = [UUID.mock.uuidString]
         let availability = Availability(environment: env)
         var receivedResult: Result<Availability.Status, CoreSdkClient.SalemoveError>?
-        availability.checkSecureConversationsAvailability { result in
+        availability.checkSecureConversationsAvailability(for: queueIds) { result in
             receivedResult = result
         }
         try XCTAssertEqual(XCTUnwrap(receivedResult), .success(.unavailable(.unauthenticated)))
@@ -40,27 +64,40 @@ final class AvailabilityTests: XCTestCase {
         env.listQueues = { callback in
             callback([.mock(id: queueId, status: .open, media: [.messaging])], nil)
         }
+        var logger = CoreSdkClient.Logger.failing
+        logger.prefixedClosure = { _ in logger }
+        logger.infoClosure = { _, _, _, _ in }
+        env.log = logger
         env.isAuthenticated = { true }
-        env.queueIds = [UUID.mock.uuidString]
         let availability = Availability(environment: env)
         var receivedResult: Result<Availability.Status, CoreSdkClient.SalemoveError>?
-        availability.checkSecureConversationsAvailability { result in
+        availability.checkSecureConversationsAvailability(for: [queueId]) { result in
             receivedResult = result
         }
-        try XCTAssertEqual(XCTUnwrap(receivedResult), .success(.available))
+        let result = try XCTUnwrap(receivedResult)
+        switch result {
+        case let .success(.available(queueIds)):
+            XCTAssertEqual(queueIds, [queueId])
+        default:
+            XCTFail("Result should be `.success(.available)`")
+        }
     }
 
     func testEmptyQueueStatusIfQueueIdsAreDifferent() throws {
         var env = Availability.Environment.failing
         let generateUUID = UUID.incrementing
+        let queueIds = [generateUUID().uuidString]
         env.listQueues = { callback in
             callback([.mock(id: generateUUID().uuidString, status: .open, media: [.messaging])], nil)
         }
+        var logger = CoreSdkClient.Logger.failing
+        logger.prefixedClosure = { _ in logger }
+        logger.warningClosure = { _, _, _, _ in }
+        env.log = logger
         env.isAuthenticated = { true }
-        env.queueIds = []
         let availability = Availability(environment: env)
         var receivedResult: Result<Availability.Status, CoreSdkClient.SalemoveError>?
-        availability.checkSecureConversationsAvailability { result in
+        availability.checkSecureConversationsAvailability(for: queueIds) { result in
             receivedResult = result
         }
         try XCTAssertEqual(XCTUnwrap(receivedResult), .success(.unavailable(.emptyQueue)))
@@ -73,11 +110,14 @@ final class AvailabilityTests: XCTestCase {
         env.listQueues = { callback in
             callback([.mock(id: queueId, status: .closed, media: [.messaging])], nil)
         }
+        var logger = CoreSdkClient.Logger.failing
+        logger.prefixedClosure = { _ in logger }
+        logger.warningClosure = { _, _, _, _ in }
+        env.log = logger
         env.isAuthenticated = { true }
-        env.queueIds = []
         let availability = Availability(environment: env)
         var receivedResult: Result<Availability.Status, CoreSdkClient.SalemoveError>?
-        availability.checkSecureConversationsAvailability { result in
+        availability.checkSecureConversationsAvailability(for: [queueId]) { result in
             receivedResult = result
         }
         try XCTAssertEqual(XCTUnwrap(receivedResult), .success(.unavailable(.emptyQueue)))
@@ -90,11 +130,58 @@ final class AvailabilityTests: XCTestCase {
         env.listQueues = { callback in
             callback([.mock(id: queueId, status: .closed, media: [.text])], nil)
         }
+        var logger = CoreSdkClient.Logger.failing
+        logger.prefixedClosure = { _ in logger }
+        logger.warningClosure = { _, _, _, _ in }
+        env.log = logger
         env.isAuthenticated = { true }
-        env.queueIds = []
         let availability = Availability(environment: env)
         var receivedResult: Result<Availability.Status, CoreSdkClient.SalemoveError>?
-        availability.checkSecureConversationsAvailability { result in
+        availability.checkSecureConversationsAvailability(for: [queueId]) { result in
+            receivedResult = result
+        }
+        try XCTAssertEqual(XCTUnwrap(receivedResult), .success(.unavailable(.emptyQueue)))
+    }
+
+    func testAvailableStatusIfNoQueueIsPassed() throws {
+        var env = Availability.Environment.failing
+        let queueId = UUID.mock.uuidString
+        env.listQueues = { callback in
+            callback([.mock(id: queueId, status: .open, isDefault: true, media: [.messaging])], nil)
+        }
+        var logger = CoreSdkClient.Logger.failing
+        logger.prefixedClosure = { _ in logger }
+        logger.infoClosure = { _, _, _, _ in }
+        env.log = logger
+        env.isAuthenticated = { true }
+        let availability = Availability(environment: env)
+        var receivedResult: Result<Availability.Status, CoreSdkClient.SalemoveError>?
+        availability.checkSecureConversationsAvailability(for: []) { result in
+            receivedResult = result
+        }
+        let result = try XCTUnwrap(receivedResult)
+        switch result {
+        case let .success(.available(queueIds)):
+            XCTAssertEqual(queueIds, [queueId])
+        default:
+            XCTFail("Result should be `.success(.available)`")
+        }
+    }
+
+    func testEmptyQueueStatusStatusIfThereIsNoDefaultQueuesWithProperConditions() throws {
+        var env = Availability.Environment.failing
+        let queueId = UUID.mock.uuidString
+        env.listQueues = { callback in
+            callback([.mock(id: queueId, status: .closed, isDefault: true, media: [.text])], nil)
+        }
+        var logger = CoreSdkClient.Logger.failing
+        logger.prefixedClosure = { _ in logger }
+        logger.warningClosure = { _, _, _, _ in }
+        env.log = logger
+        env.isAuthenticated = { true }
+        let availability = Availability(environment: env)
+        var receivedResult: Result<Availability.Status, CoreSdkClient.SalemoveError>?
+        availability.checkSecureConversationsAvailability(for: []) { result in
             receivedResult = result
         }
         try XCTAssertEqual(XCTUnwrap(receivedResult), .success(.unavailable(.emptyQueue)))

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+GVA.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+GVA.swift
@@ -127,6 +127,7 @@ extension SecureConversationsTranscriptModelTests {
         var logger = CoreSdkClient.Logger.failing
         logger.prefixedClosure = { _ in logger }
         logger.infoClosure = { _, _, _, _ in }
+        logger.warningClosure = { _, _, _, _ in }
         modelEnv.log = logger
 
         let json = """
@@ -149,8 +150,8 @@ extension SecureConversationsTranscriptModelTests {
 
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
-            queueIds: modelEnv.queueIds,
-            isAuthenticated: { true }
+            isAuthenticated: { true },
+            log: logger
         )
 
         let viewModel = TranscriptModel(
@@ -184,6 +185,7 @@ private extension SecureConversationsTranscriptModelTests {
         var logger = CoreSdkClient.Logger.failing
         logger.prefixedClosure = { _ in logger }
         logger.infoClosure = { _, _, _, _ in }
+        logger.warningClosure = { _, _, _, _ in }
         modelEnv.log = logger
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in .mock() }
@@ -192,8 +194,8 @@ private extension SecureConversationsTranscriptModelTests {
         modelEnv.maximumUploads = { 2 }
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
-            queueIds: modelEnv.queueIds,
-            isAuthenticated: { true }
+            isAuthenticated: { true },
+            log: logger
         )
 
         return TranscriptModel(

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+URLs.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+URLs.swift
@@ -81,6 +81,7 @@ private extension SecureConversationsTranscriptModelTests {
         var logger = CoreSdkClient.Logger.failing
         logger.prefixedClosure = { _ in logger }
         logger.infoClosure = { _, _, _, _ in }
+        logger.warningClosure = { _, _, _, _ in }
         modelEnv.log = logger
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in .mock() }
@@ -88,8 +89,8 @@ private extension SecureConversationsTranscriptModelTests {
         modelEnv.maximumUploads = { 2 }
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
-            queueIds: modelEnv.queueIds,
-            isAuthenticated: { true }
+            isAuthenticated: { true },
+            log: logger
         )
 
         return TranscriptModel(

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests.swift
@@ -10,6 +10,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         var logger = CoreSdkClient.Logger.failing
         logger.prefixedClosure = { _ in logger }
         logger.infoClosure = { _, _, _, _ in }
+        logger.warningClosure = { _, _, _, _ in }
         modelEnv.log = logger
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in .mock() }
@@ -17,8 +18,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.maximumUploads = { 2 }
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
-            queueIds: modelEnv.queueIds,
-            isAuthenticated: { true }
+            isAuthenticated: { true },
+            log: logger
         )
         let viewModel = TranscriptModel(
             isCustomCardSupported: false,
@@ -45,8 +46,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.maximumUploads = { 2 }
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
-            queueIds: modelEnv.queueIds,
-            isAuthenticated: { false }
+            isAuthenticated: { false },
+            log: logger
         )
         let viewModel = TranscriptModel(
             isCustomCardSupported: false,
@@ -77,8 +78,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
 
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
-            queueIds: modelEnv.queueIds,
-            isAuthenticated: { true }
+            isAuthenticated: { true },
+            log: .failing
         )
 
         let viewModel = TranscriptModel(
@@ -121,8 +122,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.startSocketObservation = {}
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
-            queueIds: modelEnv.queueIds,
-            isAuthenticated: { true }
+            isAuthenticated: { true },
+            log: .failing
         )
         let viewModel = TranscriptModel(
             isCustomCardSupported: false,
@@ -147,13 +148,13 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.listQueues = { _ in }
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
-        modelEnv.getSecureUnreadMessageCount = { _ in  }
+        modelEnv.getSecureUnreadMessageCount = { _ in }
         modelEnv.startSocketObservation = {}
         modelEnv.maximumUploads = { 2 }
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
-            queueIds: modelEnv.queueIds,
-            isAuthenticated: { true }
+            isAuthenticated: { true },
+            log: .failing
         )
         let viewModel = TranscriptModel(
             isCustomCardSupported: false,
@@ -193,12 +194,12 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.listQueues = { _ in }
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
-        modelEnv.getSecureUnreadMessageCount = { _ in  }
+        modelEnv.getSecureUnreadMessageCount = { _ in }
         modelEnv.maximumUploads = { 2 }
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
-            queueIds: modelEnv.queueIds,
-            isAuthenticated: { true }
+            isAuthenticated: { true },
+            log: .failing
         )
 
         let viewModel = TranscriptModel(
@@ -233,12 +234,12 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.listQueues = { _ in }
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
-        modelEnv.getSecureUnreadMessageCount = { _ in  }
+        modelEnv.getSecureUnreadMessageCount = { _ in }
         modelEnv.maximumUploads = { 2 }
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
-            queueIds: modelEnv.queueIds,
-            isAuthenticated: { true }
+            isAuthenticated: { true },
+            log: .failing
         )
 
         let viewModel = TranscriptModel(
@@ -269,12 +270,12 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.listQueues = { _ in }
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
-        modelEnv.getSecureUnreadMessageCount = { _ in  }
+        modelEnv.getSecureUnreadMessageCount = { _ in }
         modelEnv.maximumUploads = { 2 }
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
-            queueIds: modelEnv.queueIds,
-            isAuthenticated: { true }
+            isAuthenticated: { true },
+            log: .failing
         )
 
         let viewModel = TranscriptModel(
@@ -302,7 +303,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.listQueues = { _ in }
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
-        modelEnv.getSecureUnreadMessageCount = { _ in  }
+        modelEnv.getSecureUnreadMessageCount = { _ in }
         modelEnv.createSendMessagePayload = {
             .mock(messageIdSuffix: "mock", content: $0, attachment: $1)
         }
@@ -315,8 +316,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         }
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
-            queueIds: modelEnv.queueIds,
-            isAuthenticated: { true }
+            isAuthenticated: { true },
+            log: .failing
         )
 
         let viewModel = TranscriptModel(
@@ -353,8 +354,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
 
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
-            queueIds: modelEnv.queueIds,
-            isAuthenticated: { true }
+            isAuthenticated: { true },
+            log: .failing
         )
 
         let viewModel = TranscriptModel(
@@ -394,8 +395,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
 
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
-            queueIds: modelEnv.queueIds,
-            isAuthenticated: { true }
+            isAuthenticated: { true },
+            log: .failing
         )
 
         let viewModel = TranscriptModel(
@@ -442,8 +443,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
 
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
-            queueIds: modelEnv.queueIds,
-            isAuthenticated: { true }
+            isAuthenticated: { true },
+            log: .failing
         )
 
         let interactor: Interactor = .failing
@@ -506,8 +507,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
 
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
-            queueIds: modelEnv.queueIds,
-            isAuthenticated: { true }
+            isAuthenticated: { true },
+            log: .failing
         )
 
         let interactor: Interactor = .failing
@@ -559,8 +560,10 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         var logger = CoreSdkClient.Logger.failing
         logger.prefixedClosure = { _ in logger }
         logger.infoClosure = { _, _, _, _ in }
+        logger.warningClosure = { _, _, _, _ in }
         modelEnvironment.log = logger
         var availabilityEnv = SecureConversations.Availability.Environment.failing
+        availabilityEnv.log = logger
         availabilityEnv.listQueues = { callback in
             callback([], nil)
         }
@@ -580,6 +583,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         var logger = CoreSdkClient.Logger.failing
         logger.prefixedClosure = { _ in logger }
         logger.infoClosure = { _, _, _, _ in }
+        logger.warningClosure = { _, _, _, _ in }
         modelEnvironment.log = logger
         modelEnvironment.fileManager = .mock
         modelEnvironment.maximumUploads = { 2 }
@@ -587,6 +591,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             .mock(environment: $0)
         }
         var availabilityEnv = SecureConversations.Availability.Environment.failing
+        availabilityEnv.log = logger
         availabilityEnv.listQueues = { callback in
             callback([.mock()], nil)
         }
@@ -632,6 +637,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         var logger = CoreSdkClient.Logger.failing
         logger.prefixedClosure = { _ in logger }
         logger.infoClosure = { _, _, _, _ in }
+        logger.warningClosure = { _, _, _, _ in }
         modelEnvironment.log = logger
         modelEnvironment.fileManager = .mock
         modelEnvironment.maximumUploads = { 2 }
@@ -639,6 +645,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             .mock(environment: $0)
         }
         var availabilityEnv = SecureConversations.Availability.Environment.failing
+        availabilityEnv.log = logger
         availabilityEnv.listQueues = { callback in
             callback([.mock()], nil)
         }
@@ -658,6 +665,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         var logger = CoreSdkClient.Logger.failing
         logger.prefixedClosure = { _ in logger }
         logger.infoClosure = { _, _, _, _ in }
+        logger.warningClosure = { _, _, _, _ in }
         modelEnvironment.log = logger
         modelEnvironment.fileManager = .mock
         modelEnvironment.maximumUploads = { 2 }
@@ -665,6 +673,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             .mock(environment: $0)
         }
         var availabilityEnv = SecureConversations.Availability.Environment.failing
+        availabilityEnv.log = logger
         availabilityEnv.listQueues = { callback in
             callback([.mock()], nil)
         }

--- a/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.Mock.swift
+++ b/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.Mock.swift
@@ -3,38 +3,56 @@ import Foundation
 
 extension SecureConversations.WelcomeViewModel {
     static let mock = SecureConversations.WelcomeViewModel(
-        environment: .mock,
+        environment: .mock(),
         availability: .mock,
         delegate: nil
     )
 }
 
 extension SecureConversations.WelcomeViewModel.Environment {
-    static let mock: SecureConversations.WelcomeViewModel.Environment = .init(
-        welcomeStyle: Theme().secureConversationsWelcomeStyle,
-        queueIds: [],
-        listQueues: { _ in },
-        sendSecureMessagePayload: { _, _, _ in return .mock },
-        fileUploader: .mock(),
-        uiApplication: .mock,
-        createFileUploadListModel: { _ in .mock() },
-        fetchSiteConfigurations: { _ in },
-        startSocketObservation: {},
-        stopSocketObservation: {},
-        getCurrentEngagement: { .mock() },
-        uploadSecureFile: { _, _, _ in .mock },
-        uploadFileToEngagement: { _, _, _ in },
-        createSendMessagePayload: { _, _ in .mock() },
-        log: .mock
-    )
+    static func mock(
+        welcomeStyle: SecureConversations.WelcomeStyle = Theme().secureConversationsWelcomeStyle,
+        queueIds: [String] = [],
+        listQueues: @escaping CoreSdkClient.ListQueues = { _ in },
+        sendSecureMessagePayload: @escaping CoreSdkClient.SendSecureMessagePayload = { _, _, _ in return .mock },
+        fileUploader: FileUploader = .mock(),
+        uiApplication: UIKitBased.UIApplication = .mock,
+        createFileUploadListModel: @escaping SecureConversations.FileUploadListViewModel.Create = { _ in .mock() },
+        fetchSiteConfigurations: @escaping CoreSdkClient.FetchSiteConfigurations = { _ in },
+        startSocketObservation: @escaping CoreSdkClient.StartSocketObservation = {},
+        stopSocketObservation: @escaping CoreSdkClient.StopSocketObservation = {},
+        getCurrentEngagement: @escaping CoreSdkClient.GetCurrentEngagement = { .mock() },
+        uploadSecureFile: @escaping CoreSdkClient.SecureConversationsUploadFile = { _, _, _ in .mock },
+        uploadFileToEngagement: @escaping CoreSdkClient.UploadFileToEngagement = { _, _, _ in },
+        createSendMessagePayload: @escaping CoreSdkClient.CreateSendMessagePayload = { _, _ in .mock() },
+        log: CoreSdkClient.Logger = .mock
+    ) -> SecureConversations.WelcomeViewModel.Environment {
+        .init(
+            welcomeStyle: welcomeStyle,
+            queueIds: queueIds,
+            listQueues: listQueues,
+            sendSecureMessagePayload: sendSecureMessagePayload,
+            fileUploader: fileUploader,
+            uiApplication: uiApplication,
+            createFileUploadListModel: createFileUploadListModel,
+            fetchSiteConfigurations: fetchSiteConfigurations,
+            startSocketObservation: startSocketObservation,
+            stopSocketObservation: stopSocketObservation,
+            getCurrentEngagement: getCurrentEngagement,
+            uploadSecureFile: uploadSecureFile,
+            uploadFileToEngagement: uploadFileToEngagement,
+            createSendMessagePayload: createSendMessagePayload,
+            log: log
+        )
+    }
 }
 
 extension SecureConversations.Availability {
     static let mock: SecureConversations.Availability = .init(
         environment: .init(
             listQueues: { _ in },
-            queueIds: [],
-            isAuthenticated: { true }
+            isAuthenticated: { true },
+            log: .mock
         )
     )
 }

--- a/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModelSpec.swift
+++ b/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModelSpec.swift
@@ -67,7 +67,7 @@ extension SecureConversationsWelcomeViewModelTests {
 // Is attachment available
 extension SecureConversationsWelcomeViewModelTests {
     func testIsAttachmentAvailable() throws {
-        var environment: WelcomeViewModel.Environment = .mock
+        var environment: WelcomeViewModel.Environment = .mock()
         let site: CoreSdkClient.Site = try .mock(
             allowedFileSenders: .init(operator: true, visitor: true)
         )
@@ -82,7 +82,7 @@ extension SecureConversationsWelcomeViewModelTests {
     }
 
     func testIsAttachmentNotAvailable() throws {
-        var environment: WelcomeViewModel.Environment = .mock
+        var environment: WelcomeViewModel.Environment = .mock()
         let site: CoreSdkClient.Site = try .mock(
             allowedFileSenders: .init(operator: true, visitor: false)
         )
@@ -97,7 +97,7 @@ extension SecureConversationsWelcomeViewModelTests {
     }
 
     func testIsAttachmentAvailableFailed() {
-        var environment: WelcomeViewModel.Environment = .mock
+        var environment: WelcomeViewModel.Environment = .mock()
         environment.fetchSiteConfigurations = { completion in
             completion(.failure(CoreSdkClient.GliaCoreError(reason: "")))
         }
@@ -255,7 +255,7 @@ extension SecureConversationsWelcomeViewModelTests {
     }
 
     func testFilePickerButtonIsAvailable() throws {
-        var environment: WelcomeViewModel.Environment = .mock
+        var environment: WelcomeViewModel.Environment = .mock()
         let site: CoreSdkClient.Site = try .mock(
             allowedFileSenders: .init(operator: true, visitor: true)
         )
@@ -265,7 +265,7 @@ extension SecureConversationsWelcomeViewModelTests {
         }
 
         viewModel = .init(environment: environment, availability: .mock)
-        viewModel.availabilityStatus = .available
+        viewModel.availabilityStatus = .available()
 
         if case .welcome(let props) = viewModel.props() {
             XCTAssertNotNil(props.filePickerButton)
@@ -335,7 +335,7 @@ extension SecureConversationsWelcomeViewModelTests {
     }
 
     func testSendMessageButtonStateFileUploads() {
-        viewModel.availabilityStatus = .available
+        viewModel.availabilityStatus = .available()
         let uploadFile: FileUpload.Environment.UploadFile = .toSecureMessaging { file, progress, completion in
             completion(.failure(CoreSdkClient.GliaCoreError(reason: "")))
             return .mock
@@ -354,7 +354,7 @@ extension SecureConversationsWelcomeViewModelTests {
     }
 
     func testSendMessageButtonStateInProgressFileUpload() {
-        viewModel.availabilityStatus = .available
+        viewModel.availabilityStatus = .available()
         let fileUpload: FileUpload = .mock()
         fileUpload.startUpload()
         viewModel.fileUploadListModel.environment.uploader.uploads = [fileUpload]
@@ -367,7 +367,7 @@ extension SecureConversationsWelcomeViewModelTests {
     }
 
     func testSendMessageButtonStateEmptyText() {
-        viewModel.availabilityStatus = .available
+        viewModel.availabilityStatus = .available()
         viewModel.messageText = ""
 
         if case .welcome(let props) = viewModel.props() {
@@ -378,7 +378,7 @@ extension SecureConversationsWelcomeViewModelTests {
     }
 
     func testSendMessageButtonStateSuccessfulUpload() {
-        viewModel.availabilityStatus = .available
+        viewModel.availabilityStatus = .available()
         viewModel.fileUploadListModel.environment.uploader = FileUploader(maximumUploads: 100, environment: .mock)
         viewModel.messageText = ""
 
@@ -390,7 +390,7 @@ extension SecureConversationsWelcomeViewModelTests {
     }
 
     func testSendMessageButtonStateNoQueues() {
-        viewModel.availabilityStatus = .available
+        viewModel.availabilityStatus = .available()
         viewModel.messageText = "text"
         viewModel.fileUploadListModel.environment.uploader = FileUploader(maximumUploads: 100, environment: .mock)
         viewModel.environment.queueIds = []
@@ -403,7 +403,7 @@ extension SecureConversationsWelcomeViewModelTests {
     }
 
     func testSendMessageButtonStateLoadingMessageRequestState() {
-        viewModel.availabilityStatus = .available
+        viewModel.availabilityStatus = .available()
         viewModel.messageText = "text"
         viewModel.fileUploadListModel.environment.uploader = FileUploader(maximumUploads: 100, environment: .mock)
         viewModel.environment.queueIds = [""]
@@ -417,7 +417,7 @@ extension SecureConversationsWelcomeViewModelTests {
     }
 
     func testSendMessageButtonStateWaitingMessageRequestState() {
-        viewModel.availabilityStatus = .available
+        viewModel.availabilityStatus = .available()
         viewModel.messageText = "text"
         viewModel.fileUploadListModel.environment.uploader = FileUploader(maximumUploads: 100, environment: .mock)
         viewModel.environment.queueIds = [""]
@@ -619,13 +619,11 @@ extension SecureConversationsWelcomeViewModelTests {
             )
             completion([queue], nil)
         }
-
         availability.environment.isAuthenticated = { true }
-        availability.environment.queueIds = [uuid]
 
-        viewModel = .init(environment: .mock, availability: availability)
+        viewModel = .init(environment: .mock(queueIds: [uuid]), availability: availability)
 
-        XCTAssertEqual(viewModel.availabilityStatus, .available)
+        XCTAssertEqual(viewModel.availabilityStatus, .available())
     }
 
     func testAvailabilityUnavailableEmptyQueues() {
@@ -645,7 +643,6 @@ extension SecureConversationsWelcomeViewModelTests {
         }
 
         availability.environment.isAuthenticated = { true }
-        availability.environment.queueIds = [uuid]
 
         let delegate: (WelcomeViewModel.DelegateEvent) -> Void = { event in
             switch event {
@@ -656,7 +653,7 @@ extension SecureConversationsWelcomeViewModelTests {
         }
 
         viewModel = .init(
-            environment: .mock,
+            environment: .mock(queueIds: [uuid]),
             availability: availability,
             delegate: delegate
         )
@@ -689,7 +686,6 @@ extension SecureConversationsWelcomeViewModelTests {
         }
 
         availability.environment.isAuthenticated = { false }
-        availability.environment.queueIds = [uuid]
 
         let delegate: (WelcomeViewModel.DelegateEvent) -> Void = { event in
             switch event {
@@ -700,7 +696,7 @@ extension SecureConversationsWelcomeViewModelTests {
         }
 
         viewModel = .init(
-            environment: .mock,
+            environment: .mock(queueIds: [uuid]),
             availability: availability,
             delegate: delegate
         )

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -449,12 +449,13 @@ class ChatViewModelTests: XCTestCase {
         var logger = CoreSdkClient.Logger.failing
         logger.prefixedClosure = { _ in logger }
         logger.infoClosure = { _, _, _, _ in }
+        logger.warningClosure = { _, _, _, _ in }
         transcriptModelEnv.log = logger
 
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: transcriptModelEnv.listQueues,
-            queueIds: transcriptModelEnv.queueIds,
-            isAuthenticated: { true }
+            isAuthenticated: { true },
+            log: logger
         )
         let transcriptModel = TranscriptModel(
             isCustomCardSupported: false,


### PR DESCRIPTION
**Jira issue:**
MOB-3437

**What was solved?**
If no queueId is passed to start messaging, then the SDK uses default queues supporting messaging and are not closed to send secure message to.

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [x] Did you add logging beneficial for troubleshooting of customer issues?
 - [x] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from iOS SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3589734507/Logging+from+iOS+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.

**Screenshots:**
