### PR TITLE
Fix for Message Center Unavailable dialog

### DIFF
--- a/GliaWidgets/Sources/AlertManager/AlertInputType.swift
+++ b/GliaWidgets/Sources/AlertManager/AlertInputType.swift
@@ -56,9 +56,9 @@ enum AlertInputType: Equatable {
         case (.unsupportedGvaBroadcastError, .unsupportedGvaBroadcastError):
             return true
         case (.unavailableMessageCenter, .unavailableMessageCenter):
-            return true
+            return false
         case (.unavailableMessageCenterForBeingUnauthenticated, .unavailableMessageCenterForBeingUnauthenticated):
-            return true
+            return false
         case (.mediaUpgrade, .mediaUpgrade):
             return false
         case (.screenSharing, .screenSharing):

--- a/GliaWidgets/Sources/AlertManager/AlertManager.swift
+++ b/GliaWidgets/Sources/AlertManager/AlertManager.swift
@@ -108,6 +108,8 @@ private extension AlertManager {
         case .view:
             viewController.insertChild(alertViewController)
             alertViewController.view.translatesAutoresizingMaskIntoConstraints = false
+            // Disabled interaction is needed to pass touches to the view behind
+            alertViewController.view.isUserInteractionEnabled = false
             NSLayoutConstraint.activate([
                 viewController.view.topAnchor.constraint(equalTo: alertViewController.view.topAnchor),
                 viewController.view.bottomAnchor.constraint(equalTo: alertViewController.view.bottomAnchor),


### PR DESCRIPTION
**Jira issue:**
MOB-3441

**What was solved?**
When Message Center Unavailable dialog was implemented, it allowed to touch the view behind it, as a result, to close Messaging/ChatTranscript screen. Now touches do now arrive to the views behind. Commit also fixes inability to show this dialog more than once.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from iOS SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3589734507/Logging+from+iOS+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.