### PR TITLE
Fixed Message Center availability

### DIFF
--- a/GliaWidgetsTests/SecureConversations/AvailabilityTests.swift
+++ b/GliaWidgetsTests/SecureConversations/AvailabilityTests.swift
@@ -152,6 +152,7 @@ final class AvailabilityTests: XCTestCase {
         var logger = CoreSdkClient.Logger.failing
         logger.prefixedClosure = { _ in logger }
         logger.infoClosure = { _, _, _, _ in }
+        logger.warningClosure = { _, _, _, _ in }
         env.log = logger
         env.isAuthenticated = { true }
         let availability = Availability(environment: env)


### PR DESCRIPTION
**Jira issue:**
MOB-3437

**What was solved?**
Now if passed queueIds do not match with any queue, then default queues are used instead.

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from iOS SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3589734507/Logging+from+iOS+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.