### PR TITLE
Fix auto-enqueuing for authenticated visitor

### DIFF
--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
@@ -71,7 +71,6 @@ class EngagementCoordinator: SubFlowCoordinator, FlowCoordinator {
                 showsCallBubble: false
             )
             engagement = .chat(chatViewController)
-            interactor.state = .enqueueing(.text)
             navigationPresenter.setViewControllers(
                 [chatViewController],
                 animated: false

--- a/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinatorTests.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinatorTests.swift
@@ -47,7 +47,7 @@ final class EngagementCoordinatorTests: XCTestCase {
 
         coordinator.start()
 
-        XCTAssertEqual(coordinator.interactor.state, .enqueueing(.text))
+        XCTAssertEqual(coordinator.interactor.state, .none)
         let viewController = coordinator.navigationPresenter.viewControllers.first as? ChatViewController
         XCTAssertNotNil(viewController)
         XCTAssertNotNil(coordinator.gliaViewController)
@@ -169,7 +169,6 @@ final class EngagementCoordinatorTests: XCTestCase {
 
     func test_chatCoordinatorBackOnInteractorStateNone() {
         coordinator.start()
-        coordinator.interactor.state = .none
         
         XCTAssertNotEqual(coordinator.coordinators.count, 0)
 
@@ -189,6 +188,8 @@ final class EngagementCoordinatorTests: XCTestCase {
         }
 
         coordinator.start()
+
+        coordinator.interactor.state = .enqueueing(.text)
 
         let chatCoordinator = coordinator.coordinators.last as? ChatCoordinator
         chatCoordinator?.delegate?(.back)


### PR DESCRIPTION
**Jira issue:**
MOB-3442

**What was solved?**
Previously, if an authenticated visitor has chat history, enqueuing was postponed until a visitor sends a message. This behaviour was broken after adding LO acknowledge.
This commit fixes it.
So now:
- unauthenticated visitors, if LO acknowledge is enabled, will be enqueued once they accept LO acknowledge
- unauthenticated visitors, if LO acknowledge is disabled, will be automatically enqueued
- authenticated visitors, if they do not have chat history and LO acknowledge is disabled, will be enqueued automatically
- authenticated visitors, if they do not have chat history and if LO acknowledge is enabled, will be enqueued once they accept LO acknowledge
- authenticated visitors, if LO acknowledge is enabled and if they have chat history, will be enqueued only after sending a message and accepting LO acknowledge
- authenticated visitors, if LO acknowledge is disabled and if they have chat history, will be enqueued after sending a message

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 **We should explicitly highlight that the fix will be available in versions 2.4.4 and 2.7.0+**

 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from iOS SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3589734507/Logging+from+iOS+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.