### PR TITLE
Add manual API documentation upload

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -276,6 +276,27 @@ workflows:
     - opts:
         is_expand: false
       BITRISE_EXPORT_METHOD: app-store
+  documentation_manual:
+    steps:
+    - activate-ssh-key@4: {}
+    - git-clone@8: {}
+    - cache-pull@2: {}
+    - script@1:
+        inputs:
+        - script_file_path: null
+        - content: bundle install
+    - cocoapods-install@2: {}
+    - fastlane@3:
+        inputs:
+        - work_dir: $BITRISE_SOURCE_DIR/$XCODE_PROJ_DIR
+        - lane: ios generate_docs
+    - amazon-s3-upload@3:
+        inputs:
+        - upload_bucket: $AWS_BUCKET/widgets
+        - access_key_id: $AWS_KEY
+        - secret_access_key: $AWS_PASSWORD
+        - acl_control: public-read
+        - upload_local_path: $BITRISE_SOURCE_DIR/$XCODE_PROJ_DIR/docs/
 app:
   envs:
   - opts:


### PR DESCRIPTION
**What was solved?**
This workflow is needed for the cases when API docs needs to be uploaded separately. For example, regular `documentation` workflow failed on post-release action, but release itself was successfully done.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)