### PR TITLE
GVA QuickReply conteiner doesn't close automatically

### DIFF
--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -255,6 +255,7 @@ extension ChatViewModel {
             messageText = text
         case .sendTapped:
             sendMessage()
+            action?(.quickReplyPropsUpdated(.hidden))
         case .removeUploadTapped(let upload):
             removeUpload(upload)
         case .pickMediaTapped:


### PR DESCRIPTION

**What was solved?**
If send button is clicked, quick reply container is closed.

MOB-3525

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
