### PR TITLE
GVA QuickReply conteiner does not close automatically

### DIFF
--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -255,6 +255,7 @@ extension ChatViewModel {
             messageText = text
         case .sendTapped:
             sendMessage()
+            action?(.quickReplyPropsUpdated(.hidden))
         case .removeUploadTapped(let upload):
             removeUpload(upload)
         case .pickMediaTapped:

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -889,6 +889,33 @@ class ChatViewModelTests: XCTestCase {
         }
         XCTAssertTrue(isValidInput)
     }
+
+    func test_quickReplyWillBeHiddenAfterMessageIsSent() throws {
+        enum Calls { case quickReplyHidden }
+        var calls: [Calls] = []
+        let interactorEnv = Interactor.Environment(coreSdk: .failing, gcd: .mock, log: .mock)
+        let interactor = Interactor.mock(environment: interactorEnv)
+        var viewModelEnv = ChatViewModel.Environment.failing()
+        viewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
+        viewModelEnv.fileManager.createDirectoryAtUrlWithIntermediateDirectories = { _, _, _ in }
+        viewModelEnv.createFileUploadListModel = { _ in .mock() }
+        let viewModel = ChatViewModel.mock(interactor: interactor, environment: viewModelEnv)
+        viewModel.action = { action in
+            switch action {
+            case let .quickReplyPropsUpdated(state):
+                switch state {
+                case .shown:
+                    break
+                case .hidden:
+                    calls.append(.quickReplyHidden)
+                }
+            default:
+                break
+            }
+        }
+        viewModel.event(.sendTapped)
+        XCTAssertEqual(calls, [.quickReplyHidden])
+    }
 }
 
 extension ChatChoiceCardOption {


### PR DESCRIPTION
**What was solved?**
If send button is clicked, quick reply container is closed.

MOB-3525
**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
