### PR TITLE
Add foundation import to fix compiling issues with SPM

### DIFF
--- a/GliaWidgets/Sources/Storage/FileSystemStorage.Environment.Mock.swift
+++ b/GliaWidgets/Sources/Storage/FileSystemStorage.Environment.Mock.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 #if DEBUG
 extension FileSystemStorage.Environment {
     static func mock(


### PR DESCRIPTION


**What was solved?**
SPM integration did not compile due to missing import in FileSystemStorage environment mock

MOB-3552

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
