### PR TITLE
Fix release flow

### DIFF
--- a/.github/workflows/prepare-xcframework-release.yml
+++ b/.github/workflows/prepare-xcframework-release.yml
@@ -84,22 +84,24 @@ jobs:
       
       - name: Update Package.swift
         run: |
-          filename=Package.swift
           semver=${{ steps.fetch_semver.outputs.semver}}
           checksum=${{ steps.calculate_xcf_checksum.outputs.checksum}}
-          sed -i.bak "s/\${WIDGETS_SDK_SEMVER}/$semver/g" "$filename"
-          sed -i.bak "s/\${WIDGETS_SDK_CHECKSUM}/$checksum/g" "$filename"
+          release_branch_name="release/xcf/${{ steps.fetch_semver.outputs.semver}}"
+          chmod +x ./scripts/update_ios_widgets_package.sh
+          ./scripts/update_ios_widgets_package.sh "$semver" "$checksum" "$release_branch_name"
+          
+        shell: bash
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          branch: "release/${{ steps.fetch_semver.outputs.semver}}"
+          branch: "release/xcf/${{ steps.fetch_semver.outputs.semver}}"
           title: 'GliaWidgets SDK Release ${{ steps.fetch_semver.outputs.semver}}'
           commit-message: |
-            GliaWidgets SDK Release ${{ steps.fetch_semver.outputs.semver}}
-          team-reviewers: 'tm-mobile-ios'
+            GliaWidgets SDK XCFramework Release ${{ steps.fetch_semver.outputs.semver}}
+          base: 'master'
 
       - uses: actions/create-release@v1
         id: create_release

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -82,16 +82,6 @@ workflows:
     - git-tag@1:
         inputs:
         - tag: $NEW_VERSION
-    - generate-changelog@0: {}
-    - github-release@0:
-        inputs:
-        - username: $GITHUB_USERNAME
-        - name: Glia iOS Widgets SDK $NEW_VERSION
-        - body: $BITRISE_CHANGELOG
-        - api_token: $GITHUB_API_TOKEN
-        - draft: "no"
-        - tag: $NEW_VERSION
-        - commit: $GIT_CLONE_COMMIT_HASH
     - script@1:
         inputs:
         - content: pod trunk push GliaWidgets.podspec --verbose --allow-warnings

--- a/scripts/update_ios_widgets_package.sh
+++ b/scripts/update_ios_widgets_package.sh
@@ -1,0 +1,43 @@
+SEMVER=$1
+CHECKSUM=$2
+BRANCH_NAME=$3
+
+git checkout -b "$BRANCH_NAME"
+
+# This script takes template file from templates/Package.swift
+# and replaces next placeholders:
+# - WIDGETS_SDK_SEMVER: actual value is passed in SEMVER;
+# - WIDGETS_SDK_CHECKSUM: actual value is passed in CHECKSUM;
+# - CORE_SDK_SEMVER: actual value is taken from GliaWidgets.podspec file;
+# - CORE_SDK_CHECKSUM: actual value is taken from Package.swift file;
+# Since templates/Package.swift file has placeholders for both CoreSDK and WidgetsSDK version
+# we need to replace them all.
+
+# Gets CoreSDK version from GliaWidgets.podspec file:
+# - `grep` command searches for the line containing "GliaCoreSDK', '" string.
+# - `awk` command splits `grep` output line into parts using "'" field separator (FS)
+# and returns 4th object in the result array.
+CORE_SDK_SEMVER=$(grep "GliaCoreSDK',\s*'" 'GliaWidgets.podspec' | awk -F"'" '{print $4}')
+
+# Gets CoreSDK xcframework checksum from Package.swift file:
+# - `awk` command searches for the line containing "GliaCoreSDK.xcframework.zip"
+# and returns the next line. By some reason it also returns 3rd line 🤷‍♂️.
+# - `grep` command searches in `awk` output for the line containing "checksum:".
+# - `awk` command splits `grep` output line into parts using "'" field separator (FS)
+# and returns 2nd object in the result array.
+CORE_SDK_CHECKSUM=$(awk '/GliaCoreSDK.xcframework.zip/{p=NR} NR==p+1' 'Package.swift' | grep 'checksum:' | awk -F'"' '{print $2}')
+
+# Replaces actual Package.swift file with template.
+cp templates/Package.swift Package.swift
+
+# `sed` command replaces placeholders in copied template file
+# with actual values.
+sed -i '' "s/\${CORE_SDK_SEMVER}/${CORE_SDK_SEMVER}/g" "Package.swift"
+sed -i '' "s/\${CORE_SDK_CHECKSUM}/${CORE_SDK_CHECKSUM}/g" "Package.swift"
+sed -i '' "s/\${WIDGETS_SDK_SEMVER}/${SEMVER}/g" "Package.swift"
+sed -i '' "s/\${WIDGETS_SDK_CHECKSUM}/${CHECKSUM}/g" "Package.swift"
+
+# Commits and pushes the changes.
+git add .
+git commit -m "Update Widgets SDK xcframework version"
+git push origin "$BRANCH_NAME":"$BRANCH_NAME"


### PR DESCRIPTION
MOB-3546

**What was solved?**
This commit:
- removes creating GitHub release from Deployment Bitrise workflow;
- adds bash script updating WidgetsSDK version and checksum in Package.swift;
- updates branch name and title for PRs updating xcframework version

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)