### PR TITLE
Update documentation of deprecated methods for bubble configuration

### DIFF
--- a/GliaWidgets/Public/Glia/Glia.Deprecated.swift
+++ b/GliaWidgets/Public/Glia/Glia.Deprecated.swift
@@ -181,11 +181,11 @@ extension Glia {
         )
     }
 
-    /// Deprecated, use ``Glia.startEngagement(engagementKind:in queueIds:sceneProvider:)`` instead.
+    /// Deprecated, use ``Glia.startEngagement(of kind:in queueIds:sceneProvider:)`` instead.
     /// Use ``configure(with configuration:uiConfig:theme:assetsBuilder:features:completion:)`` to pass in ``RemoteConfiguration``.
     @available(*, deprecated, message: """
-            Deprecated, use ``Glia.startEngagement(engagementKind:in queueIds:features:sceneProvider:)`` instead.
-            Use ``configure(with configuration:uiConfig:theme:assetsBuilder:completion:)`` to pass in ``RemoteConfiguration``.
+            Deprecated, use ``Glia.startEngagement(of kind:in queueIds:features:sceneProvider:)`` instead.
+            Use ``configure(with configuration:uiConfig:theme:assetsBuilder:features:completion:)`` to pass in ``RemoteConfiguration``.
         """
     )
     public func startEngagement(
@@ -205,7 +205,7 @@ extension Glia {
         )
     }
 
-    /// Deprecated, use ``Glia.startEngagement(engagementKind:in queueIds:sceneProvider:)`` instead.
+    /// Deprecated, use ``Glia.startEngagement(of kind:in queueIds:sceneProvider:)`` instead.
     /// Use ``configure(with configuration:uiConfig:theme:assetsBuilder:features:completion:)`` to pass in ``Features``.
     public func startEngagement(
         engagementKind: EngagementKind,


### PR DESCRIPTION
MOB-2648

**What was solved?**
Align documentation of deprecated method regarding bubble configuration and starting engagement.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
