### PR TITLE
Fix update_dependencies workflow

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -116,17 +116,6 @@ platform :ios do
     core_sdk_checksum = options[:core_sdk_checksum]
     UI.user_error!("No Core SDK checksum specified") unless !core_sdk_checksum.nil?
 
-    # Copy a new podspec file from template
-    sh("cp ../templates/GliaWidgets.podspec ../GliaWidgets.podspec")
-    # Replace CORE_SDK_VERSION_SEMVER with passed value.
-    sh("sed -i '' 's/${CORE_SDK_VERSION_SEMVER}/#{core_sdk_version}/g' ../GliaWidgets.podspec")
-
-    # Copy a new Package.swift file from template
-    sh("cp ../templates/Package.swift ../Package.swift")
-
-    # Replace CORE_SDK_SEMVER with passed value.
-    sh("sed -i '' 's/\${CORE_SDK_SEMVER}/#{core_sdk_version}/' ../Package.swift")
-    # Replace CORE_SDK_CHECKSUM with passed value.
-    sh("sed -i '' 's/\${CORE_SDK_CHECKSUM}/#{core_sdk_checksum}/' ../Package.swift")
+    sh("bash ../scripts/update_core_sdk_version.sh '#{project_version}' '#{core_sdk_version}' '#{core_sdk_checksum}'")
   end
 end

--- a/scripts/update_core_sdk_version.sh
+++ b/scripts/update_core_sdk_version.sh
@@ -1,0 +1,29 @@
+WIDGETS_SDK_SEMVER=$1
+CORE_SDK_SEMVER=$2
+CORE_SDK_CHECKSUM=$3
+
+# Copy a new podspec file from template
+cp ../templates/GliaWidgets.podspec ../GliaWidgets.podspec
+
+# Replace WIDGETS_SDK_VERSION_SEMVER with project_version value.
+sed -i '' "s/\${WIDGETS_SDK_VERSION_SEMVER}/${WIDGETS_SDK_SEMVER}/g" "../GliaWidgets.podspec"
+
+# Replace CORE_SDK_VERSION_SEMVER with passed value.
+sed -i '' "s/\${CORE_SDK_VERSION_SEMVER}/${CORE_SDK_SEMVER}/g" "../GliaWidgets.podspec"
+
+WIDGETS_SDK_CHECKSUM=$(awk '/GliaWidgetsXcf.xcframework.zip/{p=NR} NR==p+1' '../Package.swift' | grep 'checksum:' | awk -F'"' '{print $2}')
+
+# Copy a new Package.swift file from template
+cp ../templates/Package.swift ../Package.swift
+
+# Replace WIDGETS_SDK_SEMVER with project_version value.
+sed -i '' "s/\${WIDGETS_SDK_SEMVER}/${WIDGETS_SDK_SEMVER}/g" "../Package.swift"
+
+# Replace WIDGETS_SDK_CHECKSUM with widgets_sdk_checksum value.
+sed -i '' "s/\${WIDGETS_SDK_CHECKSUM}/${WIDGETS_SDK_CHECKSUM}/g" "../Package.swift"
+
+# Replace CORE_SDK_SEMVER with passed value.
+sed -i '' "s/\${CORE_SDK_SEMVER}/${CORE_SDK_SEMVER}/g" "../Package.swift"
+
+# Replace CORE_SDK_CHECKSUM with passed value.
+sed -i '' "s/\${CORE_SDK_CHECKSUM}/${CORE_SDK_CHECKSUM}/g" "../Package.swift"


### PR DESCRIPTION
MOB-3553

**What was solved?**
This PR fixes the issue with erasing WidgetsSDK version in Package.swift and GliaWidgets.podspec files during updating CoreSDK version.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)