### PR TITLE
Fix _increment_project_version workflow 

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -61,8 +61,7 @@ platform :ios do
       version: new_version
     )
 
-    sh("cp ../templates/GliaWidgets.podspec ../GliaWidgets.podspec")
-    sh("sed -i '' 's/\${WIDGETS_SDK_VERSION_SEMVER}/#{new_version}/' ../GliaWidgets.podspec")
+    sh("bash ../scripts/update_widgets_sdk_version.sh '#{new_version}'")
 
     new_version
   end

--- a/scripts/update_widgets_sdk_version.sh
+++ b/scripts/update_widgets_sdk_version.sh
@@ -1,0 +1,23 @@
+WIDGETS_SDK_SEMVER=$1
+
+# This script takes template file from templates/GliaWidgets.podspec
+# and replaces next placeholders:
+# - WIDGETS_SDK_VERSION_SEMVER: actual value is passed in WIDGETS_SDK_SEMVER;
+# - CORE_SDK_VERSION_SEMVER: actual value is taken from GliaWidgets.podspec file;
+# Since templates/GliaWidgets.podspec file has placeholders for both CoreSDK and WidgetsSDK version
+# we need to replace them all.
+
+# Gets CoreSDK version from GliaWidgets.podspec file:
+# - `grep` command searches for the line containing "GliaCoreSDK', '" string.
+# - `awk` command splits `grep` output line into parts using "'" field separator (FS)
+# and returns 4th object in the result array.
+CORE_SDK_SEMVER=$(grep "GliaCoreSDK',\s*'" '../GliaWidgets.podspec' | awk -F"'" '{print $4}')
+
+# Copy a new podspec file from template
+cp ../templates/GliaWidgets.podspec ../GliaWidgets.podspec
+
+# Replace WIDGETS_SDK_VERSION_SEMVER with WIDGETS_SDK_SEMVER value.
+sed -i '' "s/\${WIDGETS_SDK_VERSION_SEMVER}/${WIDGETS_SDK_SEMVER}/" "../GliaWidgets.podspec"
+
+# Replace CORE_SDK_VERSION_SEMVER with retrieved value.
+sed -i '' "s/\${CORE_SDK_VERSION_SEMVER}/${CORE_SDK_SEMVER}/g" "../GliaWidgets.podspec"


### PR DESCRIPTION
MOB-3555

**What was solved?**
This PR fixes erasing CoreSDK version in GliaWidgets.podspec file during _increment_project_version run.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)