### PR TITLE
Show bubble for restored app with authenticated visitor

### DIFF
--- a/GliaWidgets/Public/Glia/Glia.OpaqueAuthentication.swift
+++ b/GliaWidgets/Public/Glia/Glia.OpaqueAuthentication.swift
@@ -79,7 +79,7 @@ extension Glia {
                     "Authenticate. Is external access token used: \(accessToken != nil)"
                 )
 
-                let interactor = self?.rootCoordinator?.interactor
+                let interactor = self?.interactor
                 let viewFactory = self?.rootCoordinator?.viewFactory
                 let sceneProvider = self?.rootCoordinator?.sceneProvider
 


### PR DESCRIPTION
Take into account that root coordinator with interactor may not be available when application is restored, which can prevent bubble from being shown.

MOB-3562

**What was solved?**

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
