### PR TITLE
Show Survey error when engagement is ended in app background

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -616,6 +616,9 @@
 		AF7753122B19EC3200E523A2 /* Logger.Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7753112B19EC3200E523A2 /* Logger.Live.swift */; };
 		AF7753142B19ED4F00E523A2 /* Logger.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7753132B19ED4F00E523A2 /* Logger.Mock.swift */; };
 		AF7753172B1DBFE600E523A2 /* Glia.Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7753162B1DBFE600E523A2 /* Glia.Logging.swift */; };
+		AF993B392C8F5DE800DC5E69 /* EngagementCoordinator+SurveyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF993B382C8F5DE800DC5E69 /* EngagementCoordinator+SurveyTests.swift */; };
+		AF993B3C2C8F5E7000DC5E69 /* EngagementCoordinatorSecureConversationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF993B3A2C8F5E7000DC5E69 /* EngagementCoordinatorSecureConversationsTests.swift */; };
+		AF993B3D2C8F5E7000DC5E69 /* EngagementCoordinatorCallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF993B3B2C8F5E7000DC5E69 /* EngagementCoordinatorCallTests.swift */; };
 		AF9C0C3C2BC4739800C25E47 /* Transformable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9C0C3B2BC4739800C25E47 /* Transformable.swift */; };
 		AF9C0C442BC5A29B00C25E47 /* GliaPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9C0C412BC5A1F500C25E47 /* GliaPresenterTests.swift */; };
 		AF9C0C462BC5A3FB00C25E47 /* GliaPresenter.Environment.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9C0C452BC5A3FB00C25E47 /* GliaPresenter.Environment.Failing.swift */; };
@@ -1619,6 +1622,9 @@
 		AF7753112B19EC3200E523A2 /* Logger.Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.Live.swift; sourceTree = "<group>"; };
 		AF7753132B19ED4F00E523A2 /* Logger.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.Mock.swift; sourceTree = "<group>"; };
 		AF7753162B1DBFE600E523A2 /* Glia.Logging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Glia.Logging.swift; sourceTree = "<group>"; };
+		AF993B382C8F5DE800DC5E69 /* EngagementCoordinator+SurveyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EngagementCoordinator+SurveyTests.swift"; sourceTree = "<group>"; };
+		AF993B3A2C8F5E7000DC5E69 /* EngagementCoordinatorSecureConversationsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EngagementCoordinatorSecureConversationsTests.swift; sourceTree = "<group>"; };
+		AF993B3B2C8F5E7000DC5E69 /* EngagementCoordinatorCallTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EngagementCoordinatorCallTests.swift; sourceTree = "<group>"; };
 		AF9C0C3B2BC4739800C25E47 /* Transformable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transformable.swift; sourceTree = "<group>"; };
 		AF9C0C412BC5A1F500C25E47 /* GliaPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GliaPresenterTests.swift; sourceTree = "<group>"; };
 		AF9C0C452BC5A3FB00C25E47 /* GliaPresenter.Environment.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GliaPresenter.Environment.Failing.swift; sourceTree = "<group>"; };
@@ -3227,7 +3233,10 @@
 		31758EC22B5FB155007BBD9F /* EngagementCoordinator */ = {
 			isa = PBXGroup;
 			children = (
+				AF993B3B2C8F5E7000DC5E69 /* EngagementCoordinatorCallTests.swift */,
+				AF993B3A2C8F5E7000DC5E69 /* EngagementCoordinatorSecureConversationsTests.swift */,
 				31758EC32B5FB192007BBD9F /* EngagementCoordinatorTests.swift */,
+				AF993B382C8F5DE800DC5E69 /* EngagementCoordinator+SurveyTests.swift */,
 			);
 			path = EngagementCoordinator;
 			sourceTree = "<group>";
@@ -6266,6 +6275,7 @@
 				7512A5A727C3926500319DF1 /* GliaTests.swift in Sources */,
 				C0175A112A55AA3E001FACDE /* ChatMessageEntryView.+Mock.swift in Sources */,
 				31D286AD2A00DD2C009192A6 /* SecureConversations.ConfirmationViewModelTests.swift in Sources */,
+				AF993B392C8F5DE800DC5E69 /* EngagementCoordinator+SurveyTests.swift in Sources */,
 				9A3E1DA227BA7D00005634EB /* FileSystemStorage.Environment.Failing.swift in Sources */,
 				AF29810B29E0478E0005BD55 /* TranscriptModel.Environment.Failing.swift in Sources */,
 				9A1992E127D6313500161AAE /* ImageView.Cache.Failing.swift in Sources */,
@@ -6293,6 +6303,7 @@
 				EB9ADB51280EBD4E00FAE8A4 /* InteractorStateTests.swift in Sources */,
 				8491AF652AAB281500CC3E72 /* ChatViewModelTests+CustomCard.swift in Sources */,
 				EB7A1508286D98000035AC62 /* FileUploader.Environment.Failing.swift in Sources */,
+				AF993B3D2C8F5E7000DC5E69 /* EngagementCoordinatorCallTests.swift in Sources */,
 				AF2355A229C9EC7E007D9896 /* IdCollectionTests.swift in Sources */,
 				8491AF572AA0964800CC3E72 /* ChatItem.Kind.Mock.swift in Sources */,
 				84C24CFF2B8357BB0089A388 /* ProcessInfoHandling.Failing.swift in Sources */,
@@ -6310,6 +6321,7 @@
 				9AE05CB62805D2CB00871321 /* Interactor.Environment.Failing.swift in Sources */,
 				846429862A45DB4100943BD6 /* AlertViewController.Kind+Mock.swift in Sources */,
 				AF29811229E42F3C0005BD55 /* AvailabilityTests.swift in Sources */,
+				AF993B3C2C8F5E7000DC5E69 /* EngagementCoordinatorSecureConversationsTests.swift in Sources */,
 				31758EC12B5E9E22007BBD9F /* CallVisualizer.VideoCallCoordinator.Environment.Mock.swift in Sources */,
 				31758EC02B5E9E22007BBD9F /* VideoCallCoordinatorTests.swift in Sources */,
 				9AE05CB32805C9D900871321 /* ChatViewModel.Environment.Failing.swift in Sources */,

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
@@ -35,8 +35,8 @@ extension SecureConversations {
 
         private let downloader: FileDownloader
         let fileUploadListModel: SecureConversations.FileUploadListViewModel
-        private (set) var hasViewAppeared: Bool
-        private (set) var messageText = "" {
+        private(set) var hasViewAppeared: Bool
+        private(set) var messageText = "" {
             didSet {
                 validateMessage()
                 action?(.setMessageText(messageText))
@@ -45,13 +45,13 @@ extension SecureConversations {
 
         private let isCustomCardSupported: Bool
         private let isChatScrolledToBottom = ObservableValue<Bool>(with: true)
-        private (set) var isViewLoaded: Bool = false
+        private(set) var isViewLoaded: Bool = false
 
         var environment: Environment
         var availability: Availability
         var interactor: Interactor
 
-        private (set) var isSecureConversationsAvailable: Bool = true {
+        private(set) var isSecureConversationsAvailable: Bool = true {
             didSet {
                 action?(.transcript(.messageCenterAvailabilityUpdated))
             }
@@ -75,7 +75,7 @@ extension SecureConversations {
         var historySection: Section<ChatItem> { sections[0] }
         var pendingSection: Section<ChatItem> { sections[1] }
 
-        private (set) var receivedMessages = [String: [MessageSource]]()
+        private(set) var receivedMessages = [String: [MessageSource]]()
 
         let deliveredStatusText: String
 

--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.swift
@@ -21,7 +21,7 @@ extension SecureConversations {
         var messageText: String = "" { didSet { reportChange() } }
         /// Flag indicating attachment(s) availability.
         /// By default attachments are not available, until site configurations are fetched.
-        private (set) var isAttachmentsAvailable: Bool = false { didSet { reportChange() } }
+        private(set) var isAttachmentsAvailable: Bool = false { didSet { reportChange() } }
         var availabilityStatus: Availability.Status = .available(queueIds: []) { didSet { reportChange() } }
         var messageInputState: MessageInputState = .normal { didSet { reportChange() } }
         var sendMessageRequestState: SendMessageRequestState = .waiting { didSet { reportChange() } }

--- a/GliaWidgets/Sources/AlertManager/AlertManager.Environment.swift
+++ b/GliaWidgets/Sources/AlertManager/AlertManager.Environment.swift
@@ -2,9 +2,9 @@ import Foundation
 
 extension AlertManager {
     struct Environment {
-        let log: CoreSdkClient.Logger
-        let uiApplication: UIKitBased.UIApplication
-        let viewFactory: ViewFactory
+        var log: CoreSdkClient.Logger
+        var uiApplication: UIKitBased.UIApplication
+        var viewFactory: ViewFactory
     }
 }
 

--- a/GliaWidgets/Sources/AlertManager/AlertManager.swift
+++ b/GliaWidgets/Sources/AlertManager/AlertManager.swift
@@ -22,6 +22,10 @@ final class AlertManager {
     /// The window used to present global alerts.
     private var alertWindow: UIWindow?
 
+    /// Flag used internally to specify if view controller presentation has to be animated.
+    /// Useful to be set to false during unit tests to avoid dealing with delays, thus slow tests.
+    private var isViewControllerPresentationAnimated = true
+
     /// - Parameters:
     ///   - environment: The environment configuration for the alert manager.
     ///   - viewFactory: The view factory responsible for creating the alert views.
@@ -102,7 +106,7 @@ private extension AlertManager {
             )
             viewController.present(
                 alert,
-                animated: true,
+                animated: isViewControllerPresentationAnimated,
                 completion: nil
             )
         case .view:
@@ -117,10 +121,10 @@ private extension AlertManager {
                 viewController.view.trailingAnchor.constraint(equalTo: alertViewController.view.trailingAnchor)
             ])
         default:
-            let completion: () -> Void = {
+            let completion: () -> Void = { [isViewControllerPresentationAnimated] in
                 viewController.present(
                     alertViewController,
-                    animated: true
+                    animated: isViewControllerPresentationAnimated
                 )
             }
             guard let presented = viewController.presentedViewController as? Replaceable else {
@@ -156,7 +160,7 @@ private extension AlertManager {
         alertWindow.makeKeyAndVisible()
         alertWindow.rootViewController?.present(
             alertViewController,
-            animated: true,
+            animated: isViewControllerPresentationAnimated,
             completion: nil
         )
     }
@@ -227,3 +231,12 @@ private extension AlertManager {
             .first
     }
 }
+
+#if DEBUG
+extension AlertManager {
+    /// Enables and disables presentation animation for view controller for unit testing
+    func setViewControllerPresentationAnimated(_ isAnimated: Bool) {
+        self.isViewControllerPresentationAnimated = isAnimated
+    }
+}
+#endif

--- a/GliaWidgets/Sources/FoundationBased/FoundationBased.Interface.swift
+++ b/GliaWidgets/Sources/FoundationBased/FoundationBased.Interface.swift
@@ -75,23 +75,48 @@ enum FoundationBased {
             _ object: Any?)
         -> Void
 
+        var addObserverForNameWithObjectWithQueueUsingBlock: (
+            _ name: NSNotification.Name?,
+            _ object: Any?,
+            _ queue: Foundation.OperationQueue?,
+            _ block: @escaping @Sendable (Notification) -> Void
+        ) -> any NSObjectProtocol
+
         var removeObserverClosure: (Any) -> Void
         var removeObserverWithNameAndObject: (
             _ observer: Any,
             _ name: NSNotification.Name?,
-            _ object: Any?)
-        -> Void
+            _ object: Any?
+        ) -> Void
 
-        func addObserver(_ observer: Any, selector aSelector: Selector, name aName: NSNotification.Name?, object anObject: Any?) {
+        func addObserver(
+            _ observer: Any,
+            selector aSelector: Selector,
+            name aName: NSNotification.Name?,
+            object anObject: Any?
+        ) {
             addObserverClosure(observer, aSelector, aName, anObject)
         }
 
-        func removeObserver(_ observer: Any, name aName: NSNotification.Name?, object anObject: Any?) {
+        func removeObserver(
+            _ observer: Any,
+            name aName: NSNotification.Name?,
+            object anObject: Any?
+        ) {
             removeObserverWithNameAndObject(observer, aName, anObject)
         }
 
         func removeObserver(_ observer: Any) {
             removeObserverClosure(observer)
+        }
+
+        func addObserver(
+            forName name: NSNotification.Name?,
+            object obj: Any?,
+            queue: Foundation.OperationQueue?,
+            using block: @escaping @Sendable (Notification) -> Void
+        ) -> any NSObjectProtocol {
+            addObserverForNameWithObjectWithQueueUsingBlock(name, obj, queue, block)
         }
 
         var publisherForNotification: (NSNotification.Name) -> AnyPublisher<Notification, Never>

--- a/GliaWidgets/Sources/FoundationBased/FoundationBased.Live.swift
+++ b/GliaWidgets/Sources/FoundationBased/FoundationBased.Live.swift
@@ -65,6 +65,7 @@ extension FoundationBased.Timer.Providing {
 extension FoundationBased.NotificationCenter {
     static let live = Self(
         addObserverClosure: NotificationCenter.default.addObserver,
+        addObserverForNameWithObjectWithQueueUsingBlock: NotificationCenter.default.addObserver(forName:object:queue:using:),
         removeObserverClosure: NotificationCenter.default.removeObserver,
         removeObserverWithNameAndObject: NotificationCenter.default.removeObserver,
         publisherForNotification: { NotificationCenter.default.publisher(for: $0).eraseToAnyPublisher() }

--- a/GliaWidgets/Sources/FoundationBased/FoundationBased.Mock.swift
+++ b/GliaWidgets/Sources/FoundationBased/FoundationBased.Mock.swift
@@ -50,6 +50,9 @@ extension FoundationBased.Timer.Providing {
 extension FoundationBased.NotificationCenter {
     static let mock = Self(
         addObserverClosure: { _, _, _, _ in },
+        addObserverForNameWithObjectWithQueueUsingBlock: { _, _, _, _ in
+            NSObject()
+        },
         removeObserverClosure: { _ in },
         removeObserverWithNameAndObject: { _, _, _ in },
         publisherForNotification: { _ in

--- a/GliaWidgets/Sources/UIKitBased/UIKitBased.Interface.swift
+++ b/GliaWidgets/Sources/UIKitBased/UIKitBased.Interface.swift
@@ -12,6 +12,7 @@ enum UIKitBased {
         var isIdleTimerDisabled: (Bool) -> Void
         var windows: () -> [UIKit.UIWindow]
         var connectionScenes: () -> Set<UIScene>
+        var applicationState: () -> UIKit.UIApplication.State
     }
 
     struct UIDevice {

--- a/GliaWidgets/Sources/UIKitBased/UIKitBased.Live.swift
+++ b/GliaWidgets/Sources/UIKitBased/UIKitBased.Live.swift
@@ -11,7 +11,8 @@ extension UIKitBased.UIApplication {
         preferredContentSizeCategory: { UIApplication.shared.preferredContentSizeCategory },
         isIdleTimerDisabled: { UIApplication.shared.isIdleTimerDisabled = $0 },
         windows: { UIApplication.shared.windows },
-        connectionScenes: { UIApplication.shared.connectedScenes }
+        connectionScenes: { UIApplication.shared.connectedScenes },
+        applicationState: { UIApplication.shared.applicationState }
     )
 }
 

--- a/GliaWidgets/Sources/UIKitBased/UIKitBased.Mock.swift
+++ b/GliaWidgets/Sources/UIKitBased/UIKitBased.Mock.swift
@@ -14,7 +14,8 @@ extension UIKitBased.UIApplication {
         preferredContentSizeCategory: { .unspecified },
         isIdleTimerDisabled: { _ in },
         windows: { .init() },
-        connectionScenes: { .init() }
+        connectionScenes: { .init() },
+        applicationState: { .inactive }
     )
 }
 

--- a/GliaWidgets/Sources/ViewModel/Call/CallViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Call/CallViewModel.swift
@@ -11,7 +11,7 @@ class CallViewModel: EngagementViewModel, ViewModel {
     private let unreadMessages: ObservableValue<Int>
 
     /// Speaker button state used for logging.
-    private (set) var loggedSpeakerButtonOnState: Bool = false {
+    private(set) var loggedSpeakerButtonOnState: Bool = false {
         didSet {
             guard loggedSpeakerButtonOnState != oldValue else { return }
             environment.log.prefixed(Self.self).info(

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -32,7 +32,7 @@ class ChatViewModel: EngagementViewModel {
 
     private let downloader: FileDownloader
     private let deliveredStatusText: String
-    private (set) var messageText = "" {
+    private(set) var messageText = "" {
         didSet {
             validateMessage()
             sendMessagePreview(messageText)
@@ -43,12 +43,12 @@ class ChatViewModel: EngagementViewModel {
     private var pendingMessages: [OutgoingMessage] = []
     var isViewLoaded: Bool = false
     var isChoiceCardInputModeEnabled: Bool = false
-    private (set) var siteConfiguration: CoreSdkClient.Site?
+    private(set) var siteConfiguration: CoreSdkClient.Site?
     // Stored message ids retrieved from history.
     // They are used to discard messages received from socket
     // to avoid duplication.
-    private (set) var historyMessageIds: Set<ChatMessage.MessageId> = []
-    private (set) var receivedMessageIds: Set<ChatMessage.MessageId> = []
+    private(set) var historyMessageIds: Set<ChatMessage.MessageId> = []
+    private(set) var receivedMessageIds: Set<ChatMessage.MessageId> = []
 
     var mediaPickerButtonVisibility: MediaPickerButtonVisibility {
         guard let site = siteConfiguration else { return .disabled }

--- a/GliaWidgets/SwiftUI/Components/SnackBarView/SerialQueue.swift
+++ b/GliaWidgets/SwiftUI/Components/SnackBarView/SerialQueue.swift
@@ -51,7 +51,7 @@ extension SerialQueue {
     /// ```
     final class Operation {
         var didFinish: (() -> Void)?
-        let action: (_ done: @escaping() -> Void) -> Void
+        let action: (_ done: @escaping () -> Void) -> Void
 
         init(action: @escaping (_ done: @escaping () -> Void) -> Void) {
             self.action = action

--- a/GliaWidgetsTests/FoundationBased.Failing.swift
+++ b/GliaWidgetsTests/FoundationBased.Failing.swift
@@ -85,6 +85,10 @@ extension FoundationBased.NotificationCenter {
         addObserverClosure: { _, _, _, _ in
             fail("\(Self.self).addObserverClosure")
         },
+        addObserverForNameWithObjectWithQueueUsingBlock: { _, _, _, _ in
+            fail("\(Self.self).addObserverForNameWithObjectWithQueueUsingBlock")
+            return NSObject()
+        },
         removeObserverClosure: { _ in
             fail("\(Self.self).removeObserverClosure")
         },

--- a/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator+SurveyTests.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator+SurveyTests.swift
@@ -1,0 +1,94 @@
+@testable import GliaWidgets
+import XCTest
+
+class EngagementCoordinatorSurveyTests: XCTestCase {
+    func test_surveyCompletesWithUnexpectedError() {
+        let coreSdkClient = CoreSdkClient.failing
+        let engagement = CoreSdkClient.Engagement(
+            id: "", 
+            engagedOperator: nil,
+            source: .coreEngagement,
+            fetchSurvey: { _, callback in
+                callback(.failure(.mock()))
+            },
+            mediaStreams: .init(audio: .none, video: .oneWay)
+        )
+        let interactor = Interactor.mock(environment: .init(coreSdk: coreSdkClient, gcd: .failing, log: .failing))
+        interactor.currentEngagement = engagement
+        var alertManagerEnv = AlertManager.Environment.failing()
+        var log = CoreSdkClient.Logger.failing
+        log.prefixedClosure = { _ in log }
+        var messages: [String] = []
+        log.infoClosure = { message, _, _, _ in
+            messages.append("\(message)")
+        }
+        alertManagerEnv.log = log
+        alertManagerEnv.uiApplication.connectionScenes = { [] }
+        var engagementCoordinatorEnv = EngagementCoordinator.Environment.failing
+        engagementCoordinatorEnv.alertManager = .failing(environment: alertManagerEnv, viewFactory: .mock())
+        engagementCoordinatorEnv.alertManager.setViewControllerPresentationAnimated(false)
+        engagementCoordinatorEnv.uiApplication.applicationState = { .inactive }
+        let coordinator = EngagementCoordinator(
+            interactor: interactor,
+            viewFactory: ViewFactory.mock(),
+            sceneProvider: nil,
+            engagementKind: .audioCall,
+            screenShareHandler: .mock,
+            features: [],
+            environment: engagementCoordinatorEnv
+        )
+        coordinator.end(surveyPresentation: .presentSurvey)
+        XCTAssertEqual(messages, ["Show Unexpected error Dialog"])
+    }
+
+    func test_surveyCompletesWithErrorAndRetries() throws {
+        let coreSdkClient = CoreSdkClient.failing
+        var expectedErrors = [CoreSdkClient.GliaCoreError.mock()]
+        let survey = try CoreSdkClient.Survey.mock()
+
+        let engagement = CoreSdkClient.Engagement(
+            id: "", engagedOperator: nil,
+            source: .coreEngagement,
+            fetchSurvey: { _, callback in
+                if let err = expectedErrors.first {
+                    expectedErrors.removeFirst()
+                    callback(.failure(err))
+                } else {
+                     callback(.success(survey))
+                }
+            },
+            mediaStreams: .init(audio: .none, video: .oneWay)
+        )
+        let interactor = Interactor.mock(environment: .init(coreSdk: coreSdkClient, gcd: .failing, log: .failing))
+        interactor.currentEngagement = engagement
+        var log = CoreSdkClient.Logger.failing
+        log.prefixedClosure = { _ in log }
+        var messages: [String] = []
+        log.infoClosure = { message, _, _, _ in
+            messages.append("\(message)")
+        }
+        var engagementCoordinatorEnv = EngagementCoordinator.Environment.failing
+        engagementCoordinatorEnv.log = log
+        engagementCoordinatorEnv.uiApplication.applicationState = { .background }
+        engagementCoordinatorEnv.notificationCenter.addObserverForNameWithObjectWithQueueUsingBlock = { _, _, _, callback in
+            callback(Notification(name: UIApplication.willEnterForegroundNotification))
+            return NSObject()
+        }
+        engagementCoordinatorEnv.notificationCenter.removeObserverClosure = { _ in }
+        engagementCoordinatorEnv.notificationCenter.addObserverClosure = { _, _, _, _ in }
+        engagementCoordinatorEnv.uiApplication.windows = { [UIWindow.mock()] }
+        let coordinator = EngagementCoordinator(
+            interactor: interactor,
+            viewFactory: ViewFactory.mock(),
+            sceneProvider: nil,
+            engagementKind: .audioCall,
+            screenShareHandler: .mock,
+            features: [],
+            environment: engagementCoordinatorEnv
+        )
+        // Set dummy observer to avoid early out during notification center callback invocation.
+        coordinator.applicationStateObserver = NSObject()
+        coordinator.end(surveyPresentation: .presentSurvey)
+        XCTAssertEqual(messages, ["Survey loaded", "Create Survey screen"])
+    }
+}

--- a/GliaWidgetsTests/UIKitBased.Failing.swift
+++ b/GliaWidgetsTests/UIKitBased.Failing.swift
@@ -32,6 +32,10 @@ extension UIKitBased.UIApplication {
         connectionScenes: {
             fail("\(Self.self).connectionScenes")
             return .init()
+        },
+        applicationState: {
+            fail("\(Self.self).applicationState")
+            return .inactive
         }
     )
 }


### PR DESCRIPTION
MOB-3560

**What was solved?**
Address issue of blocked UI by showing dialog for received error from survey API, but first try to re-request Survey in case of error in background.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
