### PR TITLE
Show snackbar when engagement request is timed out

### DIFF
--- a/GliaWidgets/Public/Glia/Glia+RestoreEngagement.swift
+++ b/GliaWidgets/Public/Glia/Glia+RestoreEngagement.swift
@@ -49,6 +49,7 @@ extension Glia {
 
         func showSnackBarMessage() {
             environment.snackBar.showSnackBarMessage(
+                text: viewFactory.theme.snackBar.text,
                 style: viewFactory.theme.snackBar,
                 topMostViewController: GliaPresenter(
                     environment: .create(

--- a/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
+++ b/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
@@ -93,8 +93,8 @@ extension CallVisualizer {
         coordinator.handleAcceptedUpgrade()
     }
 
-    func handleEngagementRequestAccepted(request: CoreSdkClient.Request, answer: Command<Bool>) {
-        coordinator.handleEngagementRequestAccepted(request: request, answer: answer)
+    func handleEngagementRequest(request: CoreSdkClient.Request, answer: Command<Bool>) {
+        coordinator.handleEngagementRequest(request: request, answer: answer)
     }
 
     func addVideoStream(stream: CoreSdkClient.VideoStreamable) {
@@ -131,7 +131,7 @@ extension CallVisualizer {
             else {
                 switch event {
                 case let .onEngagementRequest(request, answer):
-                    self?.handleEngagementRequestAccepted(request: request, answer: answer)
+                    self?.handleEngagementRequest(request: request, answer: answer)
                 default: return
                 }
                 return

--- a/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
@@ -55,17 +55,35 @@ extension CallVisualizer {
             showVideoCallViewController()
         }
 
-        func handleEngagementRequestAccepted(request: CoreSdkClient.Request, answer: Command<Bool>) {
-            if let outcome = request.outcome, outcome == "timed_out" {
-                self.environment.alertManager.dismissCurrentAlert()
-                answer(false)
+        func handleEngagementRequest(
+            request: CoreSdkClient.Request,
+            answer: Command<Bool>
+        ) {
+            guard let outcome = request.outcome else {
+                handleEngagementRequestOutcomeNil(answer: answer)
                 return
             }
+            if outcome == "timed_out" {
+                handleEngagementRequestOutcomeTimeout(answer: answer)
+            }
+        }
+
+        func handleEngagementRequestOutcomeTimeout(answer: Command<Bool>) {
+            environment.alertManager.dismissCurrentAlert()
+            environment.gcd.mainQueue.asyncAfterDeadline(.now() + 0.5) {
+                // Will be swapped for localized string
+                self.showSnackBarMessage(text: "Request has timed out")
+            }
+            answer(false)
+        }
+
+        func handleEngagementRequestOutcomeNil(answer: Command<Bool>) {
             fetchSiteConfigurations { [weak self] site in
                 let showSnackBarIfNeeded: () -> Void = {
                     guard site.mobileObservationEnabled == true else { return }
                     guard site.mobileObservationIndicationEnabled == true else { return }
-                    self?.showSnackBarMessage()
+                    guard let self else { return }
+                    self.showSnackBarMessage(text: self.environment.viewFactory.theme.snackBar.text)
                 }
                 let completion: Command<Bool> = .init { isAccepted in
                     if isAccepted {
@@ -100,7 +118,8 @@ extension CallVisualizer {
             fetchSiteConfigurations { [weak self] site in
                 guard site.mobileObservationEnabled == true else { return }
                 guard site.mobileObservationIndicationEnabled == true else { return }
-                self?.showSnackBarMessage()
+                guard let self else { return }
+                self.showSnackBarMessage(text: self.environment.viewFactory.theme.snackBar.text)
             }
         }
 
@@ -428,8 +447,9 @@ private extension CallVisualizer.Coordinator {
 // MARK: - Live Observation
 
 private extension CallVisualizer.Coordinator {
-    func showSnackBarMessage() {
+    func showSnackBarMessage(text: String) {
         environment.snackBar.showSnackBarMessage(
+            text: text,
             style: environment.viewFactory.theme.snackBar,
             topMostViewController: topMostViewController,
             timerProviding: environment.timerProviding,

--- a/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar.Interface.swift
+++ b/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar.Interface.swift
@@ -32,6 +32,7 @@ struct SnackBar {
     }
 
     func showSnackBarMessage(
+        text: String,
         style: Theme.SnackBarStyle,
         topMostViewController: UIViewController,
         timerProviding: FoundationBased.Timer.Providing,
@@ -39,7 +40,7 @@ struct SnackBar {
         notificationCenter: FoundationBased.NotificationCenter
     ) {
         self.present(
-            text: style.text,
+            text: text,
             style: style,
             for: topMostViewController,
             bottomOffset: -60,

--- a/GliaWidgetsTests/Sources/CallVisualizer/Coordinator/CallVisualizerCoordinatorTests.swift
+++ b/GliaWidgetsTests/Sources/CallVisualizer/Coordinator/CallVisualizerCoordinatorTests.swift
@@ -54,7 +54,7 @@ final class CallVisualizerCoordinatorTests: XCTestCase {
         }
 
         let request = CoreSdkClient.Request(id: "123", outcome: nil, platform: nil)
-        coordinator.handleEngagementRequestAccepted(request: request, answer: answer)
+        coordinator.handleEngagementRequest(request: request, answer: answer)
         XCTAssertEqual(answers, [true])
     }
 
@@ -87,7 +87,7 @@ final class CallVisualizerCoordinatorTests: XCTestCase {
 
         let answer = Command<Bool> { _ in }
         let request = CoreSdkClient.Request(id: "123", outcome: nil, platform: nil)
-        coordinator.handleEngagementRequestAccepted(request: request, answer: answer)
+        coordinator.handleEngagementRequest(request: request, answer: answer)
 
         XCTAssertTrue(coordinator.environment.presenter.getInstance()?.presentedViewController is AlertViewController)
     }
@@ -121,7 +121,7 @@ final class CallVisualizerCoordinatorTests: XCTestCase {
 
         let answer = Command<Bool> { _ in }
         let request = CoreSdkClient.Request(id: "123", outcome: "timed_out", platform: nil)
-        coordinator.handleEngagementRequestAccepted(request: request, answer: answer)
+        coordinator.handleEngagementRequest(request: request, answer: answer)
 
         XCTAssertFalse(coordinator.environment.presenter.getInstance()?.presentedViewController is AlertViewController)
     }


### PR DESCRIPTION
**What was solved?**
Snackbar needs to be showed after request has timed out. Also, if outcome is anythign but nil or timed_out, we need to ignore it

MOB-3499

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
