### PR TITLE
Add EntryWidget UI

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -880,35 +880,24 @@
 		C0D6C9F72C0D2F6D00D4709B /* AlertPlacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6C9F62C0D2F6D00D4709B /* AlertPlacement.swift */; };
 		C0D6C9FB2C0D2F9A00D4709B /* AlertInputType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6C9FA2C0D2F9A00D4709B /* AlertInputType.swift */; };
 		C0D6CA002C106A1F00D4709B /* AlertManager.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6C9FF2C106A1F00D4709B /* AlertManager.Failing.swift */; };
-		C0D6CA232C1861F400D4709B /* VideoCallView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA222C1861F400D4709B /* VideoCallView.Environment.swift */; };
-		C0D6CA3D2C19A82100D4709B /* VideoCallViewController.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA3C2C19A82100D4709B /* VideoCallViewController.Environment.swift */; };
-		C0D6CA0B2C18472400D4709B /* SecureConversations.Coordinator.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA0A2C18472400D4709B /* SecureConversations.Coordinator.Environment.swift */; };
-		C0D6CA0F2C184AB700D4709B /* SecureConversations.WelcomeViewModel.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA0E2C184AB700D4709B /* SecureConversations.WelcomeViewModel.Environment.swift */; };
-		C0D6CA112C184CCA00D4709B /* SecureConversations.WelcomeViewController.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA102C184CCA00D4709B /* SecureConversations.WelcomeViewController.Environment.swift */; };
-		C0D6CA132C184DFF00D4709B /* FileDownloader.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA122C184DFF00D4709B /* FileDownloader.Environment.swift */; };
-		C0D6CA0B2C18472400D4709B /* SecureConversations.Coordinator.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA0A2C18472400D4709B /* SecureConversations.Coordinator.Environment.swift */; };
-		C0D6CA0F2C184AB700D4709B /* SecureConversations.WelcomeViewModel.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA0E2C184AB700D4709B /* SecureConversations.WelcomeViewModel.Environment.swift */; };
-		C0D6CA112C184CCA00D4709B /* SecureConversations.WelcomeViewController.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA102C184CCA00D4709B /* SecureConversations.WelcomeViewController.Environment.swift */; };
-		C0D6CA132C184DFF00D4709B /* FileDownloader.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA122C184DFF00D4709B /* FileDownloader.Environment.swift */; };
-		C0D6CA172C18584E00D4709B /* SecureConversations.WelcomeView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA162C18584E00D4709B /* SecureConversations.WelcomeView.Environment.swift */; };
-		C0D6CA192C18590400D4709B /* UserImageView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA182C18590400D4709B /* UserImageView.Environment.swift */; };
 		C0D6CA052C172F8F00D4709B /* CallCoordinator.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA042C172F8F00D4709B /* CallCoordinator.Environment.swift */; };
 		C0D6CA072C1843A900D4709B /* EngagementViewController.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA062C1843A900D4709B /* EngagementViewController.Environment.swift */; };
 		C0D6CA092C18451800D4709B /* CallViewController.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA082C18451800D4709B /* CallViewController.Environment.swift */; };
+		C0D6CA0B2C18472400D4709B /* SecureConversations.Coordinator.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA0A2C18472400D4709B /* SecureConversations.Coordinator.Environment.swift */; };
+		C0D6CA0D2C1848E700D4709B /* GliaViewController.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA0C2C1848E700D4709B /* GliaViewController.Environment.swift */; };
+		C0D6CA0F2C184AB700D4709B /* SecureConversations.WelcomeViewModel.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA0E2C184AB700D4709B /* SecureConversations.WelcomeViewModel.Environment.swift */; };
+		C0D6CA112C184CCA00D4709B /* SecureConversations.WelcomeViewController.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA102C184CCA00D4709B /* SecureConversations.WelcomeViewController.Environment.swift */; };
+		C0D6CA132C184DFF00D4709B /* FileDownloader.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA122C184DFF00D4709B /* FileDownloader.Environment.swift */; };
+		C0D6CA152C184F1900D4709B /* SecureConversations.MessagesWithUnreadCountLoader.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA142C184F1900D4709B /* SecureConversations.MessagesWithUnreadCountLoader.Environment.swift */; };
+		C0D6CA172C18584E00D4709B /* SecureConversations.WelcomeView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA162C18584E00D4709B /* SecureConversations.WelcomeView.Environment.swift */; };
+		C0D6CA192C18590400D4709B /* UserImageView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA182C18590400D4709B /* UserImageView.Environment.swift */; };
 		C0D6CA1B2C185BDE00D4709B /* EngagementView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA1A2C185BDE00D4709B /* EngagementView.Environment.swift */; };
 		C0D6CA1D2C185D2900D4709B /* CallView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA1C2C185D2900D4709B /* CallView.Environment.swift */; };
-		C0D6CA0D2C1848E700D4709B /* GliaViewController.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA0C2C1848E700D4709B /* GliaViewController.Environment.swift */; };
 		C0D6CA1F2C185E3500D4709B /* BubbleView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA1E2C185E3500D4709B /* BubbleView.Environment.swift */; };
 		C0D6CA212C185F1000D4709B /* AlertTypeComposer.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA202C185F1000D4709B /* AlertTypeComposer.Environment.swift */; };
 		C0D6CA232C1861F400D4709B /* VideoCallView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA222C1861F400D4709B /* VideoCallView.Environment.swift */; };
 		C0D6CA252C1862C900D4709B /* AlertManager.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA242C1862C900D4709B /* AlertManager.Environment.swift */; };
 		C0D6CA272C18743E00D4709B /* CallDurationCounter.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA262C18743E00D4709B /* CallDurationCounter.Environment.swift */; };
-		C0D6CA3F2C19A8DA00D4709B /* SecureConversations.FileUploadView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA3E2C19A8DA00D4709B /* SecureConversations.FileUploadView.Environment.swift */; };
-		C0D6CA412C19A97100D4709B /* SecureConversations.FileUploadListView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA402C19A97100D4709B /* SecureConversations.FileUploadListView.Environment.swift */; };
-		C0D6CA3F2C19A8DA00D4709B /* SecureConversations.FileUploadView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA3E2C19A8DA00D4709B /* SecureConversations.FileUploadView.Environment.swift */; };
-		C0D6CA412C19A97100D4709B /* SecureConversations.FileUploadListView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA402C19A97100D4709B /* SecureConversations.FileUploadListView.Environment.swift */; };
-		C0D6CA432C19AA0900D4709B /* SecureConversations.MessageTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA422C19AA0900D4709B /* SecureConversations.MessageTextView.swift */; };
-		C0D6CA452C19AA8000D4709B /* SecureConversations.MessageTextView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA442C19AA8000D4709B /* SecureConversations.MessageTextView.Environment.swift */; };
 		C0D6CA292C199A4700D4709B /* UnreadMessageIndicatorView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA282C199A4700D4709B /* UnreadMessageIndicatorView.Environment.swift */; };
 		C0D6CA2B2C19A0E800D4709B /* OperatorChatMessageView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA2A2C19A0E800D4709B /* OperatorChatMessageView.Environment.swift */; };
 		C0D6CA2D2C19A19000D4709B /* ChoiceCardView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA2C2C19A19000D4709B /* ChoiceCardView.Environment.swift */; };
@@ -919,41 +908,26 @@
 		C0D6CA372C19A4EB00D4709B /* GvaPersistentButtonView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA362C19A4EB00D4709B /* GvaPersistentButtonView.Environment.swift */; };
 		C0D6CA392C19A57200D4709B /* ChatMessageEntryView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA382C19A57200D4709B /* ChatMessageEntryView.Environment.swift */; };
 		C0D6CA3B2C19A61900D4709B /* ChatMessageView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA3A2C19A61900D4709B /* ChatMessageView.Environment.swift */; };
-		C0D6CA272C18743E00D4709B /* CallDurationCounter.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA262C18743E00D4709B /* CallDurationCounter.Environment.swift */; };
-		C0D6CA472C19B35B00D4709B /* BubbleWindow.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA462C19B35B00D4709B /* BubbleWindow.Environment.swift */; };
-		C0D6CA0B2C18472400D4709B /* SecureConversations.Coordinator.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA0A2C18472400D4709B /* SecureConversations.Coordinator.Environment.swift */; };
-		C0D6CA0F2C184AB700D4709B /* SecureConversations.WelcomeViewModel.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA0E2C184AB700D4709B /* SecureConversations.WelcomeViewModel.Environment.swift */; };
-		C0D6CA112C184CCA00D4709B /* SecureConversations.WelcomeViewController.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA102C184CCA00D4709B /* SecureConversations.WelcomeViewController.Environment.swift */; };
-		C0D6CA152C184F1900D4709B /* SecureConversations.MessagesWithUnreadCountLoader.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA142C184F1900D4709B /* SecureConversations.MessagesWithUnreadCountLoader.Environment.swift */; };
-		C0D6CA172C18584E00D4709B /* SecureConversations.WelcomeView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA162C18584E00D4709B /* SecureConversations.WelcomeView.Environment.swift */; };
+		C0D6CA3D2C19A82100D4709B /* VideoCallViewController.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA3C2C19A82100D4709B /* VideoCallViewController.Environment.swift */; };
 		C0D6CA3F2C19A8DA00D4709B /* SecureConversations.FileUploadView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA3E2C19A8DA00D4709B /* SecureConversations.FileUploadView.Environment.swift */; };
 		C0D6CA412C19A97100D4709B /* SecureConversations.FileUploadListView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA402C19A97100D4709B /* SecureConversations.FileUploadListView.Environment.swift */; };
 		C0D6CA432C19AA0900D4709B /* SecureConversations.MessageTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA422C19AA0900D4709B /* SecureConversations.MessageTextView.swift */; };
 		C0D6CA452C19AA8000D4709B /* SecureConversations.MessageTextView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA442C19AA8000D4709B /* SecureConversations.MessageTextView.Environment.swift */; };
-		C0D6CA532C19BC0300D4709B /* FilePreviewView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA522C19BC0300D4709B /* FilePreviewView.Environment.swift */; };
-		C0D6CA552C19BCDB00D4709B /* SecureConversations.FilePreviewView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA542C19BCDB00D4709B /* SecureConversations.FilePreviewView.Environment.swift */; };
-		C0D6CA5B2C19BF1D00D4709B /* SecureConversations.ConfirmationViewModel.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA5A2C19BF1D00D4709B /* SecureConversations.ConfirmationViewModel.Environment.swift */; };
-		C0D6CA5F2C19C34F00D4709B /* ChatFileDownloadContentView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA5E2C19C34F00D4709B /* ChatFileDownloadContentView.Environment.swift */; };
+		C0D6CA472C19B35B00D4709B /* BubbleWindow.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA462C19B35B00D4709B /* BubbleWindow.Environment.swift */; };
 		C0D6CA492C19B64700D4709B /* ImageView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA482C19B64700D4709B /* ImageView.Environment.swift */; };
 		C0D6CA4B2C19B6D100D4709B /* GvaGalleryListView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA4A2C19B6D100D4709B /* GvaGalleryListView.Environment.swift */; };
 		C0D6CA4D2C19B86000D4709B /* OnHoldOverlayView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA4C2C19B86000D4709B /* OnHoldOverlayView.Environment.swift */; };
-		C0D6CA5D2C19C07200D4709B /* ConnectOperatorView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA5C2C19C07200D4709B /* ConnectOperatorView.Environment.swift */; };
-		C0D6CA5F2C19C34F00D4709B /* ChatFileDownloadContentView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA5E2C19C34F00D4709B /* ChatFileDownloadContentView.Environment.swift */; };
+		C0D6CA4F2C19B9A300D4709B /* GliaPresenter.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA4E2C19B9A300D4709B /* GliaPresenter.Environment.swift */; };
+		C0D6CA512C19BB5600D4709B /* SurveyViewController.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA502C19BB5600D4709B /* SurveyViewController.Environment.swift */; };
 		C0D6CA532C19BC0300D4709B /* FilePreviewView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA522C19BC0300D4709B /* FilePreviewView.Environment.swift */; };
 		C0D6CA552C19BCDB00D4709B /* SecureConversations.FilePreviewView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA542C19BCDB00D4709B /* SecureConversations.FilePreviewView.Environment.swift */; };
 		C0D6CA572C19BDCD00D4709B /* FilePickerViewModel.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA562C19BDCD00D4709B /* FilePickerViewModel.Environment.swift */; };
 		C0D6CA592C19BE9D00D4709B /* FilePickerController.Envrionment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA582C19BE9D00D4709B /* FilePickerController.Envrionment.swift */; };
-		C0D6CA4D2C19B86000D4709B /* OnHoldOverlayView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA4C2C19B86000D4709B /* OnHoldOverlayView.Environment.swift */; };
-		C0D6CA5D2C19C07200D4709B /* ConnectOperatorView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA5C2C19C07200D4709B /* ConnectOperatorView.Environment.swift */; };
-		C0D6CA612C19C4D900D4709B /* OnHoldOverlayVisualEffectView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA602C19C4D900D4709B /* OnHoldOverlayVisualEffectView.Environment.swift */; };
-		C0D6CA612C19C4D900D4709B /* OnHoldOverlayVisualEffectView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA602C19C4D900D4709B /* OnHoldOverlayVisualEffectView.Environment.swift */; };
-		C0D6CA4F2C19B9A300D4709B /* GliaPresenter.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA4E2C19B9A300D4709B /* GliaPresenter.Environment.swift */; };
-		C0D6CA512C19BB5600D4709B /* SurveyViewController.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA502C19BB5600D4709B /* SurveyViewController.Environment.swift */; };
-		C0D6CA532C19BC0300D4709B /* FilePreviewView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA522C19BC0300D4709B /* FilePreviewView.Environment.swift */; };
-		C0D6CA632C19C59100D4709B /* Glia.OpaqueAuthentication.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA622C19C59100D4709B /* Glia.OpaqueAuthentication.Environment.swift */; };
-		C0D6CA572C19BDCD00D4709B /* FilePickerViewModel.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA562C19BDCD00D4709B /* FilePickerViewModel.Environment.swift */; };
-		C0D6CA592C19BE9D00D4709B /* FilePickerController.Envrionment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA582C19BE9D00D4709B /* FilePickerController.Envrionment.swift */; };
 		C0D6CA5B2C19BF1D00D4709B /* SecureConversations.ConfirmationViewModel.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA5A2C19BF1D00D4709B /* SecureConversations.ConfirmationViewModel.Environment.swift */; };
+		C0D6CA5D2C19C07200D4709B /* ConnectOperatorView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA5C2C19C07200D4709B /* ConnectOperatorView.Environment.swift */; };
+		C0D6CA5F2C19C34F00D4709B /* ChatFileDownloadContentView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA5E2C19C34F00D4709B /* ChatFileDownloadContentView.Environment.swift */; };
+		C0D6CA612C19C4D900D4709B /* OnHoldOverlayVisualEffectView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA602C19C4D900D4709B /* OnHoldOverlayVisualEffectView.Environment.swift */; };
+		C0D6CA632C19C59100D4709B /* Glia.OpaqueAuthentication.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA622C19C59100D4709B /* Glia.OpaqueAuthentication.Environment.swift */; };
 		C0E948042AB1D5D200890026 /* ActionButtonSwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E948032AB1D5D200890026 /* ActionButtonSwiftUI.swift */; };
 		C0E948062AB1D64700890026 /* HeaderButtonSwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E948052AB1D64700890026 /* HeaderButtonSwiftUI.swift */; };
 		C0E948092AB1D6AB00890026 /* HeaderSwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E948082AB1D6AB00890026 /* HeaderSwiftUI.swift */; };
@@ -961,6 +935,17 @@
 		C0EC58CE2B02775100E78C70 /* SnackBar+View+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EC58CD2B02775100E78C70 /* SnackBar+View+Mock.swift */; };
 		C0EC58D02B028FB100E78C70 /* SnackBarVoiceOverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EC58CF2B028FB100E78C70 /* SnackBarVoiceOverTests.swift */; };
 		C0EC58D22B02909500E78C70 /* SnackBarDynamicTypeFontTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EC58D12B02909500E78C70 /* SnackBarDynamicTypeFontTests.swift */; };
+		C0F3DE372C69F51D00DE6D7B /* EntryWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F3DE362C69F51D00DE6D7B /* EntryWidget.swift */; };
+		C0F3DE392C69FC2100DE6D7B /* EntryWidget.Presentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F3DE382C69FC2100DE6D7B /* EntryWidget.Presentation.swift */; };
+		C0F3DE3B2C6E0DD900DE6D7B /* EntryWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F3DE3A2C6E0DD900DE6D7B /* EntryWidgetView.swift */; };
+		C0F3DE3D2C6E170600DE6D7B /* EntryWidgetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F3DE3C2C6E170600DE6D7B /* EntryWidgetViewModel.swift */; };
+		C0F3DE3F2C6E176A00DE6D7B /* EntryWidget.Channel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F3DE3E2C6E176A00DE6D7B /* EntryWidget.Channel.swift */; };
+		C0F3DE412C6E36C900DE6D7B /* View+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F3DE402C6E36C900DE6D7B /* View+Extensions.swift */; };
+		C0F3DE432C6E3D2400DE6D7B /* Theme.EntryWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F3DE422C6E3D2400DE6D7B /* Theme.EntryWidget.swift */; };
+		C0F3DE452C6E3D7C00DE6D7B /* EntryWidgetStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F3DE442C6E3D7C00DE6D7B /* EntryWidgetStyle.swift */; };
+		C0F3DE482C6E468400DE6D7B /* PoweredByView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F3DE472C6E468400DE6D7B /* PoweredByView.swift */; };
+		C0F7EA382CA1D6D40038019C /* CustomPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F7EA372CA1D6D40038019C /* CustomPresentationController.swift */; };
+		C0F7EA3A2CA1D7050038019C /* EntryWidget.SizeConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F7EA392CA1D7050038019C /* EntryWidget.SizeConstraints.swift */; };
 		C4119E06268F41D1004DFEFB /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C4119E05268F41D1004DFEFB /* Main.storyboard */; };
 		C42463742673ABE10082C135 /* ScreenShareHandler.Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42463732673ABE10082C135 /* ScreenShareHandler.Interface.swift */; };
 		C43C12F92694B14900C37E1B /* GliaPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C43C12F82694B14900C37E1B /* GliaPresenter.swift */; };
@@ -1921,29 +1906,15 @@
 		C0D6C9F62C0D2F6D00D4709B /* AlertPlacement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertPlacement.swift; sourceTree = "<group>"; };
 		C0D6C9FA2C0D2F9A00D4709B /* AlertInputType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertInputType.swift; sourceTree = "<group>"; };
 		C0D6C9FF2C106A1F00D4709B /* AlertManager.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertManager.Failing.swift; sourceTree = "<group>"; };
-		C0D6CA0A2C18472400D4709B /* SecureConversations.Coordinator.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.Coordinator.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA0E2C184AB700D4709B /* SecureConversations.WelcomeViewModel.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.WelcomeViewModel.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA102C184CCA00D4709B /* SecureConversations.WelcomeViewController.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.WelcomeViewController.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA142C184F1900D4709B /* SecureConversations.MessagesWithUnreadCountLoader.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.MessagesWithUnreadCountLoader.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA162C18584E00D4709B /* SecureConversations.WelcomeView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.WelcomeView.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA3E2C19A8DA00D4709B /* SecureConversations.FileUploadView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FileUploadView.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA402C19A97100D4709B /* SecureConversations.FileUploadListView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FileUploadListView.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA422C19AA0900D4709B /* SecureConversations.MessageTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.MessageTextView.swift; sourceTree = "<group>"; };
-		C0D6CA442C19AA8000D4709B /* SecureConversations.MessageTextView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.MessageTextView.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA522C19BC0300D4709B /* FilePreviewView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewView.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA542C19BCDB00D4709B /* SecureConversations.FilePreviewView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FilePreviewView.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA5A2C19BF1D00D4709B /* SecureConversations.ConfirmationViewModel.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.ConfirmationViewModel.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA5E2C19C34F00D4709B /* ChatFileDownloadContentView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFileDownloadContentView.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA182C18590400D4709B /* UserImageView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserImageView.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA042C172F8F00D4709B /* CallCoordinator.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallCoordinator.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA062C1843A900D4709B /* EngagementViewController.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngagementViewController.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA082C18451800D4709B /* CallViewController.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallViewController.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA1A2C185BDE00D4709B /* EngagementView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngagementView.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA1C2C185D2900D4709B /* CallView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallView.Environment.swift; sourceTree = "<group>"; };
+		C0D6CA0A2C18472400D4709B /* SecureConversations.Coordinator.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.Coordinator.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA0C2C1848E700D4709B /* GliaViewController.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GliaViewController.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA0E2C184AB700D4709B /* SecureConversations.WelcomeViewModel.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.WelcomeViewModel.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA102C184CCA00D4709B /* SecureConversations.WelcomeViewController.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.WelcomeViewController.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA122C184DFF00D4709B /* FileDownloader.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDownloader.Environment.swift; sourceTree = "<group>"; };
+		C0D6CA142C184F1900D4709B /* SecureConversations.MessagesWithUnreadCountLoader.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.MessagesWithUnreadCountLoader.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA162C18584E00D4709B /* SecureConversations.WelcomeView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.WelcomeView.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA182C18590400D4709B /* UserImageView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserImageView.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA1A2C185BDE00D4709B /* EngagementView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngagementView.Environment.swift; sourceTree = "<group>"; };
@@ -1953,12 +1924,6 @@
 		C0D6CA222C1861F400D4709B /* VideoCallView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCallView.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA242C1862C900D4709B /* AlertManager.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertManager.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA262C18743E00D4709B /* CallDurationCounter.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallDurationCounter.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA0E2C184AB700D4709B /* SecureConversations.WelcomeViewModel.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.WelcomeViewModel.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA102C184CCA00D4709B /* SecureConversations.WelcomeViewController.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.WelcomeViewController.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA122C184DFF00D4709B /* FileDownloader.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDownloader.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA222C1861F400D4709B /* VideoCallView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCallView.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA3C2C19A82100D4709B /* VideoCallViewController.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCallViewController.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA1E2C185E3500D4709B /* BubbleView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BubbleView.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA282C199A4700D4709B /* UnreadMessageIndicatorView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnreadMessageIndicatorView.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA2A2C19A0E800D4709B /* OperatorChatMessageView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatorChatMessageView.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA2C2C19A19000D4709B /* ChoiceCardView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChoiceCardView.Environment.swift; sourceTree = "<group>"; };
@@ -1969,31 +1934,25 @@
 		C0D6CA362C19A4EB00D4709B /* GvaPersistentButtonView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GvaPersistentButtonView.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA382C19A57200D4709B /* ChatMessageEntryView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageEntryView.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA3A2C19A61900D4709B /* ChatMessageView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageView.Environment.swift; sourceTree = "<group>"; };
+		C0D6CA3C2C19A82100D4709B /* VideoCallViewController.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCallViewController.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA3E2C19A8DA00D4709B /* SecureConversations.FileUploadView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FileUploadView.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA402C19A97100D4709B /* SecureConversations.FileUploadListView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FileUploadListView.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA422C19AA0900D4709B /* SecureConversations.MessageTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.MessageTextView.swift; sourceTree = "<group>"; };
 		C0D6CA442C19AA8000D4709B /* SecureConversations.MessageTextView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.MessageTextView.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA3E2C19A8DA00D4709B /* SecureConversations.FileUploadView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FileUploadView.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA402C19A97100D4709B /* SecureConversations.FileUploadListView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FileUploadListView.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA262C18743E00D4709B /* CallDurationCounter.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallDurationCounter.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA462C19B35B00D4709B /* BubbleWindow.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BubbleWindow.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA482C19B64700D4709B /* ImageView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageView.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA4A2C19B6D100D4709B /* GvaGalleryListView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GvaGalleryListView.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA5C2C19C07200D4709B /* ConnectOperatorView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectOperatorView.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA522C19BC0300D4709B /* FilePreviewView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewView.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA562C19BDCD00D4709B /* FilePickerViewModel.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePickerViewModel.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA582C19BE9D00D4709B /* FilePickerController.Envrionment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePickerController.Envrionment.swift; sourceTree = "<group>"; };
-		C0D6CA5A2C19BF1D00D4709B /* SecureConversations.ConfirmationViewModel.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.ConfirmationViewModel.Environment.swift; sourceTree = "<group>"; };
+		C0D6CA4C2C19B86000D4709B /* OnHoldOverlayView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnHoldOverlayView.Environment.swift; sourceTree = "<group>"; };
+		C0D6CA4E2C19B9A300D4709B /* GliaPresenter.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GliaPresenter.Environment.swift; sourceTree = "<group>"; };
+		C0D6CA502C19BB5600D4709B /* SurveyViewController.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyViewController.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA522C19BC0300D4709B /* FilePreviewView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewView.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA542C19BCDB00D4709B /* SecureConversations.FilePreviewView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FilePreviewView.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA562C19BDCD00D4709B /* FilePickerViewModel.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePickerViewModel.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA582C19BE9D00D4709B /* FilePickerController.Envrionment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePickerController.Envrionment.swift; sourceTree = "<group>"; };
-		C0D6CA4C2C19B86000D4709B /* OnHoldOverlayView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnHoldOverlayView.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA4C2C19B86000D4709B /* OnHoldOverlayView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnHoldOverlayView.Environment.swift; sourceTree = "<group>"; };
+		C0D6CA5A2C19BF1D00D4709B /* SecureConversations.ConfirmationViewModel.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.ConfirmationViewModel.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA5C2C19C07200D4709B /* ConnectOperatorView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectOperatorView.Environment.swift; sourceTree = "<group>"; };
+		C0D6CA5E2C19C34F00D4709B /* ChatFileDownloadContentView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFileDownloadContentView.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA602C19C4D900D4709B /* OnHoldOverlayVisualEffectView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnHoldOverlayVisualEffectView.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA4E2C19B9A300D4709B /* GliaPresenter.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GliaPresenter.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA502C19BB5600D4709B /* SurveyViewController.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyViewController.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA622C19C59100D4709B /* Glia.OpaqueAuthentication.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Glia.OpaqueAuthentication.Environment.swift; sourceTree = "<group>"; };
 		C0E948032AB1D5D200890026 /* ActionButtonSwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionButtonSwiftUI.swift; sourceTree = "<group>"; };
 		C0E948052AB1D64700890026 /* HeaderButtonSwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderButtonSwiftUI.swift; sourceTree = "<group>"; };
@@ -2002,6 +1961,17 @@
 		C0EC58CD2B02775100E78C70 /* SnackBar+View+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SnackBar+View+Mock.swift"; sourceTree = "<group>"; };
 		C0EC58CF2B028FB100E78C70 /* SnackBarVoiceOverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnackBarVoiceOverTests.swift; sourceTree = "<group>"; };
 		C0EC58D12B02909500E78C70 /* SnackBarDynamicTypeFontTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnackBarDynamicTypeFontTests.swift; sourceTree = "<group>"; };
+		C0F3DE362C69F51D00DE6D7B /* EntryWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryWidget.swift; sourceTree = "<group>"; };
+		C0F3DE382C69FC2100DE6D7B /* EntryWidget.Presentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryWidget.Presentation.swift; sourceTree = "<group>"; };
+		C0F3DE3A2C6E0DD900DE6D7B /* EntryWidgetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryWidgetView.swift; sourceTree = "<group>"; };
+		C0F3DE3C2C6E170600DE6D7B /* EntryWidgetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryWidgetViewModel.swift; sourceTree = "<group>"; };
+		C0F3DE3E2C6E176A00DE6D7B /* EntryWidget.Channel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryWidget.Channel.swift; sourceTree = "<group>"; };
+		C0F3DE402C6E36C900DE6D7B /* View+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extensions.swift"; sourceTree = "<group>"; };
+		C0F3DE422C6E3D2400DE6D7B /* Theme.EntryWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.EntryWidget.swift; sourceTree = "<group>"; };
+		C0F3DE442C6E3D7C00DE6D7B /* EntryWidgetStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryWidgetStyle.swift; sourceTree = "<group>"; };
+		C0F3DE472C6E468400DE6D7B /* PoweredByView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoweredByView.swift; sourceTree = "<group>"; };
+		C0F7EA372CA1D6D40038019C /* CustomPresentationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPresentationController.swift; sourceTree = "<group>"; };
+		C0F7EA392CA1D7050038019C /* EntryWidget.SizeConstraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryWidget.SizeConstraints.swift; sourceTree = "<group>"; };
 		C4119E05268F41D1004DFEFB /* Main.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		C42463732673ABE10082C135 /* ScreenShareHandler.Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenShareHandler.Interface.swift; sourceTree = "<group>"; };
 		C43C12F82694B14900C37E1B /* GliaPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GliaPresenter.swift; sourceTree = "<group>"; };
@@ -2696,6 +2666,7 @@
 				75FF151527F4E11000FE7BE2 /* Survey */,
 				C09047052B7E1574003C437C /* Snackbar */,
 				1A60AF7925656E0500E53F53 /* Theme.swift */,
+				C0F3DE422C6E3D2400DE6D7B /* Theme.EntryWidget.swift */,
 				C09047032B7E153F003C437C /* Theme.RemoteConfig.swift */,
 				9A19926D27D3BB7800161AAE /* Theme.Mock.swift */,
 				1A0C9A6625C16DC400815406 /* Theme+Chat.swift */,
@@ -2728,6 +2699,7 @@
 		1A60AFC12566857200E53F53 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				C0F3DE352C69F4A700DE6D7B /* EntryWidget */,
 				C0D6C9E72C09C70B00D4709B /* AlertManager */,
 				84C24CF62B8353840089A388 /* ProcessInfoHandling */,
 				84520BD92B0FA14700F97617 /* WebViewController */,
@@ -4559,6 +4531,7 @@
 			children = (
 				C06152D42AB1BC1300063BF8 /* Font+Extensions.swift */,
 				AF18F1D42ABD954500121627 /* View+Accessibility.swift */,
+				C0F3DE402C6E36C900DE6D7B /* View+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -4952,6 +4925,7 @@
 		C0E948012AB1D5B100890026 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				C0F3DE462C6E466F00DE6D7B /* PoweredBy */,
 				75D987F22AF29EF50016A702 /* SnackBarView */,
 				C0E948072AB1D69C00890026 /* Header */,
 				C0E948022AB1D5BC00890026 /* Buttons */,
@@ -4975,6 +4949,29 @@
 				C0E948082AB1D6AB00890026 /* HeaderSwiftUI.swift */,
 			);
 			path = Header;
+			sourceTree = "<group>";
+		};
+		C0F3DE352C69F4A700DE6D7B /* EntryWidget */ = {
+			isa = PBXGroup;
+			children = (
+				C0F3DE362C69F51D00DE6D7B /* EntryWidget.swift */,
+				C0F7EA392CA1D7050038019C /* EntryWidget.SizeConstraints.swift */,
+				C0F3DE382C69FC2100DE6D7B /* EntryWidget.Presentation.swift */,
+				C0F3DE3E2C6E176A00DE6D7B /* EntryWidget.Channel.swift */,
+				C0F3DE3A2C6E0DD900DE6D7B /* EntryWidgetView.swift */,
+				C0F3DE3C2C6E170600DE6D7B /* EntryWidgetViewModel.swift */,
+				C0F3DE442C6E3D7C00DE6D7B /* EntryWidgetStyle.swift */,
+				C0F7EA372CA1D6D40038019C /* CustomPresentationController.swift */,
+			);
+			path = EntryWidget;
+			sourceTree = "<group>";
+		};
+		C0F3DE462C6E466F00DE6D7B /* PoweredBy */ = {
+			isa = PBXGroup;
+			children = (
+				C0F3DE472C6E468400DE6D7B /* PoweredByView.swift */,
+			);
+			path = PoweredBy;
 			sourceTree = "<group>";
 		};
 		C42463722673ABCD0082C135 /* Screensharing */ = {
@@ -5572,6 +5569,7 @@
 				1A0C9A8C25C4092400815406 /* CallButtonStyle.swift in Sources */,
 				C0D6CA412C19A97100D4709B /* SecureConversations.FileUploadListView.Environment.swift in Sources */,
 				C09046CA2B7E05F7003C437C /* AttachmentSourceListStyle.Mock.swift in Sources */,
+				C0F3DE412C6E36C900DE6D7B /* View+Extensions.swift in Sources */,
 				1A6075E7258220E300569B0E /* UserImageStyle.swift in Sources */,
 				1ABD6C5D25B59D1C00D56EFA /* BubbleWindow.swift in Sources */,
 				75940964298D3889008B173A /* MessageRenderer.Web.swift in Sources */,
@@ -5678,6 +5676,7 @@
 				C0D6CA2B2C19A0E800D4709B /* OperatorChatMessageView.Environment.swift in Sources */,
 				3197F7B129E958F4008EE9F7 /* SystemMessageStyle.swift in Sources */,
 				3100D92C296E946600DEC9CE /* SecureConversations.ConfirmationViewController.swift in Sources */,
+				C0F3DE3B2C6E0DD900DE6D7B /* EntryWidgetView.swift in Sources */,
 				C090474C2B7E210C003C437C /* FileUploadStyle.Equatable.swift in Sources */,
 				C09047402B7E1FBC003C437C /* MessageCenterFileUploadStyle.swift in Sources */,
 				9A8130BB27D7A41000220BBD /* FileUpload.Environment.Interface.swift in Sources */,
@@ -5687,6 +5686,7 @@
 				C090477C2B7E27F1003C437C /* EngagementStyle.Equatable.swift in Sources */,
 				8491AF132A7ACC5400CC3E72 /* Theme.OperatorChatMessageStyle.swift in Sources */,
 				845E2F93283FB6D000C04D56 /* Theme.Survey.Accessibility.swift in Sources */,
+				C0F3DE452C6E3D7C00DE6D7B /* EntryWidgetStyle.swift in Sources */,
 				75940959298D386F008B173A /* UIStackView.Extensions.swift in Sources */,
 				C07F627D2AC2F31F003EFC97 /* ScreenSharingViewModel.swift in Sources */,
 				1A0C9A9125C41AB900815406 /* CallButtonBar.swift in Sources */,
@@ -5703,6 +5703,7 @@
 				C0D6CA232C1861F400D4709B /* VideoCallView.Environment.swift in Sources */,
 				C09046D02B7E074B003C437C /* OperatorTypingIndicatorStyle.RemoteConfig.swift in Sources */,
 				9A186A3B27F5E6B50055886D /* ChatFileContentStyle.Accessibility.swift in Sources */,
+				C0F3DE3D2C6E170600DE6D7B /* EntryWidgetViewModel.swift in Sources */,
 				C09046FA2B7E10C7003C437C /* Theme.ChoiceCardStyle.Options.swift in Sources */,
 				7594091529891C5C008B173A /* Environment.swift in Sources */,
 				9A3E1D9927B6D0DB005634EB /* FoundationBased.Live.swift in Sources */,
@@ -5747,6 +5748,7 @@
 				C0D6CA632C19C59100D4709B /* Glia.OpaqueAuthentication.Environment.swift in Sources */,
 				7594095A298D386F008B173A /* NSLayoutConstraint+Extensions.swift in Sources */,
 				C07F62462ABC322B003EFC97 /* OrientationManager.Mock.swift in Sources */,
+				C0F7EA3A2CA1D7050038019C /* EntryWidget.SizeConstraints.swift in Sources */,
 				C0D2F06829A4B71C00803B47 /* VideoCallViewModel.Mock.swift in Sources */,
 				AFEF5C6F29928DB0005C3D8D /* SecureConversations.FileUploadView.swift in Sources */,
 				C0D6CA092C18451800D4709B /* CallViewController.Environment.swift in Sources */,
@@ -5764,6 +5766,7 @@
 				84265E64298D7B2900D65842 /* ScreenSharingViewStyle.Accessibility.swift in Sources */,
 				756B8B202996EFA2001D2BB2 /* Header.Props.swift in Sources */,
 				AFA2FDFC289082F500428E6D /* OnHoldOverlayStyle.Mock.swift in Sources */,
+				C0F3DE432C6E3D2400DE6D7B /* Theme.EntryWidget.swift in Sources */,
 				C090476E2B7E2546003C437C /* UnreadMessageDividerStyle.Equatable.swift in Sources */,
 				C09047602B7E2320003C437C /* ChatFileDownloadStyle.RemoteConfig.swift in Sources */,
 				1A0C142925B84E5500B00695 /* EngagementViewController.swift in Sources */,
@@ -5801,6 +5804,7 @@
 				75B7BD792A39D12B0060794D /* Button.swift in Sources */,
 				9A19926C27D3BA8700161AAE /* ViewFactory.Mock.swift in Sources */,
 				C09047822B7E29F8003C437C /* CallButtonStyle.StateStyle.RemoteConfig.swift in Sources */,
+				C0F3DE372C69F51D00DE6D7B /* EntryWidget.swift in Sources */,
 				C0D6CA3F2C19A8DA00D4709B /* SecureConversations.FileUploadView.Environment.swift in Sources */,
 				1A60B02D256BF7FF00E53F53 /* OperatorChatMessageView.swift in Sources */,
 				C43C12F92694B14900C37E1B /* GliaPresenter.swift in Sources */,
@@ -5903,6 +5907,7 @@
 				C0D6CA392C19A57200D4709B /* ChatMessageEntryView.Environment.swift in Sources */,
 				C0D6CA372C19A4EB00D4709B /* GvaPersistentButtonView.Environment.swift in Sources */,
 				6EEAD84E2701A8C10074C191 /* ChoiceCardOptionStateStyle.swift in Sources */,
+				C0F7EA382CA1D6D40038019C /* CustomPresentationController.swift in Sources */,
 				C090472A2B7E1C4C003C437C /* GvaPersistentButtonStyle.RemoteConfig.swift in Sources */,
 				C090467A2B7D0183003C437C /* WelcomeStyle.TitleStyle.RemoteConfig.swift in Sources */,
 				84520BE92B176C6500F97617 /* ChatViewModel+LiveObservation.swift in Sources */,
@@ -6051,6 +6056,7 @@
 				75940985298D38C2008B173A /* VisitorCodeCoordinator+DelegateEvent.swift in Sources */,
 				1A0C9AC225C9400000815406 /* CallDurationCounter.swift in Sources */,
 				9A19926527D3BA3A00161AAE /* UIKitBased.Mock.swift in Sources */,
+				C0F3DE482C6E468400DE6D7B /* PoweredByView.swift in Sources */,
 				C0D2F06B29A4DAA000803B47 /* VideoCallViewMock.swift in Sources */,
 				1AFB1E6225F7AE1300CA460D /* ChatEngagementFile.swift in Sources */,
 				84681A9D2A669DB500DD7406 /* QuickReplyButtonCell.swift in Sources */,
@@ -6150,6 +6156,7 @@
 				75940981298D38C2008B173A /* VisitorCodeView+NumberView.swift in Sources */,
 				7529F2B427E1D503004D3581 /* Survey.swift in Sources */,
 				84681AA12A66B9F100DD7406 /* SelfSizingCollectionView.swift in Sources */,
+				C0F3DE392C69FC2100DE6D7B /* EntryWidget.Presentation.swift in Sources */,
 				1A5F494B25CA86CA003E3678 /* Call.swift in Sources */,
 				8491AF1D2A7D01BF00CC3E72 /* Theme.ChatMessageStyle.swift in Sources */,
 				84265E65298D7B2900D65842 /* ScreenSharingView.swift in Sources */,
@@ -6256,6 +6263,7 @@
 				C0D2F07329A4DC2000803B47 /* CallStyle.Mock.swift in Sources */,
 				846A5C3629CB3E270049B29F /* ScreenShareHandler.Mock.swift in Sources */,
 				C0D2F03B299149D600803B47 /* VideoCallViewModel.swift in Sources */,
+				C0F3DE3F2C6E176A00DE6D7B /* EntryWidget.Channel.swift in Sources */,
 				C0D2F02E2991221900803B47 /* VideoCallCoordinator.DelegateEvent.swift in Sources */,
 				1A2DA73125EFA77E00032611 /* FileUploader.swift in Sources */,
 				84520BE32B14B97A00F97617 /* Theme+WebView.swift in Sources */,
@@ -6642,7 +6650,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -6700,7 +6708,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -6729,6 +6737,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = GliaWidgets/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -6762,6 +6771,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = GliaWidgets/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -6783,6 +6793,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = GliaWidgetsTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -6802,6 +6813,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = GliaWidgetsTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -6830,6 +6842,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = TestingApp/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Glia Widgets";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -6861,6 +6874,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = TestingApp/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Glia Widgets";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -6884,7 +6898,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.glia.TestingAppTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -6903,7 +6917,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.glia.TestingAppTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -119,6 +119,9 @@ public class Glia {
 
     private(set) var configuration: Configuration?
 
+    // Interface for entry widget
+    public private(set) var entryWidget: EntryWidget
+
     init(environment: Environment) {
         self.environment = environment
         self.theme = Theme()
@@ -157,6 +160,7 @@ public class Glia {
                 viewFactory: viewFactory
             )
         )
+        entryWidget = .init(theme: theme)
     }
 
     /// Setup SDK using specific engagement configuration without starting the engagement.

--- a/GliaWidgets/Sources/EntryWidget/CustomPresentationController.swift
+++ b/GliaWidgets/Sources/EntryWidget/CustomPresentationController.swift
@@ -1,0 +1,82 @@
+import UIKit
+
+final class CustomPresentationController: UIPresentationController {
+    private let height: CGFloat
+
+    private let dimmingView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor.black.withAlphaComponent(0.13)
+        return view
+    }()
+
+    init(
+        presentedViewController: UIViewController,
+        presenting presentingViewController: UIViewController?,
+        height: CGFloat
+    ) {
+        self.height = height
+        super.init(
+            presentedViewController: presentedViewController,
+            presenting: presentingViewController
+        )
+        let tapGesture = UITapGestureRecognizer(
+            target: self,
+            action: #selector(dimmingViewTapped)
+        )
+        dimmingView.addGestureRecognizer(tapGesture)
+    }
+
+    @objc private func dimmingViewTapped() {
+        presentedViewController.dismiss(animated: true)
+    }
+
+    override var frameOfPresentedViewInContainerView: CGRect {
+        guard let containerView = containerView else { return .zero }
+
+        let topSafeAreaInset = containerView.safeAreaInsets.top
+        let yOffset = containerView.bounds.height - height - (topSafeAreaInset / 2)
+
+        return CGRect(
+            x: 0,
+            y: yOffset,
+            width: containerView.bounds.width,
+            height: height + (topSafeAreaInset / 2)
+        )
+    }
+
+    override func containerViewWillLayoutSubviews() {
+        super.containerViewWillLayoutSubviews()
+        presentedView?.layer.cornerRadius = 24
+        presentedView?.layer.masksToBounds = true
+        presentedView?.frame = frameOfPresentedViewInContainerView
+    }
+
+    override func presentationTransitionWillBegin() {
+        super.presentationTransitionWillBegin()
+
+        guard let containerView = containerView else { return }
+        dimmingView.frame = containerView.bounds
+        containerView.insertSubview(dimmingView, at: 0)
+        dimmingView.alpha = 0
+        presentedViewController.transitionCoordinator?.animate(
+            alongsideTransition: { _ in
+                self.dimmingView.alpha = 1
+            }
+        )
+    }
+
+    override func dismissalTransitionWillBegin() {
+        super.dismissalTransitionWillBegin()
+        presentedViewController.transitionCoordinator?.animate(
+            alongsideTransition: { _ in
+                self.dimmingView.alpha = 0
+            }
+        )
+    }
+
+    override func dismissalTransitionDidEnd(_ completed: Bool) {
+        if completed {
+            dimmingView.removeFromSuperview()
+        }
+    }
+}

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.Channel.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.Channel.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+extension EntryWidget {
+    enum Channel {
+        case chat
+        case audio
+        case video
+        case secureMessaging
+
+        var headline: String {
+            switch self {
+            case .chat:
+                return "Live Chat"
+            case .audio:
+                return "Audio"
+            case .video:
+                return "Video"
+            case .secureMessaging:
+                return "SecureMessaging"
+            }
+        }
+
+        var subheadline: String {
+            switch self {
+            case .chat:
+                return "For the texter in all of us"
+            case .audio:
+                return "Speak through your phone"
+            case .video:
+                return "You'll see us, but we won't see you"
+            case .secureMessaging:
+                return "Start a conversation, we'll get back to you"
+            }
+        }
+
+        var image: UIImage {
+            switch self {
+            case .chat:
+                return Asset.callChat.image
+            case .audio:
+                return Asset.callMuteInactive.image
+            case .video:
+                return Asset.callVideoActive.image
+            case .secureMessaging:
+                return Asset.mcEnvelope.image
+            }
+        }
+    }
+}

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.Presentation.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.Presentation.swift
@@ -1,0 +1,8 @@
+import UIKit
+
+extension EntryWidget {
+    public enum Presentation {
+        case sheet(UIViewController)
+        case embedded(UIView)
+    }
+}

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.SizeConstraints.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.SizeConstraints.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension EntryWidget {
+    struct SizeConstraints {
+        let singleCellHeight: CGFloat
+        let singleCellIconSize: CGFloat
+        let poweredByContainerHeight: CGFloat
+        let sheetHeaderHeight: CGFloat
+        let sheetHeaderDraggerWidth: CGFloat
+        let sheetHeaderDraggerHeight: CGFloat
+        let dividerHeight: CGFloat
+    }
+}

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
@@ -1,0 +1,167 @@
+import Foundation
+import UIKit
+import SwiftUI
+
+public final class EntryWidget: NSObject {
+    private var hostedViewController: UIViewController?
+    private var embeddedView: UIView?
+    private var queueIds: [String] = []
+
+    // Channels will become dynamic in the subsequent PRs
+    private var channels: [Channel] = [.chat, .audio, .video, .secureMessaging]
+    private let theme: Theme
+    private let sizeConstraints: SizeConstraints = .init(
+        singleCellHeight: 72,
+        singleCellIconSize: 24,
+        poweredByContainerHeight: 40,
+        sheetHeaderHeight: 36,
+        sheetHeaderDraggerWidth: 32,
+        sheetHeaderDraggerHeight: 4,
+        dividerHeight: 1
+    )
+
+    init(theme: Theme) {
+        self.theme = theme
+    }
+
+    public func show(by presentation: EntryWidget.Presentation) {
+        switch presentation {
+        case let .sheet(parentViewController):
+            showSheet(in: parentViewController)
+        case let .embedded(parentView):
+            showView(in: parentView)
+        }
+    }
+
+    func hide() {
+        hostedViewController?.dismiss(animated: true, completion: nil)
+        hostedViewController = nil
+        embeddedView?.removeFromSuperview()
+        embeddedView = nil
+    }
+
+    func createEntryWidgetView(
+        queueIds: [String],
+        channels: [Channel] = [.chat, .audio, .video]
+    ) {
+        self.queueIds = queueIds
+        self.channels = channels
+    }
+}
+
+private extension EntryWidget {
+    func showView(in parentView: UIView) {
+        parentView.subviews.forEach { $0.removeFromSuperview() }
+        let model = makeViewModel(
+            channels: channels,
+            selection: { channel in
+                // Logic for handling this callback will be handled later - MOB-3473
+                print(channel.headline)
+            }
+        )
+        let view = makeView(model: model)
+        let hostingController = UIHostingController(rootView: view)
+
+        parentView.addSubview(hostingController.view)
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            hostingController.view.widthAnchor.constraint(equalTo: parentView.widthAnchor),
+            hostingController.view.heightAnchor.constraint(equalTo: parentView.heightAnchor),
+            hostingController.view.centerXAnchor.constraint(equalTo: parentView.centerXAnchor),
+            hostingController.view.centerYAnchor.constraint(equalTo: parentView.centerYAnchor)
+        ])
+
+        embeddedView = hostingController.view
+    }
+
+    func showSheet(in parentViewController: UIViewController) {
+        let model = makeViewModel(
+            channels: channels,
+            selection: { channel in
+                print(channel.headline)
+            }
+        )
+        let view = makeView(model: model)
+        let hostingController = UIHostingController(rootView: view)
+
+        hostingController.view.backgroundColor = UIColor.white
+        
+        // Due to the more modern sheet presenting approach being
+        // available starting from iOS 16, we need to handle cases
+        // where the visitor has either iOS 14 or 15 installed. For
+        // such visitors, we fall back on CustomPresentationController
+        //
+        if #available(iOS 16.0, *) {
+            guard let sheet = hostingController.sheetPresentationController else { return }
+            let smallDetent: UISheetPresentationController.Detent = .custom { _ in
+                return self.calculateHeight(
+                    channels: self.channels,
+                    showPoweredBy: self.theme.showsPoweredBy,
+                    sizeConstraints: self.sizeConstraints
+                )
+            }
+            sheet.detents = [smallDetent]
+            sheet.prefersScrollingExpandsWhenScrolledToEdge = true
+            sheet.preferredCornerRadius = 24
+        } else {
+            hostingController.modalPresentationStyle = .custom
+            hostingController.transitioningDelegate = self
+        }
+
+        parentViewController.present(hostingController, animated: true, completion: nil)
+        hostedViewController = hostingController
+    }
+
+    func makeView(model: EntryWidgetView.Model) -> EntryWidgetView {
+        .init(model: model)
+    }
+
+    func makeViewModel(
+        channels: [Channel],
+        selection: @escaping (Channel) -> Void
+    ) -> EntryWidgetView.Model {
+        .init(
+            style: theme.entryWidgetStyle,
+            sizeConstrainsts: sizeConstraints,
+            channels: channels,
+            channelSelected: selection
+        )
+    }
+
+    func calculateHeight(
+        channels: [Channel],
+        showPoweredBy: Bool,
+        sizeConstraints: SizeConstraints
+    ) -> CGFloat {
+        var appliedHeight: CGFloat = 0
+
+        appliedHeight += sizeConstraints.sheetHeaderHeight
+        channels.forEach { _ in
+            appliedHeight += sizeConstraints.singleCellHeight
+            appliedHeight += sizeConstraints.dividerHeight
+        }
+        appliedHeight += sizeConstraints.poweredByContainerHeight
+
+        return appliedHeight
+    }
+}
+
+extension EntryWidget: UIViewControllerTransitioningDelegate {
+    public func presentationController(
+        forPresented presented: UIViewController,
+        presenting: UIViewController?,
+        source: UIViewController
+    ) -> UIPresentationController? {
+        let height = calculateHeight(
+            channels: channels,
+            showPoweredBy: theme.showsPoweredBy,
+            sizeConstraints: sizeConstraints
+        )
+        return CustomPresentationController(
+            presentedViewController: presented,
+            presenting: presenting,
+            height: height
+        )
+    }
+}

--- a/GliaWidgets/Sources/EntryWidget/EntryWidgetStyle.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidgetStyle.swift
@@ -1,0 +1,71 @@
+import UIKit
+
+public struct EntryWidgetStyle {
+    /// Engagement channel style.
+    public var channel: EntryWidgetChannelStyle
+
+    /// Background color of the view.
+    public var backgroundColor: UIColor
+
+    /// Style of 'powered by' view.
+    public var poweredBy: PoweredByStyle
+
+    /// The color of the dragger
+    public var draggerColor: UIColor
+
+    /// - Parameters:
+    ///   - channel: Engagement channel style.
+    ///   - backgroundColor: Background color of the view.
+    ///   - poweredBy: Style of 'powered by' view.
+    ///   - draggerColor: The color of the dragger
+    ///
+    public init(
+        channel: EntryWidgetChannelStyle,
+        backgroundColor: UIColor,
+        poweredBy: PoweredByStyle,
+        draggerColor: UIColor
+    ) {
+        self.channel = channel
+        self.backgroundColor = backgroundColor
+        self.poweredBy = poweredBy
+        self.draggerColor = draggerColor
+    }
+}
+
+public struct EntryWidgetChannelStyle {
+    /// Font of the headline text.
+    public var headlineFont: UIFont
+
+    /// Color of the headline text.
+    public var headlineColor: UIColor
+
+    /// Font of the subheadline text.
+    public var subheadlineFont: UIFont
+
+    /// Color of the subheadline text.
+    public var subheadlineColor: UIColor
+
+    /// Color of the icon.
+    public var iconColor: UIColor
+
+    /// - Parameters:
+    ///   - headlineFont: Font of the headline text.
+    ///   - headlineColor: Color of the headline text.
+    ///   - subheadlineFont: Font of the subheadline text.
+    ///   - subheadlineColor: Color of the subheadline text.
+    ///   - iconColor: Color of the icon.
+    ///
+    public init(
+        headlineFont: UIFont,
+        headlineColor: UIColor,
+        subheadlineFont: UIFont,
+        subheadlineColor: UIColor,
+        iconColor: UIColor
+    ) {
+        self.headlineFont = headlineFont
+        self.headlineColor = headlineColor
+        self.subheadlineFont = subheadlineFont
+        self.subheadlineColor = subheadlineColor
+        self.iconColor = iconColor
+    }
+}

--- a/GliaWidgets/Sources/EntryWidget/EntryWidgetView.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidgetView.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+
+struct EntryWidgetView: View {
+    @StateObject var model: Model
+
+    var body: some View {
+        VStack(spacing: 0) {
+            headerView()
+            channelsView()
+            poweredByView()
+        }
+        .maxSize()
+        .padding(.horizontal)
+    }
+}
+
+private extension EntryWidgetView {
+    @ViewBuilder
+    func channelsView() -> some View {
+        VStack(spacing: 0) {
+            ForEach(model.channels.indices, id: \.self) { index in
+                channelCell(channel: model.channels[index])
+                Divider()
+                    .height(model.sizeConstraints.dividerHeight)
+            }
+        }
+    }
+
+    @ViewBuilder
+    func poweredByView() -> some View {
+        PoweredByView(
+            style: model.style.poweredBy,
+            containerHeight: model.sizeConstraints.poweredByContainerHeight
+        )
+    }
+
+    @ViewBuilder
+    func headerView() -> some View {
+        VStack {
+            Capsule(style: .continuous)
+                .fill(model.style.draggerColor.swiftUIColor())
+                .width(model.sizeConstraints.sheetHeaderDraggerWidth)
+                .height(model.sizeConstraints.sheetHeaderDraggerHeight)
+        }
+        .maxWidth()
+        .height(model.sizeConstraints.sheetHeaderHeight)
+    }
+
+    @ViewBuilder
+    func channelCell(channel: EntryWidget.Channel) -> some View {
+        HStack(spacing: 16) {
+            icon(channel.image)
+            VStack(alignment: .leading, spacing: 2) {
+                headlineText(channel.headline)
+                subheadlineText(channel.subheadline)
+            }
+        }
+        .maxWidth(alignment: .leading)
+        .height(model.sizeConstraints.singleCellHeight)
+        .contentShape(.rect)
+        .onTapGesture {
+            model.selectChannel(channel)
+        }
+    }
+
+    @ViewBuilder
+    func icon(_ image: UIImage) -> some View {
+        image.asSwiftUIImage()
+            .resizable()
+            .fit()
+            .width(model.sizeConstraints.singleCellIconSize)
+            .height(model.sizeConstraints.singleCellIconSize)
+            .setColor(model.style.channel.iconColor.swiftUIColor())
+    }
+
+    @ViewBuilder
+    func headlineText(_ label: String) -> some View {
+        Text(label)
+            .font(.convert(model.style.channel.headlineFont))
+            .setColor(model.style.channel.headlineColor.swiftUIColor())
+    }
+
+    @ViewBuilder
+    func subheadlineText(_ label: String) -> some View {
+        Text(label)
+            .font(.convert(model.style.channel.subheadlineFont))
+            .setColor(model.style.channel.subheadlineColor.swiftUIColor())
+    }
+}

--- a/GliaWidgets/Sources/EntryWidget/EntryWidgetViewModel.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidgetViewModel.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+extension EntryWidgetView {
+    class Model: ObservableObject {
+        let style: EntryWidgetStyle
+        let channelSelected: (EntryWidget.Channel) -> Void
+        let channels: [EntryWidget.Channel]
+        let sizeConstraints: EntryWidget.SizeConstraints
+
+        init(
+            style: EntryWidgetStyle,
+            sizeConstrainsts: EntryWidget.SizeConstraints,
+            channels: [EntryWidget.Channel],
+            channelSelected: @escaping (EntryWidget.Channel) -> Void
+        ) {
+            self.style = style
+            self.sizeConstraints = sizeConstrainsts
+            self.channels = channels
+            self.channelSelected = channelSelected
+        }
+
+        func selectChannel(_ channel: EntryWidget.Channel) {
+            channelSelected(channel)
+        }
+    }
+}

--- a/GliaWidgets/Sources/Extensions/UIColor+Extensions.swift
+++ b/GliaWidgets/Sources/Extensions/UIColor+Extensions.swift
@@ -1,4 +1,5 @@
 import UIKit
+import SwiftUI
 
 extension UIColor {
     convenience init(hex: Int, alpha: CGFloat = 1.0) {
@@ -8,6 +9,10 @@ extension UIColor {
             blue: CGFloat(hex & 0xff) / 255.0,
             alpha: alpha
         )
+    }
+
+    func swiftUIColor() -> SwiftUI.Color {
+        return SwiftUI.Color(self)
     }
 
     var hex: String {

--- a/GliaWidgets/Sources/Extensions/UIImage+Extensions.swift
+++ b/GliaWidgets/Sources/Extensions/UIImage+Extensions.swift
@@ -1,5 +1,6 @@
 import UIKit
 import AVFoundation
+import SwiftUI
 
 extension UIImage {
     func resized(to size: CGSize) -> UIImage? {
@@ -73,5 +74,9 @@ extension UIImage {
         let newImage: UIImage = UIGraphicsGetImageFromCurrentImageContext() ?? UIImage()
         UIGraphicsEndImageContext()
         return newImage
+    }
+
+    func asSwiftUIImage() -> SwiftUI.Image {
+        SwiftUI.Image(uiImage: self)
     }
 }

--- a/GliaWidgets/Sources/Theme/Theme.EntryWidget.swift
+++ b/GliaWidgets/Sources/Theme/Theme.EntryWidget.swift
@@ -1,0 +1,30 @@
+import UIKit
+
+extension Theme {
+    var entryWidgetStyle: EntryWidgetStyle {
+        let channel: EntryWidgetChannelStyle = .init(
+            headlineFont: font.bodyText,
+            headlineColor: color.baseDark,
+            subheadlineFont: font.caption,
+            subheadlineColor: color.baseNormal,
+            iconColor: color.primary
+        )
+
+        let backgroundColor = color.baseLight
+
+        let poweredBy = PoweredByStyle(
+            text: Localization.General.powered,
+            font: font.caption,
+            accessibility: .init(isFontScalingEnabled: true)
+        )
+
+        let style: EntryWidgetStyle = .init(
+            channel: channel,
+            backgroundColor: backgroundColor,
+            poweredBy: poweredBy, 
+            draggerColor: color.baseShade
+        )
+
+        return style
+    }
+}

--- a/GliaWidgets/Sources/Theme/Theme.swift
+++ b/GliaWidgets/Sources/Theme/Theme.swift
@@ -70,6 +70,9 @@ public class Theme {
     /// Chat view style.
     public lazy var webView: WebViewStyle = { webViewStyle }()
 
+    /// EntryWidget style.
+    public lazy var entryWidget: EntryWidgetStyle = { entryWidgetStyle }()
+
     /// Initilizes the theme with base color and font style.
     /// - Parameters:
     ///   - colorStyle: Color style for the theme. Defaults to `default` style.

--- a/GliaWidgets/SwiftUI/Components/PoweredBy/PoweredByView.swift
+++ b/GliaWidgets/SwiftUI/Components/PoweredBy/PoweredByView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct PoweredByView: View {
+    let style: PoweredByStyle
+    let containerHeight: CGFloat
+    let color: UIColor = Color.baseShade
+
+    init(
+        style: PoweredByStyle,
+        containerHeight: CGFloat
+    ) {
+        self.style = style
+        self.containerHeight = containerHeight
+    }
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Text(Localization.General.powered)
+                .setColor(color.swiftUIColor())
+                .opacity(0.5)
+                .font(.convert(style.font))
+            Asset.gliaLogo.image.asSwiftUIImage()
+                .resizable()
+                .fit()
+                .height(20)
+                .setColor(color.swiftUIColor())
+        }
+        .height(containerHeight)
+    }
+}

--- a/GliaWidgets/SwiftUI/Extensions/View+Extensions.swift
+++ b/GliaWidgets/SwiftUI/Extensions/View+Extensions.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+extension SwiftUI.View {
+    func maxWidth(alignment: Alignment = .center) -> some View {
+        return self
+            .frame(
+                maxWidth: .infinity,
+                alignment: alignment
+            )
+    }
+
+    func maxSize(alignment: Alignment = .center) -> some View {
+        return self
+            .frame(
+                maxWidth: .infinity,
+                maxHeight: .infinity,
+                alignment: alignment
+            )
+    }
+
+    func maxHeight(alignment: Alignment = .center) -> some View {
+        return self
+            .frame(
+                maxHeight: .infinity,
+                alignment: alignment
+            )
+    }
+
+    func fit() -> some View {
+        return self
+            .aspectRatio(contentMode: .fit)
+    }
+
+    func fill() -> some View {
+        return self
+            .aspectRatio(contentMode: .fill)
+    }
+
+    func height(_ value: CGFloat) -> some View {
+        return self
+            .frame(height: value)
+    }
+
+    func width(_ value: CGFloat) -> some View {
+        return self
+            .frame(width: value)
+    }
+
+    func setColor(_ color: SwiftUI.Color) -> some View {
+        return self
+            .foregroundColor(color)
+    }
+}

--- a/TestingApp/Main.storyboard
+++ b/TestingApp/Main.storyboard
@@ -3,7 +3,7 @@
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -21,7 +21,7 @@
                                 <rect key="frame" x="0.0" y="48" width="414" height="814"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="A3Y-Xf-Ufg">
-                                        <rect key="frame" x="0.0" y="16" width="414" height="1068"/>
+                                        <rect key="frame" x="0.0" y="16" width="414" height="1117.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Configuration" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4l1-DH-Wkd">
                                                 <rect key="frame" x="155.5" y="0.0" width="103.5" height="20.5"/>
@@ -166,14 +166,22 @@
                                                     </button>
                                                 </subviews>
                                             </stackView>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3hO-Oq-9Lh" userLabel="Contact Us">
+                                                <rect key="frame" x="148" y="291.5" width="118.5" height="34.5"/>
+                                                <state key="normal" title="Button"/>
+                                                <buttonConfiguration key="configuration" style="plain" title="EntryWidget"/>
+                                                <connections>
+                                                    <action selector="contactUsTapped" destination="Y6W-OH-hqX" eventType="touchUpInside" id="8xb-3R-JHf"/>
+                                                </connections>
+                                            </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Utils" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fwb-CM-wR2">
-                                                <rect key="frame" x="190" y="291.5" width="34" height="20.5"/>
+                                                <rect key="frame" x="190" y="341" width="34" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="P9U-ba-KVy">
-                                                <rect key="frame" x="179.5" y="327" width="55" height="30"/>
+                                                <rect key="frame" x="179.5" y="376.5" width="55" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_resume_button"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="mbg-qw-hCC"/>
@@ -184,7 +192,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0wb-9L-Csn">
-                                                <rect key="frame" x="161" y="372" width="92" height="30"/>
+                                                <rect key="frame" x="161" y="421.5" width="92" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_clearSession_button"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="wht-81-BI4"/>
@@ -195,7 +203,7 @@
                                                 </connections>
                                             </button>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Dmx-9D-42U">
-                                                <rect key="frame" x="88.5" y="417" width="237.5" height="95"/>
+                                                <rect key="frame" x="88.5" y="466.5" width="237.5" height="95"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Authentication during engagement" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JXc-IZ-au3">
                                                         <rect key="frame" x="0.0" y="0.0" width="237.5" height="18"/>
@@ -242,7 +250,7 @@
                                                 </subviews>
                                             </stackView>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ojd-PF-wje">
-                                                <rect key="frame" x="119" y="527" width="176" height="30"/>
+                                                <rect key="frame" x="119" y="576.5" width="176" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_secureConversations_button"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="Nk7-ud-fyb"/>
@@ -255,7 +263,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3Ys-xS-zdq">
-                                                <rect key="frame" x="126" y="572" width="162" height="30"/>
+                                                <rect key="frame" x="126" y="621.5" width="162" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_endEngagement_button"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="QkV-yj-Sti"/>
@@ -266,7 +274,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tYL-hF-sF1">
-                                                <rect key="frame" x="152" y="617" width="110" height="30"/>
+                                                <rect key="frame" x="152" y="666.5" width="110" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_visitorInfo_button"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
@@ -276,7 +284,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PbA-Oy-bDr">
-                                                <rect key="frame" x="113.5" y="662" width="187" height="30"/>
+                                                <rect key="frame" x="113.5" y="711.5" width="187" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_sensitiveData_button"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
@@ -286,13 +294,13 @@
                                                 </connections>
                                             </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="UI customization" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E1e-uA-HuC">
-                                                <rect key="frame" x="143.5" y="707" width="127.5" height="20.5"/>
+                                                <rect key="frame" x="143.5" y="756.5" width="127.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ezc-iY-PbB">
-                                                <rect key="frame" x="141" y="742.5" width="132" height="30"/>
+                                                <rect key="frame" x="141" y="792" width="132" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_endEngagement_button"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="Nef-0j-qW7"/>
@@ -303,13 +311,13 @@
                                                 </connections>
                                             </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VisitorCode" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tI8-TQ-jWA">
-                                                <rect key="frame" x="162.5" y="787.5" width="89" height="20.5"/>
+                                                <rect key="frame" x="162.5" y="837" width="89" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="1gR-qB-lno">
-                                                <rect key="frame" x="90.5" y="823" width="233" height="30"/>
+                                                <rect key="frame" x="90.5" y="872.5" width="233" height="30"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YnU-rR-gCc">
                                                         <rect key="frame" x="0.0" y="0.0" width="88" height="30"/>
@@ -338,7 +346,7 @@
                                                 </subviews>
                                             </stackView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7mi-et-ybT">
-                                                <rect key="frame" x="0.0" y="868" width="414" height="200"/>
+                                                <rect key="frame" x="0.0" y="917.5" width="414" height="200"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="200" id="GaG-7F-RUb"/>

--- a/TestingApp/ViewController/ViewController.swift
+++ b/TestingApp/ViewController/ViewController.swift
@@ -98,6 +98,10 @@ class ViewController: UIViewController {
         }
     }
 
+    @IBAction private func contactUsTapped() {
+        Glia.sharedInstance.entryWidget.show(by: .sheet(self))
+    }
+
     @IBAction private func audioTapped() {
         do {
             try presentGlia(.audioCall)


### PR DESCRIPTION



**What was solved?**
This PR adds EntryWidget bottom sheet. In addition it adds the necessary support files to be able to develop EntryWidget with SwiftUI.

Because this PR is a foundation for the rest of the tickets, some of the elements, such as `channel` enum will be altered later on

MOB-3477

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
