### PR TITLE
Add EntryWidget embedded view

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -948,6 +948,7 @@
 		C0F3DE482C6E468400DE6D7B /* PoweredByView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F3DE472C6E468400DE6D7B /* PoweredByView.swift */; };
 		C0F7EA382CA1D6D40038019C /* CustomPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F7EA372CA1D6D40038019C /* CustomPresentationController.swift */; };
 		C0F7EA3A2CA1D7050038019C /* EntryWidget.SizeConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F7EA392CA1D7050038019C /* EntryWidget.SizeConstraints.swift */; };
+		C0F7EA3C2CA581E70038019C /* Glia+EntryWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F7EA3B2CA581E70038019C /* Glia+EntryWidget.swift */; };
 		C4119E06268F41D1004DFEFB /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C4119E05268F41D1004DFEFB /* Main.storyboard */; };
 		C42463742673ABE10082C135 /* ScreenShareHandler.Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42463732673ABE10082C135 /* ScreenShareHandler.Interface.swift */; };
 		C43C12F92694B14900C37E1B /* GliaPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C43C12F82694B14900C37E1B /* GliaPresenter.swift */; };
@@ -1976,6 +1977,7 @@
 		C0F3DE472C6E468400DE6D7B /* PoweredByView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoweredByView.swift; sourceTree = "<group>"; };
 		C0F7EA372CA1D6D40038019C /* CustomPresentationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPresentationController.swift; sourceTree = "<group>"; };
 		C0F7EA392CA1D7050038019C /* EntryWidget.SizeConstraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryWidget.SizeConstraints.swift; sourceTree = "<group>"; };
+		C0F7EA3B2CA581E70038019C /* Glia+EntryWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Glia+EntryWidget.swift"; sourceTree = "<group>"; };
 		C4119E05268F41D1004DFEFB /* Main.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		C42463732673ABE10082C135 /* ScreenShareHandler.Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenShareHandler.Interface.swift; sourceTree = "<group>"; };
 		C43C12F82694B14900C37E1B /* GliaPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GliaPresenter.swift; sourceTree = "<group>"; };
@@ -3609,6 +3611,7 @@
 				755D187E29A6B1B90009F5E8 /* Glia+StartEngagement.swift */,
 				AFC7ABB72C2D93A0006F15AA /* Glia+RestoreEngagement.swift */,
 				215A258F2CA44D8A0013023E /* Glia+EngagementLauncher.swift */,
+				C0F7EA3B2CA581E70038019C /* Glia+EntryWidget.swift */,
 			);
 			path = Glia;
 			sourceTree = "<group>";
@@ -6099,6 +6102,7 @@
 				C0D2F0332991377C00803B47 /* VideoCallViewController.swift in Sources */,
 				1A8B61D225C974A1000D780E /* ChatCallUpgradeView.swift in Sources */,
 				845E2F88283FB49F00C04D56 /* Theme.Survey.BooleanQuestion.Accessibility.swift in Sources */,
+				C0F7EA3C2CA581E70038019C /* Glia+EntryWidget.swift in Sources */,
 				C06A7584296EC9DC006B69A2 /* NumberSlotStyle.Accessibility.swift in Sources */,
 				8491AF212A7D1F7900CC3E72 /* ChatView.GvaGallery.swift in Sources */,
 				847956402ADED7A2004EF60C /* CallVisualizer.Action.swift in Sources */,

--- a/GliaWidgets/Public/Glia/Glia+EntryWidget.swift
+++ b/GliaWidgets/Public/Glia/Glia+EntryWidget.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+extension Glia {
+    /// Retrieves an instance of `EntryWidget`.
+    ///
+    /// - Parameters:
+    ///   - queueIds: A list of queue IDs to be used for the engagement launcher. When nil, the default queues will be used.
+    ///
+    /// - Returns:
+    ///   - `EntryWidget` instance.
+    public func getEntryWidget(queueIds: [String]) -> EntryWidget {
+        // The real implementation will be added once EngagementLauncher is added
+        .init(theme: theme)
+    }
+}

--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -119,9 +119,6 @@ public class Glia {
 
     private(set) var configuration: Configuration?
 
-    // Interface for entry widget
-    public private(set) var entryWidget: EntryWidget
-
     init(environment: Environment) {
         self.environment = environment
         self.theme = Theme()
@@ -160,7 +157,6 @@ public class Glia {
                 viewFactory: viewFactory
             )
         )
-        entryWidget = .init(theme: theme)
     }
 
     /// Setup SDK using specific engagement configuration without starting the engagement.

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
@@ -53,6 +53,7 @@ private extension EntryWidget {
     func showView(in parentView: UIView) {
         parentView.subviews.forEach { $0.removeFromSuperview() }
         let model = makeViewModel(
+            showHeader: false,
             channels: channels,
             selection: { channel in
                 // Logic for handling this callback will be handled later - MOB-3473
@@ -77,8 +78,10 @@ private extension EntryWidget {
 
     func showSheet(in parentViewController: UIViewController) {
         let model = makeViewModel(
+            showHeader: true,
             channels: channels,
             selection: { channel in
+                // Logic for handling this callback will be handled later - MOB-3473
                 print(channel.headline)
             }
         )
@@ -86,7 +89,7 @@ private extension EntryWidget {
         let hostingController = UIHostingController(rootView: view)
 
         hostingController.view.backgroundColor = UIColor.white
-        
+
         // Due to the more modern sheet presenting approach being
         // available starting from iOS 16, we need to handle cases
         // where the visitor has either iOS 14 or 15 installed. For
@@ -97,7 +100,6 @@ private extension EntryWidget {
             let smallDetent: UISheetPresentationController.Detent = .custom { _ in
                 return self.calculateHeight(
                     channels: self.channels,
-                    showPoweredBy: self.theme.showsPoweredBy,
                     sizeConstraints: self.sizeConstraints
                 )
             }
@@ -118,11 +120,13 @@ private extension EntryWidget {
     }
 
     func makeViewModel(
+        showHeader: Bool,
         channels: [Channel],
         selection: @escaping (Channel) -> Void
     ) -> EntryWidgetView.Model {
         .init(
-            style: theme.entryWidgetStyle,
+            theme: theme,
+            showHeader: showHeader,
             sizeConstrainsts: sizeConstraints,
             channels: channels,
             channelSelected: selection
@@ -131,7 +135,6 @@ private extension EntryWidget {
 
     func calculateHeight(
         channels: [Channel],
-        showPoweredBy: Bool,
         sizeConstraints: SizeConstraints
     ) -> CGFloat {
         var appliedHeight: CGFloat = 0
@@ -155,7 +158,6 @@ extension EntryWidget: UIViewControllerTransitioningDelegate {
     ) -> UIPresentationController? {
         let height = calculateHeight(
             channels: channels,
-            showPoweredBy: theme.showsPoweredBy,
             sizeConstraints: sizeConstraints
         )
         return CustomPresentationController(

--- a/GliaWidgets/Sources/EntryWidget/EntryWidgetView.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidgetView.swift
@@ -5,9 +5,13 @@ struct EntryWidgetView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            headerView()
+            if model.showHeader {
+                headerView()
+            }
             channelsView()
-            poweredByView()
+            if model.showPoweredBy {
+                poweredByView()
+            }
         }
         .maxSize()
         .padding(.horizontal)

--- a/GliaWidgets/Sources/EntryWidget/EntryWidgetViewModel.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidgetViewModel.swift
@@ -2,25 +2,42 @@ import SwiftUI
 
 extension EntryWidgetView {
     class Model: ObservableObject {
-        let style: EntryWidgetStyle
+        let theme: Theme
         let channelSelected: (EntryWidget.Channel) -> Void
         let channels: [EntryWidget.Channel]
         let sizeConstraints: EntryWidget.SizeConstraints
+        let showHeader: Bool
+
+        var style: EntryWidgetStyle {
+            theme.entryWidgetStyle
+        }
+
+        var showPoweredBy: Bool {
+            // Once EntryWidget will be displayed in Secure
+            // Conversations, additional checks will be added here
+            guard theme.showsPoweredBy else { return false }
+
+            return true
+        }
 
         init(
-            style: EntryWidgetStyle,
+            theme: Theme,
+            showHeader: Bool,
             sizeConstrainsts: EntryWidget.SizeConstraints,
             channels: [EntryWidget.Channel],
             channelSelected: @escaping (EntryWidget.Channel) -> Void
         ) {
-            self.style = style
+            self.theme = theme
             self.sizeConstraints = sizeConstrainsts
+            self.showHeader = showHeader
             self.channels = channels
             self.channelSelected = channelSelected
         }
+    }
+}
 
-        func selectChannel(_ channel: EntryWidget.Channel) {
-            channelSelected(channel)
-        }
+extension EntryWidgetView.Model {
+    func selectChannel(_ channel: EntryWidget.Channel) {
+        channelSelected(channel)
     }
 }

--- a/GliaWidgets/Sources/Theme/Theme.EntryWidget.swift
+++ b/GliaWidgets/Sources/Theme/Theme.EntryWidget.swift
@@ -21,7 +21,7 @@ extension Theme {
         let style: EntryWidgetStyle = .init(
             channel: channel,
             backgroundColor: backgroundColor,
-            poweredBy: poweredBy, 
+            poweredBy: poweredBy,
             draggerColor: color.baseShade
         )
 

--- a/TestingApp/Main.storyboard
+++ b/TestingApp/Main.storyboard
@@ -21,7 +21,7 @@
                                 <rect key="frame" x="0.0" y="48" width="414" height="814"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="A3Y-Xf-Ufg">
-                                        <rect key="frame" x="0.0" y="16" width="414" height="1117.5"/>
+                                        <rect key="frame" x="0.0" y="16" width="414" height="1500"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Configuration" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4l1-DH-Wkd">
                                                 <rect key="frame" x="155.5" y="0.0" width="103.5" height="20.5"/>
@@ -166,22 +166,41 @@
                                                     </button>
                                                 </subviews>
                                             </stackView>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3hO-Oq-9Lh" userLabel="Contact Us">
-                                                <rect key="frame" x="148" y="291.5" width="118.5" height="34.5"/>
-                                                <state key="normal" title="Button"/>
-                                                <buttonConfiguration key="configuration" style="plain" title="EntryWidget"/>
-                                                <connections>
-                                                    <action selector="contactUsTapped" destination="Y6W-OH-hqX" eventType="touchUpInside" id="8xb-3R-JHf"/>
-                                                </connections>
-                                            </button>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="EntryWidget" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Ba-8k-E2g">
+                                                <rect key="frame" x="160" y="291.5" width="94.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lRB-te-9Yv">
+                                                <rect key="frame" x="100" y="327" width="214" height="34.5"/>
+                                                <subviews>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3hO-Oq-9Lh" userLabel="Contact Us">
+                                                        <rect key="frame" x="0.0" y="0.0" width="107" height="34.5"/>
+                                                        <state key="normal" title="Button"/>
+                                                        <buttonConfiguration key="configuration" style="plain" title="Sheet"/>
+                                                        <connections>
+                                                            <action selector="entryWidgetSheetTapped" destination="Y6W-OH-hqX" eventType="touchUpInside" id="HBD-y1-fnF"/>
+                                                        </connections>
+                                                    </button>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HPY-ni-LES">
+                                                        <rect key="frame" x="107" y="0.0" width="107" height="34.5"/>
+                                                        <state key="normal" title="Button"/>
+                                                        <buttonConfiguration key="configuration" style="plain" title="Embbeded"/>
+                                                        <connections>
+                                                            <action selector="entryWidgetEmbbededTapped" destination="Y6W-OH-hqX" eventType="touchUpInside" id="9VS-X0-keW"/>
+                                                        </connections>
+                                                    </button>
+                                                </subviews>
+                                            </stackView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Utils" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fwb-CM-wR2">
-                                                <rect key="frame" x="190" y="341" width="34" height="20.5"/>
+                                                <rect key="frame" x="190" y="376.5" width="34" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="P9U-ba-KVy">
-                                                <rect key="frame" x="179.5" y="376.5" width="55" height="30"/>
+                                                <rect key="frame" x="179.5" y="412" width="55" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_resume_button"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="mbg-qw-hCC"/>
@@ -192,7 +211,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0wb-9L-Csn">
-                                                <rect key="frame" x="161" y="421.5" width="92" height="30"/>
+                                                <rect key="frame" x="161" y="457" width="92" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_clearSession_button"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="wht-81-BI4"/>
@@ -203,7 +222,7 @@
                                                 </connections>
                                             </button>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Dmx-9D-42U">
-                                                <rect key="frame" x="88.5" y="466.5" width="237.5" height="95"/>
+                                                <rect key="frame" x="88.5" y="502" width="237.5" height="95"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Authentication during engagement" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JXc-IZ-au3">
                                                         <rect key="frame" x="0.0" y="0.0" width="237.5" height="18"/>
@@ -250,7 +269,7 @@
                                                 </subviews>
                                             </stackView>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ojd-PF-wje">
-                                                <rect key="frame" x="119" y="576.5" width="176" height="30"/>
+                                                <rect key="frame" x="119" y="612" width="176" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_secureConversations_button"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="Nk7-ud-fyb"/>
@@ -263,7 +282,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3Ys-xS-zdq">
-                                                <rect key="frame" x="126" y="621.5" width="162" height="30"/>
+                                                <rect key="frame" x="126" y="657" width="162" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_endEngagement_button"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="QkV-yj-Sti"/>
@@ -274,7 +293,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tYL-hF-sF1">
-                                                <rect key="frame" x="152" y="666.5" width="110" height="30"/>
+                                                <rect key="frame" x="152" y="702" width="110" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_visitorInfo_button"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
@@ -284,7 +303,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PbA-Oy-bDr">
-                                                <rect key="frame" x="113.5" y="711.5" width="187" height="30"/>
+                                                <rect key="frame" x="113.5" y="747" width="187" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_sensitiveData_button"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
@@ -294,13 +313,13 @@
                                                 </connections>
                                             </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="UI customization" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E1e-uA-HuC">
-                                                <rect key="frame" x="143.5" y="756.5" width="127.5" height="20.5"/>
+                                                <rect key="frame" x="143.5" y="792" width="127.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ezc-iY-PbB">
-                                                <rect key="frame" x="141" y="792" width="132" height="30"/>
+                                                <rect key="frame" x="141" y="827.5" width="132" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_endEngagement_button"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="Nef-0j-qW7"/>
@@ -311,13 +330,13 @@
                                                 </connections>
                                             </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VisitorCode" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tI8-TQ-jWA">
-                                                <rect key="frame" x="162.5" y="837" width="89" height="20.5"/>
+                                                <rect key="frame" x="162.5" y="872.5" width="89" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="1gR-qB-lno">
-                                                <rect key="frame" x="90.5" y="872.5" width="233" height="30"/>
+                                                <rect key="frame" x="90.5" y="908" width="233" height="30"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YnU-rR-gCc">
                                                         <rect key="frame" x="0.0" y="0.0" width="88" height="30"/>
@@ -346,11 +365,19 @@
                                                 </subviews>
                                             </stackView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7mi-et-ybT">
-                                                <rect key="frame" x="0.0" y="917.5" width="414" height="200"/>
+                                                <rect key="frame" x="0.0" y="953" width="414" height="200"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="200" id="GaG-7F-RUb"/>
                                                     <constraint firstAttribute="height" priority="250" constant="200" id="cj8-4r-PEu"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pXZ-8Z-cyU">
+                                                <rect key="frame" x="0.0" y="1168" width="414" height="332"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="332" id="eEb-6T-YAJ"/>
+                                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="332" id="tQO-07-bfX"/>
                                                 </constraints>
                                             </view>
                                         </subviews>
@@ -358,6 +385,8 @@
                                             <constraint firstItem="qwv-F0-vOF" firstAttribute="top" secondItem="S6U-rq-MZq" secondAttribute="bottom" constant="15" id="8qB-zt-dYV"/>
                                             <constraint firstItem="S6U-rq-MZq" firstAttribute="top" secondItem="CoL-67-2P6" secondAttribute="bottom" constant="15" id="BRy-s9-qgS"/>
                                             <constraint firstAttribute="trailing" secondItem="7mi-et-ybT" secondAttribute="trailing" id="DkY-DC-Zat"/>
+                                            <constraint firstItem="pXZ-8Z-cyU" firstAttribute="leading" secondItem="A3Y-Xf-Ufg" secondAttribute="leading" id="F7u-Bw-OEA"/>
+                                            <constraint firstAttribute="trailing" secondItem="pXZ-8Z-cyU" secondAttribute="trailing" id="VYp-52-I9C"/>
                                             <constraint firstItem="7mi-et-ybT" firstAttribute="leading" secondItem="A3Y-Xf-Ufg" secondAttribute="leading" id="Wm0-4p-2bv"/>
                                         </constraints>
                                     </stackView>
@@ -387,6 +416,7 @@
                         <outlet property="autoConfigureSdkToggle" destination="rZ7-2H-jwc" id="nAr-zX-vTy"/>
                         <outlet property="configureButton" destination="4yC-lN-tH2" id="sAf-jg-YTC"/>
                         <outlet property="enablingOverwriteBubbleSwitch" destination="d3A-aT-6lw" id="Tg3-18-rBG"/>
+                        <outlet property="entryWidgetView" destination="pXZ-8Z-cyU" id="gbD-kc-o3J"/>
                         <outlet property="refreshAccessTokenButton" destination="5zf-Ur-3od" id="O5Q-56-XDi"/>
                         <outlet property="secureConversationsButton" destination="ojd-PF-wje" id="kN8-zY-QYl"/>
                         <outlet property="toggleAuthenticateButton" destination="pHy-59-v7T" id="9rO-74-dfE"/>
@@ -395,7 +425,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="132" y="84"/>
+            <point key="canvasLocation" x="131.8840579710145" y="83.705357142857139"/>
         </scene>
     </scenes>
     <resources>

--- a/TestingApp/ViewController/ViewController.swift
+++ b/TestingApp/ViewController/ViewController.swift
@@ -45,6 +45,7 @@ class ViewController: UIViewController {
 
     var authentication: Authentication?
     var authTimer: Timer?
+    var entryWidget: EntryWidget?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -69,6 +70,7 @@ class ViewController: UIViewController {
     }
 
     @IBOutlet weak var visitorCodeView: UIView!
+    @IBOutlet weak var entryWidgetView: UIView!
     @IBOutlet var toggleAuthenticateButton: UIButton!
     @IBOutlet var refreshAccessTokenButton: UIButton!
     @IBOutlet var configureButton: UIButton!
@@ -98,8 +100,12 @@ class ViewController: UIViewController {
         }
     }
 
-    @IBAction private func contactUsTapped() {
-        Glia.sharedInstance.entryWidget.show(by: .sheet(self))
+    @IBAction private func entryWidgetSheetTapped() {
+        self.entryWidget?.show(by: .sheet(self))
+    }
+
+    @IBAction private func entryWidgetEmbbededTapped() {
+        self.entryWidget?.show(by: .embedded(entryWidgetView))
     }
 
     @IBAction private func audioTapped() {
@@ -327,8 +333,10 @@ extension ViewController {
             ) { result in
                 switch result {
                 case .success:
+                    self.entryWidget = Glia.sharedInstance.getEntryWidget(queueIds: [""])
                     completionBlock("SDK has been configured")
                     completion?(.success(()))
+
                 case let .failure(error):
                     completionBlock("Error configuring the SDK")
                     completion?(.failure(error))


### PR DESCRIPTION




**What was solved?**
This PR adds the possibility to embed EntryWidget to a view. Also, as was agreed upon within the team, there is no instance of EntryWidget within Glia. EntryWidget instance will be returned from getEntryWidget method

MOB-3479

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
