### PR TITLE
Localization and error style for visitor message

### DIFF
--- a/GliaWidgets/Localization.swift
+++ b/GliaWidgets/Localization.swift
@@ -290,6 +290,10 @@ internal enum Localization {
       internal static var delivered: String { Localization.tr("Localizable", "chat.message.delivered", fallback: "Delivered") }
       /// Send a message to start chatting
       internal static var startEngagementPlaceholder: String { Localization.tr("Localizable", "chat.message.start_engagement_placeholder", fallback: "Send a message to start chatting") }
+      internal enum FailedToDeliver {
+        /// Failed to deliver. Tap to retry.
+        internal static var retry: String { Localization.tr("Localizable", "chat.message.failed_to_deliver.retry", fallback: "Failed to deliver. Tap to retry.") }
+      }
       internal enum Unread {
         internal enum Accessibility {
           /// Unread messages
@@ -459,9 +463,9 @@ internal enum Localization {
     internal static var close: String { Localization.tr("Localizable", "general.close", fallback: "Close") }
     /// Comment
     internal static var comment: String { Localization.tr("Localizable", "general.comment", fallback: "Comment") }
-    /// Company Name
+    /// 
     internal static var companyName: String { Localization.tr("Localizable", "general.company_name", fallback: "") }
-    /// Company Name without asking string provider
+    ///  without asking string provider
     internal static var companyNameLocalFallbackOnly: String { Localization.tr("Localizable", "general.company_name", fallback: "", stringProviding: nil) }
     /// Decline
     internal static var decline: String { Localization.tr("Localizable", "general.decline", fallback: "Decline") }

--- a/GliaWidgets/Resources/en.lproj/Localizable.strings
+++ b/GliaWidgets/Resources/en.lproj/Localizable.strings
@@ -125,6 +125,7 @@
 "chat.operator_name.accessibility.label" = "Operator Name";
 "chat.operator_joined.system_message" = "{operatorName} has joined the conversation.";
 "chat.message.delivered" = "Delivered";
+"chat.message.failed_to_deliver.retry" = "Failed to deliver. Tap to retry.";
 "chat.status.typing" = "Operator is typing";
 "chat.status.typing.accessibility.label" = "{operatorName} is typing";
 "chat.unread_message_divider" = "New Messages";

--- a/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration+Chat.swift
+++ b/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration+Chat.swift
@@ -60,6 +60,7 @@ extension RemoteConfiguration {
         let text: Text?
         let file: FileMessage?
         let status: Text?
+        let error: Text?
         let userImage: UserImageStyle?
     }
 

--- a/GliaWidgets/Sources/Theme/Chat/Theme.VIsitorChatMessageStyle.RemoteConfig.swift
+++ b/GliaWidgets/Sources/Theme/Chat/Theme.VIsitorChatMessageStyle.RemoteConfig.swift
@@ -21,6 +21,11 @@ extension Theme.VisitorMessageStyle {
             assetsBuilder: assetsBuilder
         )
 
+        error.apply(
+            configuration: configuration?.error,
+            assetsBuilder: assetsBuilder
+        )
+
         fileDownload.apply(
             configuration: configuration?.file,
             assetsBuilder: assetsBuilder

--- a/GliaWidgets/Sources/Theme/Chat/Theme.VisitorChatMessageStyle.swift
+++ b/GliaWidgets/Sources/Theme/Chat/Theme.VisitorChatMessageStyle.swift
@@ -21,6 +21,12 @@ public extension Theme {
         /// Text of the message delivered status.
         public var delivered: String
 
+        /// Style of the message error text.
+        public var error: Text
+
+        /// Text of the failed to deliver message status.
+        public var failedToDeliver: String
+
         /// Accessibility related properties.
         public var accessibility: Accessibility
 
@@ -31,6 +37,8 @@ public extension Theme {
         ///   - fileDownload: Style of the downloadable file content.
         ///   - status: Style of the message status text.
         ///   - delivered: Text of the message delivered status.
+        ///   - error: Style of the message error text.
+        ///   - failedToDeliver: Text of the failed to deliver message status.
         ///   - accessibility: Accessibility related properties.
         ///
         public init(
@@ -40,6 +48,14 @@ public extension Theme {
             fileDownload: ChatFileDownloadStyle,
             status: Text,
             delivered: String,
+            // TODO: default value should be removed in 3.0.0 - MOB-3610
+            error: Text = .init(
+                color: "D11149",
+                font: UIFont.systemFont(ofSize: 12, weight: .regular),
+                textStyle: .caption1,
+                accessibility: .init(isFontScalingEnabled: true)
+            ),
+            failedToDeliver: String = "",
             accessibility: Accessibility = .unsupported
         ) {
             self.text = text
@@ -48,6 +64,8 @@ public extension Theme {
             self.fileDownload = fileDownload
             self.status = status
             self.delivered = delivered
+            self.error = error
+            self.failedToDeliver = failedToDeliver
             self.accessibility = accessibility
         }
     }

--- a/GliaWidgets/Sources/Theme/Theme+Chat.swift
+++ b/GliaWidgets/Sources/Theme/Theme+Chat.swift
@@ -177,6 +177,13 @@ extension Theme {
                 accessibility: .init(isFontScalingEnabled: true)
             ),
             delivered: Localization.Chat.Message.delivered,
+            error: .init(
+                color: color.systemNegative.hex,
+                font: font.caption,
+                textStyle: .caption1,
+                accessibility: .init(isFontScalingEnabled: true)
+            ),
+            failedToDeliver: Localization.Chat.Message.FailedToDeliver.retry,
             accessibility: .init(isFontScalingEnabled: true)
         )
         let operatorImageFile = ChatImageFileContentStyle(


### PR DESCRIPTION
MOB-3597

**What was solved?**
This PR adds localization, extends VisitorChatMessageStyle and RemoteConfiguration to customize visitor message error state.

Business logic and tests will be added in further PRs.

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.
