### PR TITLE
Retry logic for chat engagement

### DIFF
--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.GVA.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.GVA.swift
@@ -100,7 +100,7 @@ private extension SecureConversations.TranscriptModel {
         let outgoingMessage = OutgoingMessage(payload: payload)
 
         appendItem(
-            .init(kind: .outgoingMessage(outgoingMessage)),
+            .init(kind: .outgoingMessage(outgoingMessage, error: nil)),
             to: pendingSection,
             animated: true
         )

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
@@ -211,6 +211,9 @@ extension SecureConversations {
                 break
             case let .gvaButtonTapped(option):
                 gvaOptionAction(for: option)()
+            case let .retryMessageTapped(message):
+                // Will be handled in next PR
+                break
             }
         }
 
@@ -265,7 +268,7 @@ extension SecureConversations.TranscriptModel {
         )
 
         appendItem(
-            .init(kind: .outgoingMessage(outgoingMessage)),
+            .init(kind: .outgoingMessage(outgoingMessage, error: nil)),
             to: pendingSection,
             animated: true
         )

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
@@ -162,6 +162,7 @@ extension ChatCoordinator {
             isWindowVisible: isWindowVisible,
             startAction: startAction,
             deliveredStatusText: viewFactory.theme.chat.visitorMessageStyle.delivered,
+            failedToDeliverStatusText: viewFactory.theme.chat.visitorMessageStyle.failedToDeliver,
             chatType: chatType,
             environment: .create(
                 with: environment,

--- a/GliaWidgets/Sources/Extensions/UITableView+Extensions.swift
+++ b/GliaWidgets/Sources/Extensions/UITableView+Extensions.swift
@@ -45,4 +45,20 @@ internal extension UITableView {
             self.scrollToRow(at: indexPath, at: .bottom, animated: animated)
         }
     }
+
+    func deleteRows(_ rows: [Int], in section: Int, animated: Bool) {
+        let refreshBlock = {
+            self.beginUpdates()
+            let indexPaths = rows.map { IndexPath(row: $0, section: section) }
+            self.deleteRows(at: indexPaths, with: .fade)
+            self.endUpdates()
+        }
+        if animated {
+            refreshBlock()
+        } else {
+            UIView.performWithoutAnimation {
+                refreshBlock()
+            }
+        }
+    }
 }

--- a/GliaWidgets/Sources/View/Chat/Message/VisitorChatMessageView.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/VisitorChatMessageView.swift
@@ -6,7 +6,15 @@ class VisitorChatMessageView: ChatMessageView {
         set { statusLabel.text = newValue }
     }
 
+    var error: String? {
+        get { return errorLabel.text }
+        set { errorLabel.text = newValue }
+    }
+
+    var messageTapped: (() -> Void)?
+
     private let statusLabel = UILabel().makeView()
+    private let errorLabel = UILabel().makeView()
     private let contentInsets = UIEdgeInsets(top: 8, left: 88, bottom: 8, right: 16)
 
     init(
@@ -42,6 +50,13 @@ class VisitorChatMessageView: ChatMessageView {
             style.accessibility.isFontScalingEnabled,
             for: statusLabel
         )
+
+        errorLabel.font = style.error.font
+        errorLabel.textColor = UIColor(hex: style.error.color)
+        setFontScalingEnabled(
+            style.accessibility.isFontScalingEnabled,
+            for: errorLabel
+        )
     }
 
     override func defineLayout() {
@@ -55,6 +70,24 @@ class VisitorChatMessageView: ChatMessageView {
         addSubview(statusLabel)
         constraints += statusLabel.topAnchor.constraint(equalTo: contentViews.bottomAnchor, constant: 2)
         constraints += statusLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -contentInsets.right)
-        constraints += statusLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -contentInsets.bottom)
+
+        addSubview(errorLabel)
+        constraints += errorLabel.topAnchor.constraint(equalTo: statusLabel.bottomAnchor, constant: 0)
+        constraints += errorLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -contentInsets.right)
+        constraints += errorLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -contentInsets.bottom)
+
+        defineTapGestureRecognizer()
+    }
+
+    func defineTapGestureRecognizer() {
+        let tapRecognizer = UITapGestureRecognizer(
+            target: self,
+            action: #selector(tapped)
+        )
+        addGestureRecognizer(tapRecognizer)
+    }
+
+    @objc private func tapped() {
+        messageTapped?()
     }
 }

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
@@ -102,6 +102,10 @@ final class ChatViewController: EngagementViewController, PopoverPresenter {
             viewModel.event(.gvaButtonTapped(option))
         }
 
+        view.retryMessageTapped = { message in
+            viewModel.event(.retryMessageTapped(message))
+        }
+
         var viewModel = viewModel
 
         viewModel.action = { [weak self, weak view] action in
@@ -131,6 +135,8 @@ final class ChatViewController: EngagementViewController, PopoverPresenter {
                 view?.refreshRows(rows, in: section, animated: animated)
             case let .refreshSection(section, animated):
                 view?.refreshSection(section, animated: animated)
+            case let .deleteRows(rows, in: section, animated: animated):
+                view?.deleteRows(rows, in: section, animated: animated)
             case .refreshAll:
                 view?.refreshAll()
             case .scrollToBottom(let animated):

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+ChoiceCards.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+ChoiceCards.swift
@@ -28,7 +28,7 @@ extension ChatViewModel {
         }
     }
 
-    private func respond(to choiceCardId: String, with selection: String?) {
+    func respond(to choiceCardId: String, with selection: String?) {
         // In the case of upgrading a secure conversation to a live chat,
         // there's a bug (MSG-483) that sends the welcome message web socket event before the
         // start engagement event. This means that we display it in the `pendingSection`

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+GVA.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+GVA.swift
@@ -128,8 +128,11 @@ private extension ChatViewModel {
                         in: self.messagesSection
                     )
                 }
-            case let .failure(error):
-                self.engagementAction?(.showAlert(.error(error: error.error)))
+            case .failure:
+                self.markMessageAsFailed(
+                    outgoingMessage,
+                    in: self.messagesSection
+                )
             }
         }
     }

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+ViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+ViewModel.swift
@@ -18,6 +18,7 @@ extension ChatViewModel: ViewModel {
             messageId: MessageRenderer.Message.Identifier
         )
         case gvaButtonTapped(GvaOption)
+        case retryMessageTapped(OutgoingMessage)
     }
 
     enum Action {
@@ -37,6 +38,7 @@ extension ChatViewModel: ViewModel {
         case refreshRow(Int, in: Int, animated: Bool)
         case refreshRows([Int], in: Int, animated: Bool)
         case refreshSection(Int, animated: Bool = false)
+        case deleteRows([Int], in: Int, animated: Bool)
         case refreshAll
         case scrollToBottom(animated: Bool)
         case updateItemsUserImage(animated: Bool)

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Mock.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Mock.swift
@@ -11,6 +11,7 @@ extension ChatViewModel {
         isWindowVisible: ObservableValue<Bool> = .init(with: true),
         startAction: StartAction = .startEngagement,
         deliveredStatusText: String = "Delivered",
+        failedToDeliverStatusText: String = "Failed",
         chatType: ChatViewModel.ChatType = .nonAuthenticated,
         environment: Environment = .mock,
         maximumUploads: () -> Int = { 2 }
@@ -25,6 +26,7 @@ extension ChatViewModel {
             isWindowVisible: isWindowVisible,
             startAction: startAction,
             deliveredStatusText: deliveredStatusText,
+            failedToDeliverStatusText: failedToDeliverStatusText,
             chatType: chatType,
             environment: environment,
             maximumUploads: maximumUploads

--- a/GliaWidgets/Sources/ViewModel/Chat/Data/ChatItem.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/Data/ChatItem.swift
@@ -30,7 +30,7 @@ class ChatItem {
     init(
         with message: OutgoingMessage
     ) {
-        kind = .outgoingMessage(message)
+        kind = .outgoingMessage(message, error: nil)
     }
 
     init?(
@@ -78,7 +78,7 @@ class ChatItem {
 extension ChatItem {
     enum Kind {
         case queueOperator
-        case outgoingMessage(OutgoingMessage)
+        case outgoingMessage(OutgoingMessage, error: String?)
         case visitorMessage(ChatMessage, status: String?)
         case operatorMessage(ChatMessage, showsImage: Bool, imageUrl: String?)
         case choiceCard(ChatMessage, showsImage: Bool, imageUrl: String?, isActive: Bool)

--- a/GliaWidgets/Sources/ViewModel/Chat/Data/OutgoingMessage.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/Data/OutgoingMessage.swift
@@ -3,18 +3,32 @@ import GliaCoreSDK
 
 class OutgoingMessage: Equatable {
     let files: [LocalFile]
+    /// Defines if the message is associated with Single Choice Response card
+    /// or Custom Response card. Used for reloading an associated card.
+    let relation: Relation
     var payload: CoreSdkClient.SendMessagePayload
 
     init(
         payload: CoreSdkClient.SendMessagePayload,
-        files: [LocalFile] = []
+        files: [LocalFile] = [],
+        relation: Relation = .none
     ) {
         self.payload = payload
         self.files = files
+        self.relation = relation
     }
 
     static func == (lhs: OutgoingMessage, rhs: OutgoingMessage) -> Bool {
         lhs.payload == rhs.payload &&
-        lhs.files == rhs.files
+        lhs.files == rhs.files &&
+        lhs.relation == rhs.relation
+    }
+}
+
+extension OutgoingMessage {
+    enum Relation: Equatable {
+        case none
+        case singleChoice(messageId: CoreSdkClient.Message.Id)
+        case customCard(messageId: MessageRenderer.Message.Identifier)
     }
 }

--- a/GliaWidgetsTests/Lib/ChatItem/ChatItem+Equatable.swift
+++ b/GliaWidgetsTests/Lib/ChatItem/ChatItem+Equatable.swift
@@ -6,7 +6,7 @@ extension ChatItem.Kind: Equatable {
         case (.queueOperator, .queueOperator):
             return true
 
-        case (.outgoingMessage(let lhsMessage), .outgoingMessage(let rhsMessage)):
+        case (.outgoingMessage(let lhsMessage, _), .outgoingMessage(let rhsMessage, _)):
             return lhsMessage.payload.messageId == rhsMessage.payload.messageId
 
         case (.visitorMessage(let lhsMessage, _), .visitorMessage(let rhsMessage, _)):

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -24,7 +24,8 @@ class ChatViewModelTests: XCTestCase {
             isCustomCardSupported: false,
             isWindowVisible: .init(with: true),
             startAction: .none,
-            deliveredStatusText: "Delivered",
+            deliveredStatusText: "Delivered", 
+            failedToDeliverStatusText: "Failed",
             chatType: .nonAuthenticated,
             environment: .init(
                 fetchFile: { _, _, _ in },
@@ -744,7 +745,7 @@ class ChatViewModelTests: XCTestCase {
 
         let outgoingMessage = OutgoingMessage(payload: .mock(messageIdSuffix: messageIdSuffix))
         viewModel.pendingSection.append(
-            .init(kind: .outgoingMessage(outgoingMessage))
+            .init(kind: .outgoingMessage(outgoingMessage, error: nil))
         )
 
         viewModel.interactorEvent(.receivedMessage(.mock(id: outgoingMessage.payload.messageId.rawValue)))

--- a/GliaWidgetsTests/ViewModel/Chat/Mocks/ChatItem.Kind.Mock.swift
+++ b/GliaWidgetsTests/ViewModel/Chat/Mocks/ChatItem.Kind.Mock.swift
@@ -14,7 +14,7 @@ extension ChatItem.Kind {
     static func mock(kind: Internal) -> ChatItem.Kind {
         switch kind {
         case .queueOperator: return .queueOperator
-        case .outgoingMessage: return .outgoingMessage(.mock())
+        case .outgoingMessage: return .outgoingMessage(.mock(), error: nil)
         case .visitorMessage: return .visitorMessage(.mock(), status: nil)
         case .operatorMessage:
             return .operatorMessage(


### PR DESCRIPTION
MOB-3597

**What was solved?**
This PR adds retry logic for regular chat engagement:
- marking failed messages;
- tap actions for undelivered messages;
- replacement logic after successful retry;
- extends Outgoing message model with `relation` property to keep association with response cards;

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.