### PR TITLE
Add accessibility identifiers to 'submit' and 'cancel' survey buttons

### DIFF
--- a/GliaWidgets/Sources/ViewController/Survey/SurveyViewController.View.swift
+++ b/GliaWidgets/Sources/ViewController/Survey/SurveyViewController.View.swift
@@ -35,11 +35,13 @@ extension Survey {
             // from getting truncated, for example for large
             // dynamic font types.
             $0.titleLabel?.lineBreakMode = .byWordWrapping
+            $0.accessibilityIdentifier = "survey_cancel_button"
         }
         let submitButton = UIButton(type: .custom).make {
             $0.setTitle(Localization.General.submit, for: .normal)
             $0.titleLabel?.numberOfLines = 0
             $0.titleLabel?.lineBreakMode = .byWordWrapping
+            $0.accessibilityIdentifier = "survey_submit_button"
         }
         lazy var buttonStackView = UIStackView.make(.horizontal, spacing: 16)(
             cancelButton,


### PR DESCRIPTION
In order to ensure in acceptance tests that survey gets shown when engagement ended by operator in background, survey_cancel_button and survey_submit_button accessibility identifiers must be assigned to relevant buttons.

MOB-3612

**What was solved?**

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
