### PR TITLE
Snapshot test for message sending error state

### DIFF
--- a/SnapshotTests/ChatViewControllerLayoutTests.swift
+++ b/SnapshotTests/ChatViewControllerLayoutTests.swift
@@ -72,4 +72,10 @@ final class ChatViewControllerLayoutTests: SnapshotTestCase {
         viewController.assertSnapshot(as: .image, in: .portrait)
         viewController.assertSnapshot(as: .image, in: .landscape)
     }
+
+    func test_messageSendingFailedState() throws {
+        let viewController = try ChatViewController.mockMessageSendingFailedState()
+        viewController.assertSnapshot(as: .image, in: .portrait)
+        viewController.assertSnapshot(as: .image, in: .landscape)
+    }
 }


### PR DESCRIPTION
MOB-3597

**What was solved?**
This test covers visitor message sending error state

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
![test_messageSendingFailedState 390x844-15-5-3x](https://github.com/user-attachments/assets/2a294fb5-2f78-42e5-9361-f075e399dfbb)