### PR TITLE
Bump CoreSDK version to 1.5.4

### DIFF
--- a/GliaWidgets.podspec
+++ b/GliaWidgets.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   }
   s.exclude_files         = ['GliaWidgets/Window/**']
 
-  s.dependency 'GliaCoreSDK', '1.5.3'
+  s.dependency 'GliaCoreSDK', '1.5.4'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -35,8 +35,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "GliaCoreSDK",
-            url: "https://github.com/salemove/ios-bundle/releases/download/1.5.3/GliaCoreSDK.xcframework.zip",
-            checksum: "8362e8640383090ddfdfa5ff85d3664f06ce6cef9753b1d5ee1b2287f2ed880c"
+            url: "https://github.com/salemove/ios-bundle/releases/download/1.5.4/GliaCoreSDK.xcframework.zip",
+            checksum: "a740f6d42f7f89c1f8feb04a3bbdb6424d66a94b39d457597ae6f384ea4a8ad5"
         ),
         .binaryTarget(
             name: "GliaWidgetsSDKXcf",

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
     - AccessibilitySnapshot/Core
     - SnapshotTesting (~> 1.0)
   - GliaCoreDependency (2.3.0)
-  - GliaCoreSDK (1.5.3):
+  - GliaCoreSDK (1.5.4):
     - GliaCoreDependency (= 2.3.0)
     - TwilioVoice (= 6.8.0)
     - WebRTC-lib (= 119.0.0)
@@ -35,7 +35,7 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   AccessibilitySnapshot: a91e4a69f870188b51f43863d9fc7269d07cdd93
   GliaCoreDependency: 37f48a5a32e2646617b87cbe9d4b30eedd123f6f
-  GliaCoreSDK: c19c3955c89efcbc01abb19d0744ddb81fc6d521
+  GliaCoreSDK: da5ed1a3d8fa7db7b9ace3cbb1fbda01a2c9b7cd
   SnapshotTesting: 6141c48b6aa76ead61431ca665c14ab9a066c53b
   SwiftLint: eb47480d47c982481592c195c221d11013a679cc
   TwilioVoice: 9563c9ad71b9ab7bbad0b59b67cfe4be96c75d23


### PR DESCRIPTION
**What was solved?**
Bump CoreSDK version to 1.5.4

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
