### PR TITLE
Message tap interception fix

### DIFF
--- a/GliaWidgets/Sources/View/Chat/Message/VisitorChatMessageView.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/VisitorChatMessageView.swift
@@ -84,10 +84,20 @@ class VisitorChatMessageView: ChatMessageView {
             target: self,
             action: #selector(tapped)
         )
+        tapRecognizer.delegate = self
         addGestureRecognizer(tapRecognizer)
     }
 
     @objc private func tapped() {
         messageTapped?()
+    }
+}
+
+extension VisitorChatMessageView: UIGestureRecognizerDelegate {
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        true
     }
 }


### PR DESCRIPTION
MOB-3597

**What was solved?**
This PR allows tap recognizer handle events simultaneously with other recognizers, so fixes conflict of tapping on message UITextView

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)