### PR TITLE
Implement QueuesMonitor to observe queues' engagement type updates

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -165,10 +165,13 @@
 		1AFB1E6825F7AE3C00CA460D /* ChatAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AFB1E6725F7AE3C00CA460D /* ChatAttachment.swift */; };
 		1AFB1E7425F8B00B00CA460D /* ChatTextContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AFB1E7325F8B00B00CA460D /* ChatTextContentView.swift */; };
 		1AFB1E7825F8B26800CA460D /* ChatTextContentStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AFB1E7725F8B26800CA460D /* ChatTextContentStyle.swift */; };
+		2100B4802CB6B5A400AC7527 /* LockIsolated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2100B47F2CB6B5A400AC7527 /* LockIsolated.swift */; };
 		215A25902CA44D8A0013023E /* Glia+EngagementLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215A258F2CA44D8A0013023E /* Glia+EngagementLauncher.swift */; };
 		215A25932CA44D900013023E /* EngagementLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215A25912CA44D900013023E /* EngagementLauncher.swift */; };
 		215A25982CABC7DF0013023E /* EngagementLauncherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215A25972CABC7DF0013023E /* EngagementLauncherTests.swift */; };
 		215A259A2CAC19780013023E /* GliaTests+EngagementLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215A25992CAC19780013023E /* GliaTests+EngagementLauncher.swift */; };
+		2198B7AC2CAEB14D002C442B /* QueuesMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2198B7AB2CAEB14D002C442B /* QueuesMonitor.swift */; };
+		2198B7AE2CB035A6002C442B /* QueuesMonitor.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2198B7AD2CB035A6002C442B /* QueuesMonitor.Environment.swift */; };
 		23D69155F4F4C5043173EF05 /* Pods_GliaWidgets.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F7A5CDD05FB57D55971AA68A /* Pods_GliaWidgets.framework */; };
 		3100D929296E946600DEC9CE /* SecureConversations.ConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3100D924296E946600DEC9CE /* SecureConversations.ConfirmationView.swift */; };
 		3100D92A296E946600DEC9CE /* Theme+SecureConversationsConfirmation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3100D925296E946600DEC9CE /* Theme+SecureConversationsConfirmation.swift */; };
@@ -1206,10 +1209,13 @@
 		1AFB1E6725F7AE3C00CA460D /* ChatAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachment.swift; sourceTree = "<group>"; };
 		1AFB1E7325F8B00B00CA460D /* ChatTextContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTextContentView.swift; sourceTree = "<group>"; };
 		1AFB1E7725F8B26800CA460D /* ChatTextContentStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTextContentStyle.swift; sourceTree = "<group>"; };
+		2100B47F2CB6B5A400AC7527 /* LockIsolated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockIsolated.swift; sourceTree = "<group>"; };
 		215A258F2CA44D8A0013023E /* Glia+EngagementLauncher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Glia+EngagementLauncher.swift"; sourceTree = "<group>"; };
 		215A25912CA44D900013023E /* EngagementLauncher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EngagementLauncher.swift; sourceTree = "<group>"; };
 		215A25972CABC7DF0013023E /* EngagementLauncherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngagementLauncherTests.swift; sourceTree = "<group>"; };
 		215A25992CAC19780013023E /* GliaTests+EngagementLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GliaTests+EngagementLauncher.swift"; sourceTree = "<group>"; };
+		2198B7AB2CAEB14D002C442B /* QueuesMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueuesMonitor.swift; sourceTree = "<group>"; };
+		2198B7AD2CB035A6002C442B /* QueuesMonitor.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueuesMonitor.Environment.swift; sourceTree = "<group>"; };
 		235300A49A5836A51EB1C4E8 /* Pods-GliaWidgets.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GliaWidgets.release.xcconfig"; path = "Target Support Files/Pods-GliaWidgets/Pods-GliaWidgets.release.xcconfig"; sourceTree = "<group>"; };
 		2797F86D83B9055FAD6E596E /* Pods-SnapshotTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SnapshotTests.debug.xcconfig"; path = "Target Support Files/Pods-SnapshotTests/Pods-SnapshotTests.debug.xcconfig"; sourceTree = "<group>"; };
 		3100D924296E946600DEC9CE /* SecureConversations.ConfirmationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecureConversations.ConfirmationView.swift; sourceTree = "<group>"; };
@@ -2723,6 +2729,7 @@
 		1A60AFC12566857200E53F53 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				2198B7AA2CAEB13E002C442B /* QueuesMonitor */,
 				215A25922CA44D900013023E /* EngagementLauncher */,
 				C0F3DE352C69F4A700DE6D7B /* EntryWidget */,
 				C0D6C9E72C09C70B00D4709B /* AlertManager */,
@@ -2766,6 +2773,7 @@
 				84A318A02869ECFC00CA1DE5 /* Unavailable.swift */,
 				1A2DA72B25EF9B5B00032611 /* Upload */,
 				845A28FD28AFF2DC008558EA /* URLScheme */,
+				2100B4812CB8078E00AC7527 /* Utilities */,
 				1A60AF6925656C0A00E53F53 /* View */,
 				1A60AF6725656BF200E53F53 /* ViewController */,
 				1A60AFCC256694E300E53F53 /* ViewFactory */,
@@ -3214,6 +3222,14 @@
 			path = Video;
 			sourceTree = "<group>";
 		};
+		2100B4812CB8078E00AC7527 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				2100B47F2CB6B5A400AC7527 /* LockIsolated.swift */,
+			);
+			path = Utilities;
+			sourceTree = "<group>";
+		};
 		215A25922CA44D900013023E /* EngagementLauncher */ = {
 			isa = PBXGroup;
 			children = (
@@ -3228,6 +3244,15 @@
 				215A25972CABC7DF0013023E /* EngagementLauncherTests.swift */,
 			);
 			path = EngagementLauncher;
+			sourceTree = "<group>";
+		};
+		2198B7AA2CAEB13E002C442B /* QueuesMonitor */ = {
+			isa = PBXGroup;
+			children = (
+				2198B7AB2CAEB14D002C442B /* QueuesMonitor.swift */,
+				2198B7AD2CB035A6002C442B /* QueuesMonitor.Environment.swift */,
+			);
+			path = QueuesMonitor;
 			sourceTree = "<group>";
 		};
 		3100D921296E943100DEC9CE /* Welcome */ = {
@@ -5613,6 +5638,7 @@
 				1A6EBB0325ADB82000EE325D /* MediaUpgradeActionView.swift in Sources */,
 				9AB196E627C510DA00FD60AB /* ChatMessage.Mock.swift in Sources */,
 				C08D776428F5910A000461E5 /* UIView+Extensions.swift in Sources */,
+				2198B7AC2CAEB14D002C442B /* QueuesMonitor.swift in Sources */,
 				C090467F2B7D022C003C437C /* WelcomeStyle.FilePickerButtonStyle.RemoteConfig.swift in Sources */,
 				C0D6CA4F2C19B9A300D4709B /* GliaPresenter.Environment.swift in Sources */,
 				9A19926A27D3BA8700161AAE /* ViewFactory.Environment.Interface.swift in Sources */,
@@ -5770,6 +5796,7 @@
 				7594091529891C5C008B173A /* Environment.swift in Sources */,
 				9A3E1D9927B6D0DB005634EB /* FoundationBased.Live.swift in Sources */,
 				84265E4C298D7B1900D65842 /* CallVisualizer.Coordinator.Environment.swift in Sources */,
+				2198B7AE2CB035A6002C442B /* QueuesMonitor.Environment.swift in Sources */,
 				1A7CA82F25751B5A0047CBBE /* ConnectOperatorStyle.swift in Sources */,
 				C06A757F296EC76B006B69A2 /* VisitorCodeStyle.swift in Sources */,
 				9AB196D227C3D74300FD60AB /* Interactor.Environment.Interface.swift in Sources */,
@@ -6185,6 +6212,7 @@
 				1A60AFCA2566943F00E53F53 /* EngagementCoordinator.swift in Sources */,
 				1ABD6C9225B6F2D200D56EFA /* String+TemplateString.swift in Sources */,
 				C09046EE2B7E0F70003C437C /* Theme.OperatorChatMessageStyle.Accessibility.swift in Sources */,
+				2100B4802CB6B5A400AC7527 /* LockIsolated.swift in Sources */,
 				84265E61298D7B2900D65842 /* ScreenSharingCoordinator.swift in Sources */,
 				C09047662B7E2396003C437C /* ChatFileDownloadErrorStateStyle.swift in Sources */,
 				1A60B0042567F25600E53F53 /* Header.swift in Sources */,

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -178,6 +178,20 @@ struct CoreSdkClient {
     typealias GetCameraDeviceManageable = () throws -> CameraDeviceManageableClient
 
     var getCameraDeviceManageable: GetCameraDeviceManageable
+
+    typealias SubscribeForQueuesUpdates = (
+        _ queueIds: [String],
+        _ completion: @escaping (Result<GliaCoreSDK.Queue, GliaCoreSDK.GliaCoreError>) -> Void
+    ) -> String?
+
+    var subscribeForQueuesUpdates: SubscribeForQueuesUpdates
+
+    typealias UnsubscribeFromUpdates = (
+        _ queueCallbackId: String,
+        _ onError: @escaping (GliaCoreSDK.GliaCoreError) -> Void
+    ) -> Void
+
+    var unsubscribeFromUpdates: UnsubscribeFromUpdates
 }
 
 extension CoreSdkClient {

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
@@ -60,7 +60,9 @@ extension CoreSdkClient {
                 try CameraDeviceManageableClient(
                     GliaCore.sharedInstance.cameraDeviceManageable()
                 )
-            }
+            },
+            subscribeForQueuesUpdates: GliaCore.sharedInstance.subscribeForQueuesUpdates(forQueues:completion:),
+            unsubscribeFromUpdates: GliaCore.sharedInstance.unsubscribeFromUpdates(queueCallbackId:onError:)
         )
     }()
 }

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -37,7 +37,9 @@ extension CoreSdkClient {
         stopSocketObservation: {},
         createSendMessagePayload: { _, _ in .mock() },
         createLogger: { _ in Logger.mock },
-        getCameraDeviceManageable: { .mock }
+        getCameraDeviceManageable: { .mock },
+        subscribeForQueuesUpdates: { _, _ in UUID().uuidString },
+        unsubscribeFromUpdates: { _, _ in }
     )
 }
 

--- a/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.Environment.swift
+++ b/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.Environment.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension QueuesMonitor {
+    struct Environment {
+        var sdkClient: CoreSdkClient
+    }
+}

--- a/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.swift
+++ b/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.swift
@@ -1,0 +1,89 @@
+import Foundation
+import GliaCoreSDK
+import Combine
+
+// TODO: Add unit tests in context of MOB-3669
+class QueuesMonitor {
+    enum State {
+        case idle
+        case updated([Queue])
+        case failed(Error)
+    }
+
+    @Published private(set) var state: State = .idle
+
+    private let environment: Environment
+    private var subscriptionId: String? {
+        _subscriptionId.value
+    }
+    private var queues: [Queue] {
+        _queues.value
+    }
+    
+    private var _subscriptionId: LockIsolated<String?> = .init(nil)
+    private var _queues: LockIsolated<[Queue]> = .init([])
+
+    init(environment: Environment) {
+        self.environment = environment
+
+        startMonitoring()
+    }
+
+    func startMonitoring() {
+        environment.sdkClient.listQueues { [weak self] queues, error in
+            guard let self else {
+                return
+            }
+            if let error {
+                self.state = .failed(error)
+                return
+            }
+
+            if let queues {
+                self._queues.setValue(queues)
+                self.state = .updated(queues)
+                self.observeQueuesUpdates(queues)
+                return
+            }
+        }
+    }
+
+    func stopMonitoring() {
+        if let subscriptionId {
+            environment.sdkClient.unsubscribeFromUpdates(subscriptionId) { [weak self] error in
+                self?.state = .failed(error)
+            }
+        }
+    }
+}
+
+private extension QueuesMonitor {
+    func updateQueue(_ queue: Queue) {
+        _queues.withValue { queues in
+            guard let indexToChange = queues.firstIndex(where: { $0.id == queue.id }) else {
+                queues.append(queue)
+                return
+            }
+            queues[indexToChange] = queue
+        }
+    }
+
+    func observeQueuesUpdates(_ queues: [Queue]) {
+        let queuesIds = queues.map { $0.id }
+        let subscriptionId = environment.sdkClient.subscribeForQueuesUpdates(queuesIds) { [weak self] result in
+            guard let self else {
+                return
+            }
+            switch result {
+            case .success(let queue):
+                self.updateQueue(queue)
+                self.state = .updated(self.queues)
+                return
+            case .failure(let error):
+                self.state = .failed(error)
+                return
+            }
+        }
+        _subscriptionId.setValue(subscriptionId)
+    }
+}

--- a/GliaWidgets/Sources/Utilities/LockIsolated.swift
+++ b/GliaWidgets/Sources/Utilities/LockIsolated.swift
@@ -1,0 +1,130 @@
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+/// SOFTWARE.
+///
+/// Extracted from:
+/// https://github.com/pointfreeco/swift-concurrency-extras/blob/main/Sources/ConcurrencyExtras/LockIsolated.swift
+
+import Foundation
+
+/// A generic wrapper for isolating a mutable value with a lock.
+///
+/// If you trust the sendability of the underlying value, consider using ``UncheckedSendable``,
+/// instead.
+@dynamicMemberLookup
+public final class LockIsolated<Value>: @unchecked Sendable {
+    private var _value: Value
+    private let lock = NSRecursiveLock()
+
+    /// Initializes lock-isolated state around a value.
+    ///
+    /// - Parameter value: A value to isolate with a lock.
+    public init(_ value: @autoclosure @Sendable () throws -> Value) rethrows {
+        self._value = try value()
+    }
+
+    public subscript<Subject: Sendable>(dynamicMember keyPath: KeyPath<Value, Subject>) -> Subject {
+        self.lock.sync {
+            self._value[keyPath: keyPath]
+        }
+    }
+
+    /// Perform an operation with isolated access to the underlying value.
+    ///
+    /// Useful for modifying a value in a single transaction.
+    ///
+    /// ```swift
+    /// // Isolate an integer for concurrent read/write access:
+    /// var count = LockIsolated(0)
+    ///
+    /// func increment() {
+    ///   // Safely increment it:
+    ///   self.count.withValue { $0 += 1 }
+    /// }
+    /// ```
+    ///
+    /// - Parameter operation: An operation to be performed on the the underlying value with a lock.
+    /// - Returns: The result of the operation.
+    public func withValue<T: Sendable>(
+        _ operation: @Sendable (inout Value) throws -> T
+    ) rethrows -> T {
+        try self.lock.sync {
+            var value = self._value
+            defer { self._value = value }
+            return try operation(&value)
+        }
+    }
+
+    /// Overwrite the isolated value with a new value.
+    ///
+    /// ```swift
+    /// // Isolate an integer for concurrent read/write access:
+    /// var count = LockIsolated(0)
+    ///
+    /// func reset() {
+    ///   // Reset it:
+    ///   self.count.setValue(0)
+    /// }
+    /// ```
+    ///
+    /// > Tip: Use ``withValue(_:)`` instead of ``setValue(_:)`` if the value being set is derived
+    /// > from the current value. That is, do this:
+    /// >
+    /// > ```swift
+    /// > self.count.withValue { $0 += 1 }
+    /// > ```
+    /// >
+    /// > ...and not this:
+    /// >
+    /// > ```swift
+    /// > self.count.setValue(self.count + 1)
+    /// > ```
+    /// >
+    /// > ``withValue(_:)`` isolates the entire transaction and avoids data races between reading and
+    /// > writing the value.
+    ///
+    /// - Parameter newValue: The value to replace the current isolated value with.
+    public func setValue(_ newValue: @autoclosure @Sendable () throws -> Value) rethrows {
+        try self.lock.sync {
+            self._value = try newValue()
+        }
+    }
+}
+
+extension LockIsolated where Value: Sendable {
+    /// The lock-isolated value.
+    public var value: Value {
+        self.lock.sync {
+            self._value
+        }
+    }
+}
+
+#if swift(<6)
+@available(*, deprecated, message: "Lock isolated values should not be equatable")
+extension LockIsolated: Equatable where Value: Equatable {
+    public static func == (lhs: LockIsolated, rhs: LockIsolated) -> Bool {
+        lhs.value == rhs.value
+    }
+}
+
+@available(*, deprecated, message: "Lock isolated values should not be hashable")
+extension LockIsolated: Hashable where Value: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self.value)
+    }
+}
+#endif
+
+extension NSRecursiveLock {
+    @inlinable @discardableResult
+    @_spi(Internals) public func sync<R>(work: () throws -> R) rethrows -> R {
+        self.lock()
+        defer { self.unlock() }
+        return try work()
+    }
+}

--- a/GliaWidgetsTests/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/CoreSDKClient.Failing.swift
@@ -67,6 +67,13 @@ extension CoreSdkClient {
         },
         getCameraDeviceManageable: {
             .failing
+        },
+        subscribeForQueuesUpdates: { _, _ in
+            fail("\(Self.self).subscribeForQueuesUpdates")
+            return UUID().uuidString
+        },
+        unsubscribeFromUpdates: { _, _ in
+            fail("\(Self.self).unsubscribeFromUpdates")
         }
     )
 }


### PR DESCRIPTION
**What was solved?**
This PR introduces QueuesMonitor that needed to update available engagement types instantly. This doesn't include tests which will be added in further PRs along with integration of QueuesMonitor to EntryWidget.

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
