### PR TITLE
Remove successfully sent message from pending list to omit resending

### DIFF
--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -204,6 +204,11 @@ class ChatViewModel: EngagementViewModel {
                     guard let self else { return }
                     switch result {
                     case let .success(message):
+                        // When pending message is successfully delivered,
+                        // it has to be removed from the `pendingMessages` list, to avoid
+                        // situation where it gets sent again, for example after
+                        // transfer to another operator.
+                        removePendingMessage(by: message.id)
                         self.replace(
                             outgoingMessage,
                             uploads: [],
@@ -910,6 +915,10 @@ extension ChatViewModel {
     ) -> Bool {
         return section.item(after: row) == nil
     }
+
+    func removePendingMessage(by messageId: String) {
+        pendingMessages.removeAll { $0.payload.messageId.rawValue.uppercased() == messageId.uppercased() }
+    }
 }
 
 // MARK: Call
@@ -938,7 +947,7 @@ extension ChatViewModel {
     }
 }
 
-// MARK: Site Confgurations
+// MARK: Site Configurations
 
 extension ChatViewModel {
     func fetchSiteConfigurations() {
@@ -975,6 +984,16 @@ extension ChatViewModel {
     func invokeSetTextAndSendMessage(text: String) {
         self.messageText = text
         self.sendMessage()
+    }
+
+    /// Sets pending messages list for unit testing
+    func setPendingMessagesForTesting(_ message: [OutgoingMessage]) {
+        self.pendingMessages = message
+    }
+
+    /// Gets pending messages list for unit testing
+    func getPendingMessageForTesting() -> [OutgoingMessage] {
+        self.pendingMessages
     }
 }
 #endif


### PR DESCRIPTION
Address issue, where pending message is attempted to be sent after operator transferring, by removing pending outgoing message once it was successfully delivered. Previously this resulted in 'Something went wrong' message, because API request was failing for already sent message, but now such request is not even executed.

MOB-3656

**What was solved?**

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
