### PR TITLE
Update 'Check Messages' button and margins on SC Welcome screen

### DIFF
--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeView.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeView.swift
@@ -5,7 +5,7 @@ import Dispatch
 
 extension SecureConversations {
     final class WelcomeView: BaseView {
-        static let sideMargin = 24.0
+        static let sideMargin = 16.0
         static let filePickerButtonSize = 44.0
 
         var props: Props {

--- a/GliaWidgets/SecureConversations/Welcome/Theme+SecureConversationsWelcome.swift
+++ b/GliaWidgets/SecureConversations/Welcome/Theme+SecureConversationsWelcome.swift
@@ -26,8 +26,8 @@ extension Theme {
 
         let checkMessagesButtonStyle = SecureConversations.WelcomeStyle.CheckMessagesButtonStyle(
             title: Localization.MessageCenter.Welcome.checkMessages,
-            font: font.header2,
-            textStyle: .title2,
+            font: font.bodyText,
+            textStyle: .body,
             color: color.primary,
             accessibility: .init(
                 isFontScalingEnabled: true,


### PR DESCRIPTION
MOB-3691

**What was solved?**
Update SC Welcome screen according to new design: decrease 'Check Messages' button size and side margins.
Snapshots are to be added in separate PR

**Before:**
<img src="https://github.com/user-attachments/assets/645c8983-5470-4f46-8df6-cd47f401b5df" width="428" height="926">

**After:**
<img src="https://github.com/user-attachments/assets/435b7ba4-8d00-4746-b9fe-9a07146f4314" width="428" height="926">

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
