### PR TITLE
Make entry widget height dynamic

### DIFF
--- a/GliaWidgets/Public/Glia/Glia+EntryWidget.swift
+++ b/GliaWidgets/Public/Glia/Glia+EntryWidget.swift
@@ -10,6 +10,7 @@ extension Glia {
     ///   - `EntryWidget` instance.
     public func getEntryWidget(queueIds: [String]) throws -> EntryWidget {
         EntryWidget(
+            queueIds: queueIds,
             environment: .init(
                 queuesMonitor: environment.queuesMonitor,
                 engagementLauncher: try getEngagementLauncher(queueIds: queueIds),

--- a/GliaWidgets/Sources/EntryWidget/CustomPresentationController.swift
+++ b/GliaWidgets/Sources/EntryWidget/CustomPresentationController.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 final class CustomPresentationController: UIPresentationController {
-    private let height: CGFloat
+    private var height: CGFloat
     private let cornerRadius: CGFloat
     private let dimmingView: UIView = {
         let view = UIView()
@@ -79,6 +79,15 @@ final class CustomPresentationController: UIPresentationController {
     override func dismissalTransitionDidEnd(_ completed: Bool) {
         if completed {
             dimmingView.removeFromSuperview()
+        }
+    }
+}
+
+extension CustomPresentationController {
+    func updateHeight(to newHeight: CGFloat) {
+        self.height = newHeight
+        UIView.animate(withDuration: 0.3) {
+            self.presentedView?.frame = self.frameOfPresentedViewInContainerView
         }
     }
 }

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.Channel.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.Channel.swift
@@ -2,10 +2,10 @@ import GliaCoreSDK
 import SwiftUI
 
 extension EntryWidget {
-    enum Channel {
-        case chat
-        case audio
+    enum MediaTypeItem: Int {
         case video
+        case audio
+        case chat
         case secureMessaging
 
         var headline: String {
@@ -17,7 +17,7 @@ extension EntryWidget {
             case .video:
                 return "Video"
             case .secureMessaging:
-                return "SecureMessaging"
+                return "Secure Messaging"
             }
         }
 
@@ -49,7 +49,7 @@ extension EntryWidget {
     }
 }
 
-extension EntryWidget.Channel {
+extension EntryWidget.MediaTypeItem {
     init?(mediaType: MediaType) {
         switch mediaType {
         case .audio:

--- a/GliaWidgets/Sources/EntryWidget/EntryWidgetView.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidgetView.swift
@@ -9,8 +9,8 @@ struct EntryWidgetView: View {
             errorView()
         case .loading:
             loadingView()
-        case .mediaTypes:
-            mediaTypesView()
+        case let .mediaTypes(types):
+            mediaTypesView(types)
         case .offline:
             offilineView()
         }
@@ -43,6 +43,7 @@ private extension EntryWidgetView {
         }
         .maxSize()
         .padding(.horizontal)
+        .applyColorTypeBackground(model.style.backgroundColor)
     }
 
     @ViewBuilder
@@ -52,18 +53,19 @@ private extension EntryWidgetView {
     }
 
     @ViewBuilder
-    func mediaTypesView() -> some View {
+    func mediaTypesView(_ types: [EntryWidget.MediaTypeItem]) -> some View {
         VStack(spacing: 0) {
             if model.showHeader {
                 headerView()
             }
-            channelsView()
+            mediaTypes(types)
             if model.showPoweredBy {
                 poweredByView()
             }
         }
         .maxSize()
         .padding(.horizontal)
+        .applyColorTypeBackground(model.style.backgroundColor)
     }
 
     @ViewBuilder
@@ -89,16 +91,17 @@ private extension EntryWidgetView {
         }
         .maxSize()
         .padding(.horizontal)
+        .applyColorTypeBackground(model.style.backgroundColor)
     }
 }
 
 // MARK: - View Components
 private extension EntryWidgetView {
     @ViewBuilder
-    func channelsView() -> some View {
+    func mediaTypes(_ types: [EntryWidget.MediaTypeItem]) -> some View {
         VStack(spacing: 0) {
-            ForEach(model.channels.indices, id: \.self) { index in
-                channelCell(channel: model.channels[index])
+            ForEach(types.indices, id: \.self) { index in
+                mediaTypeCell(mediaType: types[index])
                 Divider()
                     .height(model.sizeConstraints.dividerHeight)
                     .setColor(model.style.dividerColor)
@@ -127,12 +130,12 @@ private extension EntryWidgetView {
     }
 
     @ViewBuilder
-    func channelCell(channel: EntryWidget.Channel) -> some View {
+    func mediaTypeCell(mediaType: EntryWidget.MediaTypeItem) -> some View {
         HStack(spacing: 16) {
-            icon(channel.image)
+            icon(mediaType.image)
             VStack(alignment: .leading, spacing: 2) {
-                headlineText(channel.headline)
-                subheadlineText(channel.subheadline)
+                headlineText(mediaType.headline)
+                subheadlineText(mediaType.subheadline)
             }
         }
         .maxWidth(alignment: .leading)
@@ -140,7 +143,7 @@ private extension EntryWidgetView {
         .applyColorTypeBackground(model.style.mediaTypeItem.backgroundColor)
         .contentShape(.rect)
         .onTapGesture {
-            model.selectChannel(channel)
+            model.selectMediaType(mediaType)
         }
     }
 

--- a/GliaWidgets/Sources/EntryWidget/EntryWidgetViewModel.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidgetViewModel.swift
@@ -2,13 +2,12 @@ import SwiftUI
 
 extension EntryWidgetView {
     class Model: ObservableObject {
-        @Published var viewState: ViewState
-        @Published var channels: [EntryWidget.Channel] = []
+        @Published var viewState: EntryWidget.ViewState = .loading
         let theme: Theme
-        let channelSelected: (EntryWidget.Channel) throws -> Void
+        let mediaTypeSelected: (EntryWidget.MediaTypeItem) -> Void
         let sizeConstraints: EntryWidget.SizeConstraints
         let showHeader: Bool
-
+        var retryMonitoring: (() -> Void)?
         var style: EntryWidgetStyle {
             theme.entryWidgetStyle
         }
@@ -24,42 +23,24 @@ extension EntryWidgetView {
         init(
             theme: Theme,
             showHeader: Bool,
-            sizeConstrainsts: EntryWidget.SizeConstraints,
-            channels: Published<[EntryWidget.Channel]>.Publisher,
-            channelSelected: @escaping (EntryWidget.Channel) throws -> Void
+            sizeConstraints: EntryWidget.SizeConstraints,
+            viewStatePublisher: Published<EntryWidget.ViewState>.Publisher,
+            mediaTypeSelected: @escaping (EntryWidget.MediaTypeItem) -> Void
         ) {
             self.theme = theme
-            self.sizeConstraints = sizeConstrainsts
             self.showHeader = showHeader
-            self.channelSelected = channelSelected
-            self.viewState = .mediaTypes
+            self.sizeConstraints = sizeConstraints
+            self.mediaTypeSelected = mediaTypeSelected
 
-            channels.assign(to: &self.$channels)
+            viewStatePublisher.assign(to: &$viewState)
         }
-    }
-}
 
-extension EntryWidgetView.Model {
-    func selectChannel(_ channel: EntryWidget.Channel) {
-        do {
-            try channelSelected(channel)
-        } catch {
-            // TODO: Distinguish errors on View if needed 
-            viewState = .error
+        func selectMediaType(_ mediaTypeItem: EntryWidget.MediaTypeItem) {
+            mediaTypeSelected(mediaTypeItem)
         }
-    }
 
-    func onTryAgainTapped() {
-        // The logic will be added together with EngagementLauncher integration
-        print("Try again button tapped")
-    }
-}
-
-extension EntryWidgetView.Model {
-    enum ViewState {
-        case error
-        case loading
-        case mediaTypes
-        case offline
+        func onTryAgainTapped() {
+            retryMonitoring?()
+        }
     }
 }


### PR DESCRIPTION
**What was solved?**
In order to make entry widget height dynamic we need to observe the
mediaTypes and viewState. If mediaTypes are not present, we show the
default full scale of the EntryWidget, by switching the viewState.

MOB-3676
**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
