### PR TITLE
Entry widget localization

### DIFF
--- a/GliaWidgets/Localization.swift
+++ b/GliaWidgets/Localization.swift
@@ -716,6 +716,56 @@ internal enum Localization {
     /// Could not load the visitor code. Please try refreshing.
     internal static var failed: String { Localization.tr("Localizable", "visitor_code.failed", fallback: "Could not load the visitor code. Please try refreshing.") }
   }
+  internal enum EntryWidget {
+    internal enum LiveChat {
+      internal enum Button {
+        /// Live Chat
+        internal static var label: String { Localization.tr("Localizable", "entry_widget.live_chat.button.label", fallback: "Live Chat") }
+        /// For the texter in all of us
+        internal static var description: String { Localization.tr("Localizable", "entry_widget.live_chat.button.description", fallback: "For the texter in all of us") }
+      }
+    }
+    internal enum Audio {
+      internal enum Button {
+        /// Audio
+        internal static var label: String { Localization.tr("Localizable", "entry_widget.audio.button.label", fallback: "Audio") }
+        /// Speak through your device
+        internal static var description: String { Localization.tr("Localizable", "entry_widget.audio.button.description", fallback: "Speak through your device") }
+      }
+    }
+    internal enum Video {
+      internal enum Button {
+        /// Video
+        internal static var label: String { Localization.tr("Localizable", "entry_widget.video.button.label", fallback: "Video") }
+        /// Face-to-face, just like in person
+        internal static var description: String { Localization.tr("Localizable", "entry_widget.video.button.description", fallback: "Face-to-face, just like in person") }
+      }
+    }
+    internal enum SecureMessaging {
+      internal enum Button {
+        /// Secure Messaging
+        internal static var label: String { Localization.tr("Localizable", "entry_widget.secure_messaging.button.label", fallback: "Secure Messaging") }
+        /// Start a conversation, we’ll get back to you
+        internal static var description: String { Localization.tr("Localizable", "entry_widget.secure_messaging.button.description", fallback: "Start a conversation, we’ll get back to you") }
+      }
+    }
+    internal enum EmptyState {
+      /// Support team is currently offline
+      internal static var title: String { Localization.tr("Localizable", "entry_widget.empty_state.title", fallback: "Support team is currently offline") }
+      /// We are here to assist you during our business hours.
+      internal static var description: String { Localization.tr("Localizable", "entry_widget.empty_state.description", fallback: "We are here to assist you during our business hours.") }
+    }
+    internal enum ErrorState {
+      /// Oops! Contacts Couldn't Be Loaded
+      internal static var title: String { Localization.tr("Localizable", "entry_widget.error_state.title", fallback: "Oops! Contacts Couldn't Be Loaded") }
+      /// We couldn't load the contacts at this time. This may be due to a temporary syncing issue or network problem.
+      internal static var description: String { Localization.tr("Localizable", "entry_widget.error_state.description", fallback: "We couldn't load the contacts at this time. This may be due to a temporary syncing issue or network problem.") }
+      internal enum TryAgain {
+        /// Try again
+        internal static var label: String { Localization.tr("Localizable", "entry_widget.error_state.try_again.button.label", fallback: "Try again") }
+      }
+    }
+  }
 }
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:enable nesting type_body_length type_name vertical_whitespace_opening_braces

--- a/GliaWidgets/Resources/en.lproj/Localizable.strings
+++ b/GliaWidgets/Resources/en.lproj/Localizable.strings
@@ -249,3 +249,17 @@
 "secure_messaging.chat.leave_current_conversation.message" = "You have an ongoing conversation. Starting a new conversation before ongoing ones are resolved may lead to our agents overlooking your current query.";
 "secure_messaging.chat.leave_current_conversation.button.positive" = "Stay";
 "secure_messaging.chat.leave_current_conversation.button.negative" = "Leave";
+
+"entry_widget.live_chat.button.label" = "Live Chat";
+"entry_widget.live_chat.button.description" = "For the texter in all of us";
+"entry_widget.audio.button.label" = "Audio";
+"entry_widget.audio.button.description" = "Speak through your device";
+"entry_widget.video.button.label" = "Video";
+"entry_widget.video.button.description" = "Face-to-face, just like in person";
+"entry_widget.secure_messaging.button.label" = "Secure Messaging";
+"entry_widget.secure_messaging.button.description" = "Start a conversation, we’ll get back to you";
+"entry_widget.empty_state.title" = "Support team is currently offline";
+"entry_widget.empty_state.description" = "We are here to assist you during our business hours.";
+"entry_widget.error_state.title" = "Oops! Contacts Couldn't Be Loaded";
+"entry_widget.error_state.description" = "We couldn't load the contacts at this time. This may be due to a temporary syncing issue or network problem.";
+"entry_widget.error_state.try_again.button.label" = "Try again";

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.Channel.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.Channel.swift
@@ -11,26 +11,26 @@ extension EntryWidget {
         var headline: String {
             switch self {
             case .chat:
-                return "Live Chat"
+                return Localization.EntryWidget.LiveChat.Button.label
             case .audio:
-                return "Audio"
+                return Localization.EntryWidget.Audio.Button.label
             case .video:
-                return "Video"
+                return Localization.EntryWidget.Video.Button.label
             case .secureMessaging:
-                return "Secure Messaging"
+                return Localization.EntryWidget.SecureMessaging.Button.label
             }
         }
 
         var subheadline: String {
             switch self {
             case .chat:
-                return "For the texter in all of us"
+                return Localization.EntryWidget.LiveChat.Button.description
             case .audio:
-                return "Speak through your device"
+                return Localization.EntryWidget.Audio.Button.description
             case .video:
-                return "Face-to-face, just like in person"
+                return Localization.EntryWidget.Video.Button.description
             case .secureMessaging:
-                return "Start a conversation, we'll get back to you"
+                return Localization.EntryWidget.SecureMessaging.Button.description
             }
         }
 

--- a/GliaWidgets/Sources/EntryWidget/EntryWidgetView.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidgetView.swift
@@ -26,12 +26,10 @@ private extension EntryWidgetView {
                 headerView()
             }
             VStack(spacing: 16) {
-                // Will be swapped for localized string in MOB-3607
-                Text("Oops! Contacts Couldn't Be Loaded")
+                Text(Localization.EntryWidget.ErrorState.title)
                     .setFont(model.style.errorTitleFont)
                     .setColor(model.style.errorTitleColor)
-                // Will be swapped for localized string in MOB-3607
-                Text("We couldn't load the contacts at this time. This may be due to a temporary syncing issue or network problem.")
+                Text(Localization.EntryWidget.ErrorState.description)
                     .setFont(model.style.errorMessageFont)
                     .setColor(model.style.errorTitleColor)
                 errorButton()
@@ -75,12 +73,10 @@ private extension EntryWidgetView {
                 headerView()
             }
             VStack(spacing: 16) {
-                // Will be swapped for localized string in MOB-3607
-                Text("Support team is currently offline")
+                Text(Localization.EntryWidget.EmptyState.title)
                     .setFont(model.style.errorTitleFont)
                     .setColor(model.style.errorTitleColor)
-                // Will be swapped for localized string in MOB-3607
-                Text(" We are here to assist you during our business hours: Monday to Friday 9:00 AM - 5:00 PM")
+                Text(Localization.EntryWidget.EmptyState.description)
                     .setFont(model.style.errorMessageFont)
                     .setColor(model.style.errorTitleColor)
             }

--- a/GliaWidgets/Sources/Theme/Theme.EntryWidget.swift
+++ b/GliaWidgets/Sources/Theme/Theme.EntryWidget.swift
@@ -22,7 +22,7 @@ extension Theme {
         )
 
         let errorButton: ActionButtonStyle = .init(
-            title: "Try again", // Will be swapped for localized string in MOB-3607
+            title: Localization.EntryWidget.ErrorState.TryAgain.label,
             titleFont: font.bodyText,
             titleColor: color.primary,
             backgroundColor: .fill(color: color.baseLight),


### PR DESCRIPTION
https://glia.atlassian.net/browse/MOB-3607

**What was solved?**
Add new localizations for the Entry Widget and replace the hardcoded strings with them in the Entry Widget.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
