### PR TITLE
Fix widgets xcframework versioning

### DIFF
--- a/scripts/update_core_sdk_version.sh
+++ b/scripts/update_core_sdk_version.sh
@@ -11,16 +11,19 @@ sed -i '' "s/\${WIDGETS_SDK_VERSION_SEMVER}/${WIDGETS_SDK_SEMVER}/g" "../GliaWid
 # Replace CORE_SDK_VERSION_SEMVER with passed value.
 sed -i '' "s/\${CORE_SDK_VERSION_SEMVER}/${CORE_SDK_SEMVER}/g" "../GliaWidgets.podspec"
 
-WIDGETS_SDK_CHECKSUM=$(awk '/GliaWidgetsXcf.xcframework.zip/{p=NR} NR==p+1' '../Package.swift' | grep 'checksum:' | awk -F'"' '{print $2}')
+# Retrieves XCFramework semmer from Package.swift file to prevent version changes.
+# That's required because WIDGETS_SDK_SEMVER is always higher than XCFramework semver
+WIDGETS_SDK_XCFRAMEWORK_SEMVER=$(grep 'GliaWidgetsXcf.xcframework.zip' '../Package.swift' | awk -F"/" '{print $8}')
+WIDGETS_SDK_XCFRAMEWORK_CHECKSUM=$(awk '/GliaWidgetsXcf.xcframework.zip/{p=NR} NR==p+1' '../Package.swift' | grep 'checksum:' | awk -F'"' '{print $2}')
 
 # Copy a new Package.swift file from template
 cp ../templates/Package.swift ../Package.swift
 
 # Replace WIDGETS_SDK_SEMVER with project_version value.
-sed -i '' "s/\${WIDGETS_SDK_SEMVER}/${WIDGETS_SDK_SEMVER}/g" "../Package.swift"
+sed -i '' "s/\${WIDGETS_SDK_SEMVER}/${WIDGETS_SDK_XCFRAMEWORK_SEMVER}/g" "../Package.swift"
 
 # Replace WIDGETS_SDK_CHECKSUM with widgets_sdk_checksum value.
-sed -i '' "s/\${WIDGETS_SDK_CHECKSUM}/${WIDGETS_SDK_CHECKSUM}/g" "../Package.swift"
+sed -i '' "s/\${WIDGETS_SDK_CHECKSUM}/${WIDGETS_SDK_XCFRAMEWORK_CHECKSUM}/g" "../Package.swift"
 
 # Replace CORE_SDK_SEMVER with passed value.
 sed -i '' "s/\${CORE_SDK_SEMVER}/${CORE_SDK_SEMVER}/g" "../Package.swift"


### PR DESCRIPTION
**What was solved?**
On dependencies-update workflow run, GliaWidgetsXcf.xcframework semver changes to project semver value, which is always higher and, as a result, incorrect. The changes introduced in this PR retrieve xcframework semver from Package.swift file, which allows to not break versioning.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)