### PR TITLE
Add new public interfaces to the Entry Widget

### DIFF
--- a/TestingApp/ViewController/ViewController.swift
+++ b/TestingApp/ViewController/ViewController.swift
@@ -101,11 +101,11 @@ class ViewController: UIViewController {
     }
 
     @IBAction private func entryWidgetSheetTapped() {
-        self.entryWidget?.show(by: .sheet(self))
+        self.entryWidget?.show(in: self)
     }
 
     @IBAction private func entryWidgetEmbbededTapped() {
-        self.entryWidget?.show(by: .embedded(entryWidgetView))
+        self.entryWidget?.embed(in: entryWidgetView)
     }
 
     @IBAction private func audioTapped() {


### PR DESCRIPTION
**What was solved?**
Add new public interaces to EntryWidget. We now have a clear distinction between the sheet interfaces and the embedded one.

MOB-3409
**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
