### PR TITLE
Run snapshot test using corresponding branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,14 @@ clone-snapshots:
 	@echo "	⏬  Cloning snapshots..."
 	@command git clone git@github.com:salemove/ios-widgets-snapshots.git SnapshotTests/__Snapshots__
 
+source_branch := $(shell git rev-parse --abbrev-ref HEAD)
 clone-snapshots-ci:
 	@echo "	⏬  Cloning snapshots..."
 	@command git clone $(repo_url) SnapshotTests/__Snapshots__
+	@command cd SnapshotTests/__Snapshots__ && ./checkout.sh $(SOURCE_BRANCH) $(destination_branch)
 
 commit-snapshots:
-	@echo "	💾  Commiting snapshots..."
+	@echo "	💾  Committing snapshots..."
 	@command cd SnapshotTests/__Snapshots__ && git add . && git commit -a -m "Update snapshots."
 
 push-snapshots:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -188,7 +188,7 @@ workflows:
         inputs:
         - content: |-
             #!/usr/bin/env bash # fail if any commands fails set -e # make pipelines' return status equal the last command to exit with a non-zero status, or zero if all commands exit successfully set -o pipefail # debug log set -x
-            make clone-snapshots-ci repo_url="https://$GITHUB_USERNAME:$GITHUB_API_TOKEN@$SNAPSHOTS_REPO"
+            make clone-snapshots-ci repo_url="https://$GITHUB_USERNAME:$GITHUB_API_TOKEN@$SNAPSHOTS_REPO" destination_branch=$BITRISEIO_GIT_BRANCH_DEST
     - cache-pull@2: {}
     - certificate-and-profile-installer@1: {}
     - script:


### PR DESCRIPTION
MOB-3716

**What was solved?**
This PR extends clone-snapshots-ci make command by running checkout.sh script, which tries to make checkout to the source branch in Snapshots if it exists, otherwise tries to make checkout to the destination branch if it exists, otherwise makes checkout to master branch

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)