### PR TITLE
Introduce SC bottom banner UI on chat screen

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -616,6 +616,7 @@
 		AF35DFF12A507CA70038BCA7 /* VisitorInfoViewController.Cells.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF35DFF02A507CA70038BCA7 /* VisitorInfoViewController.Cells.swift */; };
 		AF35DFF32A507D3E0038BCA7 /* UIView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF35DFF22A507D3E0038BCA7 /* UIView+Extensions.swift */; };
 		AF39330B29B2A6A00008B60D /* ChatViewModel.SecureConverstaions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF39330A29B2A6A00008B60D /* ChatViewModel.SecureConverstaions.swift */; };
+		AF3AFB842CC68AB30072E7A9 /* SecureMessagingBottomBannerViewStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3AFB832CC68AB30072E7A9 /* SecureMessagingBottomBannerViewStyle.swift */; };
 		AF3BD1DD2A41D09100A7713E /* VisitorInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3BD1DC2A41D09100A7713E /* VisitorInfoViewController.swift */; };
 		AF3BD1DF2A42026D00A7713E /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3BD1DE2A42026D00A7713E /* Command.swift */; };
 		AF3D520B2983235C00AD8E69 /* FileUploader.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D520A2983235C00AD8E69 /* FileUploader.Mock.swift */; };
@@ -664,10 +665,12 @@
 		AFBBF5782851C391004993B3 /* Glia.Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBBF5772851C391004993B3 /* Glia.Deprecated.swift */; };
 		AFC40C1C29965F0F001B4C53 /* SecureConversations.ChatWithTranscriptModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFC40C1B29965F0F001B4C53 /* SecureConversations.ChatWithTranscriptModel.swift */; };
 		AFC7ABB82C2D93A0006F15AA /* Glia+RestoreEngagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFC7ABB72C2D93A0006F15AA /* Glia+RestoreEngagement.swift */; };
+		AFCA8A422CC7939F008B7DD3 /* SecureMessagingBottomBannerViewStyle.RemoteConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCA8A412CC7939F008B7DD3 /* SecureMessagingBottomBannerViewStyle.RemoteConfig.swift */; };
 		AFCF8A5A2A02A97100B7ABB3 /* ChatItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCF8A592A02A97100B7ABB3 /* ChatItemTests.swift */; };
 		AFCF8A5C2A02AB3000B7ABB3 /* OutgoingMessage.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCF8A5B2A02AB3000B7ABB3 /* OutgoingMessage.Mock.swift */; };
 		AFD3C52C2A472B7500BC37A9 /* VisitorInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFD3C52B2A472B7500BC37A9 /* VisitorInfoModel.swift */; };
 		AFE7C7F82B28F15B00997B6A /* Logger.Implementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE7C7F72B28F15B00997B6A /* Logger.Implementation.swift */; };
+		AFE82C782CC2ACA1005E641F /* SecureMessagingBottomBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE82C772CC2ACA1005E641F /* SecureMessagingBottomBannerView.swift */; };
 		AFEF5C6F29928DB0005C3D8D /* SecureConversations.FileUploadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFEF5C6E29928DB0005C3D8D /* SecureConversations.FileUploadView.swift */; };
 		AFEF5C7129929601005C3D8D /* SecureConversations.FilePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFEF5C7029929601005C3D8D /* SecureConversations.FilePreviewView.swift */; };
 		AFEF5C7429929A8D005C3D8D /* SecureConversations.FileUploadListViewModel.Environment.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFEF5C7329929A8D005C3D8D /* SecureConversations.FileUploadListViewModel.Environment.Failing.swift */; };
@@ -1662,6 +1665,7 @@
 		AF35DFF02A507CA70038BCA7 /* VisitorInfoViewController.Cells.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitorInfoViewController.Cells.swift; sourceTree = "<group>"; };
 		AF35DFF22A507D3E0038BCA7 /* UIView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extensions.swift"; sourceTree = "<group>"; };
 		AF39330A29B2A6A00008B60D /* ChatViewModel.SecureConverstaions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.SecureConverstaions.swift; sourceTree = "<group>"; };
+		AF3AFB832CC68AB30072E7A9 /* SecureMessagingBottomBannerViewStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureMessagingBottomBannerViewStyle.swift; sourceTree = "<group>"; };
 		AF3BD1DC2A41D09100A7713E /* VisitorInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitorInfoViewController.swift; sourceTree = "<group>"; };
 		AF3BD1DE2A42026D00A7713E /* Command.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
 		AF3D520A2983235C00AD8E69 /* FileUploader.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploader.Mock.swift; sourceTree = "<group>"; };
@@ -1710,10 +1714,12 @@
 		AFBBF5772851C391004993B3 /* Glia.Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Glia.Deprecated.swift; sourceTree = "<group>"; };
 		AFC40C1B29965F0F001B4C53 /* SecureConversations.ChatWithTranscriptModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.ChatWithTranscriptModel.swift; sourceTree = "<group>"; };
 		AFC7ABB72C2D93A0006F15AA /* Glia+RestoreEngagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Glia+RestoreEngagement.swift"; sourceTree = "<group>"; };
+		AFCA8A412CC7939F008B7DD3 /* SecureMessagingBottomBannerViewStyle.RemoteConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureMessagingBottomBannerViewStyle.RemoteConfig.swift; sourceTree = "<group>"; };
 		AFCF8A592A02A97100B7ABB3 /* ChatItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatItemTests.swift; sourceTree = "<group>"; };
 		AFCF8A5B2A02AB3000B7ABB3 /* OutgoingMessage.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutgoingMessage.Mock.swift; sourceTree = "<group>"; };
 		AFD3C52B2A472B7500BC37A9 /* VisitorInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitorInfoModel.swift; sourceTree = "<group>"; };
 		AFE7C7F72B28F15B00997B6A /* Logger.Implementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.Implementation.swift; sourceTree = "<group>"; };
+		AFE82C772CC2ACA1005E641F /* SecureMessagingBottomBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureMessagingBottomBannerView.swift; sourceTree = "<group>"; };
 		AFEF5C6E29928DB0005C3D8D /* SecureConversations.FileUploadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FileUploadView.swift; sourceTree = "<group>"; };
 		AFEF5C7029929601005C3D8D /* SecureConversations.FilePreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FilePreviewView.swift; sourceTree = "<group>"; };
 		AFEF5C7329929A8D005C3D8D /* SecureConversations.FileUploadListViewModel.Environment.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FileUploadListViewModel.Environment.Failing.swift; sourceTree = "<group>"; };
@@ -2859,6 +2865,9 @@
 				C090476D2B7E2546003C437C /* UnreadMessageDividerStyle.Equatable.swift */,
 				AF10ED8E29BF849A00E85309 /* UnreadMessageDividerView.swift */,
 				1A8B61D025C97481000D780E /* Upgrade */,
+				AFE82C772CC2ACA1005E641F /* SecureMessagingBottomBannerView.swift */,
+				AF3AFB832CC68AB30072E7A9 /* SecureMessagingBottomBannerViewStyle.swift */,
+				AFCA8A412CC7939F008B7DD3 /* SecureMessagingBottomBannerViewStyle.RemoteConfig.swift */,
 			);
 			path = Chat;
 			sourceTree = "<group>";
@@ -5683,6 +5692,7 @@
 				C09046CA2B7E05F7003C437C /* AttachmentSourceListStyle.Mock.swift in Sources */,
 				C0F3DE412C6E36C900DE6D7B /* View+Extensions.swift in Sources */,
 				1A6075E7258220E300569B0E /* UserImageStyle.swift in Sources */,
+				AFCA8A422CC7939F008B7DD3 /* SecureMessagingBottomBannerViewStyle.RemoteConfig.swift in Sources */,
 				1ABD6C5D25B59D1C00D56EFA /* BubbleWindow.swift in Sources */,
 				75940964298D3889008B173A /* MessageRenderer.Web.swift in Sources */,
 				C0E948042AB1D5D200890026 /* ActionButtonSwiftUI.swift in Sources */,
@@ -5737,6 +5747,7 @@
 				AF10ED8F29BF849A00E85309 /* UnreadMessageDividerView.swift in Sources */,
 				1AC8AADD25D419CE00DAFE50 /* VideoStreamView.swift in Sources */,
 				8491AF152A7ACDB000CC3E72 /* Theme.SystemMessageStyle.swift in Sources */,
+				AFE82C782CC2ACA1005E641F /* SecureMessagingBottomBannerView.swift in Sources */,
 				C090472E2B7E1CB2003C437C /* GvaPersistentButtonStyle.ButtonStyle.RemoteConfig.swift in Sources */,
 				C09047622B7E234E003C437C /* ChatFileDownloadStateStyle.swift in Sources */,
 				C0B325E72AC5A8FA006BC430 /* AlertViewController+LiveObservationConfirmation.swift in Sources */,
@@ -5798,6 +5809,7 @@
 				84520BE72B1769AB00F97617 /* ChatViewController.Environment.swift in Sources */,
 				210150792CC14E8200294BA4 /* QueuesMonitor.Mock.swift in Sources */,
 				3100D92B296E946600DEC9CE /* SecureConversations.ConfirmationStyle.swift in Sources */,
+				AF3AFB842CC68AB30072E7A9 /* SecureMessagingBottomBannerViewStyle.swift in Sources */,
 				C090477C2B7E27F1003C437C /* EngagementStyle.Equatable.swift in Sources */,
 				8491AF132A7ACC5400CC3E72 /* Theme.OperatorChatMessageStyle.swift in Sources */,
 				845E2F93283FB6D000C04D56 /* Theme.Survey.Accessibility.swift in Sources */,

--- a/GliaWidgets/Sources/Theme/Theme+Chat.swift
+++ b/GliaWidgets/Sources/Theme/Theme+Chat.swift
@@ -395,6 +395,14 @@ extension Theme {
             fileDownload: fileDownload
         )
 
+        let secureMessagingBottomBannerStyle = SecureMessagingBottomBannerViewStyle(
+            message: Localization.SecureMessaging.Chat.Banner.bottom,
+            font: font.caption,
+            textColor: color.baseNormal,
+            backgroundColor: color.baseNeutral,
+            dividerColor: color.baseShade
+        )
+
         return ChatStyle(
             header: header,
             connect: connect,
@@ -420,7 +428,8 @@ extension Theme {
             secureTranscriptHeader: secureTranscriptHeader,
             unreadMessageDivider: unreadMessageDivider,
             systemMessageStyle: systemMessage,
-            gliaVirtualAssistant: gliaVirtualAssistantStyle
+            gliaVirtualAssistant: gliaVirtualAssistantStyle,
+            secureMessagingBottomBannerStyle: secureMessagingBottomBannerStyle
         )
     }
 

--- a/GliaWidgets/Sources/View/Chat/ChatStyle.Deprecated.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatStyle.Deprecated.swift
@@ -88,7 +88,8 @@ extension ChatStyle {
         secureTranscriptHeader: HeaderStyle,
         unreadMessageDivider: UnreadMessageDividerStyle,
         systemMessage: SystemMessageStyle,
-        gliaVirtualAssistant: GliaVirtualAssistantStyle
+        gliaVirtualAssistant: GliaVirtualAssistantStyle,
+        secureMessagingBottomBannerStyle: SecureMessagingBottomBannerViewStyle
     ) {
         self.init(
             header: header,
@@ -111,7 +112,8 @@ extension ChatStyle {
             secureTranscriptHeader: secureTranscriptHeader,
             unreadMessageDivider: unreadMessageDivider,
             systemMessageStyle: systemMessage.toNewSystemMessageStyle(),
-            gliaVirtualAssistant: gliaVirtualAssistant
+            gliaVirtualAssistant: gliaVirtualAssistant,
+            secureMessagingBottomBannerStyle: secureMessagingBottomBannerStyle
         )
     }
 }

--- a/GliaWidgets/Sources/View/Chat/ChatStyle.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatStyle.swift
@@ -53,6 +53,9 @@ public class ChatStyle: EngagementStyle {
     /// Style of the Glia Virtual Assistant
     public var gliaVirtualAssistant: GliaVirtualAssistantStyle
 
+    /// Style of the secure messaging bottom banner view.
+    public var secureMessagingBottomBannerStyle: SecureMessagingBottomBannerViewStyle
+
     /// - Parameters:
     ///   - header: Style of the view's header (navigation bar area) when the screen is displaying live chat.
     ///   - connect: Styles for different engagement connection states.
@@ -95,7 +98,8 @@ public class ChatStyle: EngagementStyle {
         secureTranscriptHeader: HeaderStyle,
         unreadMessageDivider: UnreadMessageDividerStyle,
         systemMessageStyle: Theme.SystemMessageStyle,
-        gliaVirtualAssistant: GliaVirtualAssistantStyle
+        gliaVirtualAssistant: GliaVirtualAssistantStyle,
+        secureMessagingBottomBannerStyle: SecureMessagingBottomBannerViewStyle
     ) {
         self.title = title
         self.visitorMessageStyle = visitorMessageStyle
@@ -114,6 +118,7 @@ public class ChatStyle: EngagementStyle {
         self.unreadMessageDivider = unreadMessageDivider
         self.systemMessageStyle = systemMessageStyle
         self.gliaVirtualAssistant = gliaVirtualAssistant
+        self.secureMessagingBottomBannerStyle = secureMessagingBottomBannerStyle
 
         super.init(
             header: header,

--- a/GliaWidgets/Sources/View/Chat/ChatView.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatView.swift
@@ -25,6 +25,7 @@ class ChatView: EngagementView {
     var selectCustomCardOption: ((HtmlMetadata.Option, MessageRenderer.Message.Identifier) -> Void)?
     var gvaButtonTapped: ((GvaOption) -> Void)?
     var retryMessageTapped: ((OutgoingMessage) -> Void)?
+    let secureMessagingBottomBannerView = SecureMessagingBottomBannerView().makeView()
 
     let style: ChatStyle
     let environment: Environment
@@ -144,6 +145,13 @@ class ChatView: EngagementView {
         constraints += quickReplyView.layoutIn(safeAreaLayoutGuide, edges: .horizontal)
         constraints += quickReplyView.topAnchor.constraint(equalTo: tableAndIndicatorStack.bottomAnchor)
 
+        addSubview(secureMessagingBottomBannerView)
+        constraints += [
+            secureMessagingBottomBannerView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            secureMessagingBottomBannerView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            secureMessagingBottomBannerView.topAnchor.constraint(equalTo: quickReplyView.bottomAnchor)
+        ]
+
         addSubview(messageEntryView)
         let messageEntryInsets = UIEdgeInsets(
             top: 0,
@@ -161,7 +169,7 @@ class ChatView: EngagementView {
         }
 
         constraints += messageEntryView.layoutIn(safeAreaLayoutGuide, edges: .horizontal)
-        constraints += messageEntryView.topAnchor.constraint(equalTo: quickReplyView.bottomAnchor)
+        constraints += messageEntryView.topAnchor.constraint(equalTo: secureMessagingBottomBannerView.bottomAnchor)
 
         addSubview(unreadMessageIndicatorView)
         unreadMessageIndicatorView.translatesAutoresizingMaskIntoConstraints = false
@@ -169,6 +177,11 @@ class ChatView: EngagementView {
 
         constraints += unreadMessageIndicatorView.bottomAnchor.constraint(
             equalTo: messageEntryView.topAnchor, constant: kUnreadMessageIndicatorInset
+        )
+
+        secureMessagingBottomBannerView.props = .init(
+            style: style.secureMessagingBottomBannerStyle,
+            isHidden: true // Logic to show/hide SC bottom banner is to be added with MOB-3634
         )
     }
 }

--- a/GliaWidgets/Sources/View/Chat/SecureMessagingBottomBannerView.swift
+++ b/GliaWidgets/Sources/View/Chat/SecureMessagingBottomBannerView.swift
@@ -1,0 +1,98 @@
+import UIKit
+
+final class SecureMessagingBottomBannerView: UIView {
+    private static let horizontalMargins = 16.0
+    private static let verticalMargins = 8.0
+
+    private let label = UILabel().makeView()
+    private let divider = UIView().makeView()
+
+    private lazy var labelConstraints: [NSLayoutConstraint] = [
+        label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Self.horizontalMargins),
+        label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Self.horizontalMargins),
+        label.topAnchor.constraint(equalTo: topAnchor, constant: Self.verticalMargins),
+        label.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Self.verticalMargins)
+    ]
+
+    var props = Props.initial {
+        didSet {
+            guard props != oldValue else {
+                return
+            }
+            renderProps()
+        }
+    }
+
+    init() {
+        super.init(frame: .zero)
+        setup()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    private func setup() {
+        addSubview(label)
+        label.numberOfLines = 0
+        renderHidden(isHidden)
+        renderProps()
+        addSubview(divider)
+        NSLayoutConstraint.activate([
+            divider.heightAnchor.constraint(equalToConstant: 1),
+            divider.topAnchor.constraint(equalTo: topAnchor, constant: -1),
+            divider.leadingAnchor.constraint(equalTo: leadingAnchor),
+            divider.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
+    }
+
+    override var isHidden: Bool {
+        didSet {
+            super.isHidden = self.isHidden
+            guard isHidden != oldValue else {
+                return
+            }
+            renderHidden(self.isHidden)
+        }
+    }
+
+    private func renderHidden(_ hidden: Bool) {
+        // In order to avoid breaking auto-layout constraints
+        // we deactivate label constraints if view gets hidden.
+        if hidden {
+            NSLayoutConstraint.deactivate(labelConstraints)
+        } else {
+            NSLayoutConstraint.activate(labelConstraints)
+        }
+        // Layout manually to enforce constraints to be applied immediately,
+        // thus affecting the `frame`.
+        layoutIfNeeded()
+    }
+
+    private func renderProps() {
+        label.text = props.style.message
+        label.textColor = props.style.textColor
+        backgroundColor = props.style.backgroundColor
+        label.font = props.style.font
+        isHidden = props.isHidden
+        divider.backgroundColor = props.style.dividerColor
+    }
+
+    override var intrinsicContentSize: CGSize {
+        // When view is hidden, we should report zero height, to ensure that
+        // it does not affect existing layout, by avoiding introduction of unnecessary
+        // vertical gap, while keeping the view in hierarchy.
+        isHidden ? .init(width: label.intrinsicContentSize.width, height: 0)
+                 : label.intrinsicContentSize
+    }
+}
+
+extension SecureMessagingBottomBannerView {
+    struct Props: Equatable {
+        let style: SecureMessagingBottomBannerViewStyle
+        let isHidden: Bool
+    }
+}
+
+extension SecureMessagingBottomBannerView.Props {
+    fileprivate static let initial = Self(style: .initial, isHidden: false)
+}

--- a/GliaWidgets/Sources/View/Chat/SecureMessagingBottomBannerViewStyle.RemoteConfig.swift
+++ b/GliaWidgets/Sources/View/Chat/SecureMessagingBottomBannerViewStyle.RemoteConfig.swift
@@ -1,0 +1,3 @@
+// TODO: Unified customization will be implemented with MOB-3717
+
+import Foundation

--- a/GliaWidgets/Sources/View/Chat/SecureMessagingBottomBannerViewStyle.swift
+++ b/GliaWidgets/Sources/View/Chat/SecureMessagingBottomBannerViewStyle.swift
@@ -1,0 +1,45 @@
+import UIKit
+
+/// Style of the secure messaging bottom banner view.
+public struct SecureMessagingBottomBannerViewStyle: Equatable {
+    /// Text of the banner message.
+    public var message: String
+    /// Font of banner message.
+    public var font: UIFont
+    /// Color of the text of the  banner message.
+    public var textColor: UIColor
+    /// Color of the banner background.
+    public var backgroundColor: UIColor
+    /// Color of the banner divider.
+    public var dividerColor: UIColor
+
+    /// - Parameters:
+    ///   - message: Text of the banner message.
+    ///   - font: Font of banner message.
+    ///   - textColor: Color of the text of the  banner message.
+    ///   - backgroundColor: Color of the banner background.
+    ///   - dividerColor: Color of the banner divider.
+    public init(
+        message: String,
+        font: UIFont,
+        textColor: UIColor,
+        backgroundColor: UIColor,
+        dividerColor: UIColor
+    ) {
+        self.message = message
+        self.font = font
+        self.textColor = textColor
+        self.backgroundColor = backgroundColor
+        self.dividerColor = dividerColor
+    }
+}
+
+extension SecureMessagingBottomBannerViewStyle {
+    static let initial = Self(
+        message: "",
+        font: .preferredFont(forTextStyle: .caption1),
+        textColor: .label,
+        backgroundColor: .red,
+        dividerColor: .yellow
+    )
+}

--- a/GliaWidgetsTests/Sources/ChatView/ChatStyle.Mock.swift
+++ b/GliaWidgetsTests/Sources/ChatView/ChatStyle.Mock.swift
@@ -1,6 +1,7 @@
 import UIKit
 @testable import GliaWidgets
 
+#if DEBUG
 extension ChatStyle {
     static func mock(
         header: HeaderStyle = .mock(),
@@ -22,7 +23,8 @@ extension ChatStyle {
         secureTranscriptHeader: HeaderStyle = .mock(),
         unreadMessageDivider: UnreadMessageDividerStyle = .mock(),
         systemMessageStyle: Theme.SystemMessageStyle = .mock(),
-        gliaVirtualAssistant: GliaVirtualAssistantStyle = .mock()
+        gliaVirtualAssistant: GliaVirtualAssistantStyle = .mock(),
+        secureMessagingBottomBannerStyle: SecureMessagingBottomBannerViewStyle = .mock()
     ) -> ChatStyle {
         ChatStyle.init(
             header: header,
@@ -44,7 +46,8 @@ extension ChatStyle {
             secureTranscriptHeader: secureTranscriptHeader,
             unreadMessageDivider: unreadMessageDivider,
             systemMessageStyle: systemMessageStyle,
-            gliaVirtualAssistant: gliaVirtualAssistant
+            gliaVirtualAssistant: gliaVirtualAssistant,
+            secureMessagingBottomBannerStyle: secureMessagingBottomBannerStyle
         )
     }
 }
@@ -533,3 +536,22 @@ extension Theme.ChatTextContentStyle {
         )
     }
 }
+
+extension SecureMessagingBottomBannerViewStyle {
+    static func mock(
+        message: String = Localization.SecureMessaging.Chat.Banner.bottom,
+        font: UIFont = Theme().chat.secureMessagingBottomBannerStyle.font,
+        textColor: UIColor = Theme().chat.secureMessagingBottomBannerStyle.textColor,
+        backgroundColor: UIColor = Theme().chat.secureMessagingBottomBannerStyle.backgroundColor,
+        dividerColor: UIColor = Theme().chat.secureMessagingBottomBannerStyle.dividerColor
+    ) -> Self {
+        .init(
+            message: message,
+            font: font,
+            textColor: textColor,
+            backgroundColor: backgroundColor,
+            dividerColor: dividerColor
+        )
+    }
+}
+#endif


### PR DESCRIPTION
MOB-3720

**What was solved?**
Add initial implementation of SC bottom banner UI.
Snapshot tests and unified customization are to be added in separate PRs.


<img src="https://github.com/user-attachments/assets/95d5e447-11be-43d2-a1ed-aad30ecf8172" width="428" height="926">


**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
