### PR TITLE
Fix sending message with attachments

### DIFF
--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -432,7 +432,7 @@ extension ChatViewModel {
         let uploads = fileUploadListModel.succeededUploads
         let files = uploads.map { $0.localFile }
 
-        let payload = environment.createSendMessagePayload(messageText, nil)
+        let payload = environment.createSendMessagePayload(messageText, attachment)
 
         let outgoingMessage = OutgoingMessage(
             payload: payload,
@@ -446,17 +446,9 @@ extension ChatViewModel {
             fileUploadListModel.succeededUploads.forEach { action?(.removeUpload($0)) }
             fileUploadListModel.removeSucceededUploads()
             action?(.scrollToBottom(animated: true))
-            let messageTextTemp = messageText
             messageText = ""
 
-            // In order to keep using same payload, with its
-            // initial ID, we make mutable copy of it
-            // and assign attachment and content accordingly
-            // before passing payload to send-message request.
-            var messagePayload = outgoingMessage.payload
-            messagePayload.content = messageTextTemp
-            messagePayload.attachment = attachment
-            interactor.send(messagePayload: messagePayload) { [weak self] result in
+            interactor.send(messagePayload: outgoingMessage.payload) { [weak self] result in
                 guard let self else { return }
 
                 switch result {


### PR DESCRIPTION
**What was solved?**
This PR fixes the case when OutgoingMessage stored in messagesSection did not include attachment object after sending. It led to the situation when the attachment was missed if initial send message request failed.
Now failed-to-send messages with attachments can be successfully resent.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.