### PR TITLE
Fix title's font of GVA persisent button

### DIFF
--- a/GliaWidgets/SecureConversations/Welcome/Theme+SecureConversationsWelcome.swift
+++ b/GliaWidgets/SecureConversations/Welcome/Theme+SecureConversationsWelcome.swift
@@ -39,7 +39,7 @@ extension Theme {
         let messageTitleStyle = SecureConversations.WelcomeStyle.MessageTitleStyle(
             title: Localization.MessageCenter.Welcome.messageTitle,
             font: font.mediumSubtitle1,
-            textStyle: .subheadline,
+            textStyle: .headline,
             color: .black,
             accessibility: .init(isFontScalingEnabled: true)
         )

--- a/GliaWidgets/Sources/Extensions/UIFont+Extensions.swift
+++ b/GliaWidgets/Sources/Extensions/UIFont+Extensions.swift
@@ -50,3 +50,22 @@ extension UIFont {
         return UIFont(descriptor: descriptor, size: size)
     }
 }
+
+extension UIFont {
+    static func scaledFont(forTextStyle: UIFont.TextStyle) -> UIFont? {
+        var descriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: forTextStyle)
+        guard let style = FontScaling.Style(forTextStyle),
+              let description = FontScaling.theme.descriptions[style] else {
+            return nil
+        }
+        descriptor = descriptor.addingAttributes(
+            [
+                UIFontDescriptor.AttributeName.traits: [UIFontDescriptor.TraitKey.weight: description.weight]
+            ]
+        )
+        /// Create a font copy with original size to scale it with current preferred content size category
+        let fontCopy = UIFont(descriptor: descriptor, size: description.size)
+
+        return UIFontMetrics(forTextStyle: forTextStyle).scaledFont(for: fontCopy)
+    }
+}

--- a/GliaWidgets/Sources/Theme/Survey/Theme.Survey.BooleanQuestion.swift
+++ b/GliaWidgets/Sources/Theme/Survey/Theme.Survey.BooleanQuestion.swift
@@ -23,7 +23,7 @@ public extension Theme.SurveyStyle {
                 title: .init(
                     color: color.baseDark.hex,
                     font: font.mediumSubtitle1,
-                    textStyle: .subheadline,
+                    textStyle: .headline,
                     accessibility: .init(isFontScalingEnabled: true)
                 ),
                 option: .init(

--- a/GliaWidgets/Sources/Theme/Survey/Theme.Survey.InputQuestion.swift
+++ b/GliaWidgets/Sources/Theme/Survey/Theme.Survey.InputQuestion.swift
@@ -26,7 +26,7 @@ public extension Theme.SurveyStyle {
                 title: .init(
                     color: color.baseDark.hex,
                     font: font.mediumSubtitle1,
-                    textStyle: .subheadline,
+                    textStyle: .headline,
                     accessibility: .init(isFontScalingEnabled: true)
                 ),
                 option: .init(

--- a/GliaWidgets/Sources/Theme/Survey/Theme.Survey.ScaleQuestion.swift
+++ b/GliaWidgets/Sources/Theme/Survey/Theme.Survey.ScaleQuestion.swift
@@ -23,7 +23,7 @@ public extension Theme.SurveyStyle {
                 title: .init(
                     color: color.baseDark.hex,
                     font: font.mediumSubtitle1,
-                    textStyle: .subheadline,
+                    textStyle: .headline,
                     accessibility: .init(isFontScalingEnabled: true)
                 ),
                 option: .init(

--- a/GliaWidgets/Sources/Theme/Survey/Theme.Survey.SingleQuestion.swift
+++ b/GliaWidgets/Sources/Theme/Survey/Theme.Survey.SingleQuestion.swift
@@ -26,7 +26,7 @@ public extension Theme.SurveyStyle {
                 title: .init(
                     color: color.baseDark.hex,
                     font: font.mediumSubtitle1,
-                    textStyle: .subheadline,
+                    textStyle: .headline,
                     accessibility: .init(isFontScalingEnabled: true)
                 ),
                 tintColor: color.primary.hex,

--- a/GliaWidgets/Sources/Theme/Theme+Gva.swift
+++ b/GliaWidgets/Sources/Theme/Theme+Gva.swift
@@ -8,7 +8,7 @@ extension Theme {
             title: .init(
                 text: .init(
                     color: UIColor.black.hex,
-                    font: font.bodyText,
+                    font: font.mediumSubtitle1,
                     textStyle: .headline,
                     accessibility: .init(isFontScalingEnabled: true)
                 ),
@@ -60,7 +60,7 @@ extension Theme {
             title: .init(
                 font: font.mediumSubtitle1,
                 textColor: color.baseDark,
-                textStyle: .body
+                textStyle: .headline
             ),
             subtitle: .init(
                 font: font.caption,

--- a/GliaWidgets/Sources/Theme/ThemeFont.swift
+++ b/GliaWidgets/Sources/Theme/ThemeFont.swift
@@ -68,7 +68,7 @@ public struct ThemeFont {
         self.bodyText = fontScaling.uiFont(with: .body) // bodyText ?? Font.regular(16) // .body
         self.subtitle = fontScaling.uiFont(with: .footnote) // subtitle ?? Font.regular(14) // .footnote
         self.mediumSubtitle1 = fontScaling.uiFont(
-            with: .subheadline,
+            with: .headline,
             font: .systemFont(ofSize: 16, weight: .medium)
         ) // medium16 ?? Font.medium(16) // .subheadline
         self.mediumSubtitle2 = fontScaling.uiFont(with: .subheadline)// mediumSubtitle ?? Font.medium(14) // .subheadline
@@ -102,11 +102,11 @@ extension FontScaling.Style {
         case .footnote:
             return .init(weight: .regular, size: 14)  // subtitle ?? Font.regular(14) // ???
         case .headline:
-            return .init(weight: .bold, size: 17)
+            return .init(weight: .medium, size: 16) // mediumSubtitle1 ?? Font.medium(16)
         case .largeTitle:
             return .init(weight: .regular, size: 34)
         case .subheadline:
-            return .init(weight: .medium, size: 14) // mediumSubtitle ?? Font.medium(14)
+            return .init(weight: .medium, size: 14) // mediumSubtitle2 ?? Font.medium(14)
         case .title1:
             return .init(weight: .bold, size: 24) // header1 ?? Font.bold(24)
         case .title2:

--- a/GliaWidgets/Sources/View/Chat/Message/Content/Text/ChatTextContentView.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/Content/Text/ChatTextContentView.swift
@@ -125,8 +125,12 @@ class ChatTextContentView: BaseView {
             var constraints = [NSLayoutConstraint](); defer { constraints.activate() }
             constraints += textView.layoutInSuperview(insets: kTextInsets)
         }
+
+        /// Retrieve scaled font for given text style because font of attributed font does not change with dynamic size update
+        let scaledFont = UIFont.scaledFont(forTextStyle: style.text.textStyle) ?? style.text.font
+
         let attributes: [NSAttributedString.Key: Any] = [
-            .font: UIFont.preferredFont(forTextStyle: style.text.textStyle),
+            .font: scaledFont,
             .foregroundColor: UIColor(hex: style.text.color)
         ]
 


### PR DESCRIPTION
MOB-3704

**What was solved?**
This PR fixes the font style issue with the GVA persistent button title. Previously there was confusion between `mediumSubtitle1` and `mediumSubtitle2`, as both were using the `.subheadline` text style. Now, `mediumSubtitle1` utilizes the `.headline` text style, which was not in use before and `mediumSubtitle2` uses `.subheadline`.

Additionally, this update includes alignment of all styles that use `mediumSubtitle1` to match the design specifications, ensuring consistency across all labels using this style.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [X] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [X] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
<div style="display: flex; justify-content: space-around;">
<img width="200" alt="Screenshot 2024-09-20 at 17 24 55"  title="Medium font sizes" src="https://github.com/user-attachments/assets/950fbb28-e14e-44ef-8776-bc7c78ffa49c">
<img width="200" alt="Screenshot 2024-09-20 at 17 24 55"  title="Dynamic Type Sizes" src="https://github.com/user-attachments/assets/a84aa865-1521-4a63-9482-7b5ed0667c61">
</div>
