### PR TITLE
Implement unified customization for SC bottom banner

### DIFF
--- a/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration+Chat.swift
+++ b/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration+Chat.swift
@@ -19,6 +19,7 @@ extension RemoteConfiguration {
         let newMessagesDividerText: Text?
         let systemMessage: MessageBalloon?
         let gva: Gva?
+        let secureMessaging: SecureConversations?
     }
 
     struct Gva: Codable {

--- a/GliaWidgets/Sources/Theme/Theme+Chat.swift
+++ b/GliaWidgets/Sources/Theme/Theme+Chat.swift
@@ -398,8 +398,9 @@ extension Theme {
         let secureMessagingBottomBannerStyle = SecureMessagingBottomBannerViewStyle(
             message: Localization.SecureMessaging.Chat.Banner.bottom,
             font: font.caption,
+            textStyle: .caption1,
             textColor: color.baseNormal,
-            backgroundColor: color.baseNeutral,
+            backgroundColor: .fill(color: color.baseNeutral),
             dividerColor: color.baseShade
         )
 

--- a/GliaWidgets/Sources/View/Chat/ChatStyle.RemoteConfig.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatStyle.RemoteConfig.swift
@@ -55,12 +55,26 @@ extension ChatStyle {
             text: configuration?.newMessagesDividerText,
             assetBuilder: assetsBuilder
         )
+        applyAdditionalStyles(
+            configuration: configuration,
+            assetsBuilder: assetsBuilder
+        )
+    }
+
+    private func applyAdditionalStyles(
+        configuration: RemoteConfiguration.Chat?,
+        assetsBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
         systemMessageStyle.apply(
             configuration: configuration?.systemMessage,
             assetsBuilder: assetsBuilder
         )
         gliaVirtualAssistant.apply(
             configuration: configuration?.gva,
+            assetBuilder: assetsBuilder
+        )
+        secureMessagingBottomBannerStyle.apply(
+            configuration: configuration?.secureMessaging,
             assetBuilder: assetsBuilder
         )
         applyBackground(color: configuration?.background?.color)

--- a/GliaWidgets/Sources/View/Chat/SecureMessagingBottomBannerView.swift
+++ b/GliaWidgets/Sources/View/Chat/SecureMessagingBottomBannerView.swift
@@ -71,7 +71,7 @@ final class SecureMessagingBottomBannerView: UIView {
     private func renderProps() {
         label.text = props.style.message
         label.textColor = props.style.textColor
-        backgroundColor = props.style.backgroundColor
+        backgroundColor = props.style.backgroundColor.color
         label.font = props.style.font
         isHidden = props.isHidden
         divider.backgroundColor = props.style.dividerColor

--- a/GliaWidgets/Sources/View/Chat/SecureMessagingBottomBannerViewStyle.RemoteConfig.swift
+++ b/GliaWidgets/Sources/View/Chat/SecureMessagingBottomBannerViewStyle.RemoteConfig.swift
@@ -1,3 +1,37 @@
-// TODO: Unified customization will be implemented with MOB-3717
+import UIKit
 
-import Foundation
+extension SecureMessagingBottomBannerViewStyle {
+    mutating func apply(
+        configuration: RemoteConfiguration.SecureConversations?,
+        assetBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
+        configuration?.bottomBannerBackground?.color.unwrap {
+            switch $0.type {
+            case .fill:
+                $0.value
+                    .map { UIColor(hex: $0) }
+                    .first
+                    .unwrap { backgroundColor = .fill(color: $0) }
+            case .gradient:
+                let colors = $0.value.convertToCgColors()
+                backgroundColor = .gradient(colors: colors)
+            }
+        }
+
+        configuration?.topBannerDividerColor?.value
+            .map { UIColor(hex: $0) }
+            .first
+            .unwrap { dividerColor = $0 }
+
+        configuration?.bottomBannerText?.foreground?.value
+            .map { UIColor(hex: $0) }
+            .first
+            .unwrap { textColor = $0 }
+
+        UIFont.convertToFont(
+            uiFont: assetBuilder.fontBuilder(configuration?.bottomBannerText?.font),
+            textStyle: textStyle
+        )
+        .unwrap { font = $0 }
+    }
+}

--- a/GliaWidgets/Sources/View/Chat/SecureMessagingBottomBannerViewStyle.swift
+++ b/GliaWidgets/Sources/View/Chat/SecureMessagingBottomBannerViewStyle.swift
@@ -6,24 +6,28 @@ public struct SecureMessagingBottomBannerViewStyle: Equatable {
     public var message: String
     /// Font of banner message.
     public var font: UIFont
+    /// Style of the text of the  banner message.
+    public var textStyle: UIFont.TextStyle
     /// Color of the text of the  banner message.
     public var textColor: UIColor
     /// Color of the banner background.
-    public var backgroundColor: UIColor
+    public var backgroundColor: ColorType
     /// Color of the banner divider.
     public var dividerColor: UIColor
 
     /// - Parameters:
     ///   - message: Text of the banner message.
     ///   - font: Font of banner message.
+    ///   - textStyle: Style of the text of the  banner message.
     ///   - textColor: Color of the text of the  banner message.
     ///   - backgroundColor: Color of the banner background.
     ///   - dividerColor: Color of the banner divider.
     public init(
         message: String,
         font: UIFont,
+        textStyle: UIFont.TextStyle,
         textColor: UIColor,
-        backgroundColor: UIColor,
+        backgroundColor: ColorType,
         dividerColor: UIColor
     ) {
         self.message = message
@@ -31,6 +35,7 @@ public struct SecureMessagingBottomBannerViewStyle: Equatable {
         self.textColor = textColor
         self.backgroundColor = backgroundColor
         self.dividerColor = dividerColor
+        self.textStyle = textStyle
     }
 }
 
@@ -38,8 +43,9 @@ extension SecureMessagingBottomBannerViewStyle {
     static let initial = Self(
         message: "",
         font: .preferredFont(forTextStyle: .caption1),
+        textStyle: .caption1,
         textColor: .label,
-        backgroundColor: .red,
+        backgroundColor: .fill(color: .red),
         dividerColor: .yellow
     )
 }

--- a/GliaWidgetsTests/Sources/ChatView/ChatStyle.Mock.swift
+++ b/GliaWidgetsTests/Sources/ChatView/ChatStyle.Mock.swift
@@ -541,13 +541,15 @@ extension SecureMessagingBottomBannerViewStyle {
     static func mock(
         message: String = Localization.SecureMessaging.Chat.Banner.bottom,
         font: UIFont = Theme().chat.secureMessagingBottomBannerStyle.font,
+        textStyle: UIFont.TextStyle = Theme().chat.secureMessagingBottomBannerStyle.textStyle,
         textColor: UIColor = Theme().chat.secureMessagingBottomBannerStyle.textColor,
-        backgroundColor: UIColor = Theme().chat.secureMessagingBottomBannerStyle.backgroundColor,
+        backgroundColor: ColorType = Theme().chat.secureMessagingBottomBannerStyle.backgroundColor,
         dividerColor: UIColor = Theme().chat.secureMessagingBottomBannerStyle.dividerColor
     ) -> Self {
         .init(
             message: message,
             font: font,
+            textStyle: textStyle,
             textColor: textColor,
             backgroundColor: backgroundColor,
             dividerColor: dividerColor


### PR DESCRIPTION
Add unified customization implementation for SC bottom banner.

MOB-3717

**What was solved?**

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
