### PR TITLE
Hide the "Secure Messaging" if visitor is not authenticated

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -706,6 +706,7 @@
 		C06A7584296EC9DC006B69A2 /* NumberSlotStyle.Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06A7583296EC9DC006B69A2 /* NumberSlotStyle.Accessibility.swift */; };
 		C06A7586296ECC57006B69A2 /* VisitorCodeStyle.Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06A7585296ECC57006B69A2 /* VisitorCodeStyle.Accessibility.swift */; };
 		C06A7588296ECD75006B69A2 /* Theme+VisitorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06A7587296ECD75006B69A2 /* Theme+VisitorCode.swift */; };
+		C06B6D4C2CCB917600A66D8A /* EntryWidgetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06B6D4B2CCB917600A66D8A /* EntryWidgetTests.swift */; };
 		C07F62462ABC322B003EFC97 /* OrientationManager.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07F62452ABC322B003EFC97 /* OrientationManager.Mock.swift */; };
 		C07F62772AC1BA2B003EFC97 /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07F62762AC1BA2B003EFC97 /* UIViewController+Extensions.swift */; };
 		C07F62792AC2D2E8003EFC97 /* BackgroundSwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07F62782AC2D2E8003EFC97 /* BackgroundSwiftUI.swift */; };
@@ -1756,6 +1757,7 @@
 		C06A7583296EC9DC006B69A2 /* NumberSlotStyle.Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberSlotStyle.Accessibility.swift; sourceTree = "<group>"; };
 		C06A7585296ECC57006B69A2 /* VisitorCodeStyle.Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitorCodeStyle.Accessibility.swift; sourceTree = "<group>"; };
 		C06A7587296ECD75006B69A2 /* Theme+VisitorCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Theme+VisitorCode.swift"; sourceTree = "<group>"; };
+		C06B6D4B2CCB917600A66D8A /* EntryWidgetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryWidgetTests.swift; sourceTree = "<group>"; };
 		C07F62452ABC322B003EFC97 /* OrientationManager.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrientationManager.Mock.swift; sourceTree = "<group>"; };
 		C07F62762AC1BA2B003EFC97 /* UIViewController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extensions.swift"; sourceTree = "<group>"; };
 		C07F62782AC2D2E8003EFC97 /* BackgroundSwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundSwiftUI.swift; sourceTree = "<group>"; };
@@ -3558,6 +3560,7 @@
 		7512A57827BF9FB800319DF1 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				C06B6D4A2CCB916300A66D8A /* EntryWidget */,
 				210150722CC13E7300294BA4 /* QueuesMonitor */,
 				215A25962CABC7C50013023E /* EngagementLauncher */,
 				C0D6C9FE2C106A0D00D4709B /* AlertManager */,
@@ -4678,6 +4681,14 @@
 				C09046C12B7D0EEE003C437C /* NumberSlotStyle.RemoteConfig.swift */,
 			);
 			path = NumberSlot;
+			sourceTree = "<group>";
+		};
+		C06B6D4A2CCB916300A66D8A /* EntryWidget */ = {
+			isa = PBXGroup;
+			children = (
+				C06B6D4B2CCB917600A66D8A /* EntryWidgetTests.swift */,
+			);
+			path = EntryWidget;
 			sourceTree = "<group>";
 		};
 		C07F62442ABC3218003EFC97 /* OrientationManager */ = {
@@ -6535,6 +6546,7 @@
 				C0D6CA002C106A1F00D4709B /* AlertManager.Failing.swift in Sources */,
 				EB9ADB51280EBD4E00FAE8A4 /* InteractorStateTests.swift in Sources */,
 				8491AF652AAB281500CC3E72 /* ChatViewModelTests+CustomCard.swift in Sources */,
+				C06B6D4C2CCB917600A66D8A /* EntryWidgetTests.swift in Sources */,
 				EB7A1508286D98000035AC62 /* FileUploader.Environment.Failing.swift in Sources */,
 				AF993B3D2C8F5E7000DC5E69 /* EngagementCoordinatorCallTests.swift in Sources */,
 				AF2355A229C9EC7E007D9896 /* IdCollectionTests.swift in Sources */,

--- a/GliaWidgets/Public/Glia/Glia+EntryWidget.swift
+++ b/GliaWidgets/Public/Glia/Glia+EntryWidget.swift
@@ -14,7 +14,8 @@ extension Glia {
             environment: .init(
                 queuesMonitor: environment.queuesMonitor,
                 engagementLauncher: try getEngagementLauncher(queueIds: queueIds),
-                theme: theme
+                theme: theme,
+                isAuthenticated: environment.isAuthenticated
             )
         )
     }

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
@@ -83,14 +83,7 @@ extension EngagementCoordinator.Environment {
             messagesWithUnreadCountLoaderScheduler: environment.messagesWithUnreadCountLoaderScheduler,
             secureMarkMessagesAsRead: environment.coreSdk.secureMarkMessagesAsRead,
             downloadSecureFile: environment.coreSdk.downloadSecureFile,
-            isAuthenticated: { [environment] in
-                do {
-                    return try environment.coreSdk.authentication(.forbiddenDuringEngagement).isAuthenticated
-                } catch {
-                    debugPrint(#function, "isAuthenticated:", error.localizedDescription)
-                    return false
-                }
-            },
+            isAuthenticated: environment.isAuthenticated,
             startSocketObservation: environment.coreSdk.startSocketObservation,
             stopSocketObservation: environment.coreSdk.stopSocketObservation,
             pushNotifications: environment.coreSdk.pushNotifications,

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.Environment.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.Environment.swift
@@ -5,5 +5,6 @@ extension EntryWidget {
         var queuesMonitor: QueuesMonitor
         var engagementLauncher: EngagementLauncher
         var theme: Theme
+        var isAuthenticated: () -> Bool
     }
 }

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
@@ -15,7 +15,7 @@ public final class EntryWidget: NSObject {
     private var cancellables = CancelBag()
     private let environment: Environment
 
-    @Published private var viewState: ViewState = .loading
+    @Published private(set) var viewState: ViewState = .loading
 
     private let sizeConstraints: SizeConstraints = .init(
         singleCellHeight: 72,
@@ -98,6 +98,10 @@ private extension EntryWidget {
                 }
             }
         }
+        if !environment.isAuthenticated() {
+            availableMediaTypes.remove(.secureMessaging)
+        }
+
         return Array(availableMediaTypes).sorted(by: { $0.rawValue < $1.rawValue })
     }
 

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Interface.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Interface.swift
@@ -54,6 +54,7 @@ extension Glia {
         var processInfo: ProcessInfoHandling
         var cameraDeviceManager: CoreSdkClient.GetCameraDeviceManageable
         var queuesMonitor: QueuesMonitor
+        var isAuthenticated: () -> Bool
     }
 }
 

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Live.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Live.swift
@@ -49,7 +49,18 @@ extension Glia.Environment {
                 subscribeForQueuesUpdates: CoreSdkClient.live.subscribeForQueuesUpdates,
                 unsubscribeFromUpdates: CoreSdkClient.live.unsubscribeFromUpdates
             )
-        )
+        ),
+        // This logic was moved here from EngagementCoordinator.Environment
+        // Because it will be used for EntryWidget as well. This is as of now
+        // The simplest way to determine if visitor is authenticated or not
+        isAuthenticated: {
+            do {
+                return try CoreSdkClient.live.authentication(.forbiddenDuringEngagement).isAuthenticated
+            } catch {
+                debugPrint(#function, "isAuthenticated:", error.localizedDescription)
+                return false
+            }
+        }
     )
 }
 

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Mock.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Mock.swift
@@ -34,7 +34,8 @@ extension Glia.Environment {
         snackBar: .mock,
         processInfo: .mock(),
         cameraDeviceManager: { .mock },
-        queuesMonitor: .mock
+        queuesMonitor: .mock,
+        isAuthenticated: { false }
     )
 }
 

--- a/GliaWidgetsTests/Glia.Environment.Failing.swift
+++ b/GliaWidgetsTests/Glia.Environment.Failing.swift
@@ -66,7 +66,11 @@ extension Glia.Environment {
             fail("\(Self.self).cameraDeviceManager")
             return .failing
         },
-        queuesMonitor: .failing
+        queuesMonitor: .failing,
+        isAuthenticated: {
+            fail("\(Self.self).isAuthenticated")
+            return false
+        }
     )
 }
 

--- a/GliaWidgetsTests/Sources/EntryWidget/EntryWidgetTests.swift
+++ b/GliaWidgetsTests/Sources/EntryWidget/EntryWidgetTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+import Combine
+import GliaCoreSDK
+
+@testable import GliaWidgets
+
+class EntryWidgetTests: XCTestCase {
+
+    func test_secureMessagingIsHiddenWhenUserIsNotAuthenticated() {
+        let mockQueueId = "mockQueueId"
+        let mockQueue = Queue.mock(id: mockQueueId, media: [.messaging, .audio])
+
+        var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
+        queueMonitorEnvironment.listQueues = { completion in
+            completion([mockQueue], nil)
+        }
+        queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
+            completion(.success(mockQueue))
+            return UUID().uuidString
+        }
+        let queuesMonitor = QueuesMonitor(environment: queueMonitorEnvironment)
+
+
+        var engagementLauncher = EngagementLauncher { _, _ in }
+        var isAuthenticated: () -> Bool = { false }
+
+        let entryWidget = EntryWidget(
+            queueIds: [mockQueueId],
+            environment: .init(
+                queuesMonitor: queuesMonitor,
+                engagementLauncher: engagementLauncher,
+                theme: Theme(),
+                isAuthenticated: isAuthenticated
+            )
+        )
+
+        entryWidget.show(in: .init())
+
+        if case let .mediaTypes(mediaTypes) = entryWidget.viewState {
+            XCTAssertFalse(mediaTypes.contains(.secureMessaging))
+        } else {
+            XCTFail("Unexpected view state")
+        }
+    }
+
+    func test_secureMessagingIsShownWhenUserIsAuthenticated() {
+        let mockQueueId = "mockQueueId"
+        let mockQueue = Queue.mock(id: mockQueueId, media: [.messaging, .audio])
+
+        var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
+        queueMonitorEnvironment.listQueues = { completion in
+            completion([mockQueue], nil)
+        }
+        queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
+            completion(.success(mockQueue))
+            return UUID().uuidString
+        }
+        let queuesMonitor = QueuesMonitor(environment: queueMonitorEnvironment)
+        var engagementLauncher = EngagementLauncher { _, _ in }
+        var isAuthenticated: () -> Bool = { true }
+
+        let entryWidget = EntryWidget(
+            queueIds: [mockQueueId],
+            environment: .init(
+                queuesMonitor: queuesMonitor,
+                engagementLauncher: engagementLauncher,
+                theme: Theme(),
+                isAuthenticated: isAuthenticated
+            )
+        )
+
+        entryWidget.show(in: .init())
+
+        if case let .mediaTypes(mediaTypes) = entryWidget.viewState {
+            XCTAssertTrue(mediaTypes.contains(.secureMessaging))
+        } else {
+            XCTFail("Unexpected view state")
+        }
+    }
+}

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -87,6 +87,7 @@ final class GliaTests: XCTestCase {
         gliaEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
+        gliaEnv.isAuthenticated = { return false }
         gliaEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
         gliaEnv.coreSdk.fetchSiteConfigurations = { _ in }
         gliaEnv.uuid = { .mock }


### PR DESCRIPTION
This PR checks for authentication status to determine if secure messaging will be displayed in the available media type section in Entry Widget

MOB-3658

**What was solved?**

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
