### PR TITLE
Make passed getEngagementLauncher queuesId paramater non-nullable

### DIFF
--- a/GliaWidgets/Public/Glia/Glia+EngagementLauncher.swift
+++ b/GliaWidgets/Public/Glia/Glia+EngagementLauncher.swift
@@ -8,8 +8,8 @@ extension Glia {
     ///
     /// - Returns:
     ///   - `EngagementLauncher` instance.
-    public func getEngagementLauncher(queueIds: [String]?) throws -> EngagementLauncher {
-        let parameters = try getEngagementParameters(in: queueIds ?? [])
+    public func getEngagementLauncher(queueIds: [String]) throws -> EngagementLauncher {
+        let parameters = try getEngagementParameters(in: queueIds)
         return try EngagementLauncher { [weak self] engagementKind, sceneProvider in
             try self?.resolveEngangementState(
                 engagementKind: engagementKind,

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+EngagementLauncher.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+EngagementLauncher.swift
@@ -11,7 +11,7 @@ extension GliaTests {
         ) { _ in }
 
         XCTAssertNoThrow(
-            try sdk.getEngagementLauncher(queueIds: nil)
+            try sdk.getEngagementLauncher(queueIds: [])
         )
     }
     
@@ -23,7 +23,7 @@ extension GliaTests {
             theme: .mock()
         ) { _ in }
         
-        let engagementLauncher = try sdk.getEngagementLauncher(queueIds: nil)
+        let engagementLauncher = try sdk.getEngagementLauncher(queueIds: [])
         
         try engagementLauncher.startChat()
 
@@ -38,7 +38,7 @@ extension GliaTests {
             theme: .mock()
         ) { _ in }
         
-        let engagementLauncher = try sdk.getEngagementLauncher(queueIds: nil)
+        let engagementLauncher = try sdk.getEngagementLauncher(queueIds: [])
         
         try engagementLauncher.startAudioCall()
 
@@ -53,7 +53,7 @@ extension GliaTests {
             theme: .mock()
         ) { _ in }
         
-        let engagementLauncher = try sdk.getEngagementLauncher(queueIds: nil)
+        let engagementLauncher = try sdk.getEngagementLauncher(queueIds: [])
         
         try engagementLauncher.startVideoCall()
 
@@ -68,7 +68,7 @@ extension GliaTests {
             theme: .mock()
         ) { _ in }
         
-        let engagementLauncher = try sdk.getEngagementLauncher(queueIds: nil)
+        let engagementLauncher = try sdk.getEngagementLauncher(queueIds: [])
         
         try engagementLauncher.startSecureMessaging()
 


### PR DESCRIPTION
MOB-3738
**What was solved?**
This PR makes `queuesId` passed parameter of public method `getEngagementLauncher` non-nullable.

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
