### PR TITLE
Leave Current Conversation dialog UI

### DIFF
--- a/GliaWidgets/Sources/AlertManager/Alert/AlertViewController+Confirmation.swift
+++ b/GliaWidgets/Sources/AlertManager/Alert/AlertViewController+Confirmation.swift
@@ -1,7 +1,90 @@
 import UIKit
 
 extension AlertViewController {
+    func makeLeaveConversationAlertView(
+        with conf: ConfirmationAlertConfiguration,
+        accessibilityIdentifier: String,
+        confirmed: @escaping () -> Void
+    ) -> AlertView {
+        let alertView = makeAlertView(
+            with: conf,
+            accessibilityIdentifier: accessibilityIdentifier,
+            confirmed: confirmed
+        )
+        let alertStyle = viewFactory.theme.alert
+        var negativeButtonStyle = alertStyle.negativeNeutralAction
+        var positiveButtonStyle = alertStyle.positiveAction
+
+        if conf.switchButtonBackgroundColors {
+            negativeButtonStyle = alertStyle.positiveAction
+            positiveButtonStyle = alertStyle.negativeNeutralAction
+        }
+
+        negativeButtonStyle.title = conf.negativeTitle
+        positiveButtonStyle.title = conf.positiveTitle
+
+        let confirmButton: ActionButton = ActionButton(
+            props: .init(
+                style: negativeButtonStyle,
+                tap: .init { [weak self] in self?.dismiss(animated: true) { confirmed() } },
+                accessibilityIdentifier: "alert_negative_button"
+            )
+        )
+        let declineButton = ActionButton(
+            props: ActionButton.Props(
+                style: positiveButtonStyle,
+                tap: .init { [weak self] in self?.dismiss(animated: true) },
+                accessibilityIdentifier: "alert_positive_button"
+            )
+        )
+        alertView.addActionView(declineButton)
+        alertView.addActionView(confirmButton)
+        return alertView
+    }
+
     func makeConfirmationAlertView(
+        with conf: ConfirmationAlertConfiguration,
+        accessibilityIdentifier: String,
+        confirmed: @escaping () -> Void
+    ) -> AlertView {
+        let alertView = makeAlertView(
+            with: conf,
+            accessibilityIdentifier: accessibilityIdentifier,
+            confirmed: confirmed
+        )
+        let alertStyle = viewFactory.theme.alert
+        var negativeButtonStyle = alertStyle.negativeAction
+        var positiveButtonStyle = alertStyle.positiveAction
+
+        if conf.switchButtonBackgroundColors {
+            negativeButtonStyle = alertStyle.positiveAction
+            positiveButtonStyle = alertStyle.negativeAction
+        }
+
+        negativeButtonStyle.title = conf.negativeTitle
+        positiveButtonStyle.title = conf.positiveTitle
+
+        let declineButton: ActionButton = ActionButton(
+            props: .init(
+                style: negativeButtonStyle,
+                tap: .init { [weak self] in self?.dismiss(animated: true) },
+                accessibilityIdentifier: "alert_negative_button"
+            )
+        )
+        let confirmButton = ActionButton(
+            props: ActionButton.Props(
+                style: positiveButtonStyle,
+                tap: .init { [weak self] in self?.dismiss(animated: true) { confirmed() } },
+                accessibilityIdentifier: "alert_positive_button"
+            )
+        )
+
+        alertView.addActionView(declineButton)
+        alertView.addActionView(confirmButton)
+        return alertView
+    }
+
+    private func makeAlertView(
         with conf: ConfirmationAlertConfiguration,
         accessibilityIdentifier: String,
         confirmed: @escaping () -> Void
@@ -11,37 +94,6 @@ extension AlertViewController {
         alertView.message = conf.message
         alertView.showsPoweredBy = conf.showsPoweredBy
         alertView.accessibilityIdentifier = accessibilityIdentifier
-
-        let alertStyle = viewFactory.theme.alert
-
-        var negativeButtonStyle = alertStyle.negativeAction
-        var positiveButtonStyle = alertStyle.positiveAction
-
-        if conf.switchButtonBackgroundColors {
-            negativeButtonStyle = alertStyle.positiveAction
-            positiveButtonStyle = alertStyle.negativeAction
-        }
-
-        negativeButtonStyle.title = conf.negativeTitle ?? ""
-        positiveButtonStyle.title = conf.positiveTitle ?? ""
-
-        let negativeButton: ActionButton = ActionButton(
-            props: .init(
-                style: negativeButtonStyle,
-                tap: .init { [weak self] in self?.dismiss(animated: true) },
-                accessibilityIdentifier: "alert_negative_button"
-            )
-        )
-        let positiveButton = ActionButton(
-            props: ActionButton.Props(
-                style: positiveButtonStyle,
-                tap: .init { [weak self] in self?.dismiss(animated: true) { confirmed() } },
-                accessibilityIdentifier: "alert_positive_button"
-            )
-        )
-
-        alertView.addActionView(negativeButton)
-        alertView.addActionView(positiveButton)
 
         return alertView
     }

--- a/GliaWidgets/Sources/AlertManager/Alert/AlertViewController.swift
+++ b/GliaWidgets/Sources/AlertManager/Alert/AlertViewController.swift
@@ -109,6 +109,12 @@ class AlertViewController: UIViewController, Replaceable {
                 accessibilityIdentifier: accessibilityIdentifier,
                 confirmed: confirmed
             )
+        case let .leaveConversation(conf, accessibilityIdentifier, confirmed):
+            return makeLeaveConversationAlertView(
+                with: conf,
+                accessibilityIdentifier: accessibilityIdentifier,
+                confirmed: confirmed
+            )
         case let .singleAction(conf, accessibilityIdentifier, actionTapped):
             return makeSingleActionAlertView(
                 with: conf,

--- a/GliaWidgets/Sources/AlertManager/AlertInputType.swift
+++ b/GliaWidgets/Sources/AlertManager/AlertInputType.swift
@@ -33,6 +33,7 @@ enum AlertInputType: Equatable {
         declined: (() -> Void)? = nil,
         answer: CoreSdkClient.AnswerBlock
     )
+    case leaveCurrentConversation(confirmed: () -> Void)
 
     static func == (lhs: AlertInputType, rhs: AlertInputType) -> Bool {
         switch (lhs, rhs) {
@@ -65,6 +66,8 @@ enum AlertInputType: Equatable {
             return false
         case let (.error(lhsError, _), .error(rhsError, _)):
             return (lhsError as NSError?) == (rhsError as NSError?)
+        case (.leaveCurrentConversation, .leaveCurrentConversation):
+            return true
         default:
             return false
         }

--- a/GliaWidgets/Sources/AlertManager/AlertStyle.swift
+++ b/GliaWidgets/Sources/AlertManager/AlertStyle.swift
@@ -44,6 +44,9 @@ public struct AlertStyle: Equatable {
     /// Style of a negative action button.
     public var negativeAction: ActionButtonStyle
 
+    /// Style of a new negative action button.
+    public var negativeNeutralAction: ActionButtonStyle
+
     /// Style of 'powered by' view.
     public var poweredBy: PoweredByStyle
 
@@ -65,6 +68,7 @@ public struct AlertStyle: Equatable {
     ///   - actionAxis: Direction of the action buttons.
     ///   - positiveAction: Style of a positive action button.
     ///   - negativeAction: Style of a negative action button.
+    ///   - newNegativeAction: Style of a new negative action button.
     ///   - poweredBy: Style of 'powered by' view.
     ///   - accessibility: Accessibility related properties.
     ///
@@ -83,6 +87,7 @@ public struct AlertStyle: Equatable {
         actionAxis: NSLayoutConstraint.Axis,
         positiveAction: ActionButtonStyle,
         negativeAction: ActionButtonStyle,
+        negativeNeutralAction: ActionButtonStyle,
         poweredBy: PoweredByStyle,
         accessibility: Accessibility = .unsupported
     ) {
@@ -100,6 +105,7 @@ public struct AlertStyle: Equatable {
         self.actionAxis = actionAxis
         self.positiveAction = positiveAction
         self.negativeAction = negativeAction
+        self.negativeNeutralAction = negativeNeutralAction
         self.poweredBy = poweredBy
         self.accessibility = accessibility
     }

--- a/GliaWidgets/Sources/AlertManager/AlertType.swift
+++ b/GliaWidgets/Sources/AlertManager/AlertType.swift
@@ -16,6 +16,11 @@ enum AlertType {
         accessibilityIdentifier: String,
         confirmed: () -> Void
     )
+    case leaveConversation(
+        conf: ConfirmationAlertConfiguration,
+        accessibilityIdentifier: String,
+        confirmed: () -> Void
+    )
     case singleAction(
         conf: SingleActionAlertConfiguration,
         accessibilityIdentifier: String,
@@ -55,7 +60,7 @@ enum AlertType {
             return .highest
         case .confirmation, .liveObservationConfirmation:
             return .high
-        case .message, .systemAlert, .view:
+        case .message, .systemAlert, .view, .leaveConversation:
             return .regular
         }
     }

--- a/GliaWidgets/Sources/AlertManager/AlertTypeComposer.swift
+++ b/GliaWidgets/Sources/AlertManager/AlertTypeComposer.swift
@@ -84,6 +84,9 @@ extension AlertManager.AlertTypeComposer {
                 error: error,
                 dismissed: dismissed
             )
+
+        case let .leaveCurrentConversation(confirmed):
+            return leaveCurrentConversationAlertType(confirmed: confirmed)
         }
     }
 
@@ -323,6 +326,15 @@ private extension AlertManager.AlertTypeComposer {
             theme.alertConfiguration.screenShareOffer.withOperatorName(operators),
             accepted: acceptedOffer,
             declined: declinedOffer
+        )
+    }
+
+    func leaveCurrentConversationAlertType(confirmed: @escaping () -> Void) -> AlertType {
+        environment.log.prefixed(Self.self).info("Show Leave Current Conversations Dialog")
+        return .leaveConversation(
+            conf: theme.alertConfiguration.leaveCurrentConversation,
+            accessibilityIdentifier: "alert_confirmation_leaveCurrentConversation",
+            confirmed: confirmed
         )
     }
 }

--- a/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.Mock.swift
+++ b/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.Mock.swift
@@ -2,8 +2,8 @@
 extension AlertConfiguration {
     static func mock(showsPoweredBy: Bool = true) -> Self {
         .init(
-            leaveQueue: .init(showsPoweredBy: showsPoweredBy),
-            endEngagement: .init(showsPoweredBy: showsPoweredBy),
+            leaveQueue: .mock(showsPoweredBy: showsPoweredBy),
+            endEngagement: .mock(showsPoweredBy: showsPoweredBy),
             operatorEndedEngagement: .mock(),
             operatorsUnavailable: .mock(),
             mediaUpgrade: .mock(),
@@ -21,7 +21,8 @@ extension AlertConfiguration {
             unavailableMessageCenterForBeingUnauthenticated: .mock(),
             unsupportedGvaBroadcastError: .mock(),
             liveObservationConfirmation: .mock(),
-            expiredAccessTokenError: .mock()
+            expiredAccessTokenError: .mock(),
+            leaveCurrentConversation: .mock()
         )
     }
 }
@@ -54,8 +55,12 @@ extension ScreenShareOfferAlertConfiguration {
 }
 
 extension ConfirmationAlertConfiguration {
-    static func mock() -> Self {
-        .init(showsPoweredBy: true)
+    static func mock(showsPoweredBy: Bool = true) -> ConfirmationAlertConfiguration {
+        .init(
+            negativeTitle: "",
+            positiveTitle: "",
+            showsPoweredBy: showsPoweredBy
+        )
     }
 
     static func liveObservationMock() -> Self {

--- a/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.swift
+++ b/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.swift
@@ -60,6 +60,9 @@ public struct AlertConfiguration {
     /// Configuration of expired access token error
     public var expiredAccessTokenError: MessageAlertConfiguration
 
+    /// Configuration of the current conversation leaving confirmation alert.
+    public var leaveCurrentConversation: ConfirmationAlertConfiguration
+
     /// - Parameters:
     ///   - leaveQueue: Configuration of the queue leaving confirmation alert.
     ///   - endEngagement: Configuration of the engagement ending confirmation alert.
@@ -81,7 +84,8 @@ public struct AlertConfiguration {
     ///     due to unauthenticated visitor.
     ///   - unsupportedGvaBroadcastError: Configuration of the unsupported GVA broadcast events error alert.
     ///   - liveObservationConfirmation: Configuration of the Live Observation confirmation alert
-    ///   
+    ///   - leaveCurrentConversation: Configuration of the current conversation leaving confirmation alert.
+    ///
     public init(
         leaveQueue: ConfirmationAlertConfiguration,
         endEngagement: ConfirmationAlertConfiguration,
@@ -102,7 +106,8 @@ public struct AlertConfiguration {
         unavailableMessageCenterForBeingUnauthenticated: MessageAlertConfiguration,
         unsupportedGvaBroadcastError: MessageAlertConfiguration,
         liveObservationConfirmation: ConfirmationAlertConfiguration,
-        expiredAccessTokenError: MessageAlertConfiguration
+        expiredAccessTokenError: MessageAlertConfiguration,
+        leaveCurrentConversation: ConfirmationAlertConfiguration
     ) {
         self.leaveQueue = leaveQueue
         self.endEngagement = endEngagement
@@ -124,5 +129,6 @@ public struct AlertConfiguration {
         self.unsupportedGvaBroadcastError = unsupportedGvaBroadcastError
         self.liveObservationConfirmation = liveObservationConfirmation
         self.expiredAccessTokenError = expiredAccessTokenError
+        self.leaveCurrentConversation = leaveCurrentConversation
     }
 }

--- a/GliaWidgets/Sources/Theme/Alert/ConfirmationAlertConfiguration.swift
+++ b/GliaWidgets/Sources/Theme/Alert/ConfirmationAlertConfiguration.swift
@@ -15,10 +15,10 @@ public struct ConfirmationAlertConfiguration {
     public var secondLinkButtonUrl: String?
 
     /// Title of the negative action button.
-    public var negativeTitle: String?
+    public var negativeTitle: String
 
     /// Title of the positive action button.
-    public var positiveTitle: String?
+    public var positiveTitle: String
 
     /// Indicates whether the action button's colors should be switched.
     public var switchButtonBackgroundColors = false

--- a/GliaWidgets/Sources/Theme/Theme+Alert.swift
+++ b/GliaWidgets/Sources/Theme/Theme+Alert.swift
@@ -30,6 +30,18 @@ extension Theme {
                 isFontScalingEnabled: true
             )
         )
+        let negativeNeutralAction = ActionButtonStyle(
+            title: Localization.SecureMessaging.Chat.LeaveCurrentConversation.Button.negative,
+            titleFont: font.buttonLabel,
+            titleColor: color.systemNegative,
+            backgroundColor: .fill(color: .clear),
+            borderWidth: 1,
+            borderColor: color.baseShade,
+            accessibility: .init(
+                label: Localization.SecureMessaging.Chat.LeaveCurrentConversation.Button.negative,
+                isFontScalingEnabled: true
+            )
+        )
         let positiveAction = ActionButtonStyle(
             title: Localization.General.yes,
             titleFont: font.buttonLabel,
@@ -58,6 +70,7 @@ extension Theme {
             actionAxis: .horizontal,
             positiveAction: positiveAction,
             negativeAction: negativeAction,
+            negativeNeutralAction: negativeNeutralAction,
             poweredBy: poweredBy,
             accessibility: .init(isFontScalingEnabled: true)
         )

--- a/GliaWidgets/Sources/Theme/Theme+AlertConfiguration.swift
+++ b/GliaWidgets/Sources/Theme/Theme+AlertConfiguration.swift
@@ -149,6 +149,15 @@ extension Theme {
             showsPoweredBy: showsPoweredBy
         )
 
+        let leaveCurrentConversation = ConfirmationAlertConfiguration(
+            title: Localization.SecureMessaging.Chat.LeaveCurrentConversation.title,
+            message: Localization.SecureMessaging.Chat.LeaveCurrentConversation.message,
+            negativeTitle: Localization.SecureMessaging.Chat.LeaveCurrentConversation.Button.negative,
+            positiveTitle: Localization.SecureMessaging.Chat.LeaveCurrentConversation.Button.positive,
+            switchButtonBackgroundColors: false,
+            showsPoweredBy: showsPoweredBy
+        )
+
         return AlertConfiguration(
             leaveQueue: leaveQueue,
             endEngagement: endEngagement,
@@ -169,7 +178,8 @@ extension Theme {
             unavailableMessageCenterForBeingUnauthenticated: unavailableMessageCenterForBeingUnauthenticated,
             unsupportedGvaBroadcastError: unsupportedGvaBroadcastError,
             liveObservationConfirmation: liveObservationConfirmation,
-            expiredAccessTokenError: expiredAccessTokenError
+            expiredAccessTokenError: expiredAccessTokenError,
+            leaveCurrentConversation: leaveCurrentConversation
         )
     }
 }


### PR DESCRIPTION
MOB-3734

**What was solved?**
This PR introduces:
 - new alert dialog called Leave Current Conversation;
 - style for the same dialog
 
 Note: Snapshot tests will be added in next PR
 
**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
![Simulator Screenshot - iPhone 15 - 2024-10-25 at 13 14 46](https://github.com/user-attachments/assets/f8b0fc59-c40f-4a52-bcab-f656f09d9589)