### PR TITLE
Remote config for Leave Current Conversation dialog

### DIFF
--- a/GliaWidgets/Sources/AlertManager/AlertStyle.RemoteConfig.swift
+++ b/GliaWidgets/Sources/AlertManager/AlertStyle.RemoteConfig.swift
@@ -23,6 +23,10 @@ extension AlertStyle {
             configuration: configuration?.negativeButton,
             assetsBuilder: assetsBuilder
         )
+        negativeNeutralAction.apply(
+            configuration: configuration?.negativeNeutralButton,
+            assetsBuilder: assetsBuilder
+        )
         applyTitleConfiguration(
             configuration?.title,
             assetsBuilder: assetsBuilder
@@ -32,6 +36,7 @@ extension AlertStyle {
             configuration?.message,
             assetsBuilder: assetsBuilder
         )
+        applyButtonAxisConfiguration(configuration?.buttonAxis)
     }
 }
 

--- a/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration.swift
+++ b/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration.swift
@@ -60,6 +60,7 @@ extension RemoteConfiguration {
         let linkButton: Button?
         let positiveButton: Button?
         let negativeButton: Button?
+        let negativeNeutralButton: Button?
         let buttonAxis: Axis?
     }
 


### PR DESCRIPTION
MOB-3737

**What was solved?**
This commit:
 - Extends RemoteConfiguration.AlertStyle with negativeNeutralButton (screenshot 1)
 - fixes missed applying buttons alignment in alerts (screenshot 2)
 
 Note: Snapshot test will be added in next PR
 
**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
![Simulator Screenshot - iPhone 15 - 2024-10-25 at 14 09 51](https://github.com/user-attachments/assets/a9f7c6eb-6b95-441b-87ae-dd7eb304aa66) ![Simulator Screenshot - iPhone 15 - 2024-10-25 at 14 13 01](https://github.com/user-attachments/assets/fb3fa787-89b9-46af-9580-344a7c6c1368)