### PR TITLE
Snapshot tests for Leave Current Conversation dialog

### DIFF
--- a/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.Mock.swift
+++ b/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.Mock.swift
@@ -84,6 +84,16 @@ extension ConfirmationAlertConfiguration {
             showsPoweredBy: true
         )
     }
+
+    static func leaveConversationMock() -> Self {
+        .init(
+            title: "Leave Current Conversation?",
+            message: "mocked-message",
+            negativeTitle: "Leave",
+            positiveTitle: "Stay",
+            showsPoweredBy: true
+        )
+    }
 }
 
 extension SingleMediaUpgradeAlertConfiguration {

--- a/SnapshotTests/AlertViewControllerDynamicTypeFontTests.swift
+++ b/SnapshotTests/AlertViewControllerDynamicTypeFontTests.swift
@@ -74,4 +74,15 @@ final class AlertViewControllerDynamicTypeFontTests: SnapshotTestCase {
         alert.assertSnapshot(as: .extra3LargeFont, in: .portrait)
         alert.assertSnapshot(as: .extra3LargeFont, in: .landscape)
     }
+
+    func test_leaveCurrentConversationAlert() {
+        let alert = alert(ofKind: .leaveConversation(
+            conf: .leaveConversationMock(),
+            accessibilityIdentifier: "mocked-accessibility-identifier",
+            confirmed: {}
+        ))
+
+        alert.assertSnapshot(as: .extra3LargeFont, in: .portrait)
+        alert.assertSnapshot(as: .extra3LargeFont, in: .landscape)
+    }
 }

--- a/SnapshotTests/AlertViewControllerLayoutTests.swift
+++ b/SnapshotTests/AlertViewControllerLayoutTests.swift
@@ -74,4 +74,15 @@ final class AlertViewControllerLayoutTests: SnapshotTestCase {
         alert.assertSnapshot(as: .image, in: .portrait)
         alert.assertSnapshot(as: .image, in: .landscape)
     }
+
+    func test_leaveCurrentConversationAlert() {
+        let alert = alert(ofKind: .leaveConversation(
+            conf: .leaveConversationMock(),
+            accessibilityIdentifier: "mocked-accessibility-identifier",
+            confirmed: {}
+        ))
+
+        alert.assertSnapshot(as: .image, in: .portrait)
+        alert.assertSnapshot(as: .image, in: .landscape)
+    }
 }

--- a/SnapshotTests/AlertViewControllerVoiceOverTests.swift
+++ b/SnapshotTests/AlertViewControllerVoiceOverTests.swift
@@ -61,6 +61,16 @@ final class AlertViewControllerVoiceOverTests: SnapshotTestCase {
         alert.assertSnapshot(as: .accessibilityImage)
     }
 
+    func test_leaveCurrentConversationAlert() {
+        let alert = alert(ofKind: .leaveConversation(
+            conf: .leaveConversationMock(),
+            accessibilityIdentifier: "mocked-accessibility-identifier",
+            confirmed: {}
+        ))
+
+        alert.assertSnapshot(as: .accessibilityImage)
+    }
+
     private func alert(ofKind type: AlertType) -> AlertViewController {
         let viewController = AlertViewController(
             type: type,


### PR DESCRIPTION
MOB-3736

**What was solved?**
This PR introduces snapshot tests for Leave Current Conversation dialog

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.