### PR TITLE
Add unified customization for new SC unavailability indicator for chat

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -678,6 +678,7 @@
 		AFEF5C7429929A8D005C3D8D /* SecureConversations.FileUploadListViewModel.Environment.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFEF5C7329929A8D005C3D8D /* SecureConversations.FileUploadListViewModel.Environment.Failing.swift */; };
 		AFF9542A2ADD8DB600C277E0 /* CoreSDKConfigurator.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF954292ADD8DB600C277E0 /* CoreSDKConfigurator.Mock.swift */; };
 		AFF9542C2ADDA10600C277E0 /* CoreSDKConfigurator.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF9542B2ADDA10600C277E0 /* CoreSDKConfigurator.Failing.swift */; };
+		AFF960982CCCFCA8006BF3BF /* SendingMessageUnavailableBannerViewStyle.RemoteConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF960972CCCFCA8006BF3BF /* SendingMessageUnavailableBannerViewStyle.RemoteConfig.swift */; };
 		AFFA99822C57D658004A2825 /* GliaTests+RestoreEngagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFFA99812C57D658004A2825 /* GliaTests+RestoreEngagement.swift */; };
 		C0175A0F2A55A624001FACDE /* ChatMessagaEntryViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0175A0E2A55A624001FACDE /* ChatMessagaEntryViewTests.swift */; };
 		C0175A112A55AA3E001FACDE /* ChatMessageEntryView.+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0175A102A55AA3E001FACDE /* ChatMessageEntryView.+Mock.swift */; };
@@ -1730,6 +1731,7 @@
 		AFEF5C7329929A8D005C3D8D /* SecureConversations.FileUploadListViewModel.Environment.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FileUploadListViewModel.Environment.Failing.swift; sourceTree = "<group>"; };
 		AFF954292ADD8DB600C277E0 /* CoreSDKConfigurator.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSDKConfigurator.Mock.swift; sourceTree = "<group>"; };
 		AFF9542B2ADDA10600C277E0 /* CoreSDKConfigurator.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSDKConfigurator.Failing.swift; sourceTree = "<group>"; };
+		AFF960972CCCFCA8006BF3BF /* SendingMessageUnavailableBannerViewStyle.RemoteConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendingMessageUnavailableBannerViewStyle.RemoteConfig.swift; sourceTree = "<group>"; };
 		AFFA99812C57D658004A2825 /* GliaTests+RestoreEngagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GliaTests+RestoreEngagement.swift"; sourceTree = "<group>"; };
 		B97A8A0B9AD30D0AB8666042 /* Pods_GliaWidgetsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GliaWidgetsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0175A0E2A55A624001FACDE /* ChatMessagaEntryViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessagaEntryViewTests.swift; sourceTree = "<group>"; };
@@ -2876,6 +2878,7 @@
 				AFCA8A412CC7939F008B7DD3 /* SecureMessagingBottomBannerViewStyle.RemoteConfig.swift */,
 				AFCA8A432CCA8474008B7DD3 /* SendingMessageUnavailableBannerView.swift */,
 				AFCA8A452CCA8648008B7DD3 /* SendingMessageUnavailableBannerViewStyle.swift */,
+				AFF960972CCCFCA8006BF3BF /* SendingMessageUnavailableBannerViewStyle.RemoteConfig.swift */,
 			);
 			path = Chat;
 			sourceTree = "<group>";
@@ -6359,6 +6362,7 @@
 				C090475C2B7E2254003C437C /* FileUploadListStyle.Mock.swift in Sources */,
 				1A4AD3AF256D283700468BFB /* ChatMessageView.swift in Sources */,
 				C0175A2C2A67E2E9001FACDE /* Theme+Gva.swift in Sources */,
+				AFF960982CCCFCA8006BF3BF /* SendingMessageUnavailableBannerViewStyle.RemoteConfig.swift in Sources */,
 				C09047702B7E2554003C437C /* UnreadMessageDividerStyle.RemoteConfig.swift in Sources */,
 				6E60DD5827146DDB001422EF /* SingleActionAlertConfiguration.swift in Sources */,
 				C49A29E32614A29700819269 /* FilePreviewStyle.swift in Sources */,

--- a/GliaWidgets/Sources/View/Chat/ChatStyle.RemoteConfig.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatStyle.RemoteConfig.swift
@@ -77,6 +77,10 @@ extension ChatStyle {
             configuration: configuration?.secureMessaging,
             assetBuilder: assetsBuilder
         )
+        sendingMessageUnavailableBannerViewStyle.apply(
+            configuration: configuration?.secureMessaging,
+            assetBuilder: assetsBuilder
+        )
         applyBackground(color: configuration?.background?.color)
     }
 

--- a/GliaWidgets/Sources/View/Chat/SendingMessageUnavailableBannerViewStyle.RemoteConfig.swift
+++ b/GliaWidgets/Sources/View/Chat/SendingMessageUnavailableBannerViewStyle.RemoteConfig.swift
@@ -1,0 +1,36 @@
+import UIKit
+
+extension SendingMessageUnavailableBannerViewStyle {
+    mutating func apply(
+        configuration: RemoteConfiguration.SecureConversations?,
+        assetBuilder: RemoteConfiguration.AssetsBuilder
+    ) {
+        configuration?.unavailableStatusBackground?.color.unwrap {
+            switch $0.type {
+            case .fill:
+                $0.value
+                    .map { UIColor(hex: $0) }
+                    .first
+                    .unwrap { backgroundColor = .fill(color: $0) }
+            case .gradient:
+                let colors = $0.value.convertToCgColors()
+                backgroundColor = .gradient(colors: colors)
+            }
+        }
+        configuration?.unavailableStatusText?.foreground?.value
+            .map { UIColor(hex: $0) }
+            .first
+            .unwrap { textColor = $0 }
+
+        configuration?.unavailableStatusText?.foreground?.value
+            .map { UIColor(hex: $0) }
+            .first
+            .unwrap { iconColor = $0 }
+
+        UIFont.convertToFont(
+            uiFont: assetBuilder.fontBuilder(configuration?.unavailableStatusText?.font),
+            textStyle: textStyle
+        )
+        .unwrap { font = $0 }
+    }
+}


### PR DESCRIPTION
MOB-3742

**What was solved?**
Add unified customization send message unavailability indicator for chat screen.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
