### PR TITLE
Make EntryWidget sheet landscape adaptable

### DIFF
--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
@@ -190,6 +190,8 @@ private extension EntryWidget {
             sheet.detents = [smallDetent]
             sheet.prefersScrollingExpandsWhenScrolledToEdge = true
             sheet.preferredCornerRadius = environment.theme.entryWidget.cornerRadius
+            sheet.prefersEdgeAttachedInCompactHeight = true
+            sheet.widthFollowsPreferredContentSizeWhenEdgeAttached = true
         } else {
             hostingController.modalPresentationStyle = .custom
             hostingController.transitioningDelegate = self


### PR DESCRIPTION
**What was solved?**
UISheetPresentation is by default favouring full screen cover in landscape mode, due to lack of space. This however also disables drag to dismiss. This behavior is overwritten in this PR and allows the sheet to be dismissed with click and with drag.

MOB-3731
**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
