### PR TITLE
Replace unavailability dialog with banner view on Transcript screen

### DIFF
--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.ChatWithTranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.ChatWithTranscriptModel.swift
@@ -69,6 +69,15 @@ extension SecureConversations.ChatWithTranscriptModel {
         }
     }
 
+    var isSecureConversationsAvailable: Bool {
+        switch self {
+        case .chat:
+            false
+        case let .transcript(model):
+            model.isSecureConversationsAvailable
+        }
+    }
+
     var numberOfSections: Int {
         switch self {
         case let .chat(model):

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
@@ -145,7 +145,7 @@ extension SecureConversations {
                     self.isSecureConversationsAvailable = false
                     self.engagementAction?(.showAlert(.unavailableMessageCenter()))
                 case .success(.unavailable(.unauthenticated)):
-                    self.engagementAction?(.showAlert(.unavailableMessageCenterForBeingUnauthenticated()))
+                    // For chat screen we no longer show unavailability dialog, but unavailability banner instead.
                     self.isSecureConversationsAvailable = false
                 }
             }

--- a/GliaWidgets/Sources/View/Chat/ChatView.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatView.swift
@@ -196,14 +196,19 @@ class ChatView: EngagementView {
             isHidden: true  // Logic to show/hide SC bottom banner is to be added with MOB-3634
         )
 
-        sendingMessageUnavailabilityBannerView.props = .init(
-            style: style.sendingMessageUnavailableBannerViewStyle,
-            isHidden: true // Logic to show/hide unavailability is to be added with MOB-3739
-        )
+        // Hide send message unavailability banner initially.
+        setSendingMessageUnavailabilityBannerHidden(true)
     }
 }
 
 extension ChatView {
+    func setSendingMessageUnavailabilityBannerHidden(_ isHidden: Bool) {
+        sendingMessageUnavailabilityBannerView.props = .init(
+            style: style.sendingMessageUnavailableBannerViewStyle,
+            isHidden: isHidden
+        )
+    }
+
     func setOperatorTypingIndicatorIsHidden(to isHidden: Bool) {
         typingIndicatorContainer.isHidden = isHidden
     }

--- a/GliaWidgets/Sources/View/Chat/ChatView.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatView.swift
@@ -116,8 +116,9 @@ class ChatView: EngagementView {
         addKeyboardDismissalTapGesture()
         typingIndicatorView.accessibilityIdentifier = "chat_typingIndicator"
         typingIndicatorContainer.isHidden = true
-        // TODO: remove this call with implementation of MOB-3739
-        renderBanners()
+        // Hide secure conversation bottom banner unavailability banner initially.
+        setSecureMessagingBottomBannerHidden(true)
+        setSendingMessageUnavailabilityBannerHidden(true)
     }
 
     override func defineLayout() {
@@ -189,22 +190,19 @@ class ChatView: EngagementView {
             equalTo: messageEntryView.topAnchor, constant: kUnreadMessageIndicatorInset
         )
     }
-
-    func renderBanners() {
-        secureMessagingBottomBannerView.props = .init(
-            style: style.secureMessagingBottomBannerStyle,
-            isHidden: true  // Logic to show/hide SC bottom banner is to be added with MOB-3634
-        )
-
-        // Hide send message unavailability banner initially.
-        setSendingMessageUnavailabilityBannerHidden(true)
-    }
 }
 
 extension ChatView {
     func setSendingMessageUnavailabilityBannerHidden(_ isHidden: Bool) {
         sendingMessageUnavailabilityBannerView.props = .init(
             style: style.sendingMessageUnavailableBannerViewStyle,
+            isHidden: isHidden
+        )
+    }
+
+    func setSecureMessagingBottomBannerHidden(_ isHidden: Bool) {
+        secureMessagingBottomBannerView.props = .init(
+            style: style.secureMessagingBottomBannerStyle,
             isHidden: isHidden
         )
     }

--- a/GliaWidgets/Sources/View/Chat/Entry/ChatMessageEntryView.swift
+++ b/GliaWidgets/Sources/View/Chat/Entry/ChatMessageEntryView.swift
@@ -36,7 +36,9 @@ class ChatMessageEntryView: BaseView {
 
     var isEnabled: Bool {
         get { return isUserInteractionEnabled }
-        set { isUserInteractionEnabled = newValue }
+        set {
+            isUserInteractionEnabled = newValue
+        }
     }
 
     var mediaPickerButtonVisibility: MediaPickerButtonVisibility = .disabled

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
@@ -259,9 +259,13 @@ final class ChatViewController: EngagementViewController, PopoverPresenter {
         switch type {
         case .chat:
             chatView.props = .init(header: props.chat)
-        case let .secureTranscript(needsTextInput):
+        case let .secureTranscript(needsTextInputEnabled):
             chatView.props = .init(header: props.secureTranscript)
-            chatView.messageEntryView.isHidden = !needsTextInput
+            // Instead of hiding text input, we need to disable it and corresponding buttons.
+            // TODO: Currently there is no 'disabled' styles for text entry, so we need to confirm with Android
+            // if introduction of such styles is required.
+            chatView.messageEntryView.isEnabled = needsTextInputEnabled
+            chatView.setSendingMessageUnavailabilityBannerHidden(viewModel.isSecureConversationsAvailable)
         }
     }
 
@@ -299,12 +303,12 @@ extension ChatViewController {
             if chatViewModel.chatType == .secureTranscript {
                 return chatViewModel.activeEngagement != nil
                 ? .chat
-                : .secureTranscript(needsTextInput: true)
+                : .secureTranscript(needsTextInputEnabled: true)
             } else {
                 return .chat
             }
         case .transcript(let transcriptModel):
-            return .secureTranscript(needsTextInput: transcriptModel.isSecureConversationsAvailable)
+            return .secureTranscript(needsTextInputEnabled: transcriptModel.isSecureConversationsAvailable)
         }
     }
 }
@@ -317,5 +321,5 @@ extension ChatViewController {
 }
 private enum CurrentChatModelType {
     case chat
-    case secureTranscript(needsTextInput: Bool)
+    case secureTranscript(needsTextInputEnabled: Bool)
 }

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
@@ -259,6 +259,8 @@ final class ChatViewController: EngagementViewController, PopoverPresenter {
         switch type {
         case .chat:
             chatView.props = .init(header: props.chat)
+            // For regular chat engagement bottom banner is hidden.
+            chatView.setSecureMessagingBottomBannerHidden(true)
         case let .secureTranscript(needsTextInputEnabled):
             chatView.props = .init(header: props.secureTranscript)
             // Instead of hiding text input, we need to disable it and corresponding buttons.
@@ -266,6 +268,8 @@ final class ChatViewController: EngagementViewController, PopoverPresenter {
             // if introduction of such styles is required.
             chatView.messageEntryView.isEnabled = needsTextInputEnabled
             chatView.setSendingMessageUnavailabilityBannerHidden(viewModel.isSecureConversationsAvailable)
+            // For secure messaging bottom banner is visible.
+            chatView.setSecureMessagingBottomBannerHidden(false)
         }
     }
 
@@ -283,7 +287,7 @@ extension ChatViewController {
         // Swap existing engagement transcript model
         // (though it is technically not for engagement)
         // with engagement chat model in superclass EngagementViewController.
-        swapAndBindEgagementViewModel(viewModel.engagementModel)
+        swapAndBindEngagementViewModel(viewModel.engagementModel)
         // Bind chat model to chat view for sending actions
         // and receiving events.
         bind(

--- a/GliaWidgets/Sources/ViewController/EngagementViewController.swift
+++ b/GliaWidgets/Sources/ViewController/EngagementViewController.swift
@@ -71,7 +71,7 @@ class EngagementViewController: UIViewController {
         }
     }
 
-    func swapAndBindEgagementViewModel(_ engagementModel: CommonEngagementModel) {
+    func swapAndBindEngagementViewModel(_ engagementModel: CommonEngagementModel) {
         self.viewModel = engagementModel
         bind(engagementViewModel: engagementModel)
     }


### PR DESCRIPTION
MOB-3739

**What was solved?**
According to new SC 2.0 design we use 'send message unavailability' view instead of dialog. These changes remove dialog and show banner instead.

**Note**: Message entry placeholder and corresponding buttons look currently active even though they are disabled. It is required to update styling to match the design to reflect disabled state - this is WIP.

<img src="https://github.com/user-attachments/assets/397bff8e-ae7c-4bf6-a433-0266e63ea93e" width="428" height="926">

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
