### PR TITLE
Toggle SC bottom banner visibility based on view model

### DIFF
--- a/GliaWidgets/Sources/View/Chat/ChatView.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatView.swift
@@ -116,8 +116,9 @@ class ChatView: EngagementView {
         addKeyboardDismissalTapGesture()
         typingIndicatorView.accessibilityIdentifier = "chat_typingIndicator"
         typingIndicatorContainer.isHidden = true
-        // TODO: remove this call with implementation of MOB-3739
-        renderBanners()
+        // Hide secure conversation bottom banner unavailability banner initially.
+        setSecureMessagingBottomBannerHidden(true)
+        setSendingMessageUnavailabilityBannerHidden(true)
     }
 
     override func defineLayout() {
@@ -189,22 +190,19 @@ class ChatView: EngagementView {
             equalTo: messageEntryView.topAnchor, constant: kUnreadMessageIndicatorInset
         )
     }
-
-    func renderBanners() {
-        secureMessagingBottomBannerView.props = .init(
-            style: style.secureMessagingBottomBannerStyle,
-            isHidden: true  // Logic to show/hide SC bottom banner is to be added with MOB-3634
-        )
-
-        // Hide send message unavailability banner initially.
-        setSendingMessageUnavailabilityBannerHidden(true)
-    }
 }
 
 extension ChatView {
     func setSendingMessageUnavailabilityBannerHidden(_ isHidden: Bool) {
         sendingMessageUnavailabilityBannerView.props = .init(
             style: style.sendingMessageUnavailableBannerViewStyle,
+            isHidden: isHidden
+        )
+    }
+
+    func setSecureMessagingBottomBannerHidden(_ isHidden: Bool) {
+        secureMessagingBottomBannerView.props = .init(
+            style: style.secureMessagingBottomBannerStyle,
             isHidden: isHidden
         )
     }

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
@@ -259,6 +259,8 @@ final class ChatViewController: EngagementViewController, PopoverPresenter {
         switch type {
         case .chat:
             chatView.props = .init(header: props.chat)
+            // For regular chat engagement bottom banner is hidden.
+            chatView.setSecureMessagingBottomBannerHidden(true)
         case let .secureTranscript(needsTextInputEnabled):
             chatView.props = .init(header: props.secureTranscript)
             // Instead of hiding text input, we need to disable it and corresponding buttons.
@@ -266,6 +268,8 @@ final class ChatViewController: EngagementViewController, PopoverPresenter {
             // if introduction of such styles is required.
             chatView.messageEntryView.isEnabled = needsTextInputEnabled
             chatView.setSendingMessageUnavailabilityBannerHidden(viewModel.isSecureConversationsAvailable)
+            // For secure messaging bottom banner is visible.
+            chatView.setSecureMessagingBottomBannerHidden(false)
         }
     }
 
@@ -283,7 +287,7 @@ extension ChatViewController {
         // Swap existing engagement transcript model
         // (though it is technically not for engagement)
         // with engagement chat model in superclass EngagementViewController.
-        swapAndBindEgagementViewModel(viewModel.engagementModel)
+        swapAndBindEngagementViewModel(viewModel.engagementModel)
         // Bind chat model to chat view for sending actions
         // and receiving events.
         bind(

--- a/GliaWidgets/Sources/ViewController/EngagementViewController.swift
+++ b/GliaWidgets/Sources/ViewController/EngagementViewController.swift
@@ -71,7 +71,7 @@ class EngagementViewController: UIViewController {
         }
     }
 
-    func swapAndBindEgagementViewModel(_ engagementModel: CommonEngagementModel) {
+    func swapAndBindEngagementViewModel(_ engagementModel: CommonEngagementModel) {
         self.viewModel = engagementModel
         bind(engagementViewModel: engagementModel)
     }


### PR DESCRIPTION
MOB-3719

**What was solved?**
Add toggling of SC bottom banner visibility based view model.

<img src="https://github.com/user-attachments/assets/397bff8e-ae7c-4bf6-a433-0266e63ea93e" width="428" height="926">


**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
