### PR TITLE
Use queues from QueuesMonitor to determine Secure Conversations availability

### DIFF
--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.Environment.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.Environment.swift
@@ -49,6 +49,7 @@ extension SecureConversations.Coordinator {
         var cameraDeviceManager: CoreSdkClient.GetCameraDeviceManageable
         var flipCameraButtonStyle: FlipCameraButtonStyle
         var alertManager: AlertManager
+        var queuesMonitor: QueuesMonitor
     }
 }
 
@@ -111,7 +112,8 @@ extension SecureConversations.Coordinator.Environment {
             maximumUploads: environment.maximumUploads,
             cameraDeviceManager: environment.cameraDeviceManager,
             flipCameraButtonStyle: environment.flipCameraButtonStyle,
-            alertManager: environment.alertManager
+            alertManager: environment.alertManager,
+            queuesMonitor: environment.queuesMonitor
         )
     }
 }

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
@@ -41,6 +41,7 @@ extension ChatCoordinator {
         var cameraDeviceManager: CoreSdkClient.GetCameraDeviceManageable
         var flipCameraButtonStyle: FlipCameraButtonStyle
         var alertManager: AlertManager
+        var queuesMonitor: QueuesMonitor
     }
 }
 
@@ -88,7 +89,8 @@ extension ChatCoordinator.Environment {
             maximumUploads: environment.maximumUploads,
             cameraDeviceManager: environment.cameraDeviceManager,
             flipCameraButtonStyle: environment.flipCameraButtonStyle,
-            alertManager: environment.alertManager
+            alertManager: environment.alertManager,
+            queuesMonitor: environment.queuesMonitor
         )
     }
 
@@ -132,7 +134,8 @@ extension ChatCoordinator.Environment {
             maximumUploads: environment.maximumUploads,
             cameraDeviceManager: environment.cameraDeviceManager,
             flipCameraButtonStyle: environment.flipCameraButtonStyle,
-            alertManager: environment.alertManager
+            alertManager: environment.alertManager,
+            queuesMonitor: environment.queuesMonitor
         )
     }
 }

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
@@ -43,7 +43,8 @@ extension EngagementCoordinator.Environment {
             .mock
         },
         flipCameraButtonStyle: .nop,
-        alertManager: .mock()
+        alertManager: .mock(),
+        queuesMonitor: .mock()
     )
 }
 #endif

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
@@ -43,6 +43,7 @@ extension EngagementCoordinator {
         var cameraDeviceManager: CoreSdkClient.GetCameraDeviceManageable
         var flipCameraButtonStyle: FlipCameraButtonStyle
         var alertManager: AlertManager
+        var queuesMonitor: QueuesMonitor
     }
 }
 
@@ -95,7 +96,8 @@ extension EngagementCoordinator.Environment {
             maximumUploads: maximumUploads,
             cameraDeviceManager: environment.cameraDeviceManager,
             flipCameraButtonStyle: viewFactory.theme.call.flipCameraButtonStyle,
-            alertManager: alertManager
+            alertManager: alertManager,
+            queuesMonitor: environment.queuesMonitor
         )
     }
 }

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
@@ -65,7 +65,6 @@ public extension EntryWidget {
     func hide() {
         hostedViewController?.dismiss(animated: true, completion: nil)
         hostedViewController = nil
-        environment.queuesMonitor.stopMonitoring()
     }
 }
 
@@ -133,14 +132,14 @@ private extension EntryWidget {
 
         viewModel.retryMonitoring = { [weak self] in
             self?.viewState = .loading
-            self?.environment.queuesMonitor.startMonitoring(queuesIds: self?.queueIds ?? [])
+            self?.environment.queuesMonitor.fetchAndMonitorQueues(queuesIds: self?.queueIds ?? [])
         }
 
         return viewModel
     }
 
     func showView(in parentView: UIView) {
-        self.environment.queuesMonitor.startMonitoring(queuesIds: self.queueIds)
+        self.environment.queuesMonitor.fetchAndMonitorQueues(queuesIds: self.queueIds)
         parentView.subviews.forEach { $0.removeFromSuperview() }
         let model = makeViewModel(showHeader: false)
         let view = makeView(model: model)
@@ -160,7 +159,7 @@ private extension EntryWidget {
     }
 
     func showSheet(in parentViewController: UIViewController) {
-        self.environment.queuesMonitor.startMonitoring(queuesIds: self.queueIds)
+        self.environment.queuesMonitor.fetchAndMonitorQueues(queuesIds: self.queueIds)
         let model = makeViewModel(showHeader: true)
         let view = makeView(model: model).accessibilityAction(.escape, {
             self.hide()

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Mock.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Mock.swift
@@ -34,7 +34,7 @@ extension Glia.Environment {
         snackBar: .mock,
         processInfo: .mock(),
         cameraDeviceManager: { .mock },
-        queuesMonitor: .mock,
+        queuesMonitor: .mock(),
         isAuthenticated: { false }
     )
 }

--- a/GliaWidgets/Sources/Interactor/Interactor.Environment.Interface.swift
+++ b/GliaWidgets/Sources/Interactor/Interactor.Environment.Interface.swift
@@ -1,6 +1,7 @@
 extension Interactor {
     struct Environment {
         var coreSdk: CoreSdkClient
+        var queuesMonitor: QueuesMonitor
         var gcd: GCD
         var log: CoreSdkClient.Logger
     }
@@ -13,6 +14,7 @@ extension Interactor.Environment {
     ) -> Self {
         .init(
             coreSdk: environment.coreSdk,
+            queuesMonitor: environment.queuesMonitor,
             gcd: environment.gcd,
             log: log
         )

--- a/GliaWidgets/Sources/Interactor/Interactor.Environment.Mock.swift
+++ b/GliaWidgets/Sources/Interactor/Interactor.Environment.Mock.swift
@@ -2,6 +2,7 @@
 extension Interactor.Environment {
     static let mock = Self(
         coreSdk: .mock,
+        queuesMonitor: .mock(),
         gcd: .mock,
         log: .mock
     )

--- a/GliaWidgets/Sources/Interactor/Interactor.swift
+++ b/GliaWidgets/Sources/Interactor/Interactor.swift
@@ -109,6 +109,7 @@ class Interactor {
 extension Interactor {
     func setQueuesIds(_ queueIds: [String]) {
         self.queueIds = queueIds
+        environment.queuesMonitor.fetchAndMonitorQueues(queuesIds: queueIds)
     }
 
     func enqueueForEngagement(

--- a/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.Live.swift
+++ b/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.Live.swift
@@ -11,7 +11,7 @@ final class QueuesMonitor {
 
     @Published private(set) var state: State = .idle
 
-    /// Declared as internal var for unit tests purposes
+    // Declared as internal var for unit tests purposes
     var environment: Environment
     private var subscriptionId: String? {
         _subscriptionId.value
@@ -27,30 +27,28 @@ final class QueuesMonitor {
         self.environment = environment
     }
 
-    func startMonitoring(queuesIds: [String]) {
-        environment.listQueues { [weak self] queues, error in
-            guard let self else {
-                return
+    /// Fetches all available site's queues and initiates queues monitoring for given queues IDs.
+    ///
+    /// - Parameters:
+    ///   - queuesIds: The queues IDs that will be monitored.
+    ///   - fetchedQueuesCompletion: Returns fetched queues result for given `queuesIds`
+    ///   if no queues were found among site's queues returns default queues.
+    ///
+    func fetchAndMonitorQueues(
+        queuesIds: [String] = [],
+        fetchedQueuesCompletion: ((Result<[Queue], GliaCoreError>) -> Void)? = nil
+    ) {
+        stopMonitoring()
+
+        fetchQueues(queuesIds: queuesIds) { [weak self] result in
+            if case let .success(queues) = result {
+                self?.observeQueuesUpdates(queues)
             }
-            if let error {
-                self.state = .failed(error)
-                return
-            }
-
-            if let queues {
-                let integratorsQueues = queues.filter { queuesIds.contains($0.id) }
-
-                let observedQueues = integratorsQueues.isEmpty ? queues.filter { $0.isDefault } : integratorsQueues
-
-                self.state = .updated(observedQueues)
-                self.observeQueuesUpdates(observedQueues)
-
-                self._observedQueues.setValue(observedQueues)
-                return
-            }
+            fetchedQueuesCompletion?(result)
         }
     }
 
+    /// Stops monitoring queues.
     func stopMonitoring() {
         if let subscriptionId {
             environment.unsubscribeFromUpdates(subscriptionId) { [weak self] error in
@@ -61,6 +59,43 @@ final class QueuesMonitor {
 }
 
 private extension QueuesMonitor {
+    func fetchQueues(queuesIds: [String], completion: @escaping (Result<[Queue], GliaCoreError>) -> Void) {
+        environment.listQueues { [weak self] queues, error in
+            guard let self else {
+                return
+            }
+            if let error {
+                self.state = .failed(error)
+                completion(.failure(error))
+                return
+            }
+
+            let observedQueues = evaluateQueues(queuesIds: queuesIds, fetchedQueues: queues)
+
+            self.state = .updated(observedQueues)
+            self._observedQueues.setValue(observedQueues)
+            completion(.success(observedQueues))
+        }
+    }
+
+    func evaluateQueues(queuesIds: [String], fetchedQueues: [Queue]?) -> [Queue] {
+        guard let queues = fetchedQueues else {
+            return []
+        }
+
+        let matchedQueues = queues.filter { queuesIds.contains($0.id) }
+
+        guard !matchedQueues.isEmpty else {
+            // If no passed queueId is matched with fetched queues,
+            // then check default queues instead
+            let defaultQueues = queues.filter(\.isDefault)
+
+            return defaultQueues
+        }
+
+        return matchedQueues
+    }
+
     func updateQueue(_ queue: Queue) {
         _observedQueues.withValue { queues in
             guard let indexToChange = queues.firstIndex(where: { $0.id == queue.id }) else {

--- a/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.Mock.swift
+++ b/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.Mock.swift
@@ -1,5 +1,17 @@
 #if DEBUG
 extension QueuesMonitor {
-    static let mock = QueuesMonitor(environment: .mock)
+    static func mock(
+        listQueues: CoreSdkClient.ListQueues? = nil,
+        subscribeForQueuesUpdates: CoreSdkClient.SubscribeForQueuesUpdates? = nil,
+        unsubscribeFromUpdates: CoreSdkClient.UnsubscribeFromUpdates? = nil
+    ) -> Self {
+        Self(
+            environment: .init(
+                listQueues: listQueues ?? QueuesMonitor.Environment.mock.listQueues,
+                subscribeForQueuesUpdates: subscribeForQueuesUpdates ?? QueuesMonitor.Environment.mock.subscribeForQueuesUpdates,
+                unsubscribeFromUpdates: unsubscribeFromUpdates ?? QueuesMonitor.Environment.mock.unsubscribeFromUpdates
+            )
+        )
+    }
 }
 #endif

--- a/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
+++ b/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
@@ -95,6 +95,7 @@ extension EngagementCoordinator.Environment {
         },
         cameraDeviceManager: { .failing },
         flipCameraButtonStyle: .nop,
-        alertManager: .failing(viewFactory: .mock())
+        alertManager: .failing(viewFactory: .mock()),
+        queuesMonitor: .failing
     )
 }

--- a/GliaWidgetsTests/Interactor/Interactor.Environment.Failing.swift
+++ b/GliaWidgetsTests/Interactor/Interactor.Environment.Failing.swift
@@ -4,6 +4,7 @@ import Foundation
 extension Interactor.Environment {
     static let failing = Self(
         coreSdk: .failing,
+        queuesMonitor: .failing,
         gcd: .failing,
         log: .failing
     )

--- a/GliaWidgetsTests/SecureConversations/Availability.Environment.Failing.swift
+++ b/GliaWidgetsTests/SecureConversations/Availability.Environment.Failing.swift
@@ -9,6 +9,7 @@ extension SecureConversations.Availability.Environment {
             fail("\(Self.self).isAuthenticated")
             return false
         },
-        log: .failing
+        log: .failing,
+        queuesMonitor: .failing
     )
 }

--- a/GliaWidgetsTests/SecureConversations/AvailabilityTests.swift
+++ b/GliaWidgetsTests/SecureConversations/AvailabilityTests.swift
@@ -11,6 +11,7 @@ final class AvailabilityTests: XCTestCase {
             callback(nil, error)
         }
         env.isAuthenticated = { true }
+        env.queuesMonitor = .mock(listQueues: env.listQueues)
         let queueIds = [UUID.mock.uuidString]
         let availability = Availability(environment: env)
         var receivedResult: Result<Availability.Status, CoreSdkClient.SalemoveError>?
@@ -30,6 +31,7 @@ final class AvailabilityTests: XCTestCase {
         logger.warningClosure = { _, _, _, _ in }
         env.log = logger
         env.isAuthenticated = { true }
+        env.queuesMonitor = .mock(listQueues: env.listQueues)
         let queueIds = [UUID.mock.uuidString]
         let availability = Availability(environment: env)
         var receivedResult: Result<Availability.Status, CoreSdkClient.SalemoveError>?
@@ -49,6 +51,7 @@ final class AvailabilityTests: XCTestCase {
         logger.warningClosure = { _, _, _, _ in }
         env.log = logger
         env.isAuthenticated = { false }
+        env.queuesMonitor = .mock(listQueues: env.listQueues)
         let queueIds = [UUID.mock.uuidString]
         let availability = Availability(environment: env)
         var receivedResult: Result<Availability.Status, CoreSdkClient.SalemoveError>?
@@ -69,6 +72,7 @@ final class AvailabilityTests: XCTestCase {
         logger.infoClosure = { _, _, _, _ in }
         env.log = logger
         env.isAuthenticated = { true }
+        env.queuesMonitor = .mock(listQueues: env.listQueues)
         let availability = Availability(environment: env)
         var receivedResult: Result<Availability.Status, CoreSdkClient.SalemoveError>?
         availability.checkSecureConversationsAvailability(for: [queueId]) { result in
@@ -95,6 +99,7 @@ final class AvailabilityTests: XCTestCase {
         logger.warningClosure = { _, _, _, _ in }
         env.log = logger
         env.isAuthenticated = { true }
+        env.queuesMonitor = .mock(listQueues: env.listQueues)
         let availability = Availability(environment: env)
         var receivedResult: Result<Availability.Status, CoreSdkClient.SalemoveError>?
         availability.checkSecureConversationsAvailability(for: queueIds) { result in
@@ -115,6 +120,7 @@ final class AvailabilityTests: XCTestCase {
         logger.warningClosure = { _, _, _, _ in }
         env.log = logger
         env.isAuthenticated = { true }
+        env.queuesMonitor = .mock(listQueues: env.listQueues)
         let availability = Availability(environment: env)
         var receivedResult: Result<Availability.Status, CoreSdkClient.SalemoveError>?
         availability.checkSecureConversationsAvailability(for: [queueId]) { result in
@@ -135,6 +141,7 @@ final class AvailabilityTests: XCTestCase {
         logger.warningClosure = { _, _, _, _ in }
         env.log = logger
         env.isAuthenticated = { true }
+        env.queuesMonitor = .mock(listQueues: env.listQueues)
         let availability = Availability(environment: env)
         var receivedResult: Result<Availability.Status, CoreSdkClient.SalemoveError>?
         availability.checkSecureConversationsAvailability(for: [queueId]) { result in
@@ -155,6 +162,7 @@ final class AvailabilityTests: XCTestCase {
         logger.warningClosure = { _, _, _, _ in }
         env.log = logger
         env.isAuthenticated = { true }
+        env.queuesMonitor = .mock(listQueues: env.listQueues)
         let availability = Availability(environment: env)
         var receivedResult: Result<Availability.Status, CoreSdkClient.SalemoveError>?
         availability.checkSecureConversationsAvailability(for: []) { result in
@@ -180,6 +188,7 @@ final class AvailabilityTests: XCTestCase {
         logger.warningClosure = { _, _, _, _ in }
         env.log = logger
         env.isAuthenticated = { true }
+        env.queuesMonitor = .mock(listQueues: env.listQueues)
         let availability = Availability(environment: env)
         var receivedResult: Result<Availability.Status, CoreSdkClient.SalemoveError>?
         availability.checkSecureConversationsAvailability(for: []) { result in

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+GVA.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+GVA.swift
@@ -151,7 +151,8 @@ extension SecureConversationsTranscriptModelTests {
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
-            log: logger
+            log: logger,
+            queuesMonitor: .mock()
         )
 
         let viewModel = TranscriptModel(
@@ -196,7 +197,8 @@ private extension SecureConversationsTranscriptModelTests {
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
-            log: logger
+            log: logger,
+            queuesMonitor: .mock()
         )
 
         return TranscriptModel(

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+MessageRetry.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+MessageRetry.swift
@@ -138,7 +138,8 @@ private extension SecureConversationsTranscriptModelTests {
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
-            log: logger
+            log: logger,
+            queuesMonitor: .mock()
         )
 
         return TranscriptModel(

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+ResponseCard.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+ResponseCard.swift
@@ -46,7 +46,8 @@ private extension SecureConversationsTranscriptModelTests {
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
-            log: logger
+            log: logger,
+            queuesMonitor: .mock()
         )
 
         return TranscriptModel(

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+URLs.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+URLs.swift
@@ -90,7 +90,8 @@ private extension SecureConversationsTranscriptModelTests {
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
-            log: logger
+            log: logger,
+            queuesMonitor: .mock()
         )
 
         return TranscriptModel(

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests.swift
@@ -19,7 +19,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
-            log: logger
+            log: logger,
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
         )
         let viewModel = TranscriptModel(
             isCustomCardSupported: false,
@@ -48,7 +49,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
             isAuthenticated: { false },
-            log: logger
+            log: logger,
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
         )
         let viewModel = TranscriptModel(
             isCustomCardSupported: false,
@@ -81,7 +83,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
-            log: .failing
+            log: .failing,
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
         )
 
         let viewModel = TranscriptModel(
@@ -126,7 +129,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
-            log: .failing
+            log: .failing,
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
         )
         let viewModel = TranscriptModel(
             isCustomCardSupported: false,
@@ -158,7 +162,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
-            log: .failing
+            log: .failing,
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
         )
         let viewModel = TranscriptModel(
             isCustomCardSupported: false,
@@ -204,7 +209,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
-            log: .failing
+            log: .failing,
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
         )
 
         let viewModel = TranscriptModel(
@@ -245,7 +251,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
-            log: .failing
+            log: .failing,
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
         )
 
         let viewModel = TranscriptModel(
@@ -282,7 +289,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
-            log: .failing
+            log: .failing,
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
         )
 
         let viewModel = TranscriptModel(
@@ -325,7 +333,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
-            log: .failing
+            log: .failing,
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
         )
 
         let viewModel = TranscriptModel(
@@ -364,7 +373,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
-            log: .failing
+            log: .failing,
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
         )
 
         let viewModel = TranscriptModel(
@@ -406,7 +416,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
-            log: .failing
+            log: .failing,
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
         )
 
         let viewModel = TranscriptModel(
@@ -455,7 +466,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
-            log: .failing
+            log: .failing,
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
         )
 
         let interactor: Interactor = .failing
@@ -520,7 +532,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
-            log: .failing
+            log: .failing,
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
         )
 
         let interactor: Interactor = .failing
@@ -581,6 +594,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             callback([], nil)
         }
         availabilityEnv.isAuthenticated = { true }
+        availabilityEnv.queuesMonitor = .mock(listQueues: availabilityEnv.listQueues)
         let model = TranscriptModel(
             isCustomCardSupported: false,
             environment: modelEnvironment,
@@ -610,6 +624,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             callback([.mock()], nil)
         }
         availabilityEnv.isAuthenticated = { false }
+        availabilityEnv.queuesMonitor = .mock(listQueues: availabilityEnv.listQueues)
         let model = TranscriptModel(
             isCustomCardSupported: false,
             environment: modelEnvironment,
@@ -637,6 +652,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             callback(nil, .mock())
         }
         availabilityEnv.isAuthenticated = { false }
+        availabilityEnv.queuesMonitor = .mock(listQueues: availabilityEnv.listQueues)
         let model = TranscriptModel(
             isCustomCardSupported: false,
             environment: modelEnvironment,
@@ -666,6 +682,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             callback([.mock()], nil)
         }
         availabilityEnv.isAuthenticated = { true }
+        availabilityEnv.queuesMonitor = .mock(listQueues: availabilityEnv.listQueues)
         let model = TranscriptModel(
             isCustomCardSupported: false,
             environment: modelEnvironment,
@@ -695,6 +712,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             callback([.mock()], nil)
         }
         availabilityEnv.isAuthenticated = { true }
+        availabilityEnv.queuesMonitor = .mock(listQueues: availabilityEnv.listQueues)
         let model = TranscriptModel(
             isCustomCardSupported: false,
             environment: modelEnvironment,

--- a/GliaWidgetsTests/SecureConversations/Coordinator/SecureConversations.Coordinator.Environment.Mock.swift
+++ b/GliaWidgetsTests/SecureConversations/Coordinator/SecureConversations.Coordinator.Environment.Mock.swift
@@ -52,6 +52,7 @@ extension SecureConversations.Coordinator.Environment {
         maximumUploads: { 2 },
         cameraDeviceManager: { .mock }, 
         flipCameraButtonStyle: .nop,
-        alertManager: .mock()
+        alertManager: .mock(),
+        queuesMonitor: .mock()
     )
 }

--- a/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.Mock.swift
+++ b/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.Mock.swift
@@ -52,7 +52,8 @@ extension SecureConversations.Availability {
         environment: .init(
             listQueues: { _ in },
             isAuthenticated: { true },
-            log: .mock
+            log: .mock,
+            queuesMonitor: .mock()
         )
     )
 }

--- a/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModelSpec.swift
+++ b/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModelSpec.swift
@@ -643,6 +643,7 @@ extension SecureConversationsWelcomeViewModelTests {
         }
 
         availability.environment.isAuthenticated = { true }
+        availability.environment.queuesMonitor = .mock(listQueues: availability.environment.listQueues)
 
         let delegate: (WelcomeViewModel.DelegateEvent) -> Void = { event in
             switch event {
@@ -686,6 +687,7 @@ extension SecureConversationsWelcomeViewModelTests {
         }
 
         availability.environment.isAuthenticated = { false }
+        availability.environment.queuesMonitor = .mock(listQueues: availability.environment.listQueues)
 
         let delegate: (WelcomeViewModel.DelegateEvent) -> Void = { event in
             switch event {

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -239,7 +239,7 @@ class ChatViewModelTests: XCTestCase {
         // Given
         enum Calls { case fetchSiteConfigurations }
         var calls: [Calls] = []
-        let interactorEnv = Interactor.Environment(coreSdk: .failing, gcd: .mock, log: .mock)
+        let interactorEnv = Interactor.Environment(coreSdk: .failing, queuesMonitor: .mock(), gcd: .mock, log: .mock)
         let interactor = Interactor.mock(environment: interactorEnv)
         var viewModelEnv = ChatViewModel.Environment.failing()
         viewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
@@ -261,7 +261,7 @@ class ChatViewModelTests: XCTestCase {
         // Given
         enum Calls { case fetchSiteConfigurations }
         var calls: [Calls] = []
-        var interactorEnv = Interactor.Environment.init(coreSdk: .failing, gcd: .mock, log: .mock)
+        var interactorEnv = Interactor.Environment.init(coreSdk: .failing, queuesMonitor: .mock(), gcd: .mock, log: .mock)
         var interactorLog = CoreSdkClient.Logger.failing
         interactorLog.infoClosure = { _, _, _, _ in }
         interactorLog.prefixedClosure = { _ in interactorLog }
@@ -456,7 +456,8 @@ class ChatViewModelTests: XCTestCase {
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: transcriptModelEnv.listQueues,
             isAuthenticated: { true },
-            log: logger
+            log: logger,
+            queuesMonitor: .mock()
         )
         let transcriptModel = TranscriptModel(
             isCustomCardSupported: false,
@@ -895,7 +896,7 @@ class ChatViewModelTests: XCTestCase {
     func test_quickReplyWillBeHiddenAfterMessageIsSent() throws {
         enum Calls { case quickReplyHidden }
         var calls: [Calls] = []
-        let interactorEnv = Interactor.Environment(coreSdk: .failing, gcd: .mock, log: .mock)
+        let interactorEnv = Interactor.Environment(coreSdk: .failing, queuesMonitor: .failing, gcd: .mock, log: .mock)
         let interactor = Interactor.mock(environment: interactorEnv)
         var viewModelEnv = ChatViewModel.Environment.failing()
         viewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
@@ -920,7 +921,7 @@ class ChatViewModelTests: XCTestCase {
     }
 
     func test_pendingMessageGetsRemovedFromListWhenMessageIsSentSuccesfully() {
-        var interactorEnv = Interactor.Environment(coreSdk: .failing, gcd: .mock, log: .mock)
+        var interactorEnv = Interactor.Environment(coreSdk: .failing, queuesMonitor: .failing, gcd: .mock, log: .mock)
         interactorEnv.coreSdk.sendMessageWithMessagePayload = { payload, callback in
             callback(.success(.mock(id: payload.messageId.rawValue)))
         }

--- a/GliaWidgetsTests/Sources/Coordinators/Chat/ChatCoordinator.Environment.Mock.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/Chat/ChatCoordinator.Environment.Mock.swift
@@ -41,6 +41,7 @@ extension ChatCoordinator.Environment {
         maximumUploads: { 2 },
         cameraDeviceManager: { .mock }, 
         flipCameraButtonStyle: .nop,
-        alertManager: .mock()
+        alertManager: .mock(),
+        queuesMonitor: .mock()
     )
 }

--- a/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator+SurveyTests.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator+SurveyTests.swift
@@ -13,7 +13,7 @@ class EngagementCoordinatorSurveyTests: XCTestCase {
             },
             mediaStreams: .init(audio: .none, video: .oneWay)
         )
-        let interactor = Interactor.mock(environment: .init(coreSdk: coreSdkClient, gcd: .failing, log: .failing))
+        let interactor = Interactor.mock(environment: .init(coreSdk: coreSdkClient, queuesMonitor: .mock(), gcd: .failing, log: .failing))
         interactor.currentEngagement = engagement
         var alertManagerEnv = AlertManager.Environment.failing()
         var log = CoreSdkClient.Logger.failing

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+EngagementLauncher.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+EngagementLauncher.swift
@@ -96,6 +96,7 @@ private extension GliaTests {
             completion(.success(()))
         }
         sdkEnv.coreSdk.getCurrentEngagement = { nil }
+        sdkEnv.queuesMonitor = .mock()
         let window = UIWindow(frame: .zero)
         window.makeKeyAndVisible()
         sdkEnv.uiApplication.windows = { [window] }

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
@@ -27,6 +27,7 @@ extension GliaTests {
         sdkEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
+        sdkEnv.queuesMonitor = .mock()
         let window = UIWindow(frame: .zero)
         window.makeKeyAndVisible()
         sdkEnv.uiApplication.windows = { [window] }
@@ -60,6 +61,7 @@ extension GliaTests {
         }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
+        environment.queuesMonitor = .mock()
 
         let rootCoordinator = EngagementCoordinator.mock(
             engagementKind: .chat,
@@ -102,6 +104,7 @@ extension GliaTests {
         sdk.environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
+        sdk.environment.queuesMonitor = .mock()
         try sdk.configure(
             with: .mock(),
             theme: .mock()
@@ -135,6 +138,7 @@ extension GliaTests {
         }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
         environment.coreSdk.getCurrentEngagement = { nil }
+        environment.queuesMonitor = .mock()
         let sdk = Glia(environment: environment)
         try sdk.configure(
             with: .mock(),
@@ -175,6 +179,7 @@ extension GliaTests {
         environment.createRootCoordinator = { _, _, _, _, _, _, _ in
             .mock(environment: .engagementCoordEnvironmentWithKeyWindow)
         }
+        environment.queuesMonitor = .mock()
         let sdk = Glia(environment: environment)
         try sdk.start(.chat, configuration: .mock(), queueID: "queueId", theme: .mock())
 
@@ -214,6 +219,7 @@ extension GliaTests {
         }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
+        environment.queuesMonitor = .mock()
 
         let sdk = Glia(environment: environment)
 
@@ -261,6 +267,7 @@ extension GliaTests {
         }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.getCurrentEngagement = { nil }
+        environment.queuesMonitor = .mock()
         var logger = CoreSdkClient.Logger.failing
         logger.configureLocalLogLevelClosure = { _ in }
         logger.configureRemoteLogLevelClosure = { _ in }
@@ -301,6 +308,7 @@ extension GliaTests {
         logger.infoClosure = { _, _, _, _ in }
         logger.prefixedClosure = { _ in logger }
         environment.coreSdk.createLogger = { _ in logger }
+        environment.queuesMonitor = .mock()
 
         var resultingViewFactory: ViewFactory?
 
@@ -352,6 +360,7 @@ extension GliaTests {
         logger.prefixedClosure = { _ in logger }
         environment.coreSdk.createLogger = { _ in logger }
         environment.print = .mock
+        environment.queuesMonitor = .mock()
         var resultingViewFactory: ViewFactory?
 
         environment.createRootCoordinator = { _, viewFactory, _, _, _, _, _ in
@@ -401,6 +410,7 @@ extension GliaTests {
         environment.coreSdk.createLogger = { _ in logger }
         environment.print = .mock
         environment.conditionalCompilation.isDebug = { true }
+        environment.queuesMonitor = .mock()
 
         var resultingViewFactory: ViewFactory?
 
@@ -424,6 +434,7 @@ extension GliaTests {
         }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.getCurrentEngagement = { nil }
+        environment.queuesMonitor = .mock()
 
         let sdk = Glia(environment: environment)
 
@@ -457,6 +468,7 @@ extension GliaTests {
         environment.coreSdk.createLogger = { _ in logger }
         environment.print = .mock
         environment.conditionalCompilation.isDebug = { true }
+        environment.queuesMonitor = .mock()
 
         var resultingViewFactory: ViewFactory?
 

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -92,6 +92,7 @@ final class GliaTests: XCTestCase {
         gliaEnv.coreSdk.fetchSiteConfigurations = { _ in }
         gliaEnv.uuid = { .mock }
         gliaEnv.gcd.mainQueue.async = { callback in callback() }
+        gliaEnv.queuesMonitor = .mock()
 
         let expectedTheme = Theme.mock(
             colorStyle: .custom(.init()),
@@ -603,6 +604,7 @@ final class GliaTests: XCTestCase {
         var engCoordEnvironment = EngagementCoordinator.Environment.engagementCoordEnvironmentWithKeyWindow
         engCoordEnvironment.fileManager = .mock
         environment.createRootCoordinator = { _, _, _, _, _, _, _ in EngagementCoordinator.mock(environment: engCoordEnvironment) }
+        environment.queuesMonitor = .mock()
 
         let sdk = Glia(environment: environment)
         enum Call {

--- a/GliaWidgetsTests/Sources/InteractorTests.swift
+++ b/GliaWidgetsTests/Sources/InteractorTests.swift
@@ -28,7 +28,7 @@ class InteractorTests: XCTestCase {
             coreSdkCalls.append(.queueForEngagement)
         }
 
-        var interactorEnv = Interactor.Environment(coreSdk: coreSdk, gcd: .failing, log: .failing)
+        var interactorEnv = Interactor.Environment(coreSdk: coreSdk, queuesMonitor: .mock(), gcd: .failing, log: .failing)
         interactorEnv.log.infoClosure = { _, _, _, _ in }
         interactorEnv.log.prefixedClosure = { _ in interactorEnv.log }
 
@@ -55,7 +55,7 @@ class InteractorTests: XCTestCase {
 
         interactor = .init(
             visitorContext: nil,
-            environment: .init(coreSdk: .failing, gcd: .mock, log: .failing)
+            environment: .init(coreSdk: .failing, queuesMonitor: .mock(), gcd: .mock, log: .failing)
         )
 
         interactor.addObserver(self, handler: { event in


### PR DESCRIPTION
MOB-3651

**What was solved?**
This PR adds usage of QueuesMonitor inside SecureConversation.Availability to use cached queues and reuse default queues fallback logic.
*Note: every time any client starts monitoring, QueuesMonitor re-request all available queues to make sure that client monitors actual queues.

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [X] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

