### PR TITLE
Add snapshot tests to EntryWidget

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -682,6 +682,9 @@
 		AFF9542C2ADDA10600C277E0 /* CoreSDKConfigurator.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF9542B2ADDA10600C277E0 /* CoreSDKConfigurator.Failing.swift */; };
 		AFF960982CCCFCA8006BF3BF /* SendingMessageUnavailableBannerViewStyle.RemoteConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF960972CCCFCA8006BF3BF /* SendingMessageUnavailableBannerViewStyle.RemoteConfig.swift */; };
 		AFFA99822C57D658004A2825 /* GliaTests+RestoreEngagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFFA99812C57D658004A2825 /* GliaTests+RestoreEngagement.swift */; };
+		C00DE0AB2CD3847B005956B4 /* EntryWidgetViewLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00DE0AA2CD3847B005956B4 /* EntryWidgetViewLayoutTests.swift */; };
+		C00DE0AD2CD3BD53005956B4 /* EntryWidgetViewVoiceOverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00DE0AC2CD3BD53005956B4 /* EntryWidgetViewVoiceOverTests.swift */; };
+		C00DE0AF2CD3BF35005956B4 /* EntryWidgetViewDynamicTypeFontTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00DE0AE2CD3BF35005956B4 /* EntryWidgetViewDynamicTypeFontTests.swift */; };
 		C0175A0F2A55A624001FACDE /* ChatMessagaEntryViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0175A0E2A55A624001FACDE /* ChatMessagaEntryViewTests.swift */; };
 		C0175A112A55AA3E001FACDE /* ChatMessageEntryView.+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0175A102A55AA3E001FACDE /* ChatMessageEntryView.+Mock.swift */; };
 		C0175A132A56E29E001FACDE /* ChatMessageCardType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0175A122A56E29E001FACDE /* ChatMessageCardType.swift */; };
@@ -1738,6 +1741,9 @@
 		AFF960972CCCFCA8006BF3BF /* SendingMessageUnavailableBannerViewStyle.RemoteConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendingMessageUnavailableBannerViewStyle.RemoteConfig.swift; sourceTree = "<group>"; };
 		AFFA99812C57D658004A2825 /* GliaTests+RestoreEngagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GliaTests+RestoreEngagement.swift"; sourceTree = "<group>"; };
 		B97A8A0B9AD30D0AB8666042 /* Pods_GliaWidgetsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GliaWidgetsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C00DE0AA2CD3847B005956B4 /* EntryWidgetViewLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryWidgetViewLayoutTests.swift; sourceTree = "<group>"; };
+		C00DE0AC2CD3BD53005956B4 /* EntryWidgetViewVoiceOverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryWidgetViewVoiceOverTests.swift; sourceTree = "<group>"; };
+		C00DE0AE2CD3BF35005956B4 /* EntryWidgetViewDynamicTypeFontTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryWidgetViewDynamicTypeFontTests.swift; sourceTree = "<group>"; };
 		C0175A0E2A55A624001FACDE /* ChatMessagaEntryViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessagaEntryViewTests.swift; sourceTree = "<group>"; };
 		C0175A102A55AA3E001FACDE /* ChatMessageEntryView.+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatMessageEntryView.+Mock.swift"; sourceTree = "<group>"; };
 		C0175A122A56E29E001FACDE /* ChatMessageCardType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageCardType.swift; sourceTree = "<group>"; };
@@ -4444,6 +4450,9 @@
 				C039FA802B19ECBA00DFD0E0 /* MediaPickerDynamicFontTests.swift */,
 				C039FA822B19ED7D00DFD0E0 /* MediaPickerVoiceOverTests.swift */,
 				848B8ADD2C0870DC00E990E6 /* CustomCardContainerViewLayoutTests.swift */,
+				C00DE0AA2CD3847B005956B4 /* EntryWidgetViewLayoutTests.swift */,
+				C00DE0AE2CD3BF35005956B4 /* EntryWidgetViewDynamicTypeFontTests.swift */,
+				C00DE0AC2CD3BD53005956B4 /* EntryWidgetViewVoiceOverTests.swift */,
 			);
 			path = SnapshotTests;
 			sourceTree = "<group>";
@@ -6669,10 +6678,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				846E822828996A5C008EFBF0 /* AlertViewControllerVoiceOverTests.swift in Sources */,
+				C00DE0AD2CD3BD53005956B4 /* EntryWidgetViewVoiceOverTests.swift in Sources */,
 				AF03A7BB2A6ED73E0081887D /* SecureConversationsWelcomeScreenDynamicTypeFontTests.swift in Sources */,
 				C0EC58CC2B0275DE00E78C70 /* SnackBarLayoutTests.swift in Sources */,
 				C0EC58D22B02909500E78C70 /* SnackBarDynamicTypeFontTests.swift in Sources */,
 				75CF8D9129C3A85C00CB1524 /* SecureConversationsWelcomeScreenVoiceOverTests.swift in Sources */,
+				C00DE0AF2CD3BF35005956B4 /* EntryWidgetViewDynamicTypeFontTests.swift in Sources */,
 				AF22C8972A61A9BF0004BF3C /* VideoCallViewControllerLayoutTests.swift in Sources */,
 				C07F62772AC1BA2B003EFC97 /* UIViewController+Extensions.swift in Sources */,
 				AF03A7BD2A6EDACF0081887D /* SecureConversationsConfirmationScreenDynamicTypeFontTests.swift in Sources */,
@@ -6698,6 +6709,7 @@
 				AF03A7B32A6EA5490081887D /* CallViewControllerDynamicTypeFontTests.swift in Sources */,
 				9A1992D827D61F8100161AAE /* ChatViewControllerVoiceOverTests.swift in Sources */,
 				AF22C8892A6184C50004BF3C /* CallViewControllerLayoutTests.swift in Sources */,
+				C00DE0AB2CD3847B005956B4 /* EntryWidgetViewLayoutTests.swift in Sources */,
 				8458769F2823FD18007AC3DF /* SurveyViewControllerVoiceOverTests.swift in Sources */,
 				C07FA05129B0E41A00E9FB7F /* VisitorCodeViewControllerVoiceOverTests.swift in Sources */,
 				75CF8DAD29C8F2B500CB1524 /* SecureConversationsConfirmationScreenVoiceOverTests.swift in Sources */,

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.Environment.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.Environment.swift
@@ -8,3 +8,18 @@ extension EntryWidget {
         var isAuthenticated: () -> Bool
     }
 }
+
+#if DEBUG
+extension EntryWidget.Environment {
+    static func mock() -> Self {
+        let engagementLauncher = EngagementLauncher { _, _ in }
+        let theme = Theme()
+        return .init(
+            queuesMonitor: .mock,
+            engagementLauncher: engagementLauncher,
+            theme: theme,
+            isAuthenticated: { true }
+        )
+    }
+}
+#endif

--- a/GliaWidgets/Sources/EntryWidget/EntryWidgetViewModel.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidgetViewModel.swift
@@ -9,7 +9,7 @@ extension EntryWidgetView {
         let showHeader: Bool
         var retryMonitoring: (() -> Void)?
         var style: EntryWidgetStyle {
-            theme.entryWidgetStyle
+            theme.entryWidget
         }
 
         var showPoweredBy: Bool {

--- a/GliaWidgets/SwiftUI/Components/PoweredBy/PoweredByView.swift
+++ b/GliaWidgets/SwiftUI/Components/PoweredBy/PoweredByView.swift
@@ -4,6 +4,7 @@ struct PoweredByView: View {
     let style: PoweredByStyle
     let containerHeight: CGFloat
     let color: UIColor = Color.baseShade
+    @ScaledMetric var scale: CGFloat = 1
 
     init(
         style: PoweredByStyle,
@@ -19,11 +20,13 @@ struct PoweredByView: View {
                 .setColor(color.swiftUIColor())
                 .opacity(0.5)
                 .font(.convert(style.font))
+                .accessibilityLabel("Powered By Glia")
             Asset.gliaLogo.image.asSwiftUIImage()
                 .resizable()
                 .fit()
-                .height(20)
+                .height(20 * scale)
                 .setColor(color.swiftUIColor())
+                .accessibilityHidden(true)
         }
         .height(containerHeight)
     }

--- a/SnapshotTests/EntryWidgetViewDynamicTypeFontTests.swift
+++ b/SnapshotTests/EntryWidgetViewDynamicTypeFontTests.swift
@@ -1,0 +1,173 @@
+import AccessibilitySnapshot
+import Combine
+@testable import GliaWidgets
+import SnapshotTesting
+import XCTest
+
+final class EntryWidgetViewDynamicTypeFontTests: SnapshotTestCase {
+    func testEntryWidgetWhenLoading() {
+        let entryWidget: EntryWidget = .mock()
+        entryWidget.show(in: .init())
+        entryWidget.viewState = .loading
+        let height = entryWidget.calculateHeight()
+        let view = entryWidget.hostedViewController?.view
+        view?.frame = viewControllerFrame(height: height)
+        view?.assertSnapshot(as: .extra3LargeFont, in: .portrait)
+        view?.assertSnapshot(as: .extra3LargeFont, in: .landscape)
+    }
+
+    func testEntryWidgetEmbeddedWhenLoading() {
+        let entryWidget: EntryWidget = .init(queueIds: [], environment: .mock())
+        let view = UIView()
+        entryWidget.embed(in: view)
+        entryWidget.viewState = .loading
+        let height = entryWidget.calculateHeight()
+        view.frame = viewControllerFrame(height: height)
+        view.assertSnapshot(as: .extra3LargeFont, in: .portrait)
+        view.assertSnapshot(as: .extra3LargeFont, in: .landscape)
+    }
+
+    func testEntryWidgetWhenError() {
+        let entryWidget: EntryWidget = .mock()
+        entryWidget.show(in: .init())
+        entryWidget.viewState = .error
+        let height = entryWidget.calculateHeight()
+        let view = entryWidget.hostedViewController?.view
+        view?.frame = viewControllerFrame(height: height)
+        view?.assertSnapshot(as: .extra3LargeFont, in: .portrait)
+        view?.assertSnapshot(as: .extra3LargeFont, in: .landscape)
+    }
+
+    func testEntryWidgetEmbeddedWhenError() {
+        let entryWidget: EntryWidget = .init(queueIds: [], environment: .mock())
+        let view = UIView()
+        entryWidget.embed(in: view)
+        entryWidget.viewState = .error
+        let height = entryWidget.calculateHeight()
+        view.frame = viewControllerFrame(height: height)
+        view.assertSnapshot(as: .extra3LargeFont, in: .portrait)
+        view.assertSnapshot(as: .extra3LargeFont, in: .landscape)
+    }
+
+    func testEntryWidgetWhenOffline() {
+        let entryWidget: EntryWidget = .mock()
+        entryWidget.show(in: .init())
+        entryWidget.viewState = .offline
+        let height = entryWidget.calculateHeight()
+        let view = entryWidget.hostedViewController?.view
+        view?.frame = viewControllerFrame(height: height)
+        view?.assertSnapshot(as: .extra3LargeFont, in: .portrait)
+        view?.assertSnapshot(as: .extra3LargeFont, in: .landscape)
+    }
+
+    func testEntryWidgetEmbeddedWhenOffline() {
+        let entryWidget: EntryWidget = .init(queueIds: [], environment: .mock())
+        let view = UIView()
+        entryWidget.embed(in: view)
+        entryWidget.viewState = .offline
+        let height = entryWidget.calculateHeight()
+        view.frame = viewControllerFrame(height: height)
+        view.assertSnapshot(as: .extra3LargeFont, in: .portrait)
+        view.assertSnapshot(as: .extra3LargeFont, in: .landscape)
+    }
+
+    func testEntryWidgetWhenFourMediaTypes() {
+        let entryWidget: EntryWidget = .mock()
+        entryWidget.show(in: .init())
+        entryWidget.viewState = .mediaTypes([.video, .audio, .chat, .secureMessaging])
+        let height = entryWidget.calculateHeight()
+        let view = entryWidget.hostedViewController?.view
+        view?.frame = viewControllerFrame(height: height)
+        view?.assertSnapshot(as: .extra3LargeFont, in: .portrait)
+        view?.assertSnapshot(as: .extra3LargeFont, in: .landscape)
+    }
+
+    func testEntryWidgetEmbeddedWhenFourMediaTypes() {
+        let entryWidget: EntryWidget = .init(queueIds: [], environment: .mock())
+        let view = UIView()
+        entryWidget.embed(in: view)
+        entryWidget.viewState = .mediaTypes([.video, .audio, .chat, .secureMessaging])
+        let height = entryWidget.calculateHeight()
+        view.frame = viewControllerFrame(height: height)
+        view.assertSnapshot(as: .extra3LargeFont, in: .portrait)
+        view.assertSnapshot(as: .extra3LargeFont, in: .landscape)
+    }
+
+    func testEntryWidgetWhenThreeMediaTypes() {
+        let entryWidget: EntryWidget = .mock()
+        entryWidget.show(in: .init())
+        entryWidget.viewState = .mediaTypes([.video, .audio, .chat])
+        let height = entryWidget.calculateHeight()
+        let view = entryWidget.hostedViewController?.view
+        view?.frame = viewControllerFrame(height: height)
+        view?.assertSnapshot(as: .extra3LargeFont, in: .portrait)
+        view?.assertSnapshot(as: .extra3LargeFont, in: .landscape)
+    }
+
+    func testEntryWidgetEmbeddedWhenThreeMediaTypes() {
+        let entryWidget: EntryWidget = .init(queueIds: [], environment: .mock())
+        let view = UIView()
+        entryWidget.embed(in: view)
+        entryWidget.viewState = .mediaTypes([.video, .audio, .chat])
+        let height = entryWidget.calculateHeight()
+        view.frame = viewControllerFrame(height: height)
+        view.assertSnapshot(as: .extra3LargeFont, in: .portrait)
+        view.assertSnapshot(as: .extra3LargeFont, in: .landscape)
+    }
+
+    func testEntryWidgetWhenTwoMediaTypes() {
+        let entryWidget: EntryWidget = .mock()
+        entryWidget.show(in: .init())
+        entryWidget.viewState = .mediaTypes([.video, .audio])
+        let height = entryWidget.calculateHeight()
+        let view = entryWidget.hostedViewController?.view
+        view?.frame = viewControllerFrame(height: height)
+        view?.assertSnapshot(as: .extra3LargeFont, in: .portrait)
+        view?.assertSnapshot(as: .extra3LargeFont, in: .landscape)
+    }
+
+    func testEntryWidgetEmbeddedWhenTwoMediaTypes() {
+        let entryWidget: EntryWidget = .init(queueIds: [], environment: .mock())
+        let view = UIView()
+        entryWidget.embed(in: view)
+        entryWidget.viewState = .mediaTypes([.video, .audio])
+        let height = entryWidget.calculateHeight()
+        view.frame = viewControllerFrame(height: height)
+        view.assertSnapshot(as: .extra3LargeFont, in: .portrait)
+        view.assertSnapshot(as: .extra3LargeFont, in: .landscape)
+    }
+
+    func testEntryWidgetWhenOneMediaTypes() {
+        let entryWidget: EntryWidget = .mock()
+        entryWidget.show(in: .init())
+        entryWidget.viewState = .mediaTypes([.video])
+        let height = entryWidget.calculateHeight()
+        let view = entryWidget.hostedViewController?.view
+        view?.frame = viewControllerFrame(height: height)
+        view?.assertSnapshot(as: .extra3LargeFont, in: .portrait)
+        view?.assertSnapshot(as: .extra3LargeFont, in: .landscape)
+    }
+
+    func testEntryWidgetEmbeddedWhenOneMediaTypes() {
+        let entryWidget: EntryWidget = .init(queueIds: [], environment: .mock())
+        let view = UIView()
+        entryWidget.embed(in: view)
+        entryWidget.viewState = .mediaTypes([.video])
+        let height = entryWidget.calculateHeight()
+        view.frame = viewControllerFrame(height: height)
+        view.assertSnapshot(as: .extra3LargeFont, in: .portrait)
+        view.assertSnapshot(as: .extra3LargeFont, in: .landscape)
+    }
+}
+
+private extension EntryWidgetViewDynamicTypeFontTests {
+    func viewControllerFrame(height: CGFloat) -> CGRect {
+        .init(
+            origin: .zero,
+            size: .init(
+                width: UIScreen.main.bounds.width,
+                height: height
+            )
+        )
+    }
+}

--- a/SnapshotTests/EntryWidgetViewLayoutTests.swift
+++ b/SnapshotTests/EntryWidgetViewLayoutTests.swift
@@ -1,0 +1,173 @@
+import AccessibilitySnapshot
+import Combine
+@testable import GliaWidgets
+import SnapshotTesting
+import XCTest
+
+final class EntryWidgetViewLayoutTests: SnapshotTestCase {
+    func testEntryWidgetWhenLoading() {
+        let entryWidget: EntryWidget = .mock()
+        entryWidget.show(in: .init())
+        entryWidget.viewState = .loading
+        let height = entryWidget.calculateHeight()
+        let view = entryWidget.hostedViewController?.view
+        view?.frame = viewControllerFrame(height: height)
+        view?.assertSnapshot(as: .image, in: .portrait)
+        view?.assertSnapshot(as: .image, in: .landscape)
+    }
+
+    func testEntryWidgetEmbeddedWhenLoading() {
+        let entryWidget: EntryWidget = .init(queueIds: [], environment: .mock())
+        let view = UIView()
+        entryWidget.embed(in: view)
+        entryWidget.viewState = .loading
+        let height = entryWidget.calculateHeight()
+        view.frame = viewControllerFrame(height: height)
+        view.assertSnapshot(as: .image, in: .portrait)
+        view.assertSnapshot(as: .image, in: .landscape)
+    }
+
+    func testEntryWidgetWhenError() {
+        let entryWidget: EntryWidget = .mock()
+        entryWidget.show(in: .init())
+        entryWidget.viewState = .error
+        let height = entryWidget.calculateHeight()
+        let view = entryWidget.hostedViewController?.view
+        view?.frame = viewControllerFrame(height: height)
+        view?.assertSnapshot(as: .image, in: .portrait)
+        view?.assertSnapshot(as: .image, in: .landscape)
+    }
+
+    func testEntryWidgetEmbeddedWhenError() {
+        let entryWidget: EntryWidget = .init(queueIds: [], environment: .mock())
+        let view = UIView()
+        entryWidget.embed(in: view)
+        entryWidget.viewState = .error
+        let height = entryWidget.calculateHeight()
+        view.frame = viewControllerFrame(height: height)
+        view.assertSnapshot(as: .image, in: .portrait)
+        view.assertSnapshot(as: .image, in: .landscape)
+    }
+
+    func testEntryWidgetWhenOffline() {
+        let entryWidget: EntryWidget = .mock()
+        entryWidget.show(in: .init())
+        entryWidget.viewState = .offline
+        let height = entryWidget.calculateHeight()
+        let view = entryWidget.hostedViewController?.view
+        view?.frame = viewControllerFrame(height: height)
+        view?.assertSnapshot(as: .image, in: .portrait)
+        view?.assertSnapshot(as: .image, in: .landscape)
+    }
+
+    func testEntryWidgetEmbeddedWhenOffline() {
+        let entryWidget: EntryWidget = .init(queueIds: [], environment: .mock())
+        let view = UIView()
+        entryWidget.embed(in: view)
+        entryWidget.viewState = .offline
+        let height = entryWidget.calculateHeight()
+        view.frame = viewControllerFrame(height: height)
+        view.assertSnapshot(as: .image, in: .portrait)
+        view.assertSnapshot(as: .image, in: .landscape)
+    }
+
+    func testEntryWidgetWhenFourMediaTypes() {
+        let entryWidget: EntryWidget = .mock()
+        entryWidget.show(in: .init())
+        entryWidget.viewState = .mediaTypes([.video, .audio, .chat, .secureMessaging])
+        let height = entryWidget.calculateHeight()
+        let view = entryWidget.hostedViewController?.view
+        view?.frame = viewControllerFrame(height: height)
+        view?.assertSnapshot(as: .image, in: .portrait)
+        view?.assertSnapshot(as: .image, in: .landscape)
+    }
+
+    func testEntryWidgetEmbeddedWhenFourMediaTypes() {
+        let entryWidget: EntryWidget = .init(queueIds: [], environment: .mock())
+        let view = UIView()
+        entryWidget.embed(in: view)
+        entryWidget.viewState = .mediaTypes([.video, .audio, .chat, .secureMessaging])
+        let height = entryWidget.calculateHeight()
+        view.frame = viewControllerFrame(height: height)
+        view.assertSnapshot(as: .image, in: .portrait)
+        view.assertSnapshot(as: .image, in: .landscape)
+    }
+
+    func testEntryWidgetWhenThreeMediaTypes() {
+        let entryWidget: EntryWidget = .mock()
+        entryWidget.show(in: .init())
+        entryWidget.viewState = .mediaTypes([.video, .audio, .chat])
+        let height = entryWidget.calculateHeight()
+        let view = entryWidget.hostedViewController?.view
+        view?.frame = viewControllerFrame(height: height)
+        view?.assertSnapshot(as: .image, in: .portrait)
+        view?.assertSnapshot(as: .image, in: .landscape)
+    }
+
+    func testEntryWidgetEmbeddedWhenThreeMediaTypes() {
+        let entryWidget: EntryWidget = .init(queueIds: [], environment: .mock())
+        let view = UIView()
+        entryWidget.embed(in: view)
+        entryWidget.viewState = .mediaTypes([.video, .audio, .chat])
+        let height = entryWidget.calculateHeight()
+        view.frame = viewControllerFrame(height: height)
+        view.assertSnapshot(as: .image, in: .portrait)
+        view.assertSnapshot(as: .image, in: .landscape)
+    }
+
+    func testEntryWidgetWhenTwoMediaTypes() {
+        let entryWidget: EntryWidget = .mock()
+        entryWidget.show(in: .init())
+        entryWidget.viewState = .mediaTypes([.video, .audio])
+        let height = entryWidget.calculateHeight()
+        let view = entryWidget.hostedViewController?.view
+        view?.frame = viewControllerFrame(height: height)
+        view?.assertSnapshot(as: .image, in: .portrait)
+        view?.assertSnapshot(as: .image, in: .landscape)
+    }
+
+    func testEntryWidgetEmbeddedWhenTwoMediaTypes() {
+        let entryWidget: EntryWidget = .init(queueIds: [], environment: .mock())
+        let view = UIView()
+        entryWidget.embed(in: view)
+        entryWidget.viewState = .mediaTypes([.video, .audio])
+        let height = entryWidget.calculateHeight()
+        view.frame = viewControllerFrame(height: height)
+        view.assertSnapshot(as: .image, in: .portrait)
+        view.assertSnapshot(as: .image, in: .landscape)
+    }
+
+    func testEntryWidgetWhenOneMediaTypes() {
+        let entryWidget: EntryWidget = .mock()
+        entryWidget.show(in: .init())
+        entryWidget.viewState = .mediaTypes([.video])
+        let height = entryWidget.calculateHeight()
+        let view = entryWidget.hostedViewController?.view
+        view?.frame = viewControllerFrame(height: height)
+        view?.assertSnapshot(as: .image, in: .portrait)
+        view?.assertSnapshot(as: .image, in: .landscape)
+    }
+
+    func testEntryWidgetEmbeddedWhenOneMediaTypes() {
+        let entryWidget: EntryWidget = .init(queueIds: [], environment: .mock())
+        let view = UIView()
+        entryWidget.embed(in: view)
+        entryWidget.viewState = .mediaTypes([.video])
+        let height = entryWidget.calculateHeight()
+        view.frame = viewControllerFrame(height: height)
+        view.assertSnapshot(as: .image, in: .portrait)
+        view.assertSnapshot(as: .image, in: .landscape)
+    }
+}
+
+private extension EntryWidgetViewLayoutTests {
+    func viewControllerFrame(height: CGFloat) -> CGRect {
+        .init(
+            origin: .zero,
+            size: .init(
+                width: UIScreen.main.bounds.width,
+                height: height
+            )
+        )
+    }
+}

--- a/SnapshotTests/EntryWidgetViewVoiceOverTests.swift
+++ b/SnapshotTests/EntryWidgetViewVoiceOverTests.swift
@@ -1,0 +1,158 @@
+import AccessibilitySnapshot
+@testable import GliaWidgets
+import SnapshotTesting
+import XCTest
+
+final class EntryWidgetViewVoiceOverTests: SnapshotTestCase {
+    func testEntryWidgetWhenLoading() {
+        let entryWidget: EntryWidget = .mock()
+        entryWidget.show(in: .init())
+        entryWidget.viewState = .loading
+        let height = entryWidget.calculateHeight()
+        let view = entryWidget.hostedViewController?.view
+        view?.frame = viewControllerFrame(height: height)
+        view?.assertSnapshot(as: .accessibilityImage)
+    }
+
+    func testEntryWidgetEmbeddedWhenLoading() {
+        let entryWidget: EntryWidget = .init(queueIds: [], environment: .mock())
+        let view = UIView()
+        entryWidget.embed(in: view)
+        entryWidget.viewState = .loading
+        let height = entryWidget.calculateHeight()
+        view.frame = viewControllerFrame(height: height)
+        view.assertSnapshot(as: .accessibilityImage)
+    }
+
+    func testEntryWidgetWhenError() {
+        let entryWidget: EntryWidget = .mock()
+        entryWidget.show(in: .init())
+        entryWidget.viewState = .error
+        let height = entryWidget.calculateHeight()
+        let view = entryWidget.hostedViewController?.view
+        view?.frame = viewControllerFrame(height: height)
+        view?.assertSnapshot(as: .accessibilityImage)
+    }
+
+    func testEntryWidgetEmbeddedWhenError() {
+        let entryWidget: EntryWidget = .init(queueIds: [], environment: .mock())
+        let view = UIView()
+        entryWidget.embed(in: view)
+        entryWidget.viewState = .error
+        let height = entryWidget.calculateHeight()
+        view.frame = viewControllerFrame(height: height)
+        view.assertSnapshot(as: .accessibilityImage)
+    }
+
+    func testEntryWidgetWhenOffline() {
+        let entryWidget: EntryWidget = .mock()
+        entryWidget.show(in: .init())
+        entryWidget.viewState = .offline
+        let height = entryWidget.calculateHeight()
+        let view = entryWidget.hostedViewController?.view
+        view?.frame = viewControllerFrame(height: height)
+        view?.assertSnapshot(as: .accessibilityImage)
+    }
+
+    func testEntryWidgetEmbeddedWhenOffline() {
+        let entryWidget: EntryWidget = .init(queueIds: [], environment: .mock())
+        let view = UIView()
+        entryWidget.embed(in: view)
+        entryWidget.viewState = .offline
+        let height = entryWidget.calculateHeight()
+        view.frame = viewControllerFrame(height: height)
+        view.assertSnapshot(as: .accessibilityImage)
+    }
+
+    func testEntryWidgetWhenFourMediaTypes() {
+        let entryWidget: EntryWidget = .mock()
+        entryWidget.show(in: .init())
+        entryWidget.viewState = .mediaTypes([.video, .audio, .chat, .secureMessaging])
+        let height = entryWidget.calculateHeight()
+        let view = entryWidget.hostedViewController?.view
+        view?.frame = viewControllerFrame(height: height)
+        view?.assertSnapshot(as: .accessibilityImage)
+    }
+
+    func testEntryWidgetEmbeddedWhenFourMediaTypes() {
+        let entryWidget: EntryWidget = .init(queueIds: [], environment: .mock())
+        let view = UIView()
+        entryWidget.embed(in: view)
+        entryWidget.viewState = .mediaTypes([.video, .audio, .chat, .secureMessaging])
+        let height = entryWidget.calculateHeight()
+        view.frame = viewControllerFrame(height: height)
+        view.assertSnapshot(as: .accessibilityImage)
+    }
+
+    func testEntryWidgetWhenThreeMediaTypes() {
+        let entryWidget: EntryWidget = .mock()
+        entryWidget.show(in: .init())
+        entryWidget.viewState = .mediaTypes([.video, .audio, .chat])
+        let height = entryWidget.calculateHeight()
+        let view = entryWidget.hostedViewController?.view
+        view?.frame = viewControllerFrame(height: height)
+        view?.assertSnapshot(as: .accessibilityImage)
+    }
+
+    func testEntryWidgetEmbeddedWhenThreeMediaTypes() {
+        let entryWidget: EntryWidget = .init(queueIds: [], environment: .mock())
+        let view = UIView()
+        entryWidget.embed(in: view)
+        entryWidget.viewState = .mediaTypes([.video, .audio, .chat])
+        let height = entryWidget.calculateHeight()
+        view.frame = viewControllerFrame(height: height)
+        view.assertSnapshot(as: .accessibilityImage)
+    }
+
+    func testEntryWidgetWhenTwoMediaTypes() {
+        let entryWidget: EntryWidget = .mock()
+        entryWidget.show(in: .init())
+        entryWidget.viewState = .mediaTypes([.video, .audio])
+        let height = entryWidget.calculateHeight()
+        let view = entryWidget.hostedViewController?.view
+        view?.frame = viewControllerFrame(height: height)
+        view?.assertSnapshot(as: .accessibilityImage)
+    }
+
+    func testEntryWidgetEmbeddedWhenTwoMediaTypes() {
+        let entryWidget: EntryWidget = .init(queueIds: [], environment: .mock())
+        let view = UIView()
+        entryWidget.embed(in: view)
+        entryWidget.viewState = .mediaTypes([.video, .audio])
+        let height = entryWidget.calculateHeight()
+        view.frame = viewControllerFrame(height: height)
+        view.assertSnapshot(as: .accessibilityImage)
+    }
+
+    func testEntryWidgetWhenOneMediaTypes() {
+        let entryWidget: EntryWidget = .mock()
+        entryWidget.show(in: .init())
+        entryWidget.viewState = .mediaTypes([.video])
+        let height = entryWidget.calculateHeight()
+        let view = entryWidget.hostedViewController?.view
+        view?.frame = viewControllerFrame(height: height)
+        view?.assertSnapshot(as: .accessibilityImage)
+    }
+
+    func testEntryWidgetEmbeddedWhenOneMediaTypes() {
+        let entryWidget: EntryWidget = .init(queueIds: [], environment: .mock())
+        let view = UIView()
+        entryWidget.embed(in: view)
+        entryWidget.viewState = .mediaTypes([.video])
+        let height = entryWidget.calculateHeight()
+        view.frame = viewControllerFrame(height: height)
+        view.assertSnapshot(as: .accessibilityImage)
+    }
+}
+
+private extension EntryWidgetViewVoiceOverTests {
+    func viewControllerFrame(height: CGFloat) -> CGRect {
+        .init(
+            origin: .zero,
+            size: .init(
+                width: UIScreen.main.bounds.width,
+                height: height
+            )
+        )
+    }
+}


### PR DESCRIPTION
This PR covers EntryWidget with snapshot tests. This also includes adding mocks for EntryWidget and EntryWidget Environment. In addition, poweredBy was altered to allow scaling with font.

MOB-3545

**What was solved?**

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
