### PR TITLE
Hide EntryWidget sheet before engagement

### DIFF
--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
@@ -105,20 +105,31 @@ private extension EntryWidget {
     }
 
     func mediaTypeSelected(_ mediaTypeItem: MediaTypeItem) {
-        do {
-            switch mediaTypeItem {
-            case .chat:
-                try environment.engagementLauncher.startChat()
-            case .audio:
-                try environment.engagementLauncher.startAudioCall()
-            case .video:
-                try environment.engagementLauncher.startVideoCall()
-            case .secureMessaging:
-                try environment.engagementLauncher.startSecureMessaging()
+        hideViewIfNecessary {
+            do {
+                switch mediaTypeItem {
+                case .chat:
+                    try self.environment.engagementLauncher.startChat()
+                case .audio:
+                    try self.environment.engagementLauncher.startAudioCall()
+                case .video:
+                    try self.environment.engagementLauncher.startVideoCall()
+                case .secureMessaging:
+                    try self.environment.engagementLauncher.startSecureMessaging()
+                }
+            } catch {
+                self.viewState = .error
             }
-        } catch {
-            viewState = .error
         }
+    }
+
+    func hideViewIfNecessary(completion: @escaping () -> Void) {
+        guard hostedViewController != nil else {
+            completion()
+            return
+        }
+        hostedViewController?.dismiss(animated: true, completion: completion)
+        hostedViewController = nil
     }
 
     func makeViewModel(showHeader: Bool) -> EntryWidgetView.Model {


### PR DESCRIPTION
**What was solved?**
Due to the different nature of chat and call views, the behaviour of alert dismissal worked way different. For Audio and Video engagements, when confrmation dialog was declined, the engagement view was dismissed alongside Entrywidget sheet. This was not intended. But for Chat, the dialog dismissal didn't dismiss EntryWidget sheet. To align them all, the entry widget is not dismissed when media type has been selected.

It also looks much better visually now with the animation.

MOB-3760
**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
