### PR TITLE
Optimize using of strings for the Entry Widget

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -660,6 +660,7 @@
 		AFA2FDFA2890827E00428E6D /* BadgeStyle.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA2FDF92890827E00428E6D /* BadgeStyle.Mock.swift */; };
 		AFA2FDFC289082F500428E6D /* OnHoldOverlayStyle.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA2FDFB289082F500428E6D /* OnHoldOverlayStyle.Mock.swift */; };
 		AFA5E96229F2CF9400F13DB7 /* SecureConversations.TranscriptModel.DividedChatItemsForUnreadCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA5E96129F2CF9400F13DB7 /* SecureConversations.TranscriptModel.DividedChatItemsForUnreadCount.swift */; };
+		AFA7A8A72CD9483C00861322 /* MediaTypeItemStyle.Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA7A8A62CD9482E00861322 /* MediaTypeItemStyle.Accessibility.swift */; };
 		AFAB409229798BD4007F96CC /* SecureConversations.FileUploadListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFAB409129798BD4007F96CC /* SecureConversations.FileUploadListView.swift */; };
 		AFB24A1A2BEAA8B700B47DBF /* CallViewModel+CameraFlip.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFB24A192BEAA8B700B47DBF /* CallViewModel+CameraFlip.swift */; };
 		AFB6A0792CCBF3B700A1ED9A /* MediaTypeItemStyle.Loading.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFB6A0782CCBF3B700A1ED9A /* MediaTypeItemStyle.Loading.swift */; };
@@ -1715,6 +1716,7 @@
 		AFA2FDF92890827E00428E6D /* BadgeStyle.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeStyle.Mock.swift; sourceTree = "<group>"; };
 		AFA2FDFB289082F500428E6D /* OnHoldOverlayStyle.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnHoldOverlayStyle.Mock.swift; sourceTree = "<group>"; };
 		AFA5E96129F2CF9400F13DB7 /* SecureConversations.TranscriptModel.DividedChatItemsForUnreadCount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.TranscriptModel.DividedChatItemsForUnreadCount.swift; sourceTree = "<group>"; };
+		AFA7A8A62CD9482E00861322 /* MediaTypeItemStyle.Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTypeItemStyle.Accessibility.swift; sourceTree = "<group>"; };
 		AFAB409129798BD4007F96CC /* SecureConversations.FileUploadListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FileUploadListView.swift; sourceTree = "<group>"; };
 		AFB24A192BEAA8B700B47DBF /* CallViewModel+CameraFlip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CallViewModel+CameraFlip.swift"; sourceTree = "<group>"; };
 		AFB6A0782CCBF3B700A1ED9A /* MediaTypeItemStyle.Loading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTypeItemStyle.Loading.swift; sourceTree = "<group>"; };
@@ -5105,6 +5107,7 @@
 				C0F3DE3A2C6E0DD900DE6D7B /* EntryWidgetView.swift */,
 				C0F3DE3C2C6E170600DE6D7B /* EntryWidgetViewModel.swift */,
 				C0C5BB762CAD4259001B2025 /* MediaTypeItemStyle.swift */,
+				AFA7A8A62CD9482E00861322 /* MediaTypeItemStyle.Accessibility.swift */,
 				C0C5BB782CAD42FD001B2025 /* MediaTypeItemStyle.RemoteConfig.swift */,
 				AFB6A0782CCBF3B700A1ED9A /* MediaTypeItemStyle.Loading.swift */,
 				AFB6A07A2CCBF53800A1ED9A /* MediaTypeItemStyle.Loading.Accessibility.swift */,
@@ -6396,6 +6399,7 @@
 				6EA3516926E139DA00BF5941 /* GliaViewTransitionController.swift in Sources */,
 				C0D2F07929A4E3DF00803B47 /* UserImageView.Mock.swift in Sources */,
 				C0D6CA3B2C19A61900D4709B /* ChatMessageView.Environment.swift in Sources */,
+				AFA7A8A72CD9483C00861322 /* MediaTypeItemStyle.Accessibility.swift in Sources */,
 				84265E6B29912E2100D65842 /* RemoteConfiguration+CallVisualizer.swift in Sources */,
 				1A1E30C725F9FDAB00850E68 /* ChatImageFileContentView.swift in Sources */,
 				AFA2FDEE28907DDB00428E6D /* EngagementCoordinator.Environment.Mock.swift in Sources */,

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.Channel.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.Channel.swift
@@ -8,45 +8,6 @@ extension EntryWidget {
         case chat
         case secureMessaging
 
-        var headline: String {
-            switch self {
-            case .chat:
-                return Localization.EntryWidget.LiveChat.Button.label
-            case .audio:
-                return Localization.EntryWidget.Audio.Button.label
-            case .video:
-                return Localization.EntryWidget.Video.Button.label
-            case .secureMessaging:
-                return Localization.EntryWidget.SecureMessaging.Button.label
-            }
-        }
-
-        var subheadline: String {
-            switch self {
-            case .chat:
-                return Localization.EntryWidget.LiveChat.Button.description
-            case .audio:
-                return Localization.EntryWidget.Audio.Button.description
-            case .video:
-                return Localization.EntryWidget.Video.Button.description
-            case .secureMessaging:
-                return Localization.EntryWidget.SecureMessaging.Button.description
-            }
-        }
-
-        var hintline: String {
-            switch self {
-            case .chat:
-                return Localization.EntryWidget.LiveChat.Button.Accessibility.hint
-            case .audio:
-                return Localization.EntryWidget.Audio.Button.Accessibility.hint
-            case .video:
-                return Localization.EntryWidget.Video.Button.Accessibility.hint
-            case .secureMessaging:
-                return Localization.EntryWidget.SecureMessaging.Button.Accessibility.hint
-            }
-        }
-
         var image: UIImage {
             switch self {
             case .chat:

--- a/GliaWidgets/Sources/EntryWidget/EntryWidgetView.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidgetView.swift
@@ -155,8 +155,8 @@ private extension EntryWidgetView {
         HStack(spacing: 16) {
             icon(mediaType.image)
             VStack(alignment: .leading, spacing: 2) {
-                headlineText(mediaType.headline)
-                subheadlineText(mediaType.subheadline)
+                headlineText(model.style.mediaTypeItem.title(for: mediaType))
+                subheadlineText(model.style.mediaTypeItem.message(for: mediaType))
             }
         }
         .maxWidth(alignment: .leading)
@@ -165,7 +165,7 @@ private extension EntryWidgetView {
         .contentShape(.rect)
         .accessibilityElement(children: .combine)
         .accessibility(addTraits: .isButton)
-        .accessibilityHint(mediaType.hintline)
+        .accessibilityHint(model.style.mediaTypeItem.accessibility.hint(for: mediaType))
         .onTapGesture {
             model.selectMediaType(mediaType)
         }
@@ -179,13 +179,13 @@ private extension EntryWidgetView {
                 .width(model.sizeConstraints.singleCellIconSize)
                 .height(model.sizeConstraints.singleCellIconSize)
             VStack(alignment: .leading, spacing: 2) {
-                Text(mediaType.headline)
+                Text(model.style.mediaTypeItem.title(for: mediaType))
                     .setFont(model.style.mediaTypeItem.titleFont)
                     .redactedPlaceholder(
                         model.style.mediaTypeItem.loading.loadingTintColor,
                         font: model.style.mediaTypeItem.titleFont
                     )
-                Text(mediaType.subheadline)
+                Text(model.style.mediaTypeItem.message(for: mediaType))
                     .setFont(model.style.mediaTypeItem.messageFont)
                     .redactedPlaceholder(
                         model.style.mediaTypeItem.loading.loadingTintColor,

--- a/GliaWidgets/Sources/EntryWidget/MediaTypeItemStyle.Accessibility.swift
+++ b/GliaWidgets/Sources/EntryWidget/MediaTypeItemStyle.Accessibility.swift
@@ -1,0 +1,59 @@
+import UIKit
+
+extension EntryWidgetStyle.MediaTypeItemStyle {
+    /// Accessibility properties for EntryWidget MediaType.
+    public struct Accessibility: Equatable {
+        /// The accessibility hint for chat media type.
+        public var chatHint: String
+
+        /// The accessibility hint for audio media type.
+        public var audioHint: String
+
+        /// The accessibility hint for video media type.
+        public var videoHint: String
+
+        /// The accessibility hint for secure messaging media type.
+        public var secureMessagingHint: String
+
+        /// - Parameters:
+        ///   - chatHint: The accessibility hint for chat media type.
+        ///   - audioHint: The accessibility hint for audio media type.
+        ///   - videoHint: The accessibility hint for video media type.
+        ///   - secureMessagingHint: The accessibility hint for secure messaging media type.
+        ///
+        public init(
+            chatHint: String,
+            audioHint: String,
+            videoHint: String,
+            secureMessagingHint: String
+        ) {
+            self.chatHint = chatHint
+            self.audioHint = audioHint
+            self.videoHint = videoHint
+            self.secureMessagingHint = secureMessagingHint
+        }
+
+        func hint(for type: EntryWidget.MediaTypeItem) -> String {
+            switch type {
+            case .chat:
+                return chatHint
+            case .audio:
+                return audioHint
+            case .video:
+                return videoHint
+            case .secureMessaging:
+                return secureMessagingHint
+            }
+        }
+    }
+}
+
+extension EntryWidgetStyle.MediaTypeItemStyle.Accessibility {
+    /// Accessibility is not supported intentionally.
+    public static let unsupported = Self(
+        chatHint: "",
+        audioHint: "",
+        videoHint: "",
+        secureMessagingHint: ""
+    )
+}

--- a/GliaWidgets/Sources/EntryWidget/MediaTypeItemStyle.swift
+++ b/GliaWidgets/Sources/EntryWidget/MediaTypeItemStyle.swift
@@ -2,6 +2,18 @@ import UIKit
 
 extension EntryWidgetStyle {
     public struct MediaTypeItemStyle {
+        /// The title for chat media type.
+        public var chatTitle: String
+
+        /// The title for audio media type.
+        public var audioTitle: String
+
+        /// The title for video media type.
+        public var videoTitle: String
+
+        /// The title for secure messaging media type.
+        public var secureMessagingTitle: String
+
         /// Font of the headline text.
         public var titleFont: UIFont
 
@@ -10,6 +22,18 @@ extension EntryWidgetStyle {
 
         /// Text style of the message text.
         public var titleTextStyle: UIFont.TextStyle
+
+        /// The subheadline (message) text for chat media type.
+        public var chatMessage: String
+
+        /// The subheadline (message) text for audio media type.
+        public var audioMessage: String
+
+        /// The subheadline (message) text for video media type.
+        public var videoMessage: String
+
+        /// The subheadline (message) text for secure messaging media type.
+        public var secureMessagingMessage: String
 
         /// Font of the subheadline (message) text.
         public var messageFont: UIFont
@@ -29,37 +53,93 @@ extension EntryWidgetStyle {
         /// Loading style of the EntryWidget MediaType.
         public var loading: LoadingStyle
 
+        /// Accessibility properties for EntryWidget MediaType Item.
+        public var accessibility: Accessibility
+
         /// - Parameters:
+        ///   - chatTitle: Title for chat media type.
+        ///   - audioTitle: Title for audio media type.
+        ///   - videoTitle: Title for video media type.
+        ///   - secureMessagingTitle: Title for secure messaging media type.
         ///   - titleFont: Font of the headline text.
         ///   - titleColor: Color of the headline text.
         ///   - titleTextStyle: The style of the title text.
+        ///   - chatMessage: The subheadline (message) text for chat media type.
+        ///   - audioMessage: The subheadline (message) text for audio media type.
+        ///   - videoMessage: The subheadline (message) text for video media type.
+        ///   - secureMessagingMessage: The subheadline (message) text for secure messaging media type.
         ///   - messageFont: Font of the subheadline (message) text.
         ///   - messageColor: Color of the subheadline (message) text.
         ///   - messageTextStyle: The style of the title text.
         ///   - iconColor: Color of the icon.
         ///   - backgroundColor: Background color of the view.
         ///   - loading: Loading style of the EntryWidget MediaType.
+        ///   - accessibility: Accessibility properties for EntryWidget MediaType Item.
         ///
         public init(
+            chatTitle: String,
+            audioTitle: String,
+            videoTitle: String,
+            secureMessagingTitle: String,
             titleFont: UIFont,
             titleColor: UIColor,
             titleTextStyle: UIFont.TextStyle,
+            chatMessage: String,
+            audioMessage: String,
+            videoMessage: String,
+            secureMessagingMessage: String,
             messageFont: UIFont,
             messageColor: UIColor,
             messageTextStyle: UIFont.TextStyle,
             iconColor: ColorType,
             backgroundColor: ColorType,
-            loading: LoadingStyle
+            loading: LoadingStyle,
+            accessibility: Accessibility
         ) {
+            self.chatTitle = chatTitle
+            self.audioTitle = audioTitle
+            self.videoTitle = videoTitle
+            self.secureMessagingTitle = secureMessagingTitle
             self.titleFont = titleFont
             self.titleColor = titleColor
             self.titleTextStyle = titleTextStyle
+            self.chatMessage = chatMessage
+            self.audioMessage = audioMessage
+            self.videoMessage = videoMessage
+            self.secureMessagingMessage = secureMessagingMessage
             self.messageFont = messageFont
             self.messageColor = messageColor
             self.messageTextStyle = messageTextStyle
             self.iconColor = iconColor
             self.backgroundColor = backgroundColor
             self.loading = loading
+            self.accessibility = accessibility
+        }
+
+        func title(for type: EntryWidget.MediaTypeItem) -> String {
+            switch type {
+            case .chat:
+                return chatTitle
+            case .audio:
+                return audioTitle
+            case .video:
+                return videoTitle
+            case .secureMessaging:
+                return secureMessagingTitle
+            }
+        }
+
+        func message(for type: EntryWidget.MediaTypeItem) -> String {
+            switch type {
+            case .chat:
+                return chatMessage
+            case .audio:
+                return audioMessage
+            case .video:
+                return videoMessage
+            case .secureMessaging:
+                return secureMessagingMessage
+            }
         }
     }
 }

--- a/GliaWidgets/Sources/Theme/Theme.EntryWidget.swift
+++ b/GliaWidgets/Sources/Theme/Theme.EntryWidget.swift
@@ -7,16 +7,32 @@ extension Theme {
             accessibility: .init(label: Localization.EntryWidget.Loading.Accessibility.label)
         )
 
+        let mediaTypeAccessibility: EntryWidgetStyle.MediaTypeItemStyle.Accessibility = .init(
+            chatHint: Localization.EntryWidget.LiveChat.Button.Accessibility.hint,
+            audioHint: Localization.EntryWidget.Audio.Button.Accessibility.hint,
+            videoHint: Localization.EntryWidget.Video.Button.Accessibility.hint,
+            secureMessagingHint: Localization.EntryWidget.SecureMessaging.Button.Accessibility.hint
+        )
+
         let mediaTypeItem: EntryWidgetStyle.MediaTypeItemStyle = .init(
+            chatTitle: Localization.EntryWidget.LiveChat.Button.label,
+            audioTitle: Localization.EntryWidget.Audio.Button.label,
+            videoTitle: Localization.EntryWidget.Video.Button.label,
+            secureMessagingTitle: Localization.EntryWidget.SecureMessaging.Button.label,
             titleFont: font.bodyText,
             titleColor: color.baseDark,
             titleTextStyle: .body,
+            chatMessage: Localization.EntryWidget.LiveChat.Button.description,
+            audioMessage: Localization.EntryWidget.Audio.Button.description,
+            videoMessage: Localization.EntryWidget.Video.Button.description,
+            secureMessagingMessage: Localization.EntryWidget.SecureMessaging.Button.description,
             messageFont: font.caption,
             messageColor: color.baseNormal,
             messageTextStyle: .caption1,
             iconColor: .fill(color: color.primary),
             backgroundColor: .fill(color: color.baseLight),
-            loading: loading
+            loading: loading,
+            accessibility: mediaTypeAccessibility
         )
 
         let backgroundColor: ColorType = .fill(color: color.baseLight)


### PR DESCRIPTION
[MOB-3753](https://glia.atlassian.net/browse/MOB-3753)

**What was solved?**
Optimized use of strings for the Entry Widget:
- Removed computed properties for title, subtitle, and hint from the MediaTypeItem.
- Added properties for the title, subtitle, and hint for each media type to the Entry Widget Style structures.
- Added functions that return the title, subtitle, and hint for the MediaTypeItem.
- Functions from the Entry Widget Style structures in the EntryWidgetView were used to display strings.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**


[MOB-3753]: https://glia.atlassian.net/browse/MOB-3753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ