### PR TITLE
Fix media upgrade dialog configuration

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -416,6 +416,7 @@
 		847956362AD96AD7004EF60C /* CoreSDKConfigurator.Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847956352AD96AD7004EF60C /* CoreSDKConfigurator.Interface.swift */; };
 		847956402ADED7A2004EF60C /* CallVisualizer.Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8479563F2ADED7A2004EF60C /* CallVisualizer.Action.swift */; };
 		847A7643285A1914004044D1 /* FileUploadListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847A7642285A1914004044D1 /* FileUploadListViewModelTests.swift */; };
+		847D7FAE2CDE0F3A00EA5C2D /* AlertTypeComposerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847D7FAD2CDE0F3A00EA5C2D /* AlertTypeComposerTests.swift */; };
 		8485704F2BEE3A0800CEBCC5 /* ChatViewTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8485704E2BEE3A0800CEBCC5 /* ChatViewTest.swift */; };
 		848570512BEE3CCC00CEBCC5 /* ChatStyle.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848570502BEE3CCC00CEBCC5 /* ChatStyle.Mock.swift */; };
 		848B8ADC2C0759C500E990E6 /* Theme.CustomCardContainerStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848B8ADB2C0759C500E990E6 /* Theme.CustomCardContainerStyle.swift */; };
@@ -1427,6 +1428,7 @@
 		847956352AD96AD7004EF60C /* CoreSDKConfigurator.Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSDKConfigurator.Interface.swift; sourceTree = "<group>"; };
 		8479563F2ADED7A2004EF60C /* CallVisualizer.Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallVisualizer.Action.swift; sourceTree = "<group>"; };
 		847A7642285A1914004044D1 /* FileUploadListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadListViewModelTests.swift; sourceTree = "<group>"; };
+		847D7FAD2CDE0F3A00EA5C2D /* AlertTypeComposerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertTypeComposerTests.swift; sourceTree = "<group>"; };
 		8485704E2BEE3A0800CEBCC5 /* ChatViewTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewTest.swift; sourceTree = "<group>"; };
 		848570502BEE3CCC00CEBCC5 /* ChatStyle.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStyle.Mock.swift; sourceTree = "<group>"; };
 		848B8ADB2C0759C500E990E6 /* Theme.CustomCardContainerStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.CustomCardContainerStyle.swift; sourceTree = "<group>"; };
@@ -4913,6 +4915,7 @@
 			isa = PBXGroup;
 			children = (
 				C0D6C9FF2C106A1F00D4709B /* AlertManager.Failing.swift */,
+				847D7FAD2CDE0F3A00EA5C2D /* AlertTypeComposerTests.swift */,
 			);
 			path = AlertManager;
 			sourceTree = "<group>";
@@ -6336,6 +6339,7 @@
 				9A1992E127D6313500161AAE /* ImageView.Cache.Failing.swift in Sources */,
 				3189DD9629E4331200D68E9F /* SecureConversations.WelcomeViewModel.Mock.swift in Sources */,
 				31D286AF2A00DE2B009192A6 /* SecureConversations.ConfirmationViewModel.Mock.swift in Sources */,
+				847D7FAE2CDE0F3A00EA5C2D /* AlertTypeComposerTests.swift in Sources */,
 				31B278012B55903C0021DEC1 /* SecureConversations.Coordinator.Environment.Mock.swift in Sources */,
 				C0D2F06429A4B1E900803B47 /* VideoCallTests.swift in Sources */,
 				31FF0DCF2B5A88F500834AFB /* CallCoordinatorTests.swift in Sources */,

--- a/GliaWidgets/Sources/AlertManager/AlertManager.swift
+++ b/GliaWidgets/Sources/AlertManager/AlertManager.swift
@@ -50,8 +50,7 @@ extension AlertManager {
         in placement: AlertPlacement,
         as input: AlertInputType
     ) {
-        guard input != currentAlert else { return }
-        let alertType = composer.composeAlert(input: input)
+        guard input != currentAlert, let alertType = try? composer.composeAlert(input: input) else { return }
 
         switch placement {
         case .global:

--- a/GliaWidgets/Sources/Component/MediaUpgrade/MediaUpgradeActionStyle.swift
+++ b/GliaWidgets/Sources/Component/MediaUpgrade/MediaUpgradeActionStyle.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 /// Style of the media upgrade action in a multiple media type alert window.
-public struct MediaUpgradeActionStyle {
+public struct MediaUpgradeActionStyle: Equatable {
     /// Title of the media upgrade action. Displayed to the left of the icon, at the top of the view.
     public var title: String
 

--- a/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.swift
+++ b/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.swift
@@ -1,5 +1,5 @@
 /// Configurations for alerts and confirmations.
-public struct AlertConfiguration {
+public struct AlertConfiguration: Equatable {
     /// Configuration of the queue leaving confirmation alert.
     public var leaveQueue: ConfirmationAlertConfiguration
 

--- a/GliaWidgets/Sources/Theme/Alert/ConfirmationAlertConfiguration.swift
+++ b/GliaWidgets/Sources/Theme/Alert/ConfirmationAlertConfiguration.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Configuration of the confirmation alert.
-public struct ConfirmationAlertConfiguration {
+public struct ConfirmationAlertConfiguration: Equatable {
     /// Title of the alert.
     public var title: String?
 

--- a/GliaWidgets/Sources/Theme/Alert/MessageAlertConfiguration.swift
+++ b/GliaWidgets/Sources/Theme/Alert/MessageAlertConfiguration.swift
@@ -1,5 +1,5 @@
 /// Configuration of a generic alert.
-public struct MessageAlertConfiguration {
+public struct MessageAlertConfiguration: Equatable {
     /// Title of the alert.
     public var title: String?
 

--- a/GliaWidgets/Sources/Theme/Alert/MultipleMediaUpgradeAlertConfiguration.swift
+++ b/GliaWidgets/Sources/Theme/Alert/MultipleMediaUpgradeAlertConfiguration.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Configuration of the media upgrade confirmation alert.
-public struct MultipleMediaUpgradeAlertConfiguration {
+public struct MultipleMediaUpgradeAlertConfiguration: Equatable {
     /// Title of the alert.
     public var title: String
 

--- a/GliaWidgets/Sources/Theme/Alert/ScreenShareOfferAlertConfiguration.swift
+++ b/GliaWidgets/Sources/Theme/Alert/ScreenShareOfferAlertConfiguration.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 /// Configuration of the screen sharing confirmation alert.
-public struct ScreenShareOfferAlertConfiguration {
+public struct ScreenShareOfferAlertConfiguration: Equatable {
     /// Title of the alert.
     public var title: String
 

--- a/GliaWidgets/Sources/Theme/Alert/SettingsAlertConfiguration.swift
+++ b/GliaWidgets/Sources/Theme/Alert/SettingsAlertConfiguration.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Configuration of the alert that offers to go to the app's settings in the Settings app.
-public struct SettingsAlertConfiguration {
+public struct SettingsAlertConfiguration: Equatable {
     /// Title of the alert.
     public var title: String
 

--- a/GliaWidgets/Sources/Theme/Alert/SingleActionAlertConfiguration.swift
+++ b/GliaWidgets/Sources/Theme/Alert/SingleActionAlertConfiguration.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Configuration of the operator ending the engagement alert.
-public struct SingleActionAlertConfiguration {
+public struct SingleActionAlertConfiguration: Equatable {
     /// Title of the alert.
     public var title: String?
 

--- a/GliaWidgets/Sources/Theme/Alert/SingleMediaUpgradeAlertConfiguration.swift
+++ b/GliaWidgets/Sources/Theme/Alert/SingleMediaUpgradeAlertConfiguration.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 /// Configuration of the media upgrade confirmation alert.
-public struct SingleMediaUpgradeAlertConfiguration {
+public struct SingleMediaUpgradeAlertConfiguration: Equatable {
     /// Title of the alert.
     public var title: String
 

--- a/GliaWidgetsTests/Sources/AlertManager/AlertTypeComposerTests.swift
+++ b/GliaWidgetsTests/Sources/AlertManager/AlertTypeComposerTests.swift
@@ -1,0 +1,79 @@
+@testable import GliaWidgets
+import UIKit
+import XCTest
+
+final class AlertTypeComposerTests: XCTestCase {
+    var composer: AlertManager.AlertTypeComposer!
+
+    override func setUp() {
+        super.setUp()
+
+        composer = .init(
+            environment: .create(with: .mock()),
+            theme: .mock()
+        )
+    }
+
+    func testComposeAlertWithAudioMediaUpgradeInput() throws {
+        let operatorName = "Mock"
+        let offer = try CoreSdkClient.MediaUpgradeOffer(type: .audio, direction: .twoWay)
+        let input: AlertInputType = .mediaUpgrade(
+            operators: operatorName,
+            offer: offer,
+            accepted: nil,
+            declined: nil,
+            answer: { _, _ in }
+        )
+        let alertType = try composer.composeAlert(input: input)
+
+        switch alertType {
+        case let .singleMediaUpgrade(configuration, _, _):
+            let expected = Theme().alertConfiguration.audioUpgrade.withOperatorName(operatorName)
+            XCTAssertEqual(configuration, expected)
+        default:
+            XCTFail("alertType should be singleMediaUpgrade")
+        }
+    }
+
+    func testComposeAlertWithOneWayVideoMediaUpgradeInput() throws {
+        let operatorName = "Mock"
+        let offer = try CoreSdkClient.MediaUpgradeOffer(type: .video, direction: .oneWay)
+        let input: AlertInputType = .mediaUpgrade(
+            operators: operatorName,
+            offer: offer,
+            accepted: nil,
+            declined: nil,
+            answer: { _, _ in }
+        )
+        let alertType = try composer.composeAlert(input: input)
+
+        switch alertType {
+        case let .singleMediaUpgrade(configuration, _, _):
+            let expected = Theme().alertConfiguration.oneWayVideoUpgrade.withOperatorName(operatorName)
+            XCTAssertEqual(configuration, expected)
+        default:
+            XCTFail("alertType should be singleMediaUpgrade")
+        }
+    }
+
+    func testComposeAlertWithTwoWayVideoMediaUpgradeInput() throws {
+        let operatorName = "Mock"
+        let offer = try CoreSdkClient.MediaUpgradeOffer(type: .video, direction: .twoWay)
+        let input: AlertInputType = .mediaUpgrade(
+            operators: operatorName,
+            offer: offer,
+            accepted: nil,
+            declined: nil,
+            answer: { _, _ in }
+        )
+        let alertType = try composer.composeAlert(input: input)
+
+        switch alertType {
+        case let .singleMediaUpgrade(configuration, _, _):
+            let expected = Theme().alertConfiguration.twoWayVideoUpgrade.withOperatorName(operatorName)
+            XCTAssertEqual(configuration, expected)
+        default:
+            XCTFail("alertType should be singleMediaUpgrade")
+        }
+    }
+}


### PR DESCRIPTION
MOB-3768

**What was solved?**
After adding AlertManager class configuring alert dialogs was broken. As a result for Audio, 1-way Video, 2-way Video offers the SDK always showed 2-way Video media upgrade dialog. That was only UI configuration issue, accepting the offer resulted in establishing right media type. This commit fixes alert configuration issue.

Acceptance tests will be added in separate task later.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [x] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.