### PR TITLE
Introduce disabled state for file upload list

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -843,8 +843,8 @@
 		C09047442B7E2016003C437C /* FileUploadStyle.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09047432B7E2016003C437C /* FileUploadStyle.Mock.swift */; };
 		C09047462B7E2064003C437C /* FileUploadErrorStateStyle.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09047452B7E2064003C437C /* FileUploadErrorStateStyle.Mock.swift */; };
 		C09047482B7E20B0003C437C /* FileUploadStateStyle.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09047472B7E20B0003C437C /* FileUploadStateStyle.Mock.swift */; };
-		C090474A2B7E20E0003C437C /* MessageCenterFileUploadStyle.Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09047492B7E20E0003C437C /* MessageCenterFileUploadStyle.Equatable.swift */; };
-		C090474C2B7E210C003C437C /* FileUploadStyle.Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C090474B2B7E210C003C437C /* FileUploadStyle.Equatable.swift */; };
+		C090474A2B7E20E0003C437C /* MessageCenterFileUploadStyle.EnabledDisabledState.Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09047492B7E20E0003C437C /* MessageCenterFileUploadStyle.EnabledDisabledState.Equatable.swift */; };
+		C090474C2B7E210C003C437C /* FileUploadStyle.EnabledDisabledState.Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C090474B2B7E210C003C437C /* FileUploadStyle.EnabledDisabledState.Equatable.swift */; };
 		C090474E2B7E2138003C437C /* FileUploadErrorStateStyle.Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C090474D2B7E2138003C437C /* FileUploadErrorStateStyle.Equatable.swift */; };
 		C09047502B7E215E003C437C /* FileUploadStateStyle.Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C090474F2B7E215E003C437C /* FileUploadStateStyle.Equatable.swift */; };
 		C09047522B7E21A2003C437C /* MessageCenterFileUploadListStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09047512B7E21A2003C437C /* MessageCenterFileUploadListStyle.swift */; };
@@ -1909,8 +1909,8 @@
 		C09047432B7E2016003C437C /* FileUploadStyle.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadStyle.Mock.swift; sourceTree = "<group>"; };
 		C09047452B7E2064003C437C /* FileUploadErrorStateStyle.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadErrorStateStyle.Mock.swift; sourceTree = "<group>"; };
 		C09047472B7E20B0003C437C /* FileUploadStateStyle.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadStateStyle.Mock.swift; sourceTree = "<group>"; };
-		C09047492B7E20E0003C437C /* MessageCenterFileUploadStyle.Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCenterFileUploadStyle.Equatable.swift; sourceTree = "<group>"; };
-		C090474B2B7E210C003C437C /* FileUploadStyle.Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadStyle.Equatable.swift; sourceTree = "<group>"; };
+		C09047492B7E20E0003C437C /* MessageCenterFileUploadStyle.EnabledDisabledState.Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCenterFileUploadStyle.EnabledDisabledState.Equatable.swift; sourceTree = "<group>"; };
+		C090474B2B7E210C003C437C /* FileUploadStyle.EnabledDisabledState.Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadStyle.EnabledDisabledState.Equatable.swift; sourceTree = "<group>"; };
 		C090474D2B7E2138003C437C /* FileUploadErrorStateStyle.Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadErrorStateStyle.Equatable.swift; sourceTree = "<group>"; };
 		C090474F2B7E215E003C437C /* FileUploadStateStyle.Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadStateStyle.Equatable.swift; sourceTree = "<group>"; };
 		C09047512B7E21A2003C437C /* MessageCenterFileUploadListStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCenterFileUploadListStyle.swift; sourceTree = "<group>"; };
@@ -2261,14 +2261,14 @@
 				C09047392B7E1ECD003C437C /* FileUploadStateStyle.RemoteConfig.swift */,
 				C09047372B7E1EA6003C437C /* FileUploadStateStyle.swift */,
 				9A186A3427F5CF3C0055886D /* FileUploadStyle.Accessibility.swift */,
-				C090474B2B7E210C003C437C /* FileUploadStyle.Equatable.swift */,
+				C090474B2B7E210C003C437C /* FileUploadStyle.EnabledDisabledState.Equatable.swift */,
 				C09047432B7E2016003C437C /* FileUploadStyle.Mock.swift */,
 				C09047352B7E1DEF003C437C /* FileUploadStyle.RemoteConfig.swift */,
 				1A0EDF5925E786DB0076D1AD /* FileUploadStyle.swift */,
 				C09047552B7E21F0003C437C /* MessageCenterFileUploadListStyle.Equatable.swift */,
 				C09047532B7E21C5003C437C /* MessageCenterFileUploadListStyle.RemoteConfig.swift */,
 				C09047512B7E21A2003C437C /* MessageCenterFileUploadListStyle.swift */,
-				C09047492B7E20E0003C437C /* MessageCenterFileUploadStyle.Equatable.swift */,
+				C09047492B7E20E0003C437C /* MessageCenterFileUploadStyle.EnabledDisabledState.Equatable.swift */,
 				C09047412B7E1FDF003C437C /* MessageCenterFileUploadStyle.RemoteConfig.swift */,
 				C090473F2B7E1FBC003C437C /* MessageCenterFileUploadStyle.swift */,
 			);
@@ -5861,7 +5861,7 @@
 				3197F7B129E958F4008EE9F7 /* SystemMessageStyle.swift in Sources */,
 				3100D92C296E946600DEC9CE /* SecureConversations.ConfirmationViewController.swift in Sources */,
 				C0F3DE3B2C6E0DD900DE6D7B /* EntryWidgetView.swift in Sources */,
-				C090474C2B7E210C003C437C /* FileUploadStyle.Equatable.swift in Sources */,
+				C090474C2B7E210C003C437C /* FileUploadStyle.EnabledDisabledState.Equatable.swift in Sources */,
 				C09047402B7E1FBC003C437C /* MessageCenterFileUploadStyle.swift in Sources */,
 				9A8130BB27D7A41000220BBD /* FileUpload.Environment.Interface.swift in Sources */,
 				C09046AB2B7D0967003C437C /* WelcomeStyle.SendButton.DisabledStyle.Accessibility.swift in Sources */,
@@ -6392,7 +6392,7 @@
 				846A5C3429CB3A130049B29F /* ScreenShareHandler.Implementation.swift in Sources */,
 				AFA2FDEC28907D7C00428E6D /* EngagementCoordinator.Environment.swift in Sources */,
 				C09046B52B7D0A84003C437C /* WelcomeStyle.MessageWarningStyle.Accessibility.swift in Sources */,
-				C090474A2B7E20E0003C437C /* MessageCenterFileUploadStyle.Equatable.swift in Sources */,
+				C090474A2B7E20E0003C437C /* MessageCenterFileUploadStyle.EnabledDisabledState.Equatable.swift in Sources */,
 				C0D6C9F72C0D2F6D00D4709B /* AlertPlacement.swift in Sources */,
 				C09046992B7D06D7003C437C /* WelcomeStyle.MessageTextViewNormalStyle.Accessibility.swift in Sources */,
 				C09047642B7E2375003C437C /* ChatFileDownloadStateStyle.RemoteConfig.swift in Sources */,

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
@@ -141,12 +141,11 @@ extension SecureConversations {
                 case let .success(.available(queueIds)):
                     self.environment.queueIds = queueIds
                     self.isSecureConversationsAvailable = true
-                case .failure, .success(.unavailable(.emptyQueue)):
-                    self.isSecureConversationsAvailable = false
-                    self.engagementAction?(.showAlert(.unavailableMessageCenter()))
-                case .success(.unavailable(.unauthenticated)):
+                    self.fileUploadListModel.isEnabled = true
+                case .failure, .success(.unavailable(.emptyQueue)), .success(.unavailable(.unauthenticated)):
                     // For chat screen we no longer show unavailability dialog, but unavailability banner instead.
                     self.isSecureConversationsAvailable = false
+                    self.fileUploadListModel.isEnabled = false
                 }
             }
         }

--- a/GliaWidgets/SecureConversations/FileUploadListView/SecureConversations.FilePreviewView.swift
+++ b/GliaWidgets/SecureConversations/FileUploadListView/SecureConversations.FilePreviewView.swift
@@ -230,5 +230,5 @@ extension SecureConversations.FilePreviewView.Kind {
 }
 
 private extension FilePreviewStyle {
-    static let initial = FileUploadStyle.initial.filePreview
+    static let initial = FileUploadStyle.initial.enabled.filePreview
 }

--- a/GliaWidgets/SecureConversations/FileUploadListView/SecureConversations.FileUploadListViewModel.swift
+++ b/GliaWidgets/SecureConversations/FileUploadListView/SecureConversations.FileUploadListViewModel.swift
@@ -6,6 +6,11 @@ extension SecureConversations {
 
         var action: ((Action) -> Void)?
         var delegate: ((DelegateEvent) -> Void)?
+        var isEnabled = true {
+            didSet {
+                reportChange()
+            }
+        }
 
         enum Event {}
         enum Action {}
@@ -91,7 +96,8 @@ extension SecureConversations {
                         style: style.item,
                         removeTapped: Cmd { [weak self] in
                             self?.removeUpload(fileUpload)
-                        }
+                        },
+                        isEnabled: isEnabled
                     )
                 }
             )

--- a/GliaWidgets/SecureConversations/FileUploadListView/SecureConversations.FileUploadView.swift
+++ b/GliaWidgets/SecureConversations/FileUploadListView/SecureConversations.FileUploadView.swift
@@ -11,6 +11,7 @@ extension SecureConversations {
             let style: Style
             let state: State
             let removeTapped: Cmd
+            let isEnabled: Bool
         }
 
         static func height(for style: Style) -> CGFloat {
@@ -68,7 +69,7 @@ extension SecureConversations {
             constraints += contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: Self.height(for: props.style))
             addSubview(contentView)
             contentView.translatesAutoresizingMaskIntoConstraints = false
-            let style = Style.Properties(style: props.style)
+            let style = Style.Properties(style: props.style, isEnabled: props.isEnabled)
             constraints += contentView.layoutInSuperview(insets: style.contentInsets)
 
             contentView.addSubview(filePreviewView)
@@ -124,7 +125,8 @@ extension SecureConversations {
 
         func renderProps() {
             let style = SecureConversations.FileUploadView.Style.Properties(
-                style: props.style
+                style: props.style,
+                isEnabled: props.isEnabled
             )
             progressView.backgroundColor = style.progressBackgroundColor
             removeButton.tintColor = style.removeButtonColor
@@ -148,7 +150,7 @@ extension SecureConversations {
 
         private func update(for state: FileUpload.State) {
             let style = SecureConversations.FileUploadView.Style.Properties(
-                style: props.style
+                style: props.style, isEnabled: props.isEnabled
             )
             switch state {
             case .none:
@@ -289,7 +291,8 @@ extension SecureConversations.FileUploadView.Props {
     init(
         fileUpload: GliaWidgets.FileUpload,
         style: SecureConversations.FileUploadView.Style,
-        removeTapped: Cmd
+        removeTapped: Cmd,
+        isEnabled: Bool
     ) {
         self.init(
             id: fileUpload.uuid.uuidString,
@@ -298,7 +301,8 @@ extension SecureConversations.FileUploadView.Props {
                 state: fileUpload.state.value,
                 localFile: fileUpload.localFile
             ),
-            removeTapped: removeTapped
+            removeTapped: removeTapped,
+            isEnabled: isEnabled
         )
     }
 }
@@ -308,6 +312,8 @@ extension FileUploadStyle {
 }
 
 extension SecureConversations.FileUploadView {
+    typealias EnabledDisabledState = StatefulStyle<Style>
+
     enum Style: Equatable {
         case chat(FileUploadStyle)
         case messageCenter(MessageCenterFileUploadStyle)
@@ -341,9 +347,11 @@ extension SecureConversations.FileUploadView.Style {
         var backgroundColor: UIColor
         var removeButtonTopRightOffset: CGSize
 
-        init(style: SecureConversations.FileUploadView.Style) {
+        init(style: SecureConversations.FileUploadView.Style, isEnabled: Bool) {
             switch style {
-            case let .chat(uploadStyle):
+            case let .chat(styleStates):
+                let uploadStyle = isEnabled ? styleStates.enabled
+                                            : styleStates.disabled
                 filePreview = uploadStyle.filePreview
                 uploading = uploadStyle.uploading
                 uploaded = uploadStyle.uploaded
@@ -358,7 +366,9 @@ extension SecureConversations.FileUploadView.Style {
                 cornerRadius = 0
                 backgroundColor = .clear
                 removeButtonTopRightOffset = .zero
-            case let .messageCenter(uploadStyle):
+            case let .messageCenter(styleStates):
+                let uploadStyle = isEnabled ? styleStates.enabled
+                                            : styleStates.disabled
                 filePreview = uploadStyle.filePreview
                 uploading = uploadStyle.uploading
                 uploaded = uploadStyle.uploaded

--- a/GliaWidgets/SecureConversations/Welcome/Theme+SecureConversationsWelcome.swift
+++ b/GliaWidgets/SecureConversations/Welcome/Theme+SecureConversationsWelcome.swift
@@ -172,7 +172,13 @@ extension Theme {
         )
 
         var uploadListStyle: MessageCenterFileUploadListStyle {
-            let filePreview = FilePreviewStyle(
+            // For now all disabled styles are the same as enabled ones.
+            // Because there is no design for disabled state of file upload
+            // and visually we do not show disabled state of file upload.
+            // But since file upload is a part of the message entry, that
+            // has to have disabled state, we need to provide these styles
+            // for file upload as well.
+            let filePreviewEnabled = FilePreviewStyle(
                 fileFont: font.subtitle,
                 fileColor: color.baseLight,
                 errorIcon: Asset.uploadError.image,
@@ -181,21 +187,44 @@ extension Theme {
                 errorBackgroundColor: color.baseNeutral,
                 accessibility: .init(isFontScalingEnabled: true)
             )
-            let uploading = FileUploadStateStyle(
+            let filePreviewDisabled = FilePreviewStyle(
+                fileFont: font.subtitle,
+                fileColor: color.baseLight,
+                errorIcon: Asset.uploadError.image,
+                errorIconColor: color.systemNegative,
+                backgroundColor: color.primary,
+                errorBackgroundColor: color.baseNeutral,
+                accessibility: .init(isFontScalingEnabled: true)
+            )
+            let uploadingEnabled = FileUploadStateStyle(
                 text: Localization.Chat.File.Upload.inProgress,
                 font: font.mediumSubtitle2,
                 textColor: color.baseDark,
                 infoFont: font.caption,
                 infoColor: color.baseNormal
             )
-            let uploaded = FileUploadStateStyle(
+            let uploadingDisabled = FileUploadStateStyle(
+                text: Localization.Chat.File.Upload.inProgress,
+                font: font.mediumSubtitle2,
+                textColor: color.baseDark,
+                infoFont: font.caption,
+                infoColor: color.baseNormal
+            )
+            let uploadedEnabled = FileUploadStateStyle(
                 text: Localization.Chat.File.Upload.success,
                 font: font.mediumSubtitle2,
                 textColor: color.baseDark,
                 infoFont: font.caption,
                 infoColor: color.baseNormal
             )
-            let error = FileUploadErrorStateStyle(
+            let uploadedDisabled = FileUploadStateStyle(
+                text: Localization.Chat.File.Upload.success,
+                font: font.mediumSubtitle2,
+                textColor: color.baseDark,
+                infoFont: font.caption,
+                infoColor: color.baseNormal
+            )
+            let errorEnabled = FileUploadErrorStateStyle(
                 text: Localization.Chat.File.Upload.failed,
                 font: font.mediumSubtitle2,
                 textColor: color.baseDark,
@@ -207,11 +236,23 @@ extension Theme {
                 infoNetworkError: Localization.Chat.File.Upload.networkError,
                 infoGenericError: Localization.Chat.File.Upload.genericError
             )
-            let upload = MessageCenterFileUploadStyle(
-                filePreview: filePreview,
-                uploading: uploading,
-                uploaded: uploaded,
-                error: error,
+            let errorDisabled = FileUploadErrorStateStyle(
+                text: Localization.Chat.File.Upload.failed,
+                font: font.mediumSubtitle2,
+                textColor: color.baseDark,
+                infoFont: font.caption,
+                infoColor: color.systemNegative,
+                infoFileTooBig: Localization.Chat.File.SizeLimit.error,
+                infoUnsupportedFileType: Localization.Chat.Attachment.unsupportedFile,
+                infoSafetyCheckFailed: Localization.Chat.File.InfectedFile.error,
+                infoNetworkError: Localization.Chat.File.Upload.networkError,
+                infoGenericError: Localization.Chat.File.Upload.genericError
+            )
+            let uploadEnabled = MessageCenterFileUploadStyle.EnabledDisabledState(
+                filePreview: filePreviewEnabled,
+                uploading: uploadingEnabled,
+                uploaded: uploadedEnabled,
+                error: errorEnabled,
                 progressColor: color.primary,
                 errorProgressColor: color.systemNegative,
                 progressBackgroundColor: color.baseNeutral,
@@ -225,7 +266,28 @@ extension Theme {
                     isFontScalingEnabled: true
                 )
             )
-
+            let uploadDisabled = MessageCenterFileUploadStyle.EnabledDisabledState(
+                filePreview: filePreviewDisabled,
+                uploading: uploadingDisabled,
+                uploaded: uploadedDisabled,
+                error: errorDisabled,
+                progressColor: color.primary,
+                errorProgressColor: color.systemNegative,
+                progressBackgroundColor: color.baseNeutral,
+                removeButtonImage: Asset.mcRemoveUpload.image,
+                removeButtonColor: color.baseNormal,
+                backgroundColor: .commonGray,
+                accessibility: .init(
+                    removeButtonAccessibilityLabel: Localization.Chat.File.RemoveUpload.Accessibility.label,
+                    progressPercentValue: Localization.Templates.percentValue,
+                    fileNameWithProgressValue: Localization.Templates.fileNameWithProgressValue,
+                    isFontScalingEnabled: true
+                )
+            )
+            let upload = MessageCenterFileUploadStyle(
+                enabled: uploadEnabled,
+                disabled: uploadDisabled
+            )
             return MessageCenterFileUploadListStyle(item: upload)
         }
 

--- a/GliaWidgets/Sources/StatefulStyle.swift
+++ b/GliaWidgets/Sources/StatefulStyle.swift
@@ -29,3 +29,5 @@ enum StatefulStyle<State> {
         }
     }
 }
+
+extension StatefulStyle: Equatable where State: Equatable {}

--- a/GliaWidgets/Sources/Theme/Theme+Chat.swift
+++ b/GliaWidgets/Sources/Theme/Theme+Chat.swift
@@ -489,7 +489,13 @@ extension Theme {
     }
 
     private var uploadListStyle: FileUploadListStyle {
-        let filePreview = FilePreviewStyle(
+        // For now all disabled styles are the same as enabled ones.
+        // Because there is no design for disabled state of file upload
+        // and visually we do not show disabled state of file upload.
+        // But since file upload is a part of the message entry, that
+        // has to have disabled state, we need to provide these styles
+        // for file upload as well.
+        let filePreviewEnabled = FilePreviewStyle(
             fileFont: font.subtitle,
             fileColor: color.baseLight,
             errorIcon: Asset.uploadError.image,
@@ -498,21 +504,44 @@ extension Theme {
             errorBackgroundColor: color.baseNeutral,
             accessibility: .init(isFontScalingEnabled: true)
         )
-        let uploading = FileUploadStateStyle(
+        let filePreviewDisabled = FilePreviewStyle(
+            fileFont: font.subtitle,
+            fileColor: color.baseLight,
+            errorIcon: Asset.uploadError.image,
+            errorIconColor: color.systemNegative,
+            backgroundColor: color.primary,
+            errorBackgroundColor: color.baseNeutral,
+            accessibility: .init(isFontScalingEnabled: true)
+        )
+        let uploadingEnabled = FileUploadStateStyle(
             text: Localization.Chat.File.Upload.inProgress,
             font: font.mediumSubtitle2,
             textColor: color.baseDark,
             infoFont: font.caption,
             infoColor: color.baseNormal
         )
-        let uploaded = FileUploadStateStyle(
+        let uploadingDisabled = FileUploadStateStyle(
+            text: Localization.Chat.File.Upload.inProgress,
+            font: font.mediumSubtitle2,
+            textColor: color.baseDark,
+            infoFont: font.caption,
+            infoColor: color.baseNormal
+        )
+        let uploadedEnabled = FileUploadStateStyle(
             text: Localization.Chat.File.Upload.success,
             font: font.mediumSubtitle2,
             textColor: color.baseDark,
             infoFont: font.caption,
             infoColor: color.baseNormal
         )
-        let error = FileUploadErrorStateStyle(
+        let uploadedDisabled = FileUploadStateStyle(
+            text: Localization.Chat.File.Upload.success,
+            font: font.mediumSubtitle2,
+            textColor: color.baseDark,
+            infoFont: font.caption,
+            infoColor: color.baseNormal
+        )
+        let errorEnabled = FileUploadErrorStateStyle(
             text: Localization.Chat.File.Upload.failed,
             font: font.mediumSubtitle2,
             textColor: color.baseDark,
@@ -524,11 +553,23 @@ extension Theme {
             infoNetworkError: Localization.Chat.File.Upload.networkError,
             infoGenericError: Localization.Chat.File.Upload.genericError
         )
-        let upload = FileUploadStyle(
-            filePreview: filePreview,
-            uploading: uploading,
-            uploaded: uploaded,
-            error: error,
+        let errorDisabled = FileUploadErrorStateStyle(
+            text: Localization.Chat.File.Upload.failed,
+            font: font.mediumSubtitle2,
+            textColor: color.baseDark,
+            infoFont: font.caption,
+            infoColor: color.systemNegative,
+            infoFileTooBig: Localization.Chat.File.SizeLimit.error,
+            infoUnsupportedFileType: Localization.Chat.Attachment.unsupportedFile,
+            infoSafetyCheckFailed: Localization.Chat.File.InfectedFile.error,
+            infoNetworkError: Localization.Chat.File.Upload.networkError,
+            infoGenericError: Localization.Chat.File.Upload.genericError
+        )
+        let uploadEnabled = FileUploadStyle.EnabledDisabledState(
+            filePreview: filePreviewEnabled,
+            uploading: uploadingEnabled,
+            uploaded: uploadedEnabled,
+            error: errorEnabled,
             progressColor: color.primary,
             errorProgressColor: color.systemNegative,
             progressBackgroundColor: color.baseNeutral,
@@ -540,6 +581,27 @@ extension Theme {
                 fileNameWithProgressValue: Localization.Templates.fileNameWithProgressValue,
                 isFontScalingEnabled: true
             )
+        )
+        let uploadDisabled = FileUploadStyle.EnabledDisabledState(
+            filePreview: filePreviewDisabled,
+            uploading: uploadingDisabled,
+            uploaded: uploadedDisabled,
+            error: errorDisabled,
+            progressColor: color.primary,
+            errorProgressColor: color.systemNegative,
+            progressBackgroundColor: color.baseNeutral,
+            removeButtonImage: Asset.uploadRemove.image,
+            removeButtonColor: color.baseNormal,
+            accessibility: .init(
+                removeButtonAccessibilityLabel: Localization.Chat.File.RemoveUpload.Accessibility.label,
+                progressPercentValue: Localization.Templates.percentValue,
+                fileNameWithProgressValue: Localization.Templates.fileNameWithProgressValue,
+                isFontScalingEnabled: true
+            )
+        )
+        let upload = FileUploadStyle(
+            enabled: uploadEnabled,
+            disabled: uploadDisabled
         )
 
         return FileUploadListStyle(item: upload)

--- a/GliaWidgets/Sources/View/Chat/Entry/Upload/FileUploadStyle.EnabledDisabledState.Equatable.swift
+++ b/GliaWidgets/Sources/View/Chat/Entry/Upload/FileUploadStyle.EnabledDisabledState.Equatable.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-extension FileUploadStyle {
-    public static func == (lhs: FileUploadStyle, rhs: FileUploadStyle) -> Bool {
+extension FileUploadStyle.EnabledDisabledState {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.filePreview == rhs.filePreview &&
         lhs.uploading == rhs.uploading &&
         lhs.uploaded == rhs.uploaded &&

--- a/GliaWidgets/Sources/View/Chat/Entry/Upload/FileUploadStyle.Mock.swift
+++ b/GliaWidgets/Sources/View/Chat/Entry/Upload/FileUploadStyle.Mock.swift
@@ -1,19 +1,26 @@
 import UIKit
 
 #if DEBUG
+extension FileUploadStyle.EnabledDisabledState {
+    static let mock = Self(
+        filePreview: .mock,
+        uploading: .mock,
+        uploaded: .mock,
+        error: .mock,
+        progressColor: .clear,
+        errorProgressColor: .clear,
+        progressBackgroundColor: .clear,
+        removeButtonImage: UIImage(),
+        removeButtonColor: .clear,
+        accessibility: .unsupported
+    )
+}
+
 extension FileUploadStyle {
-    static var mock: FileUploadStyle {
-        FileUploadStyle(
-            filePreview: .mock,
-            uploading: .mock,
-            uploaded: .mock,
-            error: .mock,
-            progressColor: .clear,
-            errorProgressColor: .clear,
-            progressBackgroundColor: .clear,
-            removeButtonImage: UIImage(),
-            removeButtonColor: .clear,
-            accessibility: .unsupported
+    static var mock: Self {
+        Self(
+            enabled: .mock,
+            disabled: .mock
         )
     }
 }

--- a/GliaWidgets/Sources/View/Chat/Entry/Upload/FileUploadStyle.RemoteConfig.swift
+++ b/GliaWidgets/Sources/View/Chat/Entry/Upload/FileUploadStyle.RemoteConfig.swift
@@ -1,23 +1,24 @@
 import UIKit
 
 extension FileUploadStyle {
-    func apply(
+    mutating func apply(
+        // TODO: provide configuration for disabled state MOB-3762.
         configuration: RemoteConfiguration.FileUploadBar?,
         assetsBuilder: RemoteConfiguration.AssetsBuilder
     ) {
-        filePreview.apply(
+        enabled.filePreview.apply(
             configuration: configuration?.filePreview,
             assetsBuilder: assetsBuilder
         )
-        uploading.apply(
+        enabled.uploading.apply(
             configuration: configuration?.uploading,
             assetsBuilder: assetsBuilder
         )
-        uploaded.apply(
+        enabled.uploaded.apply(
             configuration: configuration?.uploaded,
             assetsBuilder: assetsBuilder
         )
-        error.apply(
+        enabled.error.apply(
             configuration: configuration?.error,
             assetsBuilder: assetsBuilder
         )
@@ -25,21 +26,21 @@ extension FileUploadStyle {
         configuration?.progress?.value
             .map { UIColor(hex: $0) }
             .first
-            .unwrap { progressColor = $0 }
+            .unwrap { enabled.progressColor = $0 }
 
         configuration?.errorProgress?.value
             .map { UIColor(hex: $0) }
             .first
-            .unwrap { errorProgressColor = $0 }
+            .unwrap { enabled.errorProgressColor = $0 }
 
         configuration?.progressBackground?.value
             .map { UIColor(hex: $0) }
             .first
-            .unwrap { progressBackgroundColor = $0 }
+            .unwrap { enabled.progressBackgroundColor = $0 }
 
         configuration?.removeButton?.value
             .map { UIColor(hex: $0) }
             .first
-            .unwrap { removeButtonColor = $0 }
+            .unwrap { enabled.removeButtonColor = $0 }
     }
 }

--- a/GliaWidgets/Sources/View/Chat/Entry/Upload/FileUploadStyle.swift
+++ b/GliaWidgets/Sources/View/Chat/Entry/Upload/FileUploadStyle.swift
@@ -1,70 +1,91 @@
 import UIKit
 
 /// Style of a single upload view in the uploads list view for Chat.
-public class FileUploadStyle: Equatable {
-    /// Style of the file preview.
-    public var filePreview: FilePreviewStyle
-
-    /// Style of the uploading state.
-    public var uploading: FileUploadStateStyle
-
-    /// Style of the uploaded state.
-    public var uploaded: FileUploadStateStyle
-
-    /// Style of the error state.
-    public var error: FileUploadErrorStateStyle
-
-    /// Foreground color of the upload progress bar.
-    public var progressColor: UIColor
-
-    /// Foreground color of the upload progress bar in error state.
-    public var errorProgressColor: UIColor
-
-    /// Background color of the upload progress bar.
-    public var progressBackgroundColor: UIColor
-
-    /// Image of the remove button.
-    public var removeButtonImage: UIImage
-
-    /// Color of the remove button image.
-    public var removeButtonColor: UIColor
-
-    /// Accessibility related properties.
-    public var accessibility: Accessibility
+public struct FileUploadStyle: Equatable {
+    /// Style of the enabled state for single upload view in the uploads list view for Chat.
+    public var enabled: FileUploadStyle.EnabledDisabledState
+    /// Style of the disabled state for single upload view in the uploads list view for Chat.
+    public var disabled: FileUploadStyle.EnabledDisabledState
 
     /// - Parameters:
-    ///   - filePreview: Style of the file preview.
-    ///   - uploading: Style of the uploading state.
-    ///   - uploaded: Style of the uploaded state.
-    ///   - error: Style of the error state.
-    ///   - progressColor: Foreground color of the upload progress bar.
-    ///   - errorProgressColor: Foreground color of the upload progress bar in error state.
-    ///   - progressBackgroundColor: Background color of the upload progress bar.
-    ///   - removeButtonImage: Image of the remove button.
-    ///   - removeButtonColor: Color of the remove button image.
-    ///   - accessibility: Accessibility related properties.
-    ///
+    ///   - enabled: Style of the enabled state for single upload view in the uploads list view for Chat.
+    ///   - disabled: Style of the disabled state for single upload view in the uploads list view for Chat.
     public init(
-        filePreview: FilePreviewStyle,
-        uploading: FileUploadStateStyle,
-        uploaded: FileUploadStateStyle,
-        error: FileUploadErrorStateStyle,
-        progressColor: UIColor,
-        errorProgressColor: UIColor,
-        progressBackgroundColor: UIColor,
-        removeButtonImage: UIImage,
-        removeButtonColor: UIColor,
-        accessibility: Accessibility = .unsupported
+        enabled: FileUploadStyle.EnabledDisabledState,
+        disabled: FileUploadStyle.EnabledDisabledState
     ) {
-        self.filePreview = filePreview
-        self.uploading = uploading
-        self.uploaded = uploaded
-        self.error = error
-        self.progressColor = progressColor
-        self.errorProgressColor = errorProgressColor
-        self.progressBackgroundColor = progressBackgroundColor
-        self.removeButtonImage = removeButtonImage
-        self.removeButtonColor = removeButtonColor
-        self.accessibility = accessibility
+        self.enabled = enabled
+        self.disabled = disabled
+    }
+}
+
+extension FileUploadStyle {
+    /// Style of the enabled or disabled state for single upload view in the uploads list view for Chat.
+    public struct EnabledDisabledState: Equatable {
+        /// Style of the file preview.
+        public var filePreview: FilePreviewStyle
+
+        /// Style of the uploading state.
+        public var uploading: FileUploadStateStyle
+
+        /// Style of the uploaded state.
+        public var uploaded: FileUploadStateStyle
+
+        /// Style of the error state.
+        public var error: FileUploadErrorStateStyle
+
+        /// Foreground color of the upload progress bar.
+        public var progressColor: UIColor
+
+        /// Foreground color of the upload progress bar in error state.
+        public var errorProgressColor: UIColor
+
+        /// Background color of the upload progress bar.
+        public var progressBackgroundColor: UIColor
+
+        /// Image of the remove button.
+        public var removeButtonImage: UIImage
+
+        /// Color of the remove button image.
+        public var removeButtonColor: UIColor
+
+        /// Accessibility related properties.
+        public var accessibility: Accessibility
+
+        /// - Parameters:
+        ///   - filePreview: Style of the file preview.
+        ///   - uploading: Style of the uploading state.
+        ///   - uploaded: Style of the uploaded state.
+        ///   - error: Style of the error state.
+        ///   - progressColor: Foreground color of the upload progress bar.
+        ///   - errorProgressColor: Foreground color of the upload progress bar in error state.
+        ///   - progressBackgroundColor: Background color of the upload progress bar.
+        ///   - removeButtonImage: Image of the remove button.
+        ///   - removeButtonColor: Color of the remove button image.
+        ///   - accessibility: Accessibility related properties.
+        ///
+        public init(
+            filePreview: FilePreviewStyle,
+            uploading: FileUploadStateStyle,
+            uploaded: FileUploadStateStyle,
+            error: FileUploadErrorStateStyle,
+            progressColor: UIColor,
+            errorProgressColor: UIColor,
+            progressBackgroundColor: UIColor,
+            removeButtonImage: UIImage,
+            removeButtonColor: UIColor,
+            accessibility: Accessibility = .unsupported
+        ) {
+            self.filePreview = filePreview
+            self.uploading = uploading
+            self.uploaded = uploaded
+            self.error = error
+            self.progressColor = progressColor
+            self.errorProgressColor = errorProgressColor
+            self.progressBackgroundColor = progressBackgroundColor
+            self.removeButtonImage = removeButtonImage
+            self.removeButtonColor = removeButtonColor
+            self.accessibility = accessibility
+        }
     }
 }

--- a/GliaWidgets/Sources/View/Chat/Entry/Upload/MessageCenterFileUploadStyle.EnabledDisabledState.Equatable.swift
+++ b/GliaWidgets/Sources/View/Chat/Entry/Upload/MessageCenterFileUploadStyle.EnabledDisabledState.Equatable.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-extension MessageCenterFileUploadStyle {
-    public static func == (lhs: MessageCenterFileUploadStyle, rhs: MessageCenterFileUploadStyle) -> Bool {
+extension MessageCenterFileUploadStyle.EnabledDisabledState {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.filePreview == rhs.filePreview &&
         lhs.uploading == rhs.uploading &&
         lhs.uploaded == rhs.uploaded &&

--- a/GliaWidgets/Sources/View/Chat/Entry/Upload/MessageCenterFileUploadStyle.RemoteConfig.swift
+++ b/GliaWidgets/Sources/View/Chat/Entry/Upload/MessageCenterFileUploadStyle.RemoteConfig.swift
@@ -1,23 +1,24 @@
 import UIKit
 
 extension MessageCenterFileUploadStyle {
-    func apply(
+    mutating func apply(
+        // TODO: provide configuration for disabled state MOB-3762.
         configuration: RemoteConfiguration.FileUploadBar?,
         assetsBuilder: RemoteConfiguration.AssetsBuilder
     ) {
-        filePreview.apply(
+        enabled.filePreview.apply(
             configuration: configuration?.filePreview,
             assetsBuilder: assetsBuilder
         )
-        uploading.apply(
+        enabled.uploading.apply(
             configuration: configuration?.uploading,
             assetsBuilder: assetsBuilder
         )
-        uploaded.apply(
+        enabled.uploaded.apply(
             configuration: configuration?.uploaded,
             assetsBuilder: assetsBuilder
         )
-        error.apply(
+        enabled.error.apply(
             configuration: configuration?.error,
             assetsBuilder: assetsBuilder
         )
@@ -25,22 +26,22 @@ extension MessageCenterFileUploadStyle {
         configuration?.progress?.value
             .map { UIColor(hex: $0) }
             .first
-            .unwrap { progressColor = $0 }
+            .unwrap { enabled.progressColor = $0 }
 
         configuration?.errorProgress?.value
             .map { UIColor(hex: $0) }
             .first
-            .unwrap { errorProgressColor = $0 }
+            .unwrap { enabled.errorProgressColor = $0 }
 
         configuration?.progressBackground?.value
             .map { UIColor(hex: $0) }
             .first
-            .unwrap { progressBackgroundColor = $0 }
+            .unwrap { enabled.progressBackgroundColor = $0 }
 
         configuration?.removeButton?.value
             .map { UIColor(hex: $0) }
             .first
-            .unwrap { removeButtonColor = $0 }
+            .unwrap { enabled.removeButtonColor = $0 }
 
         // TODO: Unified for `backgroundColor` MOB-1713
     }

--- a/GliaWidgets/Sources/View/Chat/Entry/Upload/MessageCenterFileUploadStyle.swift
+++ b/GliaWidgets/Sources/View/Chat/Entry/Upload/MessageCenterFileUploadStyle.swift
@@ -1,76 +1,96 @@
 import UIKit
 
-/// Style of a single upload view in the uploads list view for Message Center Welcome screen.
-public class MessageCenterFileUploadStyle: Equatable {
-    /// Style of the file preview.
-    public var filePreview: FilePreviewStyle
-
-    /// Style of the uploading state.
-    public var uploading: FileUploadStateStyle
-
-    /// Style of the uploaded state.
-    public var uploaded: FileUploadStateStyle
-
-    /// Style of the error state.
-    public var error: FileUploadErrorStateStyle
-
-    /// Foreground color of the upload progress bar.
-    public var progressColor: UIColor
-
-    /// Foreground color of the upload progress bar in error state.
-    public var errorProgressColor: UIColor
-
-    /// Background color of the upload progress bar.
-    public var progressBackgroundColor: UIColor
-
-    /// Image of the remove button.
-    public var removeButtonImage: UIImage
-
-    /// Color of the remove button image.
-    public var removeButtonColor: UIColor
-
-    /// Background color of the upload item.
-    public var backgroundColor: UIColor
-
-    /// Accessibility related properties.
-    public var accessibility: Accessibility
+public struct MessageCenterFileUploadStyle: Equatable {
+    /// Style of the enabled state for single upload view in the uploads list view for Message Center Welcome screen.
+    public var enabled: EnabledDisabledState
+    /// Style of the disabled state for single upload view in the uploads list view for Message Center Welcome screen.
+    public var disabled: EnabledDisabledState
 
     /// - Parameters:
-    ///   - filePreview: Style of the file preview.
-    ///   - uploading: Style of the uploading state.
-    ///   - uploaded: Style of the uploaded state.
-    ///   - error: Style of the error state.
-    ///   - progressColor: Foreground color of the upload progress bar.
-    ///   - errorProgressColor: Foreground color of the upload progress bar in error state.
-    ///   - progressBackgroundColor: Background color of the upload progress bar.
-    ///   - removeButtonImage: Image of the remove button.
-    ///   - removeButtonColor: Color of the remove button image.
-    ///   - backgroundColor: Background color of the upload item.
-    ///   - accessibility: Accessibility related properties.
-    ///
+    ///   - enabled: Style of the enabled state for single upload view in the uploads list view for Message Center Welcome screen.
+    ///   - disabled: Style of the disabled state for single upload view in the uploads list view for Message Center Welcome screen.
     public init(
-        filePreview: FilePreviewStyle,
-        uploading: FileUploadStateStyle,
-        uploaded: FileUploadStateStyle,
-        error: FileUploadErrorStateStyle,
-        progressColor: UIColor,
-        errorProgressColor: UIColor,
-        progressBackgroundColor: UIColor,
-        removeButtonImage: UIImage,
-        removeButtonColor: UIColor,
-        backgroundColor: UIColor,
-        accessibility: Accessibility = .unsupported
+        enabled: EnabledDisabledState,
+        disabled: EnabledDisabledState
     ) {
-        self.filePreview = filePreview
-        self.uploading = uploading
-        self.uploaded = uploaded
-        self.error = error
-        self.progressColor = progressColor
-        self.errorProgressColor = errorProgressColor
-        self.progressBackgroundColor = progressBackgroundColor
-        self.removeButtonImage = removeButtonImage
-        self.removeButtonColor = removeButtonColor
-        self.backgroundColor = backgroundColor
-        self.accessibility = accessibility
+        self.enabled = enabled
+        self.disabled = disabled
+    }
+}
+
+extension MessageCenterFileUploadStyle {
+    /// Style of the enabled or disabled state for single upload view in the uploads list view for Message Center Welcome screen.
+    public struct EnabledDisabledState: Equatable {
+        /// Style of the file preview.
+        public var filePreview: FilePreviewStyle
+
+        /// Style of the uploading state.
+        public var uploading: FileUploadStateStyle
+
+        /// Style of the uploaded state.
+        public var uploaded: FileUploadStateStyle
+
+        /// Style of the error state.
+        public var error: FileUploadErrorStateStyle
+
+        /// Foreground color of the upload progress bar.
+        public var progressColor: UIColor
+
+        /// Foreground color of the upload progress bar in error state.
+        public var errorProgressColor: UIColor
+
+        /// Background color of the upload progress bar.
+        public var progressBackgroundColor: UIColor
+
+        /// Image of the remove button.
+        public var removeButtonImage: UIImage
+
+        /// Color of the remove button image.
+        public var removeButtonColor: UIColor
+
+        /// Background color of the upload item.
+        public var backgroundColor: UIColor
+
+        /// Accessibility related properties.
+        public var accessibility: Accessibility
+
+        /// - Parameters:
+        ///   - filePreview: Style of the file preview.
+        ///   - uploading: Style of the uploading state.
+        ///   - uploaded: Style of the uploaded state.
+        ///   - error: Style of the error state.
+        ///   - progressColor: Foreground color of the upload progress bar.
+        ///   - errorProgressColor: Foreground color of the upload progress bar in error state.
+        ///   - progressBackgroundColor: Background color of the upload progress bar.
+        ///   - removeButtonImage: Image of the remove button.
+        ///   - removeButtonColor: Color of the remove button image.
+        ///   - backgroundColor: Background color of the upload item.
+        ///   - accessibility: Accessibility related properties.
+        ///
+        public init(
+            filePreview: FilePreviewStyle,
+            uploading: FileUploadStateStyle,
+            uploaded: FileUploadStateStyle,
+            error: FileUploadErrorStateStyle,
+            progressColor: UIColor,
+            errorProgressColor: UIColor,
+            progressBackgroundColor: UIColor,
+            removeButtonImage: UIImage,
+            removeButtonColor: UIColor,
+            backgroundColor: UIColor,
+            accessibility: Accessibility = .unsupported
+        ) {
+            self.filePreview = filePreview
+            self.uploading = uploading
+            self.uploaded = uploaded
+            self.error = error
+            self.progressColor = progressColor
+            self.errorProgressColor = errorProgressColor
+            self.progressBackgroundColor = progressBackgroundColor
+            self.removeButtonImage = removeButtonImage
+            self.removeButtonColor = removeButtonColor
+            self.backgroundColor = backgroundColor
+            self.accessibility = accessibility
+        }
     }
 }

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests.swift
@@ -578,6 +578,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
 
     func testIsSecureConversationsAvailableIsFalseIsDueToEmptyQueue() {
         var modelEnvironment = TranscriptModel.Environment.failing
+        modelEnvironment.uiApplication = .mock
         modelEnvironment.fileManager = .mock
         modelEnvironment.maximumUploads = { 2 }
         modelEnvironment.createFileUploadListModel = {
@@ -611,7 +612,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         var logger = CoreSdkClient.Logger.failing
         logger.prefixedClosure = { _ in logger }
         logger.infoClosure = { _, _, _, _ in }
-        logger.warningClosure = { _, _, _, _ in }
+        logger.warningClosure = { _, _, _, _ in }        
+        modelEnvironment.uiApplication = .mock
         modelEnvironment.log = logger
         modelEnvironment.fileManager = .mock
         modelEnvironment.maximumUploads = { 2 }
@@ -641,6 +643,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         var logger = CoreSdkClient.Logger.failing
         logger.prefixedClosure = { _ in logger }
         logger.infoClosure = { _, _, _, _ in }
+        modelEnvironment.uiApplication = .mock
         modelEnvironment.log = logger
         modelEnvironment.fileManager = .mock
         modelEnvironment.maximumUploads = { 2 }
@@ -670,6 +673,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         logger.prefixedClosure = { _ in logger }
         logger.infoClosure = { _, _, _, _ in }
         logger.warningClosure = { _, _, _, _ in }
+        modelEnvironment.uiApplication = .mock
         modelEnvironment.log = logger
         modelEnvironment.fileManager = .mock
         modelEnvironment.maximumUploads = { 2 }
@@ -700,6 +704,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         logger.prefixedClosure = { _ in logger }
         logger.infoClosure = { _, _, _, _ in }
         logger.warningClosure = { _, _, _, _ in }
+        modelEnvironment.uiApplication = .mock
         modelEnvironment.log = logger
         modelEnvironment.fileManager = .mock
         modelEnvironment.maximumUploads = { 2 }

--- a/SnapshotTests/SecureConversationsWelcomeScreenDynamicTypeFontTests.swift
+++ b/SnapshotTests/SecureConversationsWelcomeScreenDynamicTypeFontTests.swift
@@ -55,7 +55,8 @@ final class SecureConversationsWelcomeScreenDynamicTypeFontTests: SnapshotTestCa
             id: "id-a",
             style: .messageCenter(theme.secureConversationsWelcome.attachmentListStyle.item),
             state: .uploaded(.init(localFile: .mock())),
-            removeTapped: .nop
+            removeTapped: .nop,
+            isEnabled: true
         )
     }
 
@@ -64,7 +65,8 @@ final class SecureConversationsWelcomeScreenDynamicTypeFontTests: SnapshotTestCa
             id: "id-b",
             style: .messageCenter(theme.secureConversationsWelcome.attachmentListStyle.item),
             state: .error(.network),
-            removeTapped: .nop
+            removeTapped: .nop,
+            isEnabled: true
         )
     }
 
@@ -99,21 +101,37 @@ final class SecureConversationsWelcomeScreenDynamicTypeFontTests: SnapshotTestCa
             fileUploadListProps: .init(
                 maxUnscrollableViews: 3,
                 style: .messageCenter(
-                    .init(item: .init(
-                        filePreview: .mock,
-                        uploading: .mock,
-                        uploaded: .mock,
-                        error: .mock,
-                        progressColor: Color.primary,
-                        errorProgressColor: Color.systemNegative,
-                        progressBackgroundColor: .clear,
-                        removeButtonImage: .mock,
-                        removeButtonColor: Color.baseShade,
-                        backgroundColor: Color.baseNeutral)
+                    .init(
+                        item: .init(
+                            enabled: .init(
+                                filePreview: .mock,
+                                uploading: .mock,
+                                uploaded: .mock,
+                                error: .mock,
+                                progressColor: Color.primary,
+                                errorProgressColor: Color.systemNegative,
+                                progressBackgroundColor: .clear,
+                                removeButtonImage: .mock,
+                                removeButtonColor: Color.baseShade,
+                                backgroundColor: Color.baseNeutral
+                            ),
+                            disabled: .init(
+                                filePreview: .mock,
+                                uploading: .mock,
+                                uploaded: .mock,
+                                error: .mock,
+                                progressColor: Color.primary,
+                                errorProgressColor: Color.systemNegative,
+                                progressBackgroundColor: .clear,
+                                removeButtonImage: .mock,
+                                removeButtonColor: Color.baseShade,
+                                backgroundColor: Color.baseNeutral
+                            )
+                        )
                     )
                 ),
                 uploads: .init(uploads),
-                isScrollingEnabled: true, 
+                isScrollingEnabled: true,
                 preferredContentSizeCategoryChanged: .nop
             ),
             headerProps: headerProps,

--- a/SnapshotTests/SecureConversationsWelcomeScreenLayoutTests.swift
+++ b/SnapshotTests/SecureConversationsWelcomeScreenLayoutTests.swift
@@ -54,7 +54,8 @@ final class SecureConversationsWelcomeScreenLayoutTests: SnapshotTestCase {
             id: "id-a",
             style: .messageCenter(theme.secureConversationsWelcome.attachmentListStyle.item),
             state: .uploaded(.init(localFile: .mock())),
-            removeTapped: .nop
+            removeTapped: .nop,
+            isEnabled: true
         )
     }
 
@@ -63,7 +64,8 @@ final class SecureConversationsWelcomeScreenLayoutTests: SnapshotTestCase {
             id: "id-b",
             style: .messageCenter(theme.secureConversationsWelcome.attachmentListStyle.item),
             state: .error(.network),
-            removeTapped: .nop
+            removeTapped: .nop,
+            isEnabled: true
         )
     }
 
@@ -98,21 +100,37 @@ final class SecureConversationsWelcomeScreenLayoutTests: SnapshotTestCase {
             fileUploadListProps: .init(
                 maxUnscrollableViews: 3,
                 style: .messageCenter(
-                    .init(item: .init(
-                        filePreview: .mock,
-                        uploading: .mock,
-                        uploaded: .mock,
-                        error: .mock,
-                        progressColor: Color.primary,
-                        errorProgressColor: Color.systemNegative,
-                        progressBackgroundColor: .clear,
-                        removeButtonImage: .mock,
-                        removeButtonColor: Color.baseShade,
-                        backgroundColor: Color.baseNeutral)
+                    .init(
+                        item: .init(
+                            enabled: .init(
+                                filePreview: .mock,
+                                uploading: .mock,
+                                uploaded: .mock,
+                                error: .mock,
+                                progressColor: Color.primary,
+                                errorProgressColor: Color.systemNegative,
+                                progressBackgroundColor: .clear,
+                                removeButtonImage: .mock,
+                                removeButtonColor: Color.baseShade,
+                                backgroundColor: Color.baseNeutral
+                            ),
+                            disabled: .init(
+                                filePreview: .mock,
+                                uploading: .mock,
+                                uploaded: .mock,
+                                error: .mock,
+                                progressColor: Color.primary,
+                                errorProgressColor: Color.systemNegative,
+                                progressBackgroundColor: .clear,
+                                removeButtonImage: .mock,
+                                removeButtonColor: Color.baseShade,
+                                backgroundColor: Color.baseNeutral
+                            )
+                        )
                     )
                 ),
                 uploads: .init(uploads),
-                isScrollingEnabled: true, 
+                isScrollingEnabled: true,
                 preferredContentSizeCategoryChanged: .nop
             ),
             headerProps: headerProps,

--- a/SnapshotTests/SecureConversationsWelcomeScreenVoiceOverTests.swift
+++ b/SnapshotTests/SecureConversationsWelcomeScreenVoiceOverTests.swift
@@ -52,7 +52,8 @@ final class SecureConversationsWelcomeScreenVoiceOverTests: SnapshotTestCase {
             id: "id-a",
             style: .messageCenter(theme.secureConversationsWelcome.attachmentListStyle.item),
             state: .uploaded(.init(localFile: .mock())),
-            removeTapped: .nop
+            removeTapped: .nop,
+            isEnabled: true
         )
     }
 
@@ -61,7 +62,8 @@ final class SecureConversationsWelcomeScreenVoiceOverTests: SnapshotTestCase {
             id: "id-b",
             style: .messageCenter(theme.secureConversationsWelcome.attachmentListStyle.item),
             state: .error(.network),
-            removeTapped: .nop
+            removeTapped: .nop,
+            isEnabled: true
         )
     }
 
@@ -96,21 +98,37 @@ final class SecureConversationsWelcomeScreenVoiceOverTests: SnapshotTestCase {
             fileUploadListProps: .init(
                 maxUnscrollableViews: 3,
                 style: .messageCenter(
-                    .init(item: .init(
-                        filePreview: .mock,
-                        uploading: .mock,
-                        uploaded: .mock,
-                        error: .mock,
-                        progressColor: Color.primary, 
-                        errorProgressColor: Color.systemNegative,
-                        progressBackgroundColor: .clear,
-                        removeButtonImage: .mock,
-                        removeButtonColor: Color.baseShade,
-                        backgroundColor: Color.baseNeutral)
+                    .init(
+                        item: .init(
+                            enabled: .init(
+                                filePreview: .mock,
+                                uploading: .mock,
+                                uploaded: .mock,
+                                error: .mock,
+                                progressColor: Color.primary,
+                                errorProgressColor: Color.systemNegative,
+                                progressBackgroundColor: .clear,
+                                removeButtonImage: .mock,
+                                removeButtonColor: Color.baseShade,
+                                backgroundColor: Color.baseNeutral
+                            ),
+                            disabled: .init(
+                                filePreview: .mock,
+                                uploading: .mock,
+                                uploaded: .mock,
+                                error: .mock,
+                                progressColor: Color.primary,
+                                errorProgressColor: Color.systemNegative,
+                                progressBackgroundColor: .clear,
+                                removeButtonImage: .mock,
+                                removeButtonColor: Color.baseShade,
+                                backgroundColor: Color.baseNeutral
+                            )
+                        )
                     )
                 ),
                 uploads: .init(uploads),
-                isScrollingEnabled: true, 
+                isScrollingEnabled: true,
                 preferredContentSizeCategoryChanged: .nop
             ),
             headerProps: headerProps,


### PR DESCRIPTION
MOB-3763

**What was solved?**
Since message entry can have disabled state, file upload list, which is a part of message entry, also needs to have disabled state. These changes introduce such state. Styles use same colors for disabled state as for enabled for now, because we do not have a flow for disabled file upload.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
