### PR TITLE
Add logs and telemetry for Entry Widget

### DIFF
--- a/GliaWidgets/Public/Glia/Glia+EngagementLauncher.swift
+++ b/GliaWidgets/Public/Glia/Glia+EngagementLauncher.swift
@@ -10,6 +10,7 @@ extension Glia {
     ///   - `EngagementLauncher` instance.
     public func getEngagementLauncher(queueIds: [String]) throws -> EngagementLauncher {
         let parameters = try getEngagementParameters(in: queueIds)
+        loggerPhase.logger.info("Returning an Engagement Launcher")
         return try EngagementLauncher { [weak self] engagementKind, sceneProvider in
             try self?.resolveEngangementState(
                 engagementKind: engagementKind,

--- a/GliaWidgets/Public/Glia/Glia+EntryWidget.swift
+++ b/GliaWidgets/Public/Glia/Glia+EntryWidget.swift
@@ -14,7 +14,7 @@ extension Glia {
             environment: .init(
                 observeSecureUnreadMessageCount: environment.coreSdk.subscribeForUnreadSCMessageCount,
                 unsubscribeFromUpdates: environment.coreSdk.unsubscribeFromUpdates,
-                queuesMonitor: environment.queuesMonitor,
+                queuesMonitor: queuesMonitor,
                 engagementLauncher: try getEngagementLauncher(queueIds: queueIds),
                 theme: theme,
                 log: loggerPhase.logger,

--- a/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
+++ b/GliaWidgets/Public/Glia/Glia+StartEngagement.swift
@@ -187,7 +187,8 @@ extension Glia {
                 loggerPhase: loggerPhase,
                 maximumUploads: { self.maximumUploads },
                 viewFactory: viewFactory,
-                alertManager: alertManager
+                alertManager: alertManager,
+                queuesMonitor: queuesMonitor
             )
         )
         rootCoordinator?.delegate = { [weak self] event in self?.handleCoordinatorEvent(event) }

--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -112,6 +112,7 @@ public class Glia {
     var theme: Theme
     var assetsBuilder: RemoteConfiguration.AssetsBuilder = .standard
     var loggerPhase: LoggerPhase
+    var queuesMonitor: QueuesMonitor
     var alertManager: AlertManager
     // We need to store `features` via `configure` or deprecated `startEngagement` methods
     // to use it when engagement gets restored for Direct ID authentication flow.
@@ -134,7 +135,6 @@ public class Glia {
                 try logger.configureLocalLogLevel(.none)
                 try logger.configureRemoteLogLevel(.info)
             }
-
             loggerPhase = .configured(logger)
         } catch {
             environment.print("Unable to configure logger: '\(error)'.")
@@ -149,7 +149,12 @@ public class Glia {
                 loggerPhase: loggerPhase
             )
         )
-
+        queuesMonitor = .init(environment: .init(
+            listQueues: environment.coreSdk.listQueues,
+            subscribeForQueuesUpdates: environment.coreSdk.subscribeForQueuesUpdates,
+            unsubscribeFromUpdates: environment.coreSdk.unsubscribeFromUpdates,
+            logger: loggerPhase.logger
+        ))
         alertManager = .init(
             environment: .create(
                 with: environment,
@@ -446,7 +451,8 @@ extension Glia {
             visitorContext: configuration.visitorContext,
             environment: .create(
                 with: environment,
-                log: loggerPhase.logger
+                log: loggerPhase.logger,
+                queuesMonitor: queuesMonitor
             )
         )
 

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
@@ -53,7 +53,8 @@ extension EngagementCoordinator.Environment {
         loggerPhase: Glia.LoggerPhase,
         maximumUploads: @escaping () -> Int,
         viewFactory: ViewFactory,
-        alertManager: AlertManager
+        alertManager: AlertManager,
+        queuesMonitor: QueuesMonitor
     ) -> Self {
         .init(
             fetchFile: environment.coreSdk.fetchFile,
@@ -97,7 +98,7 @@ extension EngagementCoordinator.Environment {
             cameraDeviceManager: environment.cameraDeviceManager,
             flipCameraButtonStyle: viewFactory.theme.call.flipCameraButtonStyle,
             alertManager: alertManager,
-            queuesMonitor: environment.queuesMonitor
+            queuesMonitor: queuesMonitor
         )
     }
 }

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Interface.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Interface.swift
@@ -53,7 +53,6 @@ extension Glia {
         var snackBar: SnackBar
         var processInfo: ProcessInfoHandling
         var cameraDeviceManager: CoreSdkClient.GetCameraDeviceManageable
-        var queuesMonitor: QueuesMonitor
         var isAuthenticated: () -> Bool
     }
 }

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Live.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Live.swift
@@ -43,13 +43,6 @@ extension Glia.Environment {
         snackBar: .live,
         processInfo: .live,
         cameraDeviceManager: { try CoreSdkClient.live.getCameraDeviceManageable() },
-        queuesMonitor: .init(
-            environment: .init(
-                listQueues: CoreSdkClient.live.listQueues,
-                subscribeForQueuesUpdates: CoreSdkClient.live.subscribeForQueuesUpdates,
-                unsubscribeFromUpdates: CoreSdkClient.live.unsubscribeFromUpdates
-            )
-        ),
         // This logic was moved here from EngagementCoordinator.Environment
         // Because it will be used for EntryWidget as well. This is as of now
         // The simplest way to determine if visitor is authenticated or not

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Mock.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Mock.swift
@@ -34,7 +34,6 @@ extension Glia.Environment {
         snackBar: .mock,
         processInfo: .mock(),
         cameraDeviceManager: { .mock },
-        queuesMonitor: .mock(),
         isAuthenticated: { false }
     )
 }

--- a/GliaWidgets/Sources/Interactor/Interactor.Environment.Interface.swift
+++ b/GliaWidgets/Sources/Interactor/Interactor.Environment.Interface.swift
@@ -10,11 +10,12 @@ extension Interactor {
 extension Interactor.Environment {
     static func create(
         with environment: Glia.Environment,
-        log: CoreSdkClient.Logger
+        log: CoreSdkClient.Logger,
+        queuesMonitor: QueuesMonitor
     ) -> Self {
         .init(
             coreSdk: environment.coreSdk,
-            queuesMonitor: environment.queuesMonitor,
+            queuesMonitor: queuesMonitor,
             gcd: environment.gcd,
             log: log
         )

--- a/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.Environment.Mock.swift
+++ b/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.Environment.Mock.swift
@@ -4,7 +4,8 @@ extension QueuesMonitor.Environment {
     static let mock: Self = .init(
         listQueues: { _ in },
         subscribeForQueuesUpdates: { _, _ in UUID().uuidString },
-        unsubscribeFromUpdates: { _, _ in }
+        unsubscribeFromUpdates: { _, _ in },
+        logger: .mock
     )
 }
 #endif

--- a/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.Environment.swift
+++ b/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.Environment.swift
@@ -5,5 +5,6 @@ extension QueuesMonitor {
         var listQueues: CoreSdkClient.ListQueues
         var subscribeForQueuesUpdates: CoreSdkClient.SubscribeForQueuesUpdates
         var unsubscribeFromUpdates: CoreSdkClient.UnsubscribeFromUpdates
+        var logger: CoreSdkClient.Logger
     }
 }

--- a/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.Mock.swift
+++ b/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.Mock.swift
@@ -9,7 +9,8 @@ extension QueuesMonitor {
             environment: .init(
                 listQueues: listQueues ?? QueuesMonitor.Environment.mock.listQueues,
                 subscribeForQueuesUpdates: subscribeForQueuesUpdates ?? QueuesMonitor.Environment.mock.subscribeForQueuesUpdates,
-                unsubscribeFromUpdates: unsubscribeFromUpdates ?? QueuesMonitor.Environment.mock.unsubscribeFromUpdates
+                unsubscribeFromUpdates: unsubscribeFromUpdates ?? QueuesMonitor.Environment.mock.unsubscribeFromUpdates,
+                logger: .mock
             )
         )
     }

--- a/GliaWidgetsTests/Glia.Environment.Failing.swift
+++ b/GliaWidgetsTests/Glia.Environment.Failing.swift
@@ -66,7 +66,6 @@ extension Glia.Environment {
             fail("\(Self.self).cameraDeviceManager")
             return .failing
         },
-        queuesMonitor: .failing,
         isAuthenticated: {
             fail("\(Self.self).isAuthenticated")
             return false

--- a/GliaWidgetsTests/QueuesMonitor.Failing.swift
+++ b/GliaWidgetsTests/QueuesMonitor.Failing.swift
@@ -5,7 +5,8 @@ extension QueuesMonitor {
         environment: .init(
             listQueues: CoreSdkClient.failing.listQueues,
             subscribeForQueuesUpdates: CoreSdkClient.failing.subscribeForQueuesUpdates,
-            unsubscribeFromUpdates: CoreSdkClient.failing.unsubscribeFromUpdates
+            unsubscribeFromUpdates: CoreSdkClient.failing.unsubscribeFromUpdates,
+            logger: .failing
         )
     )
 }

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+EngagementLauncher.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+EngagementLauncher.swift
@@ -62,7 +62,7 @@ extension GliaTests {
     
     func test_startSecureConversationUsingEngagementLauncherWithCorrectConfiguration() throws {
         let sdk = makeConfigurableSDK()
-        
+
         try sdk.configure(
             with: .mock(),
             theme: .mock()
@@ -96,12 +96,11 @@ private extension GliaTests {
             completion(.success(()))
         }
         sdkEnv.coreSdk.getCurrentEngagement = { nil }
-        sdkEnv.queuesMonitor = .mock()
         let window = UIWindow(frame: .zero)
         window.makeKeyAndVisible()
         sdkEnv.uiApplication.windows = { [window] }
         let sdk = Glia(environment: sdkEnv)
-        
+        sdk.queuesMonitor = .mock()
         return sdk
     }
 }

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
@@ -27,12 +27,11 @@ extension GliaTests {
         sdkEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
-        sdkEnv.queuesMonitor = .mock()
         let window = UIWindow(frame: .zero)
         window.makeKeyAndVisible()
         sdkEnv.uiApplication.windows = { [window] }
         let sdk = Glia(environment: sdkEnv)
-
+        sdk.queuesMonitor = .mock()
         sdk.rootCoordinator = rootCoordinator
         try sdk.configure(
             with: .mock(),
@@ -61,7 +60,6 @@ extension GliaTests {
         }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
-        environment.queuesMonitor = .mock()
 
         let rootCoordinator = EngagementCoordinator.mock(
             engagementKind: .chat,
@@ -76,6 +74,7 @@ extension GliaTests {
         window.makeKeyAndVisible()
         environment.uiApplication.windows = { [window] }
         let sdk = Glia(environment: environment)
+        sdk.queuesMonitor = .mock()
         sdk.rootCoordinator = rootCoordinator
         try sdk.configure(with: .mock(), features: .bubbleView) { _ in }
         XCTAssertEqual(sdk.features, .bubbleView)
@@ -99,12 +98,13 @@ extension GliaTests {
         gliaEnv.coreSdk.createLogger = { _ in logger }
         gliaEnv.coreSdk.localeProvider.getRemoteString = { _ in nil }
         let sdk = Glia(environment: gliaEnv)
+        sdk.queuesMonitor = .mock()
         sdk.environment.conditionalCompilation.isDebug = { true }
         sdk.environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         sdk.environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
-        sdk.environment.queuesMonitor = .mock()
+
         try sdk.configure(
             with: .mock(),
             theme: .mock()
@@ -138,8 +138,8 @@ extension GliaTests {
         }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
         environment.coreSdk.getCurrentEngagement = { nil }
-        environment.queuesMonitor = .mock()
         let sdk = Glia(environment: environment)
+        sdk.queuesMonitor = .mock()
         try sdk.configure(
             with: .mock(),
             theme: .mock()
@@ -179,8 +179,8 @@ extension GliaTests {
         environment.createRootCoordinator = { _, _, _, _, _, _, _ in
             .mock(environment: .engagementCoordEnvironmentWithKeyWindow)
         }
-        environment.queuesMonitor = .mock()
         let sdk = Glia(environment: environment)
+        sdk.queuesMonitor = .mock()
         try sdk.start(.chat, configuration: .mock(), queueID: "queueId", theme: .mock())
 
         XCTAssertTrue(sdk.isConfigured)
@@ -219,10 +219,9 @@ extension GliaTests {
         }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
-        environment.queuesMonitor = .mock()
 
         let sdk = Glia(environment: environment)
-
+        sdk.queuesMonitor = .mock()
         let theme = Theme()
         theme.call.connect.queue.firstText = "Glia 1"
         theme.chat.connect.queue.firstText = "Glia 2"
@@ -267,7 +266,7 @@ extension GliaTests {
         }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.getCurrentEngagement = { nil }
-        environment.queuesMonitor = .mock()
+
         var logger = CoreSdkClient.Logger.failing
         logger.configureLocalLogLevelClosure = { _ in }
         logger.configureRemoteLogLevelClosure = { _ in }
@@ -276,7 +275,7 @@ extension GliaTests {
         environment.coreSdk.createLogger = { _ in logger }
 
         let sdk = Glia(environment: environment)
-
+        sdk.queuesMonitor = .mock()
         // Even if theme is set, the remote string takes priority.
         let theme = Theme()
         theme.call.connect.queue.firstText = "Glia 1"
@@ -308,7 +307,6 @@ extension GliaTests {
         logger.infoClosure = { _, _, _, _ in }
         logger.prefixedClosure = { _ in logger }
         environment.coreSdk.createLogger = { _ in logger }
-        environment.queuesMonitor = .mock()
 
         var resultingViewFactory: ViewFactory?
 
@@ -332,7 +330,7 @@ extension GliaTests {
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
 
         let sdk = Glia(environment: environment)
-
+        sdk.queuesMonitor = .mock()
         try sdk.configure(
             with: .mock(companyName: "Glia"),
             theme: .mock()
@@ -360,7 +358,6 @@ extension GliaTests {
         logger.prefixedClosure = { _ in logger }
         environment.coreSdk.createLogger = { _ in logger }
         environment.print = .mock
-        environment.queuesMonitor = .mock()
         var resultingViewFactory: ViewFactory?
 
         environment.createRootCoordinator = { _, viewFactory, _, _, _, _, _ in
@@ -383,7 +380,7 @@ extension GliaTests {
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
 
         let sdk = Glia(environment: environment)
-
+        sdk.queuesMonitor = .mock()
         try sdk.configure(
             with: .mock(),
             theme: .mock()
@@ -410,7 +407,6 @@ extension GliaTests {
         environment.coreSdk.createLogger = { _ in logger }
         environment.print = .mock
         environment.conditionalCompilation.isDebug = { true }
-        environment.queuesMonitor = .mock()
 
         var resultingViewFactory: ViewFactory?
 
@@ -434,10 +430,9 @@ extension GliaTests {
         }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.getCurrentEngagement = { nil }
-        environment.queuesMonitor = .mock()
 
         let sdk = Glia(environment: environment)
-
+        sdk.queuesMonitor = .mock()
         let theme = Theme()
         theme.call.connect.queue.firstText = "Glia 1"
         theme.chat.connect.queue.firstText = "Glia 2"
@@ -468,7 +463,6 @@ extension GliaTests {
         environment.coreSdk.createLogger = { _ in logger }
         environment.print = .mock
         environment.conditionalCompilation.isDebug = { true }
-        environment.queuesMonitor = .mock()
 
         var resultingViewFactory: ViewFactory?
 
@@ -494,6 +488,7 @@ extension GliaTests {
         environment.coreSdk.getCurrentEngagement = { nil }
 
         let sdk = Glia(environment: environment)
+        sdk.queuesMonitor = .mock()
         try sdk.configure(
             with: .mock(),
             theme: .mock()

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -92,7 +92,6 @@ final class GliaTests: XCTestCase {
         gliaEnv.coreSdk.fetchSiteConfigurations = { _ in }
         gliaEnv.uuid = { .mock }
         gliaEnv.gcd.mainQueue.async = { callback in callback() }
-        gliaEnv.queuesMonitor = .mock()
 
         let expectedTheme = Theme.mock(
             colorStyle: .custom(.init()),
@@ -119,7 +118,7 @@ final class GliaTests: XCTestCase {
         }
 
         let sdk = Glia(environment: gliaEnv)
-
+        sdk.queuesMonitor = .mock()
         try sdk.start(
             .audioCall,
             configuration: .mock(),
@@ -604,9 +603,9 @@ final class GliaTests: XCTestCase {
         var engCoordEnvironment = EngagementCoordinator.Environment.engagementCoordEnvironmentWithKeyWindow
         engCoordEnvironment.fileManager = .mock
         environment.createRootCoordinator = { _, _, _, _, _, _, _ in EngagementCoordinator.mock(environment: engCoordEnvironment) }
-        environment.queuesMonitor = .mock()
 
         let sdk = Glia(environment: environment)
+        sdk.queuesMonitor = .mock()
         enum Call {
             case configureWithConfiguration
         }

--- a/GliaWidgetsTests/Sources/QueuesMonitor/QueuesMonitorTests.swift
+++ b/GliaWidgetsTests/Sources/QueuesMonitor/QueuesMonitorTests.swift
@@ -29,11 +29,14 @@ class QueuesMonitorTests: XCTestCase {
     // MARK: Fetch and Motitor queues
     func test_fetchAndMonitorQueuesWithQueuesUpdatesWithQueuesList() {
         var envCalls: [Call] = []
-
-        let mockQueueId = UUID().uuidString
+        let expectedLogMessage = "Setting up queues. 1 out of 1 queues provided by an integrator match with site queues."
+        var receivedLogMessage = ""
+        let mockQueueId = "mock_queue_id"
         let expectedObservedQueues = [Queue.mock(id: mockQueueId)]
         let mockQueues = [expectedObservedQueues[0], Queue.mock(id: UUID().uuidString)]
-
+        monitor.environment.logger.infoClosure = { logMessage, _, _, _ in
+            receivedLogMessage = logMessage as? String ?? ""
+        }
         monitor.environment.listQueues = { completion in
             envCalls.append(.listQueues)
             completion(mockQueues, nil)
@@ -57,14 +60,22 @@ class QueuesMonitorTests: XCTestCase {
 
         XCTAssertEqual(receivedQueues, expectedObservedQueues)
         XCTAssertEqual(envCalls, [.listQueues, .subscribeForQueuesUpdates])
+        XCTAssertEqual(receivedLogMessage, expectedLogMessage)
     }
 
     func test_fetchAndMonitorQueuesWithWrongQueueIdsReturnsUpdatesWithDefaultQueue() {
         var envCalls: [Call] = []
-
+        let expectedLogMessages = [
+            "Setting up queues. 0 out of 1 queues provided by an integrator match with site queues.",
+            "Setting up queues. Integrator specified an empty list of queues.",
+            "Setting up queues. Using 1 default queues."
+        ]
+        var receivedLogMessage: [String] = []
         let expectedObservedQueues = [Queue.mock(isDefault: true)]
         let mockQueues = [expectedObservedQueues[0], Queue.mock()]
-
+        monitor.environment.logger.infoClosure = { logMessage, _, _, _ in
+            receivedLogMessage.append(logMessage as? String ?? "")
+        }
         monitor.environment.listQueues = { completion in
             envCalls.append(.listQueues)
             completion(mockQueues, nil)
@@ -87,13 +98,17 @@ class QueuesMonitorTests: XCTestCase {
 
         XCTAssertEqual(receivedQueues, expectedObservedQueues)
         XCTAssertEqual(envCalls, [.listQueues, .subscribeForQueuesUpdates])
+        XCTAssertEqual(expectedLogMessages, receivedLogMessage)
     }
 
     func test_fetchAndMonitorQueuesListQueuesReturnsError() {
         var envCalls: [Call] = []
-
+        let expectedErrorLog = "Setting up queues. Failed to get site queues: mock"
+        var receivedErrorLog = ""
         let expectedError = CoreSdkClient.SalemoveError.mock()
-
+        monitor.environment.logger.errorClosure = { logMessage, _, _, _ in
+            receivedErrorLog = logMessage as? String ?? ""
+        }
         monitor.environment.listQueues = { completion in
             envCalls.append(.listQueues)
             completion(nil, expectedError)
@@ -116,12 +131,13 @@ class QueuesMonitorTests: XCTestCase {
 
         XCTAssertEqual(receivedError, expectedError)
         XCTAssertEqual(envCalls, [.listQueues])
+        XCTAssertEqual(expectedErrorLog, receivedErrorLog)
     }
 
     func test_fetchAndMonitorQueuesWithQueuesAndReceiveUpdatedQueueSuccess() {
         var envCalls: [Call] = []
 
-        let mockQueueId = UUID().uuidString
+        let mockQueueId = "mock_queue_id"
         let expectedObservedQueue = Queue.mock(id: mockQueueId, status: .closed)
         let expectedUpdatedQueue = Queue.mock(id: mockQueueId, status: .open)
         let mockQueues = [expectedObservedQueue, Queue.mock(id: UUID().uuidString)]
@@ -159,7 +175,7 @@ class QueuesMonitorTests: XCTestCase {
     func test_fetchAndMonitorQueuesWithQueuesStopsPreviousMonitoring() {
         var envCalls: [Call] = []
 
-        let mockQueueId = UUID().uuidString
+        let mockQueueId = "mock_queue_id"
         let expectedObservedQueue = Queue.mock(id: mockQueueId, status: .closed)
         let expectedUpdatedQueue = Queue.mock(id: mockQueueId, status: .open)
         let mockQueues = [expectedObservedQueue, Queue.mock(id: UUID().uuidString)]
@@ -205,7 +221,7 @@ class QueuesMonitorTests: XCTestCase {
     func test_fetchAndMonitorQueuesWithQueuesStopsPreviousMonitoringFailed() {
         var envCalls: [Call] = []
 
-        let mockQueueId = UUID().uuidString
+        let mockQueueId = "mock_queue_id"
         let expectedObservedQueue = Queue.mock(id: mockQueueId, status: .closed)
         let expectedUpdatedQueue = Queue.mock(id: mockQueueId, status: .open)
         let mockQueues = [expectedObservedQueue, Queue.mock(id: UUID().uuidString)]


### PR DESCRIPTION
**What was solved?**
This PR adds logs to EntryWidget, and aligning iOS with Android logs. Because logger was added as a dependency to QueueMonitor, it was necessary to move queueMonitor from Glia environment to Glia's class property due to Logger being initialized during GliaSDK initialization. Because of that some changes can be seen in tests as well.

MOB-3481

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
