### PR TITLE
Change Chat Button label in EntryWidget

### DIFF
--- a/GliaWidgets/Localization.swift
+++ b/GliaWidgets/Localization.swift
@@ -476,7 +476,7 @@ internal enum Localization {
         /// For the texter in all of us
         internal static var description: String { Localization.tr("Localizable", "entry_widget.live_chat.button.description", fallback: "For the texter in all of us") }
         /// Live Chat
-        internal static var label: String { Localization.tr("Localizable", "entry_widget.live_chat.button.label", fallback: "Live Chat") }
+        internal static var label: String { Localization.tr("Localizable", "entry_widget.live_chat.button.label", fallback: "Chat") }
         internal enum Accessibility {
           /// Starts a chat
           internal static var hint: String { Localization.tr("Localizable", "entry_widget.live_chat.button.accessibility.hint", fallback: "Starts a chat") }

--- a/GliaWidgets/Resources/en.lproj/Localizable.strings
+++ b/GliaWidgets/Resources/en.lproj/Localizable.strings
@@ -250,7 +250,7 @@
 "secure_messaging.chat.leave_current_conversation.button.positive" = "Stay";
 "secure_messaging.chat.leave_current_conversation.button.negative" = "Leave";
 
-"entry_widget.live_chat.button.label" = "Live Chat";
+"entry_widget.live_chat.button.label" = "Chat";
 "entry_widget.live_chat.button.description" = "For the texter in all of us";
 "entry_widget.live_chat.button.accessibility.hint" = "Starts a chat";
 "entry_widget.audio.button.label" = "Audio";


### PR DESCRIPTION
**What was solved?**
According to design, chat button label needs to be just "Chat"
**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
