### PR TITLE
Fix remote configuration not being applied to Entry Widget

### DIFF
--- a/GliaWidgets/Sources/Theme/Theme.RemoteConfig.swift
+++ b/GliaWidgets/Sources/Theme/Theme.RemoteConfig.swift
@@ -53,5 +53,9 @@ extension Theme {
             configuration: configuration.webBrowserScreen,
             assetsBuilder: assetsBuilder
         )
+        entryWidget.apply(
+            configuration: configuration.entryWidget,
+            assetsBuilder: assetsBuilder
+        )
     }
 }


### PR DESCRIPTION
**What was solved?**
Remote configuration was not applied properly. This PR fixes it.

MOB-3805

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
