### PR TITLE
SecureConversation business logic

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -430,6 +430,7 @@
 		847956402ADED7A2004EF60C /* CallVisualizer.Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8479563F2ADED7A2004EF60C /* CallVisualizer.Action.swift */; };
 		847A7643285A1914004044D1 /* FileUploadListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847A7642285A1914004044D1 /* FileUploadListViewModelTests.swift */; };
 		847D7FAE2CDE0F3A00EA5C2D /* AlertTypeComposerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847D7FAD2CDE0F3A00EA5C2D /* AlertTypeComposerTests.swift */; };
+		847D7FB42CE648AE00EA5C2D /* SecureConversations.TranscriptModel.LeaveConversation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847D7FB32CE648AE00EA5C2D /* SecureConversations.TranscriptModel.LeaveConversation.swift */; };
 		8485704F2BEE3A0800CEBCC5 /* ChatViewTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8485704E2BEE3A0800CEBCC5 /* ChatViewTest.swift */; };
 		848570512BEE3CCC00CEBCC5 /* ChatStyle.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848570502BEE3CCC00CEBCC5 /* ChatStyle.Mock.swift */; };
 		848B8ADC2C0759C500E990E6 /* Theme.CustomCardContainerStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848B8ADB2C0759C500E990E6 /* Theme.CustomCardContainerStyle.swift */; };
@@ -1489,6 +1490,7 @@
 		8479563F2ADED7A2004EF60C /* CallVisualizer.Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallVisualizer.Action.swift; sourceTree = "<group>"; };
 		847A7642285A1914004044D1 /* FileUploadListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadListViewModelTests.swift; sourceTree = "<group>"; };
 		847D7FAD2CDE0F3A00EA5C2D /* AlertTypeComposerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertTypeComposerTests.swift; sourceTree = "<group>"; };
+		847D7FB32CE648AE00EA5C2D /* SecureConversations.TranscriptModel.LeaveConversation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.TranscriptModel.LeaveConversation.swift; sourceTree = "<group>"; };
 		8485704E2BEE3A0800CEBCC5 /* ChatViewTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewTest.swift; sourceTree = "<group>"; };
 		848570502BEE3CCC00CEBCC5 /* ChatStyle.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStyle.Mock.swift; sourceTree = "<group>"; };
 		848B8ADB2C0759C500E990E6 /* Theme.CustomCardContainerStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.CustomCardContainerStyle.swift; sourceTree = "<group>"; };
@@ -3453,6 +3455,7 @@
 				8491AF4D2A9CB3A400CC3E72 /* SecureConversations.TranscriptModel.GVA.swift */,
 				31DD41642A57105400F92612 /* SecureConversations.TranscriptModel.Environment.swift */,
 				8491AF512A9F813200CC3E72 /* SecureConversations.TranscriptModel.swift */,
+				847D7FB32CE648AE00EA5C2D /* SecureConversations.TranscriptModel.LeaveConversation.swift */,
 			);
 			path = ChatTranscript;
 			sourceTree = "<group>";
@@ -5830,6 +5833,7 @@
 				846429802A45A1F200943BD6 /* OfferPresenter.swift in Sources */,
 				C0D6CA4D2C19B86000D4709B /* OnHoldOverlayView.Environment.swift in Sources */,
 				1A4AF5D325AEF543002CD0F4 /* AlertViewController+Confirmation.swift in Sources */,
+				847D7FB42CE648AE00EA5C2D /* SecureConversations.TranscriptModel.LeaveConversation.swift in Sources */,
 				755D187B29A6A7180009F5E8 /* WelcomeStyle.TitleImageStyle.swift in Sources */,
 				8491AF232A8A3EA800CC3E72 /* ChatStyle.Deprecated.swift in Sources */,
 				C09046B72B7D0A8B003C437C /* WelcomeStyle.MessageWarningStyle.RemoteConfig.swift in Sources */,

--- a/GliaWidgets/Public/Glia/Glia+EngagementLauncher.swift
+++ b/GliaWidgets/Public/Glia/Glia+EngagementLauncher.swift
@@ -12,7 +12,7 @@ extension Glia {
         let parameters = try getEngagementParameters(in: queueIds)
         loggerPhase.logger.info("Returning an Engagement Launcher")
         return try EngagementLauncher { [weak self] engagementKind, sceneProvider in
-            try self?.resolveEngangementState(
+            try self?.resolveEngagementState(
                 engagementKind: engagementKind,
                 sceneProvider: sceneProvider,
                 configuration: parameters.configuration,

--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -28,6 +28,15 @@ extension EngagementKind {
             self = .chat
         }
     }
+
+    var isMessaging: Bool {
+        switch self {
+        case .messaging:
+            return true
+        case .none, .chat, .audioCall, .videoCall:
+            return false
+        }
+    }
 }
 
 extension SecureConversations {
@@ -72,7 +81,7 @@ public class Glia {
     public static let sharedInstance = Glia(environment: .live)
 
     /// Current engagement media type.
-    public var engagement: EngagementKind { return rootCoordinator?.engagementKind ?? .none }
+    public var engagement: EngagementKind { return rootCoordinator?.engagementLaunching.currentKind ?? .none }
 
     /// Used to monitor engagement state changes.
     public var onEvent: ((GliaEvent) -> Void)?

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.Environment.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.Environment.swift
@@ -31,6 +31,8 @@ extension SecureConversations.TranscriptModel {
         var createSendMessagePayload: CoreSdkClient.CreateSendMessagePayload
         var log: CoreSdkClient.Logger
         var maximumUploads: () -> Int
+        var shouldShowLeaveSecureConversationDialog: Bool
+        var leaveCurrentSecureConversation: Cmd
     }
 }
 
@@ -69,7 +71,9 @@ extension SecureConversations.TranscriptModel.Environment {
             stopSocketObservation: environment.stopSocketObservation,
             createSendMessagePayload: environment.createSendMessagePayload,
             log: environment.log,
-            maximumUploads: environment.maximumUploads
+            maximumUploads: environment.maximumUploads,
+            shouldShowLeaveSecureConversationDialog: environment.shouldShowLeaveSecureConversationDialog,
+            leaveCurrentSecureConversation: environment.leaveCurrentSecureConversation
        )
     }
 }

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.LeaveConversation.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.LeaveConversation.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension SecureConversations.TranscriptModel {
+    func showLeaveConversationDialogIfNeeded() {
+        if environment.shouldShowLeaveSecureConversationDialog {
+            engagementAction?(.showAlert(.leaveCurrentConversation { [weak self] in
+                self?.environment.leaveCurrentSecureConversation()
+            }))
+        }
+    }
+}

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
@@ -221,7 +221,9 @@ extension SecureConversations {
         func start() {
             environment.startSocketObservation()
             fetchSiteConfigurations()
-            loadHistory { _ in }
+            loadHistory { [weak self] _ in
+                self?.showLeaveConversationDialogIfNeeded()
+            }
         }
 
         deinit {

--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.Environment.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.Environment.swift
@@ -50,6 +50,8 @@ extension SecureConversations.Coordinator {
         var flipCameraButtonStyle: FlipCameraButtonStyle
         var alertManager: AlertManager
         var queuesMonitor: QueuesMonitor
+        var shouldShowLeaveSecureConversationDialog: Bool
+        var leaveCurrentSecureConversation: Cmd
     }
 }
 
@@ -63,7 +65,9 @@ extension SecureConversations.Coordinator.Environment {
         showCallBubble: Bool,
         screenShareHandler: ScreenShareHandler,
         isWindowVisible: ObservableValue<Bool>,
-        interactor: Interactor
+        interactor: Interactor,
+        shouldShowLeaveSecureConversationDialog: Bool,
+        leaveCurrentSecureConversation: Cmd
     ) -> Self {
         .init(
             queueIds: queueIds,
@@ -113,7 +117,9 @@ extension SecureConversations.Coordinator.Environment {
             cameraDeviceManager: environment.cameraDeviceManager,
             flipCameraButtonStyle: environment.flipCameraButtonStyle,
             alertManager: environment.alertManager,
-            queuesMonitor: environment.queuesMonitor
+            queuesMonitor: environment.queuesMonitor,
+            shouldShowLeaveSecureConversationDialog: shouldShowLeaveSecureConversationDialog,
+            leaveCurrentSecureConversation: leaveCurrentSecureConversation
         )
     }
 }

--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
@@ -253,3 +253,11 @@ extension SecureConversations.Coordinator {
         case mediaPickerController(MediaPickerController)
     }
 }
+
+#if DEBUG
+extension SecureConversations.Coordinator {
+    var coordinatorEnvironment: Environment {
+        environment
+    }
+}
+#endif

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
@@ -42,13 +42,17 @@ extension ChatCoordinator {
         var flipCameraButtonStyle: FlipCameraButtonStyle
         var alertManager: AlertManager
         var queuesMonitor: QueuesMonitor
+        var shouldShowLeaveSecureConversationDialog: Bool
+        var leaveCurrentSecureConversation: Cmd
     }
 }
 
 extension ChatCoordinator.Environment {
     static func create(
         with environment: EngagementCoordinator.Environment,
-        interactor: Interactor
+        interactor: Interactor,
+        shouldShowLeaveSecureConversationDialog: Bool,
+        leaveCurrentSecureConversation: Cmd
     ) -> Self {
         .init(
             fetchFile: environment.fetchFile,
@@ -90,7 +94,9 @@ extension ChatCoordinator.Environment {
             cameraDeviceManager: environment.cameraDeviceManager,
             flipCameraButtonStyle: environment.flipCameraButtonStyle,
             alertManager: environment.alertManager,
-            queuesMonitor: environment.queuesMonitor
+            queuesMonitor: environment.queuesMonitor,
+            shouldShowLeaveSecureConversationDialog: shouldShowLeaveSecureConversationDialog,
+            leaveCurrentSecureConversation: leaveCurrentSecureConversation
         )
     }
 
@@ -135,7 +141,9 @@ extension ChatCoordinator.Environment {
             cameraDeviceManager: environment.cameraDeviceManager,
             flipCameraButtonStyle: environment.flipCameraButtonStyle,
             alertManager: environment.alertManager,
-            queuesMonitor: environment.queuesMonitor
+            queuesMonitor: environment.queuesMonitor,
+            shouldShowLeaveSecureConversationDialog: environment.shouldShowLeaveSecureConversationDialog,
+            leaveCurrentSecureConversation: environment.leaveCurrentSecureConversation
         )
     }
 }

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
@@ -44,7 +44,8 @@ extension EngagementCoordinator.Environment {
         },
         flipCameraButtonStyle: .nop,
         alertManager: .mock(),
-        queuesMonitor: .mock()
+        queuesMonitor: .mock(),
+        pendingSecureConversationStatusUpdates: { $0(false) }
     )
 }
 #endif

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
@@ -44,6 +44,7 @@ extension EngagementCoordinator {
         var flipCameraButtonStyle: FlipCameraButtonStyle
         var alertManager: AlertManager
         var queuesMonitor: QueuesMonitor
+        var pendingSecureConversationStatusUpdates: CoreSdkClient.PendingSecureConversationStatusUpdates
     }
 }
 
@@ -98,7 +99,8 @@ extension EngagementCoordinator.Environment {
             cameraDeviceManager: environment.cameraDeviceManager,
             flipCameraButtonStyle: viewFactory.theme.call.flipCameraButtonStyle,
             alertManager: alertManager,
-            queuesMonitor: queuesMonitor
+            queuesMonitor: queuesMonitor,
+            pendingSecureConversationStatusUpdates: environment.coreSdk.pendingSecureConversationStatusUpdates
         )
     }
 }

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Mock.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Mock.swift
@@ -4,7 +4,7 @@ extension EngagementCoordinator {
         interactor: Interactor = .mock(),
         viewFactory: ViewFactory = .mock(),
         sceneProvider: SceneProvider? = nil,
-        engagementKind: EngagementKind = .audioCall,
+        engagementLaunching: EngagementCoordinator.EngagementLaunching = .direct(kind: .audioCall),
         screenShareHandler: ScreenShareHandler = .mock,
         features: Features = .all,
         environment: Environment = .mock
@@ -13,7 +13,7 @@ extension EngagementCoordinator {
             interactor: interactor,
             viewFactory: viewFactory,
             sceneProvider: sceneProvider,
-            engagementKind: engagementKind,
+            engagementLaunching: engagementLaunching,
             screenShareHandler: screenShareHandler,
             features: features,
             environment: environment

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -198,6 +198,10 @@ struct CoreSdkClient {
     ) -> String?
 
     var subscribeForUnreadSCMessageCount: SubscribeForUnreadSCMessageCount
+
+    typealias PendingSecureConversationStatusUpdates = (_ callback: @escaping (Bool) -> Void) -> Void
+
+    var pendingSecureConversationStatusUpdates: PendingSecureConversationStatusUpdates
 }
 
 extension CoreSdkClient {

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
@@ -63,7 +63,8 @@ extension CoreSdkClient {
             },
             subscribeForQueuesUpdates: GliaCore.sharedInstance.subscribeForQueuesUpdates(forQueues:completion:),
             unsubscribeFromUpdates: GliaCore.sharedInstance.unsubscribeFromUpdates(queueCallbackId:onError:),
-            subscribeForUnreadSCMessageCount: GliaCore.sharedInstance.secureConversations.subscribeToUnreadMessageCount(completion:)
+            subscribeForUnreadSCMessageCount: GliaCore.sharedInstance.secureConversations.subscribeToUnreadMessageCount(completion:),
+            pendingSecureConversationStatusUpdates: GliaCore.sharedInstance.secureConversations.pendingSecureConversationStatus
         )
     }()
 }

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -40,7 +40,8 @@ extension CoreSdkClient {
         getCameraDeviceManageable: { .mock },
         subscribeForQueuesUpdates: { _, _ in UUID.mock.uuidString },
         unsubscribeFromUpdates: { _, _ in },
-        subscribeForUnreadSCMessageCount: { _ in UUID.mock.uuidString }
+        subscribeForUnreadSCMessageCount: { _ in UUID.mock.uuidString },
+        pendingSecureConversationStatusUpdates: { $0(false) }
     )
 }
 

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Interface.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Interface.swift
@@ -16,7 +16,7 @@ extension Glia {
             _ interactor: Interactor,
             _ viewFactory: ViewFactory,
             _ sceneProvider: SceneProvider?,
-            _ engagementKind: EngagementKind,
+            _ engagementLaunching: EngagementCoordinator.EngagementLaunching,
             _ screenShareHandler: ScreenShareHandler,
             _ features: Features,
             _ environment: EngagementCoordinator.Environment
@@ -62,7 +62,7 @@ extension Glia.Environment {
         interactor: Interactor,
         viewFactory: ViewFactory,
         sceneProvider: SceneProvider?,
-        engagementKind: EngagementKind,
+        engagementLaunching: EngagementCoordinator.EngagementLaunching,
         screenShareHandler: ScreenShareHandler,
         features: Features,
         environment: EngagementCoordinator.Environment
@@ -71,7 +71,7 @@ extension Glia.Environment {
             interactor,
             viewFactory,
             sceneProvider,
-            engagementKind,
+            engagementLaunching,
             screenShareHandler,
             features,
             environment

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Live.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Live.swift
@@ -20,7 +20,7 @@ extension Glia.Environment {
         uiDevice: .live,
         notificationCenter: .live,
         createRootCoordinator: EngagementCoordinator.init(
-            interactor:viewFactory:sceneProvider:engagementKind:screenShareHandler:features:environment:
+            interactor:viewFactory:sceneProvider:engagementLaunching:screenShareHandler:features:environment:
         ),
         callVisualizerPresenter: .topViewController(application: .live),
         bundleManaging: .live,

--- a/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
+++ b/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
@@ -96,6 +96,9 @@ extension EngagementCoordinator.Environment {
         cameraDeviceManager: { .failing },
         flipCameraButtonStyle: .nop,
         alertManager: .failing(viewFactory: .mock()),
-        queuesMonitor: .failing
+        queuesMonitor: .failing, 
+        pendingSecureConversationStatusUpdates: { _ in
+            fail("\(Self.self).pendingSecureConversationStatusUpdates")
+        }
     )
 }

--- a/GliaWidgetsTests/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/CoreSDKClient.Failing.swift
@@ -78,6 +78,9 @@ extension CoreSdkClient {
         subscribeForUnreadSCMessageCount: { _ in
             fail("\(Self.self).subscribeForUnreadSCMessageCount")
             return ""
+        }, 
+        pendingSecureConversationStatusUpdates: { _ in
+            fail("\(Self.self).pendingSecureConversationStatusUpdates")
         }
     )
 }

--- a/GliaWidgetsTests/Glia.Environment.Failing.swift
+++ b/GliaWidgetsTests/Glia.Environment.Failing.swift
@@ -32,7 +32,7 @@ extension Glia.Environment {
                 interactor: .mock(environment: .failing),
                 viewFactory: .mock(environment: .failing),
                 sceneProvider: nil,
-                engagementKind: .none,
+                engagementLaunching: .direct(kind: .none),
                 screenShareHandler: .mock,
                 features: [],
                 environment: .failing

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModel.Environment.Failing.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModel.Environment.Failing.swift
@@ -76,6 +76,10 @@ extension SecureConversations.TranscriptModel.Environment {
         maximumUploads: {
             fail("\(Self.self).maximumUploads")
             return 2
+        },
+        shouldShowLeaveSecureConversationDialog: false,
+        leaveCurrentSecureConversation: .init {
+            fail("\(Self.self).leaveCurrentSecureConversation")
         }
     )
 }

--- a/GliaWidgetsTests/SecureConversations/Coordinator/SecureConversations.Coordinator.Environment.Mock.swift
+++ b/GliaWidgetsTests/SecureConversations/Coordinator/SecureConversations.Coordinator.Environment.Mock.swift
@@ -53,6 +53,8 @@ extension SecureConversations.Coordinator.Environment {
         cameraDeviceManager: { .mock }, 
         flipCameraButtonStyle: .nop,
         alertManager: .mock(),
-        queuesMonitor: .mock()
+        queuesMonitor: .mock(),
+        shouldShowLeaveSecureConversationDialog: false,
+        leaveCurrentSecureConversation: .nop
     )
 }

--- a/GliaWidgetsTests/Sources/Coordinators/Chat/ChatCoordinator.Environment.Mock.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/Chat/ChatCoordinator.Environment.Mock.swift
@@ -42,6 +42,8 @@ extension ChatCoordinator.Environment {
         cameraDeviceManager: { .mock }, 
         flipCameraButtonStyle: .nop,
         alertManager: .mock(),
-        queuesMonitor: .mock()
+        queuesMonitor: .mock(),
+        shouldShowLeaveSecureConversationDialog: false,
+        leaveCurrentSecureConversation: .nop
     )
 }

--- a/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator+SurveyTests.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator+SurveyTests.swift
@@ -29,7 +29,7 @@ class EngagementCoordinatorSurveyTests: XCTestCase {
             interactor: interactor,
             viewFactory: ViewFactory.mock(),
             sceneProvider: nil,
-            engagementKind: .audioCall,
+            engagementLaunching: .direct(kind: .audioCall),
             screenShareHandler: .mock,
             features: [],
             environment: engagementCoordinatorEnv

--- a/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinatorSecureConversationsTests.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinatorSecureConversationsTests.swift
@@ -69,4 +69,22 @@ extension EngagementCoordinatorTests {
             XCTAssertTrue(calledEvents.contains(.minimized))
         }
     }
+
+    // MARK: - Leave Conversation
+    func test_leaveCurrentConversationChangesEngagementKindToInitialOne() throws {
+        coordinator = createCoordinator(with: .indirect(
+            kind: .messaging(.chatTranscript),
+            initialKind: .videoCall
+        ))
+        coordinator.start()
+
+        let subCoordinator = try XCTUnwrap(coordinator.coordinators.first as? SecureConversations.Coordinator)
+
+        XCTAssertEqual(coordinator.engagementLaunching.currentKind, .messaging(.chatTranscript))
+        XCTAssertEqual(coordinator.engagementLaunching.initialKind, .videoCall)
+
+        subCoordinator.coordinatorEnvironment.leaveCurrentSecureConversation()
+
+        XCTAssertEqual(coordinator.engagementLaunching.currentKind, .videoCall)
+    }
 }

--- a/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinatorTests.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinatorTests.swift
@@ -25,11 +25,17 @@ final class EngagementCoordinatorTests: XCTestCase {
     func createCoordinator(
         withKind engagementKind: EngagementKind = .chat
     ) -> EngagementCoordinator {
+        return createCoordinator(with: .direct(kind: engagementKind))
+    }
+
+    func createCoordinator(
+        with engagementLaunching: EngagementCoordinator.EngagementLaunching
+    ) -> EngagementCoordinator {
         return EngagementCoordinator(
             interactor: .mock(),
             viewFactory: .mock(),
             sceneProvider: MockedSceneProvider(),
-            engagementKind: engagementKind,
+            engagementLaunching: engagementLaunching,
             screenShareHandler: .mock,
             features: [],
             environment: .mock
@@ -160,7 +166,7 @@ final class EngagementCoordinatorTests: XCTestCase {
 
         callAfterTimeout {
             XCTAssertEqual(self.coordinator.navigationPresenter.viewControllers.count, 0)
-            XCTAssertEqual(self.coordinator.engagementKind, .none)
+            XCTAssertEqual(self.coordinator.engagementLaunching.currentKind, .none)
             XCTAssertTrue(calledEvents.contains(.ended))
         }
     }

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+EngagementLauncher.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+EngagementLauncher.swift
@@ -81,8 +81,11 @@ private extension GliaTests {
         var sdkEnv = Glia.Environment.failing
         sdkEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
         sdkEnv.coreSdk.localeProvider = .mock
-        sdkEnv.createRootCoordinator = { _, _, _, engagementKind, _, _, _ in
-            .mock(engagementKind: engagementKind, environment: .engagementCoordEnvironmentWithKeyWindow)
+        sdkEnv.createRootCoordinator = { _, _, _, engagementLaunching, _, _, _ in
+                .mock(
+                    engagementLaunching: engagementLaunching,
+                    environment: .engagementCoordEnvironmentWithKeyWindow
+                )
         }
         sdkEnv.print.printClosure = { _, _, _ in }
         var logger = CoreSdkClient.Logger.failing
@@ -96,6 +99,7 @@ private extension GliaTests {
             completion(.success(()))
         }
         sdkEnv.coreSdk.getCurrentEngagement = { nil }
+        sdkEnv.coreSdk.pendingSecureConversationStatusUpdates = { _ in }
         let window = UIWindow(frame: .zero)
         window.makeKeyAndVisible()
         sdkEnv.uiApplication.windows = { [window] }

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+RestoreEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+RestoreEngagement.swift
@@ -6,7 +6,7 @@ extension GliaTests {
         var sdkEnv = Glia.Environment.failing
         sdkEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
         let rootCoordinator = EngagementCoordinator.mock(
-            engagementKind: .chat,
+            engagementLaunching: .direct(kind: .chat),
             screenShareHandler: .mock,
             environment: .engagementCoordEnvironmentWithKeyWindow
         )
@@ -22,6 +22,7 @@ extension GliaTests {
         sdkEnv.coreSdk.createLogger = { _ in logger }
         let siteMock = try CoreSdkClient.Site.mock()
         sdkEnv.coreSdk.fetchSiteConfigurations = { callback in callback(.success(siteMock)) }
+        sdkEnv.coreSdk.pendingSecureConversationStatusUpdates = { _ in } 
         sdkEnv.conditionalCompilation.isDebug = { true }
         sdkEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -518,6 +518,7 @@ final class GliaTests: XCTestCase {
         }
         environment.conditionalCompilation.isDebug = { true }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
+        environment.coreSdk.pendingSecureConversationStatusUpdates = { _ in }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
         var engCoordEnvironment = EngagementCoordinator.Environment.engagementCoordEnvironmentWithKeyWindow
         engCoordEnvironment.fileManager = .mock


### PR DESCRIPTION
MOB-3628

**What was solved?**
This commit introduces next logic:
- If pending secure conversation exists, ChatTranscript screen opens and Leave Current Conversation dialog presents. Then if user press Leave, then EngagementCoordinator changes its engagement kind and starts proper flow: Chat/Audio/Video 

This commit also adds unit tests.

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.