### PR TITLE
Unified UI for disabled chat message entry

### DIFF
--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.RemoteConfig.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.RemoteConfig.swift
@@ -54,6 +54,8 @@ extension SecureConversations.WelcomeStyle {
         )
         attachmentListStyle.apply(
             configuration: configuration?.attachmentList,
+            // no disabled style in the Welcome Screen configuration
+            disabledConfiguration: configuration?.attachmentList,
             assetsBuilder: assetsBuilder
         )
         pickMediaStyle.apply(

--- a/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration+Chat.swift
+++ b/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration+Chat.swift
@@ -8,6 +8,7 @@ extension RemoteConfiguration {
         let operatorMessage: MessageBalloon?
         let visitorMessage: MessageBalloon?
         let input: Input?
+        let inputDisabled: Input?
         let responseCard: ResponseCard?
         let audioUpgrade: Upgrade?
         let videoUpgrade: Upgrade?

--- a/GliaWidgets/Sources/View/Chat/ChatStyle.RemoteConfig.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatStyle.RemoteConfig.swift
@@ -23,8 +23,7 @@ extension ChatStyle {
         )
         messageEntry.apply(
             configuration: configuration?.input,
-            // TODO: Add Unified customization (MOB-3762)
-            disabledConfiguration: configuration?.input,
+            disabledConfiguration: configuration?.inputDisabled,
             assetsBuilder: assetsBuilder
         )
         choiceCardStyle.apply(

--- a/GliaWidgets/Sources/View/Chat/Entry/ChatMessageEntryStateStyle.RemoteConfig.swift
+++ b/GliaWidgets/Sources/View/Chat/Entry/ChatMessageEntryStateStyle.RemoteConfig.swift
@@ -3,6 +3,7 @@ import UIKit
 extension ChatMessageEntryStateStyle {
     mutating func apply(
         configuration: RemoteConfiguration.Input?,
+        disabledConfiguration: RemoteConfiguration.Input?,
         assetsBuilder: RemoteConfiguration.AssetsBuilder
     ) {
         configuration?.background?.color?.value
@@ -34,19 +35,26 @@ extension ChatMessageEntryStateStyle {
             .map { UIColor(hex: $0) }
             .first
             .unwrap { separatorColor = $0 }
-        // TODO: Add Unified customization (MOB-3762)
         configuration?.mediaButton?.tintColor?.value
             .map { UIColor(hex: $0) }
             .first
             .unwrap { mediaButton.enabled.color = $0 }
-        // TODO: Add Unified customization (MOB-3762)
+        disabledConfiguration?.mediaButton?.tintColor?.value
+            .map { UIColor(hex: $0) }
+            .first
+            .unwrap { mediaButton.disabled.color = $0 }
         configuration?.sendButton?.tintColor?.value
             .map { UIColor(hex: $0) }
             .first
             .unwrap { sendButton.enabled.color = $0 }
+        disabledConfiguration?.sendButton?.tintColor?.value
+            .map { UIColor(hex: $0) }
+            .first
+            .unwrap { sendButton.disabled.color = $0 }
 
         uploadList.apply(
             configuration: configuration?.fileUploadBar,
+            disabledConfiguration: disabledConfiguration?.fileUploadBar,
             assetsBuilder: assetsBuilder
         )
     }

--- a/GliaWidgets/Sources/View/Chat/Entry/ChatMessageEntryStyle.RemoteConfig.swift
+++ b/GliaWidgets/Sources/View/Chat/Entry/ChatMessageEntryStyle.RemoteConfig.swift
@@ -6,7 +6,15 @@ extension ChatMessageEntryStyle {
         disabledConfiguration: RemoteConfiguration.Input?,
         assetsBuilder: RemoteConfiguration.AssetsBuilder
     ) {
-        enabled.apply(configuration: configuration, assetsBuilder: assetsBuilder)
-        // TODO: Add Unified customization (MOB-3762)
+        enabled.apply(
+            configuration: configuration,
+            disabledConfiguration: disabledConfiguration,
+            assetsBuilder: assetsBuilder
+        )
+        disabled.apply(
+            configuration: configuration,
+            disabledConfiguration: disabledConfiguration,
+            assetsBuilder: assetsBuilder
+        )
     }
 }

--- a/GliaWidgets/Sources/View/Chat/Entry/Upload/FileUploadListStyle.RemoteConfig.swift
+++ b/GliaWidgets/Sources/View/Chat/Entry/Upload/FileUploadListStyle.RemoteConfig.swift
@@ -3,10 +3,12 @@ import Foundation
 extension FileUploadListStyle {
     func apply(
         configuration: RemoteConfiguration.FileUploadBar?,
+        disabledConfiguration: RemoteConfiguration.FileUploadBar?,
         assetsBuilder: RemoteConfiguration.AssetsBuilder
     ) {
         item.apply(
             configuration: configuration,
+            disabledConfiguration: disabledConfiguration,
             assetsBuilder: assetsBuilder
         )
     }

--- a/GliaWidgets/Sources/View/Chat/Entry/Upload/FileUploadStyle.RemoteConfig.swift
+++ b/GliaWidgets/Sources/View/Chat/Entry/Upload/FileUploadStyle.RemoteConfig.swift
@@ -2,8 +2,8 @@ import UIKit
 
 extension FileUploadStyle {
     mutating func apply(
-        // TODO: provide configuration for disabled state MOB-3762.
         configuration: RemoteConfiguration.FileUploadBar?,
+        disabledConfiguration: RemoteConfiguration.FileUploadBar?,
         assetsBuilder: RemoteConfiguration.AssetsBuilder
     ) {
         enabled.filePreview.apply(
@@ -20,6 +20,22 @@ extension FileUploadStyle {
         )
         enabled.error.apply(
             configuration: configuration?.error,
+            assetsBuilder: assetsBuilder
+        )
+        disabled.filePreview.apply(
+            configuration: disabledConfiguration?.filePreview,
+            assetsBuilder: assetsBuilder
+        )
+        disabled.uploading.apply(
+            configuration: disabledConfiguration?.uploading,
+            assetsBuilder: assetsBuilder
+        )
+        disabled.uploaded.apply(
+            configuration: disabledConfiguration?.uploaded,
+            assetsBuilder: assetsBuilder
+        )
+        disabled.error.apply(
+            configuration: disabledConfiguration?.error,
             assetsBuilder: assetsBuilder
         )
 

--- a/GliaWidgets/Sources/View/Chat/Entry/Upload/MessageCenterFileUploadListStyle.RemoteConfig.swift
+++ b/GliaWidgets/Sources/View/Chat/Entry/Upload/MessageCenterFileUploadListStyle.RemoteConfig.swift
@@ -3,10 +3,12 @@ import Foundation
 extension MessageCenterFileUploadListStyle {
     func apply(
         configuration: RemoteConfiguration.FileUploadBar?,
+        disabledConfiguration: RemoteConfiguration.FileUploadBar?,
         assetsBuilder: RemoteConfiguration.AssetsBuilder
     ) {
         item.apply(
             configuration: configuration,
+            disabledConfiguration: disabledConfiguration,
             assetsBuilder: assetsBuilder
         )
     }

--- a/GliaWidgets/Sources/View/Chat/Entry/Upload/MessageCenterFileUploadStyle.RemoteConfig.swift
+++ b/GliaWidgets/Sources/View/Chat/Entry/Upload/MessageCenterFileUploadStyle.RemoteConfig.swift
@@ -2,8 +2,8 @@ import UIKit
 
 extension MessageCenterFileUploadStyle {
     mutating func apply(
-        // TODO: provide configuration for disabled state MOB-3762.
         configuration: RemoteConfiguration.FileUploadBar?,
+        disabledConfiguration: RemoteConfiguration.FileUploadBar?,
         assetsBuilder: RemoteConfiguration.AssetsBuilder
     ) {
         enabled.filePreview.apply(
@@ -20,6 +20,22 @@ extension MessageCenterFileUploadStyle {
         )
         enabled.error.apply(
             configuration: configuration?.error,
+            assetsBuilder: assetsBuilder
+        )
+        disabled.filePreview.apply(
+            configuration: disabledConfiguration?.filePreview,
+            assetsBuilder: assetsBuilder
+        )
+        disabled.uploading.apply(
+            configuration: disabledConfiguration?.uploading,
+            assetsBuilder: assetsBuilder
+        )
+        disabled.uploaded.apply(
+            configuration: disabledConfiguration?.uploaded,
+            assetsBuilder: assetsBuilder
+        )
+        disabled.error.apply(
+            configuration: disabledConfiguration?.error,
             assetsBuilder: assetsBuilder
         )
 


### PR DESCRIPTION
**What was solved?**
Add disabled unified customization for disabled state for chat message entry.

MOB-3762

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
