### PR TITLE
Add pending secure messaging logic to EntryWidget

### DIFF
--- a/GliaWidgets/Public/Glia/Glia+EntryWidget.swift
+++ b/GliaWidgets/Public/Glia/Glia+EntryWidget.swift
@@ -18,7 +18,8 @@ extension Glia {
                 engagementLauncher: try getEngagementLauncher(queueIds: queueIds),
                 theme: theme,
                 log: loggerPhase.logger,
-                isAuthenticated: environment.isAuthenticated
+                isAuthenticated: environment.isAuthenticated,
+                pendingSecureConversationStatusUpdates: environment.coreSdk.pendingSecureConversationStatusUpdates
             )
         )
     }

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.Environment.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.Environment.swift
@@ -9,6 +9,7 @@ extension EntryWidget {
         var theme: Theme
         var log: CoreSdkClient.Logger
         var isAuthenticated: () -> Bool
+        var pendingSecureConversationStatusUpdates: CoreSdkClient.PendingSecureConversationStatusUpdates
     }
 }
 
@@ -23,7 +24,8 @@ extension EntryWidget.Environment {
             engagementLauncher: engagementLauncher,
             theme: .mock(),
             log: .mock,
-            isAuthenticated: { true }
+            isAuthenticated: { true },
+            pendingSecureConversationStatusUpdates: { _ in }
         )
     }
 }

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
@@ -61,11 +61,23 @@ public final class EntryWidget: NSObject {
 
 // MARK: - Public methods
 public extension EntryWidget {
-    /// Displays the widget as a modal sheet in the given view controller.
+    /// Displays the widget as a modal sheet in the given view controller. If there is an ongoing secure conversation, the Chat Transcript screen will be opened instead.
     ///
     /// - Parameter viewController: The `UIViewController` in which the widget will be shown as a sheet.
     func show(in viewController: UIViewController) {
-        showSheet(in: viewController)
+        var pendingSecureConversationExists = false
+        environment.pendingSecureConversationStatusUpdates { hasPendingSecureConversation in
+            pendingSecureConversationExists = hasPendingSecureConversation
+        }
+        if pendingSecureConversationExists {
+            do {
+                try environment.engagementLauncher.startSecureMessaging()
+            } catch {
+                viewState = .error
+            }
+        } else {
+            showSheet(in: viewController)
+        }
     }
 
     /// Embeds the widget as a view in the given parent view.


### PR DESCRIPTION
MOB-3653

**What was solved?**
This commit adds next logic into `EntryWidget.show(in:)` method implementation:
- if pending secure messaging exists ChatTranscript screen will be opened.
- otherwise EntryWidget Bottom Sheet will be shown. Commit also adds unit test.

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.