### PR TITLE
Add snapshot tests for bottom banner

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -625,6 +625,7 @@
 		AF3D520F2983BC5600AD8E69 /* FileUploader.Environment.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D520E2983BC5600AD8E69 /* FileUploader.Environment.Mock.swift */; };
 		AF4698082BE3EEF30046766B /* FlipCameraButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4698072BE3EEF30046766B /* FlipCameraButton.swift */; };
 		AF4D821C29D6E572007763F8 /* TranscriptModel.DividedChatItemsForUnreadCountTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4D821B29D6E572007763F8 /* TranscriptModel.DividedChatItemsForUnreadCountTests.swift */; };
+		AF4E4A872CEBAEC700F09807 /* SecureMessagingBottomBannerViewStyle.Accessiblity.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4E4A862CEBAEC700F09807 /* SecureMessagingBottomBannerViewStyle.Accessiblity.swift */; };
 		AF552ED72BECDCDF00FD5653 /* UIButton+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF552ED62BECDCDF00FD5653 /* UIButton+Extensions.swift */; };
 		AF552ED92BECDCF700FD5653 /* UIImage+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF552ED82BECDCF700FD5653 /* UIImage+Extensions.swift */; };
 		AF552EDB2BEE783500FD5653 /* FlipCameraButtonStyle.Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF552EDA2BEE783500FD5653 /* FlipCameraButtonStyle.Accessibility.swift */; };
@@ -1692,6 +1693,7 @@
 		AF3D520E2983BC5600AD8E69 /* FileUploader.Environment.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploader.Environment.Mock.swift; sourceTree = "<group>"; };
 		AF4698072BE3EEF30046766B /* FlipCameraButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlipCameraButton.swift; sourceTree = "<group>"; };
 		AF4D821B29D6E572007763F8 /* TranscriptModel.DividedChatItemsForUnreadCountTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptModel.DividedChatItemsForUnreadCountTests.swift; sourceTree = "<group>"; };
+		AF4E4A862CEBAEC700F09807 /* SecureMessagingBottomBannerViewStyle.Accessiblity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureMessagingBottomBannerViewStyle.Accessiblity.swift; sourceTree = "<group>"; };
 		AF552ED62BECDCDF00FD5653 /* UIButton+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIButton+Extensions.swift"; sourceTree = "<group>"; };
 		AF552ED82BECDCF700FD5653 /* UIImage+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Extensions.swift"; sourceTree = "<group>"; };
 		AF552EDA2BEE783500FD5653 /* FlipCameraButtonStyle.Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlipCameraButtonStyle.Accessibility.swift; sourceTree = "<group>"; };
@@ -2908,6 +2910,7 @@
 				AF10ED8E29BF849A00E85309 /* UnreadMessageDividerView.swift */,
 				1A8B61D025C97481000D780E /* Upgrade */,
 				AFE82C772CC2ACA1005E641F /* SecureMessagingBottomBannerView.swift */,
+				AF4E4A862CEBAEC700F09807 /* SecureMessagingBottomBannerViewStyle.Accessiblity.swift */,
 				AF3AFB832CC68AB30072E7A9 /* SecureMessagingBottomBannerViewStyle.swift */,
 				AFCA8A412CC7939F008B7DD3 /* SecureMessagingBottomBannerViewStyle.RemoteConfig.swift */,
 				AFCA8A432CCA8474008B7DD3 /* SendingMessageUnavailableBannerView.swift */,
@@ -6194,6 +6197,7 @@
 				C0175A252A66A431001FACDE /* GvaPersistentButtonOptionView.swift in Sources */,
 				AF10ED9129BF85C700E85309 /* UnreadMessageDividerStyle.swift in Sources */,
 				75AF8CF127DBB1F9009EEE2C /* SurveyViewController.View.swift in Sources */,
+				AF4E4A872CEBAEC700F09807 /* SecureMessagingBottomBannerViewStyle.Accessiblity.swift in Sources */,
 				C0D6CA512C19BB5600D4709B /* SurveyViewController.Environment.swift in Sources */,
 				9AA64E142811B91C00FA56FF /* FontScaling.swift in Sources */,
 				C0D2F04629925C5A00803B47 /* VideoCallView.ConnectStatusView.swift in Sources */,

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.Environment.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.Environment.swift
@@ -77,3 +77,75 @@ extension SecureConversations.TranscriptModel.Environment {
        )
     }
 }
+
+#if DEBUG
+extension SecureConversations.TranscriptModel.Environment {
+    static func mock(
+        fetchFile: @escaping CoreSdkClient.FetchFile = { _, _, _ in },
+        downloadSecureFile: @escaping CoreSdkClient.DownloadSecureFile = { _, _, _ in .mock },
+        fileManager: FoundationBased.FileManager = .mock,
+        data: FoundationBased.Data = .mock,
+        date: @escaping () -> Date = { .mock },
+        gcd: GCD = .mock,
+        uiScreen: UIKitBased.UIScreen = .mock,
+        createThumbnailGenerator: @escaping () -> QuickLookBased.ThumbnailGenerator = { .mock },
+        createFileDownload: @escaping FileDownloader.CreateFileDownload = { _, _, _ in .mock() },
+        loadChatMessagesFromHistory: @escaping () -> Bool = { false },
+        fetchChatHistory: @escaping CoreSdkClient.FetchChatHistory = { _ in },
+        uiApplication: UIKitBased.UIApplication = .mock,
+        sendSecureMessagePayload: @escaping CoreSdkClient.SendSecureMessagePayload = { _, _, _ in .mock },
+        queueIds: [String] = [],
+        listQueues: @escaping CoreSdkClient.ListQueues = { _ in },
+        createFileUploadListModel: @escaping SecureConversations.FileUploadListViewModel.Create = { _ in .mock() },
+        uuid: @escaping () -> UUID = { .mock },
+        secureUploadFile: @escaping CoreSdkClient.SecureConversationsUploadFile = { _, _, _ in .mock },
+        fileUploadListStyle: FileUploadListStyle = .mock,
+        fetchSiteConfigurations: @escaping CoreSdkClient.FetchSiteConfigurations = { _ in },
+        getSecureUnreadMessageCount: @escaping CoreSdkClient.GetSecureUnreadMessageCount = { _ in },
+        messagesWithUnreadCountLoaderScheduler: CoreSdkClient.ReactiveSwift.DateScheduler = CoreSdkClient.ReactiveSwift.TestScheduler(),
+        secureMarkMessagesAsRead: @escaping CoreSdkClient.SecureMarkMessagesAsRead = { _ in .mock },
+        interactor: Interactor = .mock(),
+        startSocketObservation: @escaping CoreSdkClient.StartSocketObservation = {},
+        stopSocketObservation: @escaping CoreSdkClient.StopSocketObservation = {},
+        createSendMessagePayload: @escaping CoreSdkClient.CreateSendMessagePayload = { _, _ in .mock() },
+        log: CoreSdkClient.Logger = .mock,
+        maximumUploads: @escaping () -> Int = { .zero },
+        shouldShowLeaveSecureConversationDialog: Bool = false,
+        leaveCurrentSecureConversation: Cmd = .nop
+    ) -> Self {
+        Self(
+            fetchFile: fetchFile,
+            downloadSecureFile: downloadSecureFile,
+            fileManager: fileManager,
+            data: data,
+            date: date,
+            gcd: gcd,
+            uiScreen: uiScreen,
+            createThumbnailGenerator: createThumbnailGenerator,
+            createFileDownload: createFileDownload,
+            loadChatMessagesFromHistory: loadChatMessagesFromHistory,
+            fetchChatHistory: fetchChatHistory,
+            uiApplication: uiApplication,
+            sendSecureMessagePayload: sendSecureMessagePayload,
+            queueIds: queueIds,
+            listQueues: listQueues,
+            createFileUploadListModel: createFileUploadListModel,
+            uuid: uuid,
+            secureUploadFile: secureUploadFile,
+            fileUploadListStyle: fileUploadListStyle,
+            fetchSiteConfigurations: fetchSiteConfigurations,
+            getSecureUnreadMessageCount: getSecureUnreadMessageCount,
+            messagesWithUnreadCountLoaderScheduler: messagesWithUnreadCountLoaderScheduler,
+            secureMarkMessagesAsRead: secureMarkMessagesAsRead,
+            interactor: interactor,
+            startSocketObservation: startSocketObservation,
+            stopSocketObservation: stopSocketObservation,
+            createSendMessagePayload: createSendMessagePayload,
+            log: log,
+            maximumUploads: maximumUploads,
+            shouldShowLeaveSecureConversationDialog: shouldShowLeaveSecureConversationDialog,
+            leaveCurrentSecureConversation: leaveCurrentSecureConversation
+        )
+    }
+}
+#endif

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
@@ -741,6 +741,24 @@ extension SecureConversations.TranscriptModel {
     func setIsSecureConversationsAvailable(_ available: Bool) {
         self.isSecureConversationsAvailable = available
     }
+
+    static func mock(
+        isCustomCardSupported: Bool = false,
+        environment: Environment = .mock(),
+        availability: SecureConversations.Availability,
+        deliveredStatusText: String,
+        failedToDeliverStatusText: String,
+        interactor: Interactor
+    ) -> SecureConversations.TranscriptModel {
+        .init(
+            isCustomCardSupported: isCustomCardSupported,
+            environment: environment,
+            availability: availability,
+            deliveredStatusText: deliveredStatusText,
+            failedToDeliverStatusText: failedToDeliverStatusText,
+            interactor: interactor
+        )
+    }
 }
 #endif
 // MARK: View Appeared

--- a/GliaWidgets/SecureConversations/SecureConversations.Availability.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Availability.swift
@@ -114,3 +114,29 @@ extension SecureConversations.Availability.Environment {
         )
     }
 }
+
+#if DEBUG
+extension SecureConversations.Availability {
+    static func mock(
+        environment: Environment = .mock()
+    ) -> SecureConversations.Availability {
+        .init(environment: environment)
+    }
+}
+
+extension SecureConversations.Availability.Environment {
+    static func mock(
+        listQueues: @escaping CoreSdkClient.ListQueues = { _ in },
+        isAuthenticated: @escaping () -> Bool = { false },
+        log: CoreSdkClient.Logger = .mock,
+        queuesMonitor: QueuesMonitor = .mock()
+    ) -> Self {
+        .init(
+            listQueues: listQueues,
+            isAuthenticated: isAuthenticated,
+            log: log,
+            queuesMonitor: queuesMonitor
+        )
+    }
+}
+#endif

--- a/GliaWidgets/Sources/Theme/Theme+Chat.swift
+++ b/GliaWidgets/Sources/Theme/Theme+Chat.swift
@@ -445,7 +445,8 @@ extension Theme {
             textStyle: .caption1,
             textColor: color.baseNormal,
             backgroundColor: .fill(color: color.baseNeutral),
-            dividerColor: color.baseShade
+            dividerColor: color.baseShade,
+            accessibility: .init(isFontScalingEnabled: true)
         )
 
         let sendingMessageUnavailableBannerViewStyle = SendingMessageUnavailableBannerViewStyle(

--- a/GliaWidgets/Sources/View/Chat/ChatView.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatView.swift
@@ -151,15 +151,15 @@ class ChatView: EngagementView {
 
         addSubview(secureMessagingBottomBannerView)
         constraints += [
-            secureMessagingBottomBannerView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            secureMessagingBottomBannerView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            secureMessagingBottomBannerView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
+            secureMessagingBottomBannerView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor),
             secureMessagingBottomBannerView.topAnchor.constraint(equalTo: quickReplyView.bottomAnchor)
         ]
 
         addSubview(sendingMessageUnavailabilityBannerView)
         constraints += [
-            sendingMessageUnavailabilityBannerView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            sendingMessageUnavailabilityBannerView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            sendingMessageUnavailabilityBannerView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
+            sendingMessageUnavailabilityBannerView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor),
             sendingMessageUnavailabilityBannerView.topAnchor.constraint(equalTo: secureMessagingBottomBannerView.bottomAnchor)
         ]
 

--- a/GliaWidgets/Sources/View/Chat/SecureMessagingBottomBannerView.swift
+++ b/GliaWidgets/Sources/View/Chat/SecureMessagingBottomBannerView.swift
@@ -85,6 +85,7 @@ final class SecureMessagingBottomBannerView: UIView {
         label.font = props.style.font
         isHidden = props.isHidden
         divider.backgroundColor = props.style.dividerColor
+        setFontScalingEnabled(props.style.accessibility.isFontScalingEnabled, for: label)
     }
 }
 

--- a/GliaWidgets/Sources/View/Chat/SecureMessagingBottomBannerViewStyle.Accessiblity.swift
+++ b/GliaWidgets/Sources/View/Chat/SecureMessagingBottomBannerViewStyle.Accessiblity.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+extension SecureMessagingBottomBannerViewStyle {
+    /// Accessibility properties for SecureMessagingBottomBannerViewStyle.
+    public struct Accessibility: Equatable {
+        /// Flag that provides font dynamic type by setting `adjustsFontForContentSizeCategory`
+        /// for component that supports it.
+        public var isFontScalingEnabled: Bool
+
+        /// - Parameters:
+        ///   - isFontScalingEnabled: Flag that provides font dynamic type by setting
+        ///    `adjustsFontForContentSizeCategory` for component that supports it.
+        ///
+        public init(isFontScalingEnabled: Bool) {
+            self.isFontScalingEnabled = isFontScalingEnabled
+        }
+    }
+}
+
+extension SecureMessagingBottomBannerViewStyle.Accessibility {
+    /// Accessibility is not supported intentionally.
+    public static let unsupported = Self(
+        isFontScalingEnabled: false
+    )
+}

--- a/GliaWidgets/Sources/View/Chat/SecureMessagingBottomBannerViewStyle.swift
+++ b/GliaWidgets/Sources/View/Chat/SecureMessagingBottomBannerViewStyle.swift
@@ -14,6 +14,8 @@ public struct SecureMessagingBottomBannerViewStyle: Equatable {
     public var backgroundColor: ColorType
     /// Color of the banner divider.
     public var dividerColor: UIColor
+    /// Accessibility properties for SecureMessagingBottomBannerViewStyle.
+    public var accessibility: Accessibility
 
     /// - Parameters:
     ///   - message: Text of the banner message.
@@ -22,13 +24,15 @@ public struct SecureMessagingBottomBannerViewStyle: Equatable {
     ///   - textColor: Color of the text of the  banner message.
     ///   - backgroundColor: Color of the banner background.
     ///   - dividerColor: Color of the banner divider.
+    ///   - accessibility: Accessibility properties for SecureMessagingBottomBannerViewStyle.
     public init(
         message: String,
         font: UIFont,
         textStyle: UIFont.TextStyle,
         textColor: UIColor,
         backgroundColor: ColorType,
-        dividerColor: UIColor
+        dividerColor: UIColor,
+        accessibility: Accessibility
     ) {
         self.message = message
         self.font = font
@@ -36,6 +40,7 @@ public struct SecureMessagingBottomBannerViewStyle: Equatable {
         self.backgroundColor = backgroundColor
         self.dividerColor = dividerColor
         self.textStyle = textStyle
+        self.accessibility = accessibility
     }
 }
 
@@ -46,6 +51,7 @@ extension SecureMessagingBottomBannerViewStyle {
         textStyle: .caption1,
         textColor: .label,
         backgroundColor: .fill(color: .red),
-        dividerColor: .yellow
+        dividerColor: .yellow,
+        accessibility: .init(isFontScalingEnabled: true)
     )
 }

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
@@ -638,6 +638,23 @@ extension ChatViewController {
         controller.view.updateConstraints()
         return controller
     }
+
+    static func mockSecureMessagingBottomBannerView() -> ChatViewController {
+        var chatViewModelEnv = ChatViewModel.Environment.mock
+        chatViewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
+        let chatViewModel = ChatViewModel.mock(environment: chatViewModelEnv)
+
+        let transcriptModel = SecureConversations.TranscriptModel.init(
+            isCustomCardSupported: false,
+            environment: .mock(),
+            availability: .mock(),
+            deliveredStatusText: "deliveredStatusText",
+            failedToDeliverStatusText: "failedToDeliverStatusText",
+            interactor: .mock()
+        )
+
+        return .init(viewModel: .transcript(transcriptModel), environment: .mock())
+    }
 }
 
 /// Defines wrapper structure for getting decoding container.

--- a/GliaWidgetsTests/Sources/ChatView/ChatStyle.Mock.swift
+++ b/GliaWidgetsTests/Sources/ChatView/ChatStyle.Mock.swift
@@ -570,7 +570,8 @@ extension SecureMessagingBottomBannerViewStyle {
         textStyle: UIFont.TextStyle = Theme().chat.secureMessagingBottomBannerStyle.textStyle,
         textColor: UIColor = Theme().chat.secureMessagingBottomBannerStyle.textColor,
         backgroundColor: ColorType = Theme().chat.secureMessagingBottomBannerStyle.backgroundColor,
-        dividerColor: UIColor = Theme().chat.secureMessagingBottomBannerStyle.dividerColor
+        dividerColor: UIColor = Theme().chat.secureMessagingBottomBannerStyle.dividerColor,
+        accessibility: SecureMessagingBottomBannerViewStyle.Accessibility = Theme().chat.secureMessagingBottomBannerStyle.accessibility
     ) -> Self {
         .init(
             message: message,
@@ -578,7 +579,8 @@ extension SecureMessagingBottomBannerViewStyle {
             textStyle: textStyle,
             textColor: textColor,
             backgroundColor: backgroundColor,
-            dividerColor: dividerColor
+            dividerColor: dividerColor, 
+            accessibility: accessibility
         )
     }
 }

--- a/SnapshotTests/ChatViewControllerDynamicTypeFontTests.swift
+++ b/SnapshotTests/ChatViewControllerDynamicTypeFontTests.swift
@@ -37,4 +37,11 @@ final class ChatViewControllerDynamicTypeFontTests: SnapshotTestCase {
         viewController.assertSnapshot(as: .extra3LargeFont, in: .portrait)
         viewController.assertSnapshot(as: .extra3LargeFont, in: .landscape)
     }
+
+    func test_secureMessagingBottomBanner_extra3Large() {
+        let viewController = ChatViewController.mockSecureMessagingBottomBannerView()
+        viewController.updateViewConstraints()
+        viewController.assertSnapshot(as: .extra3LargeFont, in: .portrait)
+        viewController.assertSnapshot(as: .extra3LargeFont, in: .landscape)
+    }
 }

--- a/SnapshotTests/ChatViewControllerLayoutTests.swift
+++ b/SnapshotTests/ChatViewControllerLayoutTests.swift
@@ -78,4 +78,11 @@ final class ChatViewControllerLayoutTests: SnapshotTestCase {
         viewController.assertSnapshot(as: .image, in: .portrait)
         viewController.assertSnapshot(as: .image, in: .landscape)
     }
+
+    func test_secureMessagingBottomBanner() {
+        let viewController = ChatViewController.mockSecureMessagingBottomBannerView()
+        viewController.updateViewConstraints()
+        viewController.assertSnapshot(as: .image, in: .portrait)
+        viewController.assertSnapshot(as: .image, in: .landscape)
+    }
 }

--- a/SnapshotTests/ChatViewControllerVoiceOverTests.swift
+++ b/SnapshotTests/ChatViewControllerVoiceOverTests.swift
@@ -65,4 +65,10 @@ final class ChatViewControllerVoiceOverTests: SnapshotTestCase {
         view.collectionView.heightAnchor.constraint(equalToConstant: 200).isActive = true
         view.assertSnapshot(as: .accessibilityImage)
     }
+
+    func test_secureMessagingBottomBanner() {
+        let viewController = ChatViewController.mockSecureMessagingBottomBannerView()
+        viewController.updateViewConstraints()
+        viewController.assertSnapshot(as: .accessibilityImage)
+    }
 }


### PR DESCRIPTION
MOB-3718

**What was solved?**
Add bottom banner snapshot tests and update bottom banner and send message unavailable banner to take safe are guide into account.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
