### PR TITLE
Change subheadline color In EntryWidget

### DIFF
--- a/GliaWidgets/Sources/EntryWidget/EntryWidgetView.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidgetView.swift
@@ -31,7 +31,7 @@ private extension EntryWidgetView {
                     .setColor(model.style.errorTitleColor)
                 Text(model.style.errorMessage)
                     .setFont(model.style.errorMessageFont)
-                    .setColor(model.style.errorTitleColor)
+                    .setColor(model.style.errorMessageColor)
                 errorButton()
             }
             .maxHeight()
@@ -100,7 +100,7 @@ private extension EntryWidgetView {
                     .setColor(model.style.errorTitleColor)
                 Text(model.style.offlineMessage)
                     .setFont(model.style.errorMessageFont)
-                    .setColor(model.style.errorTitleColor)
+                    .setColor(model.style.errorMessageColor)
             }
             .maxHeight()
             if model.showPoweredBy {


### PR DESCRIPTION
**What was solved?**
According to the design, subheadline needs to be gray

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
