### PR TITLE
Entry Widget Accessibility identifiers

### DIFF
--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.MediaTypeItem.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.MediaTypeItem.swift
@@ -68,11 +68,20 @@ extension EntryWidget {
         }
     }
 
-    enum EngagementType: Int {
+    enum EngagementType: Int, CustomStringConvertible {
         case video
         case audio
         case chat
         case secureMessaging
+
+        var description: String {
+            switch self {
+            case .video: return "video"
+            case .audio: return "audio"
+            case .chat: return "chat"
+            case .secureMessaging: return "secureMessaging"
+            }
+        }
     }
 }
 

--- a/GliaWidgets/Sources/EntryWidget/EntryWidgetView.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidgetView.swift
@@ -29,6 +29,7 @@ private extension EntryWidgetView {
                 Text(model.style.errorTitle)
                     .setFont(model.style.errorTitleFont)
                     .setColor(model.style.errorTitleColor)
+                    .accessibilityIdentifier("entryWidget_error_title")
                 Text(model.style.errorMessage)
                     .setFont(model.style.errorMessageFont)
                     .setColor(model.style.errorTitleColor)
@@ -70,6 +71,7 @@ private extension EntryWidgetView {
         .maxSize()
         .padding(.horizontal)
         .applyColorTypeBackground(model.style.backgroundColor)
+        .accessibilityIdentifier("entryWidget_loading")
     }
 
     @ViewBuilder
@@ -98,6 +100,7 @@ private extension EntryWidgetView {
                 Text(model.style.offlineTitle)
                     .setFont(model.style.errorTitleFont)
                     .setColor(model.style.errorTitleColor)
+                    .accessibilityIdentifier("entryWidget_offline_title")
                 Text(model.style.offlineMessage)
                     .setFont(model.style.errorMessageFont)
                     .setColor(model.style.errorTitleColor)
@@ -172,6 +175,7 @@ private extension EntryWidgetView {
         .accessibilityElement(children: .combine)
         .accessibility(addTraits: .isButton)
         .accessibilityHint(model.style.mediaTypeItem.accessibility.hint(for: mediaType))
+        .accessibilityIdentifier("entryWidget_\(mediaType.type)_item")
         .onTapGesture {
             model.selectMediaType(mediaType)
         }
@@ -258,6 +262,7 @@ private extension EntryWidgetView {
             .contentShape(.rect)
             .onTapGesture(perform: model.onTryAgainTapped)
             .accessibility(addTraits: .isButton)
+            .accessibilityIdentifier("entryWidget_error_button")
     }
 
     @ViewBuilder

--- a/TestingApp/Main.storyboard
+++ b/TestingApp/Main.storyboard
@@ -177,6 +177,7 @@
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3hO-Oq-9Lh" userLabel="Contact Us">
                                                         <rect key="frame" x="0.0" y="0.0" width="107" height="34.5"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="main_entryWidget_sheet_button"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="Sheet"/>
                                                         <connections>
@@ -185,6 +186,7 @@
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HPY-ni-LES">
                                                         <rect key="frame" x="107" y="0.0" width="107" height="34.5"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="main_entryWidget_embbeded_button"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="Embbeded"/>
                                                         <connections>


### PR DESCRIPTION
MOB-3487

**What was solved?**
Add accessibility identifiers to Entry Widget items.
This makes it possible to search for items for acceptance tests.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
