### PR TITLE
Extend SCv2 logic with unreadMessageCount

### DIFF
--- a/GliaWidgets/Public/Glia/Glia+EngagementSetup.swift
+++ b/GliaWidgets/Public/Glia/Glia+EngagementSetup.swift
@@ -140,14 +140,9 @@ extension Glia {
         features: Features,
         maximize: Bool = true
     ) {
-        var pendingConversationExists = false
-        environment.coreSdk.pendingSecureConversationStatusUpdates { hasPendingConversation in
-            pendingConversationExists = hasPendingConversation
-        }
-
         let engagementLaunching: EngagementCoordinator.EngagementLaunching
 
-        switch (pendingConversationExists, engagementKind) {
+        switch (hasPendingInteraction, engagementKind) {
         case (false, _):
             // if there is no pending Secure Conversation, open regular flow.
             engagementLaunching = .direct(kind: engagementKind)

--- a/GliaWidgets/Public/Glia/Glia+EntryWidget.swift
+++ b/GliaWidgets/Public/Glia/Glia+EntryWidget.swift
@@ -19,7 +19,9 @@ extension Glia {
                 theme: theme,
                 log: loggerPhase.logger,
                 isAuthenticated: environment.isAuthenticated,
-                pendingSecureConversationStatusUpdates: environment.coreSdk.pendingSecureConversationStatusUpdates
+                hasPendingInteraction: { [weak self] in
+                    self?.hasPendingInteraction ?? false
+                }
             )
         )
     }

--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -129,6 +129,26 @@ public class Glia {
 
     private(set) var configuration: Configuration?
 
+    // Indicates whether at least one of two conditions is correct:
+    // - pending secure conversation exists;
+    // - unread message count > 0.
+    //
+    // Currently it's used to know if we have to force a visitor to SecureMessaging screen,
+    // once they try to start an engagement with media type other than `messaging`.
+    var hasPendingInteraction: Bool {
+        var pendingConversationExists = false
+        environment.coreSdk.pendingSecureConversationStatusUpdates { hasPendingConversation in
+            pendingConversationExists = hasPendingConversation
+        }
+
+        var unreadMessageCount = 0
+        environment.coreSdk.getSecureUnreadMessageCount {
+            unreadMessageCount = (try? $0.get()) ?? 0
+        }
+
+        return unreadMessageCount > 0 || pendingConversationExists
+    }
+
     init(environment: Environment) {
         self.environment = environment
         self.theme = Theme()

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.Environment.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.Environment.swift
@@ -9,7 +9,7 @@ extension EntryWidget {
         var theme: Theme
         var log: CoreSdkClient.Logger
         var isAuthenticated: () -> Bool
-        var pendingSecureConversationStatusUpdates: CoreSdkClient.PendingSecureConversationStatusUpdates
+        var hasPendingInteraction: () -> Bool
     }
 }
 
@@ -25,7 +25,7 @@ extension EntryWidget.Environment {
             theme: .mock(),
             log: .mock,
             isAuthenticated: { true },
-            pendingSecureConversationStatusUpdates: { _ in }
+            hasPendingInteraction: { false }
         )
     }
 }

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
@@ -65,11 +65,7 @@ public extension EntryWidget {
     ///
     /// - Parameter viewController: The `UIViewController` in which the widget will be shown as a sheet.
     func show(in viewController: UIViewController) {
-        var pendingSecureConversationExists = false
-        environment.pendingSecureConversationStatusUpdates { hasPendingSecureConversation in
-            pendingSecureConversationExists = hasPendingSecureConversation
-        }
-        if pendingSecureConversationExists {
+        if environment.hasPendingInteraction() {
             do {
                 try environment.engagementLauncher.startSecureMessaging()
             } catch {

--- a/GliaWidgetsTests/Sources/EntryWidget/EntryWidgetTests.swift
+++ b/GliaWidgetsTests/Sources/EntryWidget/EntryWidgetTests.swift
@@ -124,14 +124,14 @@ class EntryWidgetTests: XCTestCase {
         XCTAssertEqual(entryWidget.unreadSecureMessageSubscriptionId, mockSubscriptionId)
     }
 
-    func test_secureMessagingIsOpenedIfPendingSecureConversationExists() {
+    func test_secureMessagingIsOpenedIfPendingInteractionExists() {
         var envCalls: [Call] = []
 
         let engagementLauncher = EngagementLauncher { engagementKind, _ in
             envCalls.append(.start(engagementKind))
         }
         var environment = EntryWidget.Environment.mock()
-        environment.pendingSecureConversationStatusUpdates = { $0(true) }
+        environment.hasPendingInteraction = { true }
         environment.engagementLauncher = engagementLauncher
 
         let entryWidget = EntryWidget(

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+EngagementLauncher.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+EngagementLauncher.swift
@@ -99,6 +99,7 @@ private extension GliaTests {
             completion(.success(()))
         }
         sdkEnv.coreSdk.getCurrentEngagement = { nil }
+        sdkEnv.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
         sdkEnv.coreSdk.pendingSecureConversationStatusUpdates = { _ in }
         let window = UIWindow(frame: .zero)
         window.makeKeyAndVisible()

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+RestoreEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+RestoreEngagement.swift
@@ -22,7 +22,8 @@ extension GliaTests {
         sdkEnv.coreSdk.createLogger = { _ in logger }
         let siteMock = try CoreSdkClient.Site.mock()
         sdkEnv.coreSdk.fetchSiteConfigurations = { callback in callback(.success(siteMock)) }
-        sdkEnv.coreSdk.pendingSecureConversationStatusUpdates = { _ in } 
+        sdkEnv.coreSdk.pendingSecureConversationStatusUpdates = { _ in }
+        sdkEnv.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
         sdkEnv.conditionalCompilation.isDebug = { true }
         sdkEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
@@ -24,6 +24,7 @@ extension GliaTests {
         logger.infoClosure = { _, _, _, _ in }
         sdkEnv.coreSdk.createLogger = { _ in logger }
         sdkEnv.coreSdk.pendingSecureConversationStatusUpdates = { _ in }
+        sdkEnv.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
         sdkEnv.conditionalCompilation.isDebug = { true }
         sdkEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
@@ -94,6 +95,7 @@ extension GliaTests {
         }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
         environment.coreSdk.getCurrentEngagement = { nil }
+        environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
         try sdk.configure(
@@ -140,6 +142,7 @@ extension GliaTests {
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.pendingSecureConversationStatusUpdates = { _ in }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
+        environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
 
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
@@ -189,6 +192,7 @@ extension GliaTests {
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.pendingSecureConversationStatusUpdates = { _ in }
         environment.coreSdk.getCurrentEngagement = { nil }
+        environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
 
         var logger = CoreSdkClient.Logger.failing
         logger.configureLocalLogLevelClosure = { _ in }
@@ -253,6 +257,7 @@ extension GliaTests {
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
         environment.coreSdk.pendingSecureConversationStatusUpdates = { _ in }
+        environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
 
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
@@ -305,6 +310,7 @@ extension GliaTests {
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
         environment.coreSdk.pendingSecureConversationStatusUpdates = { _ in }
+        environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
 
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
@@ -359,6 +365,7 @@ extension GliaTests {
         }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.getCurrentEngagement = { nil }
+        environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
 
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
@@ -417,6 +424,7 @@ extension GliaTests {
             completion(.success(()))
         }
         environment.coreSdk.getCurrentEngagement = { nil }
+        environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
 
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
@@ -459,6 +467,7 @@ extension GliaTests {
             completion(.success(()))
         }
         environment.coreSdk.getCurrentEngagement = { nil }
+        environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
 
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
@@ -499,6 +508,7 @@ extension GliaTests {
             completion(.success(()))
         }
         environment.coreSdk.getCurrentEngagement = { nil }
+        environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
 
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
@@ -538,6 +548,7 @@ extension GliaTests {
             completion(.success(()))
         }
         environment.coreSdk.getCurrentEngagement = { nil }
+        environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
 
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()


### PR DESCRIPTION
MOB-3821

**What was solved?**
This PR introduces:
- internal `hasPendingInteraction` computed property that indicates either pending secure conversation exists or unread message count > 0;
- this property replaced `pendingConversationExists` value in EntryWidget and EngagementCoordinator
- unit tests

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
