### PR TITLE
Bump up Core SDK version to 2.0.2 and update SC interface

### DIFF
--- a/GliaWidgets.podspec
+++ b/GliaWidgets.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   }
   s.exclude_files         = ['GliaWidgets/Window/**']
 
-  s.dependency 'GliaCoreSDK', '2.0.1'
+  s.dependency 'GliaCoreSDK', '2.0.2'
 end

--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -137,8 +137,8 @@ public class Glia {
     // once they try to start an engagement with media type other than `messaging`.
     var hasPendingInteraction: Bool {
         var pendingConversationExists = false
-        environment.coreSdk.pendingSecureConversationStatusUpdates { hasPendingConversation in
-            pendingConversationExists = hasPendingConversation
+        environment.coreSdk.pendingSecureConversationStatusUpdates { hasPendingConversationResult in
+            pendingConversationExists = (try? hasPendingConversationResult.get()) ?? false
         }
 
         var unreadMessageCount = 0

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
@@ -45,7 +45,7 @@ extension EngagementCoordinator.Environment {
         flipCameraButtonStyle: .nop,
         alertManager: .mock(),
         queuesMonitor: .mock(),
-        pendingSecureConversationStatusUpdates: { $0(false) }
+        pendingSecureConversationStatusUpdates: { $0(.success(false)) }
     )
 }
 #endif

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -199,7 +199,7 @@ struct CoreSdkClient {
 
     var subscribeForUnreadSCMessageCount: SubscribeForUnreadSCMessageCount
 
-    typealias PendingSecureConversationStatusUpdates = (_ callback: @escaping (Bool) -> Void) -> Void
+    typealias PendingSecureConversationStatusUpdates = (_ callback: @escaping (Result<Bool, Error>) -> Void) -> Void
 
     var pendingSecureConversationStatusUpdates: PendingSecureConversationStatusUpdates
 }

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -41,7 +41,7 @@ extension CoreSdkClient {
         subscribeForQueuesUpdates: { _, _ in UUID.mock.uuidString },
         unsubscribeFromUpdates: { _, _ in },
         subscribeForUnreadSCMessageCount: { _ in UUID.mock.uuidString },
-        pendingSecureConversationStatusUpdates: { $0(false) }
+        pendingSecureConversationStatusUpdates: { $0(.success(false)) }
     )
 }
 

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
@@ -461,7 +461,7 @@ extension GliaTests {
         }
 
         environment.coreSdk.localeProvider.getRemoteString = { _ in "" }
-        environment.coreSdk.pendingSecureConversationStatusUpdates = { $0(true) }
+        environment.coreSdk.pendingSecureConversationStatusUpdates = { $0(.success(true)) }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
@@ -477,7 +477,7 @@ extension GliaTests {
         ) { _ in }
         let engagementLauncher = try sdk.getEngagementLauncher(queueIds: ["queueId"])
         try engagementLauncher.startChat()
-        
+
         XCTAssertEqual(engagementLaunching.currentKind, .messaging(.chatTranscript))
         XCTAssertEqual(engagementLaunching.initialKind, engagementKind)
     }
@@ -502,7 +502,7 @@ extension GliaTests {
         }
 
         environment.coreSdk.localeProvider.getRemoteString = { _ in "" }
-        environment.coreSdk.pendingSecureConversationStatusUpdates = { $0(false) }
+        environment.coreSdk.pendingSecureConversationStatusUpdates = { $0(.success(false)) }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
@@ -542,7 +542,7 @@ extension GliaTests {
         }
 
         environment.coreSdk.localeProvider.getRemoteString = { _ in "" }
-        environment.coreSdk.pendingSecureConversationStatusUpdates = { $0(true) }
+        environment.coreSdk.pendingSecureConversationStatusUpdates = { $0(.success(true)) }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -17,7 +17,6 @@ final class GliaTests: XCTestCase {
 
         let sdk = Glia(environment: environment)
         sdk.endEngagement { result in
-
             guard case .failure(let error) = result, let gliaError = error as? GliaError else {
                 XCTFail("GliaError.sdkIsNotConfigured expected.")
                 return
@@ -670,7 +669,7 @@ final class GliaTests: XCTestCase {
         logger.configureLocalLogLevelClosure = { _ in }
         logger.configureRemoteLogLevelClosure = { _ in }
         gliaEnv.coreSdk.createLogger = { _ in logger }
-        gliaEnv.coreSdk.pendingSecureConversationStatusUpdates = { $0(true) }
+        gliaEnv.coreSdk.pendingSecureConversationStatusUpdates = { $0(.success(true)) }
         gliaEnv.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
         gliaEnv.conditionalCompilation.isDebug = { true }
 
@@ -685,7 +684,7 @@ final class GliaTests: XCTestCase {
         logger.configureLocalLogLevelClosure = { _ in }
         logger.configureRemoteLogLevelClosure = { _ in }
         gliaEnv.coreSdk.createLogger = { _ in logger }
-        gliaEnv.coreSdk.pendingSecureConversationStatusUpdates = { $0(false) }
+        gliaEnv.coreSdk.pendingSecureConversationStatusUpdates = { $0(.success(false)) }
         gliaEnv.coreSdk.getSecureUnreadMessageCount = { $0(.success(3)) }
         gliaEnv.conditionalCompilation.isDebug = { true }
 
@@ -700,7 +699,7 @@ final class GliaTests: XCTestCase {
         logger.configureLocalLogLevelClosure = { _ in }
         logger.configureRemoteLogLevelClosure = { _ in }
         gliaEnv.coreSdk.createLogger = { _ in logger }
-        gliaEnv.coreSdk.pendingSecureConversationStatusUpdates = { $0(false) }
+        gliaEnv.coreSdk.pendingSecureConversationStatusUpdates = { $0(.success(false)) }
         gliaEnv.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
         gliaEnv.conditionalCompilation.isDebug = { true }
 

--- a/Package.swift
+++ b/Package.swift
@@ -35,8 +35,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "GliaCoreSDK",
-            url: "https://github.com/salemove/ios-bundle/releases/download/2.0.1/GliaCoreSDK.xcframework.zip",
-            checksum: "ab23649ad18a87e73d8ac2f603a9c98e4ac690fd693a6b7b9e4de5b5c3bc40bf"
+            url: "https://github.com/salemove/ios-bundle/releases/download/2.0.2/GliaCoreSDK.xcframework.zip",
+            checksum: "8a62b4c886b9f03abcd9effe8064237719a32199701497622437c7257b01a240"
         ),
         .binaryTarget(
             name: "GliaWidgetsSDKXcf",

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
     - AccessibilitySnapshot/Core
     - SnapshotTesting (~> 1.0)
   - GliaCoreDependency (2.3.0)
-  - GliaCoreSDK (2.0.1):
+  - GliaCoreSDK (2.0.2):
     - GliaCoreDependency (= 2.3.0)
     - TwilioVoice (= 6.8.0)
     - WebRTC-lib (= 119.0.0)
@@ -34,7 +34,7 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   AccessibilitySnapshot: a91e4a69f870188b51f43863d9fc7269d07cdd93
   GliaCoreDependency: 37f48a5a32e2646617b87cbe9d4b30eedd123f6f
-  GliaCoreSDK: cf69732a576a404863a926a86c1ba71993331193
+  GliaCoreSDK: 5a63103523b3eaa1db9c81f644222a70be06a2d4
   SnapshotTesting: 6141c48b6aa76ead61431ca665c14ab9a066c53b
   SwiftLint: eb47480d47c982481592c195c221d11013a679cc
   TwilioVoice: 9563c9ad71b9ab7bbad0b59b67cfe4be96c75d23


### PR DESCRIPTION
Bump up Core SDK version to 2.0.2 and update 'hasPendingSecureConversationStatus' signature to account for callback with 'Result' instead of 'Bool'.

MOB-3842

**What was solved?**

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
