### PR TITLE
Fix memory leak in Chat module

### DIFF
--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
@@ -563,7 +563,7 @@ extension SecureConversations.TranscriptModel {
                 }
 
                 if let item = items.last, case .gvaQuickReply(_, let button, _, _) = item.kind {
-                    let props = button.options.map { self.quickReplyOption($0) }
+                    let props = button.options.compactMap { [weak self] in self?.quickReplyOption($0) }
                     self.action?(.quickReplyPropsUpdated(.shown(props)))
                 }
 

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
@@ -46,7 +46,8 @@ extension EngagementCoordinator.Environment {
         alertManager: .mock(),
         queuesMonitor: .mock(),
         pendingSecureConversationStatusUpdates: { $0(.success(false)) },
-        createEntryWidget: { _ in .mock() }
+        createEntryWidget: { _ in .mock() },
+        dismissManager: .init { _, _, _ in }
     )
 }
 #endif

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
@@ -46,6 +46,7 @@ extension EngagementCoordinator {
         var queuesMonitor: QueuesMonitor
         var pendingSecureConversationStatusUpdates: CoreSdkClient.PendingSecureConversationStatusUpdates
         var createEntryWidget: EntryWidgetBuilder
+        var dismissManager: GliaPresenter.DismissManager
     }
 }
 
@@ -103,7 +104,8 @@ extension EngagementCoordinator.Environment {
             alertManager: alertManager,
             queuesMonitor: queuesMonitor,
             pendingSecureConversationStatusUpdates: environment.coreSdk.pendingSecureConversationStatusUpdates,
-            createEntryWidget: createEntryWidget
+            createEntryWidget: createEntryWidget,
+            dismissManager: environment.dismissManager
         )
     }
 }

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Interface.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Interface.swift
@@ -54,6 +54,7 @@ extension Glia {
         var processInfo: ProcessInfoHandling
         var cameraDeviceManager: CoreSdkClient.GetCameraDeviceManageable
         var isAuthenticated: () -> Bool
+        var dismissManager: GliaPresenter.DismissManager
     }
 }
 

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Live.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Live.swift
@@ -53,6 +53,9 @@ extension Glia.Environment {
                 debugPrint(#function, "isAuthenticated:", error.localizedDescription)
                 return false
             }
+        },
+        dismissManager: .init { viewController, animated, completion in
+            viewController.dismiss(animated: animated, completion: completion)
         }
     )
 }

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Mock.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Mock.swift
@@ -34,7 +34,8 @@ extension Glia.Environment {
         snackBar: .mock,
         processInfo: .mock(),
         cameraDeviceManager: { .mock },
-        isAuthenticated: { false }
+        isAuthenticated: { false },
+        dismissManager: .init { _, _, _ in }
     )
 }
 

--- a/GliaWidgets/Sources/Presenter/GliaPresenter.Environment.swift
+++ b/GliaWidgets/Sources/Presenter/GliaPresenter.Environment.swift
@@ -4,6 +4,7 @@ extension GliaPresenter {
     struct Environment {
         var appWindowsProvider: AppWindowsProvider
         var log: CoreSdkClient.Logger
+        var dismissManager: DismissManager
     }
 }
 
@@ -17,7 +18,8 @@ extension GliaPresenter.Environment {
                 uiApplication: environment.uiApplication,
                 sceneProvider: sceneProvider
             ),
-            log: environment.log
+            log: environment.log,
+            dismissManager: environment.dismissManager
         )
     }
 
@@ -31,7 +33,8 @@ extension GliaPresenter.Environment {
                     uiApplication: environment.uiApplication,
                     sceneProvider: sceneProvider
                 ),
-                log: log
+                log: log,
+                dismissManager: environment.dismissManager
             )
     }
 }

--- a/GliaWidgets/Sources/Presenter/GliaPresenter.swift
+++ b/GliaWidgets/Sources/Presenter/GliaPresenter.swift
@@ -82,21 +82,32 @@ final class GliaPresenter {
             completion?()
             return
         }
-        presentingViewController.dismiss(
+        environment.dismissManager.dismiss(
+            presentingViewController,
             animated: animated,
             completion: completion
         )
     }
 }
 
-#if DEBUG
-extension GliaPresenter.Environment {
-    static let mock = Self(
-        appWindowsProvider: .mock,
-        log: .mock
-    )
+extension GliaPresenter {
+    // DismissManaged is used to control dismiss completion delayed by CoreAnimation.
+    struct DismissManager {
+        var dismissViewControllerAnimateWithCompletion: (
+            _ viewController: UIViewController,
+            _ animated: Bool,
+            _ completion: (() -> Void)?
+        ) -> Void
+
+        func dismiss(
+            _ viewController: UIViewController,
+            animated: Bool,
+            completion: (() -> Void)? = nil
+        ) {
+            dismissViewControllerAnimateWithCompletion(viewController, animated, completion)
+        }
+    }
 }
-#endif
 
 extension GliaPresenter {
     struct AppWindowsProvider {
@@ -111,6 +122,14 @@ extension GliaPresenter.AppWindowsProvider {
 }
 
 #if DEBUG
+extension GliaPresenter.Environment {
+    static let mock = Self(
+        appWindowsProvider: .mock,
+        log: .mock,
+        dismissManager: .init { _, _, _ in }
+    )
+}
+
 extension GliaPresenter.AppWindowsProvider {
     static let mock = Self(windows: { [] })
 }

--- a/GliaWidgets/Sources/View/Chat/ChatView.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatView.swift
@@ -551,8 +551,8 @@ extension ChatView: WebMessageCardViewDelegate {
     }
 
     private func isLastMessage(_ messageId: MessageRenderer.Message.Identifier) -> Bool {
-        let numberOfSections = { self.numberOfSections?() ?? 0 }
-        let numberOfRows = { section in self.numberOfRows?(section) ?? 0 }
+        let numberOfSections = { [weak self] in self?.numberOfSections?() ?? 0 }
+        let numberOfRows = { [weak self] section in self?.numberOfRows?(section) ?? 0 }
         let sections = (0 ..< numberOfSections()).reversed()
 
         guard let section = sections.first(where: { numberOfRows($0) > 0 }) else { return false }
@@ -722,7 +722,7 @@ extension ChatView {
         let choiceCard = ChoiceCard(with: message, isActive: isActive)
         view.showsOperatorImage = showsImage
         view.setOperatorImage(fromUrl: imageUrl, animated: false)
-        view.onOptionTapped = { self.choiceOptionSelected($0, message.id) }
+        view.onOptionTapped = { [weak self] in self?.choiceOptionSelected($0, message.id) }
         view.appendContent(.choiceCard(choiceCard), animated: false)
         return .choiceCard(view)
     }

--- a/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
+++ b/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
@@ -103,6 +103,7 @@ extension EngagementCoordinator.Environment {
         createEntryWidget: { _ in
             fail("\(Self.self).createEntryWidget")
             return .mock()
-        }
+        },
+        dismissManager: .failing
     )
 }

--- a/GliaWidgetsTests/Glia.Environment.Failing.swift
+++ b/GliaWidgetsTests/Glia.Environment.Failing.swift
@@ -69,6 +69,9 @@ extension Glia.Environment {
         isAuthenticated: {
             fail("\(Self.self).isAuthenticated")
             return false
+        },
+        dismissManager: .init { _, _, _ in
+            fail("\(Self.self).dismissManager")
         }
     )
 }

--- a/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinatorCallTests.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinatorCallTests.swift
@@ -39,9 +39,7 @@ extension EngagementCoordinatorTests {
         let callCoordinator = coordinator.coordinators.first { $0 is CallCoordinator } as? CallCoordinator
         callCoordinator?.delegate?(.back)
 
-        callAfterTimeout {
-            XCTAssertTrue(calledEvents.contains(.minimized))
-        }
+        XCTAssertTrue(calledEvents.contains(.minimized))
     }
 
     func test_callDelegateBackCallFromChat() throws {
@@ -66,11 +64,9 @@ extension EngagementCoordinatorTests {
         let callCoordinator = coordinator.coordinators.first { $0 is CallCoordinator } as? CallCoordinator
         callCoordinator?.delegate?(.back)
 
-        callAfterTimeout {
-            let topmostViewController = coordinator.navigationPresenter.viewControllers.first as? ChatViewController
+        let topmostViewController = coordinator.navigationPresenter.viewControllers.first as? ChatViewController
 
-            XCTAssertNotNil(topmostViewController)
-        }
+        XCTAssertNotNil(topmostViewController)
     }
 
     func test_callDelegateEngaged() throws {
@@ -78,7 +74,6 @@ extension EngagementCoordinatorTests {
         
         coordinator.start()
 
-        try showGliaViewController()
         let callCoordinator =  try XCTUnwrap(coordinator.coordinators.first { $0 is CallCoordinator } as? CallCoordinator)
 
         callCoordinator.delegate?(.engaged(operatorImageUrl: URL.mock.absoluteString))
@@ -103,8 +98,6 @@ extension EngagementCoordinatorTests {
         let callCoordinator = coordinator.coordinators.first { $0 is CallCoordinator } as? CallCoordinator
         callCoordinator?.delegate?(.minimize)
 
-        callAfterTimeout {
-            XCTAssertEqual(calledEvents.last, .minimized)
-        }
+        XCTAssertEqual(calledEvents.last, .minimized)
     }
 }

--- a/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinatorSecureConversationsTests.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinatorSecureConversationsTests.swift
@@ -26,10 +26,8 @@ extension EngagementCoordinatorTests {
 
         let flowCoordinator = coordinator.coordinators.last
 
-        callAfterTimeout {
-            XCTAssertNil(flowCoordinator)
-            XCTAssertEqual(coordinator.coordinators.count, 0)
-        }
+        XCTAssertNil(flowCoordinator)
+        XCTAssertEqual(coordinator.coordinators.count, 0)
     }
 
     func test_secureConversationsDelegateBackTapped() throws {
@@ -45,9 +43,7 @@ extension EngagementCoordinatorTests {
         let secureConversationsCoordinator = coordinator.coordinators.first as? SecureConversations.Coordinator
         secureConversationsCoordinator?.delegate?(.backTapped)
 
-        callAfterTimeout {
-            XCTAssertTrue(calledEvents.contains(.minimized))
-        }
+        XCTAssertTrue(calledEvents.contains(.minimized))
     }
 
     func test_secureConversationsDelegateChat() throws {
@@ -60,14 +56,11 @@ extension EngagementCoordinatorTests {
         }
 
         coordinator.start()
-        try showGliaViewController()
 
         let secureConversationsCoordinator = coordinator.coordinators.first as? SecureConversations.Coordinator
         secureConversationsCoordinator?.delegate?(.chat(.back))
 
-        callAfterTimeout {
-            XCTAssertTrue(calledEvents.contains(.minimized))
-        }
+        XCTAssertTrue(calledEvents.contains(.minimized))
     }
 
     // MARK: - Leave Conversation

--- a/GliaWidgetsTests/Sources/GliaPresenter/GliaPresenter.Environment.Failing.swift
+++ b/GliaWidgetsTests/Sources/GliaPresenter/GliaPresenter.Environment.Failing.swift
@@ -3,8 +3,15 @@
 extension GliaPresenter.Environment {
     static let failing = Self(
         appWindowsProvider: .failing,
-        log: .failing
+        log: .failing,
+        dismissManager: .failing
     )
+}
+
+extension GliaPresenter.DismissManager {
+    static let failing = Self.init { _, _, _ in
+        fail("\(Self.self).dismissManager")
+    }
 }
 
 extension GliaPresenter.AppWindowsProvider {


### PR DESCRIPTION
MOB-3843

**What was solved?**
This PR introduces:
- Fixing strong reference cycle in ChatView;
- DismissManager struct allowing to take UIKit dismiss completion block execution under control;
- new unit test;
- getting rid of expectation usage in EngagementCoordinator tests.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.