### PR TITLE
Add Unit and Snapshot tests for top banner on Secure Conversations

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -180,6 +180,8 @@
 		216D31052CF4D3590019CA9E /* ChatView.DefineLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216D31042CF4D3590019CA9E /* ChatView.DefineLayout.swift */; };
 		216D31072CF5DA050019CA9E /* ChatView.Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216D31062CF5DA050019CA9E /* ChatView.Constants.swift */; };
 		216D31092CF5DC080019CA9E /* OverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216D31082CF5DC080019CA9E /* OverlayView.swift */; };
+		216D310B2CF790980019CA9E /* EntryWidget.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216D310A2CF790980019CA9E /* EntryWidget.Mock.swift */; };
+		216D310D2CF795380019CA9E /* EntryWidgetViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216D310C2CF795380019CA9E /* EntryWidgetViewModelTests.swift */; };
 		2188DED22CECC3D400FA3BEF /* SecureMessagingTopBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2188DED12CECC3D400FA3BEF /* SecureMessagingTopBannerView.swift */; };
 		2188DED42CECE15800FA3BEF /* SecureMessagingTopBannerViewStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2188DED32CECE15800FA3BEF /* SecureMessagingTopBannerViewStyle.swift */; };
 		2188DEDD2CEE2C3F00FA3BEF /* SecureMessagingBottomBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2188DED92CEE2C3F00FA3BEF /* SecureMessagingBottomBannerView.swift */; };
@@ -1264,6 +1266,8 @@
 		216D31042CF4D3590019CA9E /* ChatView.DefineLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.DefineLayout.swift; sourceTree = "<group>"; };
 		216D31062CF5DA050019CA9E /* ChatView.Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.Constants.swift; sourceTree = "<group>"; };
 		216D31082CF5DC080019CA9E /* OverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayView.swift; sourceTree = "<group>"; };
+		216D310A2CF790980019CA9E /* EntryWidget.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryWidget.Mock.swift; sourceTree = "<group>"; };
+		216D310C2CF795380019CA9E /* EntryWidgetViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryWidgetViewModelTests.swift; sourceTree = "<group>"; };
 		2188DED12CECC3D400FA3BEF /* SecureMessagingTopBannerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecureMessagingTopBannerView.swift; sourceTree = "<group>"; };
 		2188DED32CECE15800FA3BEF /* SecureMessagingTopBannerViewStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureMessagingTopBannerViewStyle.swift; sourceTree = "<group>"; };
 		2188DED92CEE2C3F00FA3BEF /* SecureMessagingBottomBannerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecureMessagingBottomBannerView.swift; sourceTree = "<group>"; };
@@ -4812,6 +4816,8 @@
 			isa = PBXGroup;
 			children = (
 				C06B6D4B2CCB917600A66D8A /* EntryWidgetTests.swift */,
+				216D310C2CF795380019CA9E /* EntryWidgetViewModelTests.swift */,
+				216D310A2CF790980019CA9E /* EntryWidget.Mock.swift */,
 			);
 			path = EntryWidget;
 			sourceTree = "<group>";
@@ -6648,6 +6654,7 @@
 				9ACC25D427B474E800BC5335 /* Glia.Environment.Failing.swift in Sources */,
 				9A8130C227D9095200220BBD /* FileDownload.Failing.swift in Sources */,
 				3189DD9429DEFAC600D68E9F /* SecureConversations.WelcomeViewModelSpec.swift in Sources */,
+				216D310D2CF795380019CA9E /* EntryWidgetViewModelTests.swift in Sources */,
 				AF4D821C29D6E572007763F8 /* TranscriptModel.DividedChatItemsForUnreadCountTests.swift in Sources */,
 				84520BF62B20936F00F97617 /* SnackBar.Failing.swift in Sources */,
 				AF1C19802B14FE9F00F8810F /* ConditionalCompilationClient.Failing.swift in Sources */,
@@ -6718,6 +6725,7 @@
 				3115EFBA2BC960B500B24D5A /* (null) in Sources */,
 				31CCE3E62BCE8F3A00F92535 /* ScreenSharingCoordinatorTests.swift in Sources */,
 				846A5C3929D18D400049B29F /* ScreenShareHandlerTests.swift in Sources */,
+				216D310B2CF790980019CA9E /* EntryWidget.Mock.swift in Sources */,
 				9AE05CB62805D2CB00871321 /* Interactor.Environment.Failing.swift in Sources */,
 				846429862A45DB4100943BD6 /* AlertViewController.Kind+Mock.swift in Sources */,
 				AF29811229E42F3C0005BD55 /* AvailabilityTests.swift in Sources */,

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.ChatWithTranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.ChatWithTranscriptModel.swift
@@ -88,7 +88,6 @@ extension SecureConversations.ChatWithTranscriptModel {
         }
     }
 
-    // TODO: Unit test to be added in  MOB-3840
     var entryWidget: EntryWidget? {
         switch self {
         case .chat:

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
@@ -155,7 +155,6 @@ private extension EntryWidget {
                 }
             }
         }
-        // TODO: Unit test to be added in  MOB-3840
         if !environment.isAuthenticated() || configuration.filterSecureConversation {
             availableMediaTypes.remove(.secureMessaging)
         }
@@ -223,11 +222,9 @@ private extension EntryWidget {
         hostingController.view.clipsToBounds = true
         hostingController.view.translatesAutoresizingMaskIntoConstraints = false
 
-        let heightConstraint = hostingController.view.heightAnchor.constraint(equalTo: parentView.heightAnchor)
-
         NSLayoutConstraint.activate([
             hostingController.view.widthAnchor.constraint(equalTo: parentView.widthAnchor),
-            heightConstraint,
+            hostingController.view.heightAnchor.constraint(equalTo: parentView.heightAnchor),
             hostingController.view.centerXAnchor.constraint(equalTo: parentView.centerXAnchor),
             hostingController.view.centerYAnchor.constraint(equalTo: parentView.centerYAnchor)
         ])
@@ -344,8 +341,8 @@ extension EntryWidget: UIViewControllerTransitioningDelegate {
 
 #if DEBUG
 extension EntryWidget {
-    static func mock() -> Self {
-        .init(queueIds: [], configuration: .default, environment: .mock())
+    static func mock(configuration: EntryWidget.Configuration? = nil) -> Self {
+        .init(queueIds: [], configuration: configuration ?? .default, environment: .mock())
     }
 }
 

--- a/GliaWidgets/Sources/EntryWidget/EntryWidgetView.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidgetView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct EntryWidgetView: View {
+    @SwiftUI.Environment(\.sizeCategory) var sizeCategory
+
     @StateObject var model: Model
 
     var body: some View {
@@ -168,7 +170,9 @@ private extension EntryWidgetView {
             icon(mediaType.image)
             VStack(alignment: .leading, spacing: 2) {
                 headlineText(model.style.mediaTypeItem.title(for: mediaType))
-                subheadlineText(model.style.mediaTypeItem.message(for: mediaType))
+                if !sizeCategory.isAccessibilityCategory {
+                    subheadlineText(model.style.mediaTypeItem.message(for: mediaType))
+                }
             }
             unreadMessageCountView(for: mediaType)
         }

--- a/GliaWidgets/Sources/EntryWidget/EntryWidgetViewModel.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidgetViewModel.swift
@@ -12,7 +12,6 @@ extension EntryWidgetView {
             theme.entryWidget
         }
 
-        // TODO: Unit test to be added in  MOB-3840
         var showPoweredBy: Bool {
             theme.showsPoweredBy && configuration.showPoweredBy
         }

--- a/GliaWidgets/Sources/View/Chat/ChatView.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatView.swift
@@ -57,7 +57,8 @@ class ChatView: EngagementView {
         return CGRect(x: x, y: y, width: width, height: height)
     }
 
-    @Published private var isTopBannerExpanded = false
+    // Made internal for Snapshot test purposes
+    @Published var isTopBannerExpanded = false
     @Published private var isTopBannerHidden = true
 
     var props: Props {

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
@@ -655,6 +655,28 @@ extension ChatViewController {
 
         return .init(viewModel: .transcript(transcriptModel), environment: .mock())
     }
+
+    static func mockSecureMessagingTopAndBottomBannerView(
+        entryWidgetViewState: EntryWidget.ViewState = .loading
+    ) -> ChatViewController {
+        var chatViewModelEnv = ChatViewModel.Environment.mock
+        chatViewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
+
+        let transcriptModel = SecureConversations.TranscriptModel.init(
+            isCustomCardSupported: false,
+            environment: .mock(createEntryWidget: { configuration in
+                let entryWidget = EntryWidget.mock(configuration: configuration)
+                entryWidget.viewState = entryWidgetViewState
+                return entryWidget
+            }),
+            availability: .mock(),
+            deliveredStatusText: "deliveredStatusText",
+            failedToDeliverStatusText: "failedToDeliverStatusText",
+            interactor: .mock()
+        )
+
+        return .init(viewModel: .transcript(transcriptModel), environment: .mock())
+    }
 }
 
 /// Defines wrapper structure for getting decoding container.

--- a/GliaWidgetsTests/SecureConversations/SecureConversations.ChatWithTranscriptModel/SecureConversations.ChatWithTranscriptModelTests.swift
+++ b/GliaWidgetsTests/SecureConversations/SecureConversations.ChatWithTranscriptModel/SecureConversations.ChatWithTranscriptModelTests.swift
@@ -70,4 +70,19 @@ final class SecureConversationsChatWithTranscriptModelTests: XCTestCase {
         XCTAssertEqual(contains, false)
         XCTAssertEqual(section.itemCount, 2)
     }
+    
+    func testEntryWidget() {
+        let chatViewModel = Model.chat(.mock())
+        let transcriptViewModel = Model.transcript(
+            .mock(
+                availability: .mock,
+                deliveredStatusText: "Delivered",
+                failedToDeliverStatusText: "Failed to deliver",
+                interactor: .mock()
+            )
+        )
+        
+        XCTAssertNil(chatViewModel.entryWidget)
+        XCTAssertNotNil(transcriptViewModel.entryWidget)
+    }
 }

--- a/GliaWidgetsTests/Sources/EntryWidget/EntryWidget.Mock.swift
+++ b/GliaWidgetsTests/Sources/EntryWidget/EntryWidget.Mock.swift
@@ -1,0 +1,26 @@
+@testable import GliaWidgets
+
+extension EntryWidget.Configuration {
+    static func mock(
+        sizeConstraint: EntryWidget.SizeConstraints? = nil,
+        showPoweredBy: Bool? = nil,
+        filterSecureConversation: Bool? = nil,
+        mediaTypeSelected: Command<EntryWidget.MediaTypeItem>? = nil
+    ) -> Self {
+        Self(
+            sizeConstraints: sizeConstraint ?? .init(
+                singleCellHeight: 72,
+                singleCellIconSize: 24,
+                poweredByContainerHeight: 40,
+                sheetHeaderHeight: 36,
+                sheetHeaderDraggerWidth: 32,
+                sheetHeaderDraggerHeight: 4,
+                dividerHeight: 1,
+                dividerHorizontalPadding: nil
+            ),
+            showPoweredBy: showPoweredBy ?? true,
+            filterSecureConversation: filterSecureConversation ?? false,
+            mediaTypeSelected: mediaTypeSelected
+        )
+    }
+}

--- a/GliaWidgetsTests/Sources/EntryWidget/EntryWidgetViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/EntryWidget/EntryWidgetViewModelTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+import Combine
+import GliaCoreSDK
+
+@testable import GliaWidgets
+
+class EntryWidgetViewModelTests: XCTestCase {
+    func test_showPoweredBy() {
+        let entryWidget = EntryWidget.mock()
+        
+        let viewModel = EntryWidgetView.Model(
+            theme: .mock(showsPoweredBy: true),
+            showHeader: true,
+            configuration: .mock(showPoweredBy: true),
+            viewStatePublisher: entryWidget.$viewState,
+            mediaTypeSelected: { _ in }
+        )
+        
+        XCTAssertTrue(viewModel.showPoweredBy)
+    }
+    
+    func test_doesNotShowPoweredByUsingThemeProperty() {
+        let entryWidget = EntryWidget.mock()
+        
+        let viewModel = EntryWidgetView.Model(
+            theme: .mock(showsPoweredBy: false),
+            showHeader: true,
+            configuration: .mock(showPoweredBy: true),
+            viewStatePublisher: entryWidget.$viewState,
+            mediaTypeSelected: { _ in }
+        )
+        
+        XCTAssertFalse(viewModel.showPoweredBy)
+    }
+    
+    func test_doesNotShowPoweredByUsingConfigurationProperty() {
+        let entryWidget = EntryWidget.mock()
+        
+        let viewModel = EntryWidgetView.Model(
+            theme: .mock(showsPoweredBy: true),
+            showHeader: true,
+            configuration: .mock(showPoweredBy: false),
+            viewStatePublisher: entryWidget.$viewState,
+            mediaTypeSelected: { _ in }
+        )
+        
+        XCTAssertFalse(viewModel.showPoweredBy)
+    }
+}

--- a/SnapshotTests/ChatViewControllerDynamicTypeFontTests.swift
+++ b/SnapshotTests/ChatViewControllerDynamicTypeFontTests.swift
@@ -38,9 +38,29 @@ final class ChatViewControllerDynamicTypeFontTests: SnapshotTestCase {
         viewController.assertSnapshot(as: .extra3LargeFont, in: .landscape)
     }
 
-    func test_secureMessagingTopAndBottomBanner_extra3Large() {
+    func test_secureMessagingBottomAndCollapsedTopBanner_extra3Large() {
         let viewController = ChatViewController.mockSecureMessagingBottomBannerView()
         viewController.updateViewConstraints()
+        viewController.assertSnapshot(as: .extra3LargeFont, in: .portrait)
+        viewController.assertSnapshot(as: .extra3LargeFont, in: .landscape)
+    }
+    
+    func test_secureMessagingBottomAndExpandedTopBanner_extra3Large() {
+        let mockEntryWidgetViewState = EntryWidget.ViewState.mediaTypes(
+            [.init(type: .chat), .init(type: .video), .init(type: .audio)]
+        )
+        let viewController = ChatViewController.mockSecureMessagingTopAndBottomBannerView(
+            entryWidgetViewState: mockEntryWidgetViewState
+        )
+        viewController.updateViewConstraints()
+        
+        (viewController.view as? ChatView)?.isTopBannerExpanded = true
+        viewController.updateViewConstraints()
+        
+        viewController.view.frame = UIScreen.main.bounds
+        viewController.view.setNeedsLayout()
+        viewController.view.layoutIfNeeded()
+        
         viewController.assertSnapshot(as: .extra3LargeFont, in: .portrait)
         viewController.assertSnapshot(as: .extra3LargeFont, in: .landscape)
     }

--- a/SnapshotTests/ChatViewControllerLayoutTests.swift
+++ b/SnapshotTests/ChatViewControllerLayoutTests.swift
@@ -79,9 +79,29 @@ final class ChatViewControllerLayoutTests: SnapshotTestCase {
         viewController.assertSnapshot(as: .image, in: .landscape)
     }
 
-    func test_secureMessagingTopAndBottomBanner() {
+    func test_secureMessagingBottomAndCollapsedTopBanner() {
         let viewController = ChatViewController.mockSecureMessagingBottomBannerView()
         viewController.updateViewConstraints()
+        viewController.assertSnapshot(as: .image, in: .portrait)
+        viewController.assertSnapshot(as: .image, in: .landscape)
+    }
+    
+    func test_secureMessagingBottomAndExpandedTopBanner() {
+        let mockEntryWidgetViewState = EntryWidget.ViewState.mediaTypes(
+            [.init(type: .chat), .init(type: .video), .init(type: .audio)]
+        )
+        let viewController = ChatViewController.mockSecureMessagingTopAndBottomBannerView(
+            entryWidgetViewState: mockEntryWidgetViewState
+        )
+        viewController.updateViewConstraints()
+        
+        (viewController.view as? ChatView)?.isTopBannerExpanded = true
+        viewController.updateViewConstraints()
+        
+        viewController.view.frame = UIScreen.main.bounds
+        viewController.view.setNeedsLayout()
+        viewController.view.layoutIfNeeded()
+        
         viewController.assertSnapshot(as: .image, in: .portrait)
         viewController.assertSnapshot(as: .image, in: .landscape)
     }

--- a/SnapshotTests/ChatViewControllerVoiceOverTests.swift
+++ b/SnapshotTests/ChatViewControllerVoiceOverTests.swift
@@ -67,8 +67,21 @@ final class ChatViewControllerVoiceOverTests: SnapshotTestCase {
     }
 
     func test_secureMessagingTopAndBottomBanner() {
-        let viewController = ChatViewController.mockSecureMessagingBottomBannerView()
+        let mockEntryWidgetViewState = EntryWidget.ViewState.mediaTypes(
+            [.init(type: .chat), .init(type: .video), .init(type: .audio)]
+        )
+        let viewController = ChatViewController.mockSecureMessagingTopAndBottomBannerView(
+            entryWidgetViewState: mockEntryWidgetViewState
+        )
         viewController.updateViewConstraints()
+        
+        (viewController.view as? ChatView)?.isTopBannerExpanded = true
+        viewController.updateViewConstraints()
+        
+        viewController.view.frame = UIScreen.main.bounds
+        viewController.view.setNeedsLayout()
+        viewController.view.layoutIfNeeded()
+        
         viewController.assertSnapshot(as: .accessibilityImage)
     }
 }


### PR DESCRIPTION
**What was solved?**
This PR adds unit and snapshot tests for top banner on Secure Conversation

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [X] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.
