### PR TITLE
Isolate pending interaction logic in separate model

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -696,6 +696,9 @@
 		AFBBF5782851C391004993B3 /* Glia.Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBBF5772851C391004993B3 /* Glia.Deprecated.swift */; };
 		AFC40C1C29965F0F001B4C53 /* SecureConversations.ChatWithTranscriptModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFC40C1B29965F0F001B4C53 /* SecureConversations.ChatWithTranscriptModel.swift */; };
 		AFC7ABB82C2D93A0006F15AA /* Glia+RestoreEngagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFC7ABB72C2D93A0006F15AA /* Glia+RestoreEngagement.swift */; };
+		AFCDA7242CF8EC2C006E339B /* SecureConversations.PendingInteraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCDA7232CF8EC2C006E339B /* SecureConversations.PendingInteraction.swift */; };
+		AFCDA7262CFA250A006E339B /* SecureConversations.PendingInteractionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCDA7252CFA250A006E339B /* SecureConversations.PendingInteractionTests.swift */; };
+		AFCDA7282CFA2ACB006E339B /* SecureConversations.PendingInteraction.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCDA7272CFA2ACB006E339B /* SecureConversations.PendingInteraction.Failing.swift */; };
 		AFCF8A5A2A02A97100B7ABB3 /* ChatItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCF8A592A02A97100B7ABB3 /* ChatItemTests.swift */; };
 		AFCF8A5C2A02AB3000B7ABB3 /* OutgoingMessage.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCF8A5B2A02AB3000B7ABB3 /* OutgoingMessage.Mock.swift */; };
 		AFD3C52C2A472B7500BC37A9 /* VisitorInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFD3C52B2A472B7500BC37A9 /* VisitorInfoModel.swift */; };
@@ -1782,6 +1785,9 @@
 		AFBBF5772851C391004993B3 /* Glia.Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Glia.Deprecated.swift; sourceTree = "<group>"; };
 		AFC40C1B29965F0F001B4C53 /* SecureConversations.ChatWithTranscriptModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.ChatWithTranscriptModel.swift; sourceTree = "<group>"; };
 		AFC7ABB72C2D93A0006F15AA /* Glia+RestoreEngagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Glia+RestoreEngagement.swift"; sourceTree = "<group>"; };
+		AFCDA7232CF8EC2C006E339B /* SecureConversations.PendingInteraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.PendingInteraction.swift; sourceTree = "<group>"; };
+		AFCDA7252CFA250A006E339B /* SecureConversations.PendingInteractionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.PendingInteractionTests.swift; sourceTree = "<group>"; };
+		AFCDA7272CFA2ACB006E339B /* SecureConversations.PendingInteraction.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.PendingInteraction.Failing.swift; sourceTree = "<group>"; };
 		AFCF8A592A02A97100B7ABB3 /* ChatItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatItemTests.swift; sourceTree = "<group>"; };
 		AFCF8A5B2A02AB3000B7ABB3 /* OutgoingMessage.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutgoingMessage.Mock.swift; sourceTree = "<group>"; };
 		AFD3C52B2A472B7500BC37A9 /* VisitorInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitorInfoModel.swift; sourceTree = "<group>"; };
@@ -3492,6 +3498,7 @@
 				AF10ED8C29BA210500E85309 /* SecureConversations.MessagesWithUnreadCountLoader.swift */,
 				C0D6CA142C184F1900D4709B /* SecureConversations.MessagesWithUnreadCountLoader.Environment.swift */,
 				3115D45B29A4FD3F00D99561 /* SecureConversations.Availability.swift */,
+				AFCDA7232CF8EC2C006E339B /* SecureConversations.PendingInteraction.swift */,
 			);
 			path = SecureConversations;
 			sourceTree = "<group>";
@@ -4759,6 +4766,8 @@
 				AF29811129E42F3C0005BD55 /* AvailabilityTests.swift */,
 				AF29810F29E06E830005BD55 /* Availability.Environment.Failing.swift */,
 				3197F7AC29E6A5C8008EE9F7 /* SecureConversations.FileUploadListView.Mock.swift */,
+				AFCDA7252CFA250A006E339B /* SecureConversations.PendingInteractionTests.swift */,
+				AFCDA7272CFA2ACB006E339B /* SecureConversations.PendingInteraction.Failing.swift */,
 			);
 			path = SecureConversations;
 			sourceTree = "<group>";
@@ -6150,6 +6159,7 @@
 				AF6291132B0813B000D3D76B /* SwiftBased.Mock.swift in Sources */,
 				1AC7A74F2582571100567FF8 /* Interactor.swift in Sources */,
 				AF552EDD2BEE954500FD5653 /* FlipCameraButtonStyle.swift in Sources */,
+				AFCDA7242CF8EC2C006E339B /* SecureConversations.PendingInteraction.swift in Sources */,
 				84C24CFC2B8354A80089A388 /* ProcessInfoHandling.Live.swift in Sources */,
 				AFB6A0792CCBF3B700A1ED9A /* MediaTypeItemStyle.Loading.swift in Sources */,
 				845E2F72283D068000C04D56 /* HeaderStyle.Accessibility.swift in Sources */,
@@ -6681,6 +6691,7 @@
 				7512A57727BE8A6700319DF1 /* InteractorTests.swift in Sources */,
 				31CCE3E92BCE8F3A00F92535 /* CallVisualizer.VideoCallCoordinator.Environment.Mock.swift in Sources */,
 				AF29811529E6D76A0005BD55 /* FileDownloadTests.swift in Sources */,
+				AFCDA7262CFA250A006E339B /* SecureConversations.PendingInteractionTests.swift in Sources */,
 				C096B40B297EBDE400F0C552 /* VisitorCodeTests.swift in Sources */,
 				31FF0DD12B5A89A600834AFB /* CallCoordinator.Environment.Mock.swift in Sources */,
 				9ACC25D427B474E800BC5335 /* Glia.Environment.Failing.swift in Sources */,
@@ -6742,6 +6753,7 @@
 				EB7A1508286D98000035AC62 /* FileUploader.Environment.Failing.swift in Sources */,
 				AF993B3D2C8F5E7000DC5E69 /* EngagementCoordinatorCallTests.swift in Sources */,
 				AF2355A229C9EC7E007D9896 /* IdCollectionTests.swift in Sources */,
+				AFCDA7282CFA2ACB006E339B /* SecureConversations.PendingInteraction.Failing.swift in Sources */,
 				8491AF572AA0964800CC3E72 /* ChatItem.Kind.Mock.swift in Sources */,
 				84C24CFF2B8357BB0089A388 /* ProcessInfoHandling.Failing.swift in Sources */,
 				AFFA99822C57D658004A2825 /* GliaTests+RestoreEngagement.swift in Sources */,

--- a/GliaWidgets/Public/Glia/Glia+EngagementSetup.swift
+++ b/GliaWidgets/Public/Glia/Glia+EngagementSetup.swift
@@ -142,7 +142,7 @@ extension Glia {
     ) {
         let engagementLaunching: EngagementCoordinator.EngagementLaunching
 
-        switch (hasPendingInteraction, engagementKind) {
+        switch (pendingInteraction.hasPendingInteraction, engagementKind) {
         case (false, _):
             // if there is no pending Secure Conversation, open regular flow.
             engagementLaunching = .direct(kind: engagementKind)

--- a/GliaWidgets/Public/Glia/Glia+EntryWidget.swift
+++ b/GliaWidgets/Public/Glia/Glia+EntryWidget.swift
@@ -25,7 +25,8 @@ extension Glia {
                 log: loggerPhase.logger,
                 isAuthenticated: environment.isAuthenticated,
                 hasPendingInteraction: { [weak self] in
-                    self?.hasPendingInteraction ?? false
+                    guard let self else { return false }
+                    return pendingInteraction.hasPendingInteraction
                 }
             )
         )

--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -135,19 +135,7 @@ public class Glia {
     //
     // Currently it's used to know if we have to force a visitor to SecureMessaging screen,
     // once they try to start an engagement with media type other than `messaging`.
-    var hasPendingInteraction: Bool {
-        var pendingConversationExists = false
-        environment.coreSdk.pendingSecureConversationStatusUpdates { hasPendingConversationResult in
-            pendingConversationExists = (try? hasPendingConversationResult.get()) ?? false
-        }
-
-        var unreadMessageCount = 0
-        environment.coreSdk.getSecureUnreadMessageCount {
-            unreadMessageCount = (try? $0.get()) ?? 0
-        }
-
-        return unreadMessageCount > 0 || pendingConversationExists
-    }
+    let pendingInteraction: SecureConversations.PendingInteraction
 
     init(environment: Environment) {
         self.environment = environment
@@ -191,6 +179,7 @@ public class Glia {
                 viewFactory: viewFactory
             )
         )
+        pendingInteraction = .init(environment: .init(with: environment.coreSdk))
     }
 
     /// Setup SDK using specific engagement configuration without starting the engagement.

--- a/GliaWidgets/SecureConversations/SecureConversations.PendingInteraction.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.PendingInteraction.swift
@@ -1,0 +1,79 @@
+import Combine
+
+extension SecureConversations {
+    final class PendingInteraction: ObservableObject {
+        @Published private(set) var pendingStatus = false
+        @Published private(set) var unreadMessageCount = 0
+        @Published private(set) var hasPendingInteraction = false
+        private let environment: Environment
+        private(set) var pendingStatusCancellationToken: String?
+        private(set) var unreadMessageCountCancellationToken: String?
+
+        init(environment: Environment) {
+            self.environment = environment
+            self.pendingStatusCancellationToken = environment.observePendingSecureConversationsStatus { [weak self] result in
+                guard let self else { return }
+                // At this point it is enough to know if there is a pending conversation,
+                // so no need to handle error.
+                pendingStatus = (try? result.get()) ?? false
+            }
+            self.unreadMessageCountCancellationToken = environment.observeSecureConversationsUnreadMessageCount { [weak self] result in
+                guard let self else { return }
+                // At this point it is enough to know if there is an unread message count,
+                // so no need to handle error.
+                unreadMessageCount = (try? result.get()) ?? 0
+            }
+
+            $pendingStatus.combineLatest($unreadMessageCount)
+                .map { hasPending, unreadCount in
+                    hasPending || unreadCount > 0
+                }
+                .assign(to: &$hasPendingInteraction)
+        }
+
+        deinit {
+            if let unreadMessageCountCancellationToken {
+                environment.unsubscribeFromUnreadCount(unreadMessageCountCancellationToken)
+            }
+
+            if let pendingStatusCancellationToken {
+                environment.unsubscribeFromPendingStatus(pendingStatusCancellationToken)
+            }
+        }
+    }
+}
+
+extension SecureConversations.PendingInteraction {
+    struct Environment {
+        var observePendingSecureConversationsStatus: CoreSdkClient.ObservePendingSecureConversationStatus
+        var observeSecureConversationsUnreadMessageCount: CoreSdkClient.SubscribeForUnreadSCMessageCount
+        var unsubscribeFromUnreadCount: CoreSdkClient.UnsubscribeFromUnreadCount
+        var unsubscribeFromPendingStatus: CoreSdkClient.UnsubscribeFromPendingSCStatus
+    }
+}
+
+extension SecureConversations.PendingInteraction.Environment {
+    init(with client: CoreSdkClient) {
+        self.observePendingSecureConversationsStatus = client.observePendingSecureConversationStatus
+        self.observeSecureConversationsUnreadMessageCount = client.subscribeForUnreadSCMessageCount
+        self.unsubscribeFromPendingStatus = client.unsubscribeFromPendingSecureConversationStatus
+        self.unsubscribeFromUnreadCount = client.unsubscribeFromUnreadCount
+    }
+}
+
+#if DEBUG
+extension SecureConversations.PendingInteraction.Environment {
+    static let mock = Self(
+        observePendingSecureConversationsStatus: { _ in nil },
+        observeSecureConversationsUnreadMessageCount: { _ in nil },
+        unsubscribeFromUnreadCount: { _ in },
+        unsubscribeFromPendingStatus: { _ in }
+    )
+}
+
+extension SecureConversations.PendingInteraction {
+    static func mock(environment: Environment = .mock) -> Self {
+        .init(environment: environment)
+    }
+}
+#endif

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
@@ -45,7 +45,7 @@ extension EngagementCoordinator.Environment {
         flipCameraButtonStyle: .nop,
         alertManager: .mock(),
         queuesMonitor: .mock(),
-        pendingSecureConversationStatusUpdates: { $0(.success(false)) },
+        pendingSecureConversationStatus: { $0(.success(false)) },
         createEntryWidget: { _ in .mock() },
         dismissManager: .init { _, _, _ in }
     )

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
@@ -44,7 +44,7 @@ extension EngagementCoordinator {
         var flipCameraButtonStyle: FlipCameraButtonStyle
         var alertManager: AlertManager
         var queuesMonitor: QueuesMonitor
-        var pendingSecureConversationStatusUpdates: CoreSdkClient.PendingSecureConversationStatusUpdates
+        var pendingSecureConversationStatus: CoreSdkClient.PendingSecureConversationStatus
         var createEntryWidget: EntryWidgetBuilder
         var dismissManager: GliaPresenter.DismissManager
     }
@@ -103,7 +103,7 @@ extension EngagementCoordinator.Environment {
             flipCameraButtonStyle: viewFactory.theme.call.flipCameraButtonStyle,
             alertManager: alertManager,
             queuesMonitor: queuesMonitor,
-            pendingSecureConversationStatusUpdates: environment.coreSdk.pendingSecureConversationStatusUpdates,
+            pendingSecureConversationStatus: environment.coreSdk.pendingSecureConversationStatus,
             createEntryWidget: createEntryWidget,
             dismissManager: environment.dismissManager
         )

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -199,9 +199,21 @@ struct CoreSdkClient {
 
     var subscribeForUnreadSCMessageCount: SubscribeForUnreadSCMessageCount
 
-    typealias PendingSecureConversationStatusUpdates = (_ callback: @escaping (Result<Bool, Error>) -> Void) -> Void
+    typealias PendingSecureConversationStatus = (_ callback: @escaping (Result<Bool, Error>) -> Void) -> Void
 
-    var pendingSecureConversationStatusUpdates: PendingSecureConversationStatusUpdates
+    var pendingSecureConversationStatus: PendingSecureConversationStatus
+
+    typealias ObservePendingSecureConversationStatus = (_ callback: @escaping (Result<Bool, Error>) -> Void) -> String?
+
+    var observePendingSecureConversationStatus: ObservePendingSecureConversationStatus
+
+    typealias UnsubscribeFromPendingSCStatus = (String) -> Void
+
+    var unsubscribeFromPendingSecureConversationStatus: UnsubscribeFromPendingSCStatus
+
+    typealias UnsubscribeFromUnreadCount = (String) -> Void
+
+    var unsubscribeFromUnreadCount: UnsubscribeFromUnreadCount
 }
 
 extension CoreSdkClient {

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
@@ -64,7 +64,12 @@ extension CoreSdkClient {
             subscribeForQueuesUpdates: GliaCore.sharedInstance.subscribeForQueuesUpdates(forQueues:completion:),
             unsubscribeFromUpdates: GliaCore.sharedInstance.unsubscribeFromUpdates(queueCallbackId:onError:),
             subscribeForUnreadSCMessageCount: GliaCore.sharedInstance.secureConversations.subscribeToUnreadMessageCount(completion:),
-            pendingSecureConversationStatusUpdates: GliaCore.sharedInstance.secureConversations.pendingSecureConversationStatus
+            pendingSecureConversationStatus: GliaCore.sharedInstance.secureConversations.pendingSecureConversationStatus,
+            observePendingSecureConversationStatus: GliaCore.sharedInstance.secureConversations.subscribeToPendingSecureConversationStatus,
+            unsubscribeFromPendingSecureConversationStatus: {
+                GliaCore.sharedInstance.secureConversations.unsubscribeFromPendingSecureConversationStatus($0)
+            },
+            unsubscribeFromUnreadCount: GliaCore.sharedInstance.secureConversations.unsubscribeFromUnreadMessageCount
         )
     }()
 }

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -41,7 +41,10 @@ extension CoreSdkClient {
         subscribeForQueuesUpdates: { _, _ in UUID.mock.uuidString },
         unsubscribeFromUpdates: { _, _ in },
         subscribeForUnreadSCMessageCount: { _ in UUID.mock.uuidString },
-        pendingSecureConversationStatusUpdates: { $0(.success(false)) }
+        pendingSecureConversationStatus: { $0(.success(false)) },
+        observePendingSecureConversationStatus: { _ in nil },
+        unsubscribeFromPendingSecureConversationStatus: { _ in },
+        unsubscribeFromUnreadCount: { _ in }
     )
 }
 

--- a/GliaWidgetsTests/CallVisualizer/CallVisualizerTests+LO.swift
+++ b/GliaWidgetsTests/CallVisualizer/CallVisualizerTests+LO.swift
@@ -30,6 +30,10 @@ extension CallVisualizerTests {
         gliaEnv.snackBar.present = { _, _, _, _, _, _, _ in
             calls.append(.presentSnackBar)
         }
+        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
         let sdk = Glia(environment: gliaEnv)
         try sdk.configure(with: .mock(), theme: .mock(), completion: { _ in })
 
@@ -66,6 +70,10 @@ extension CallVisualizerTests {
         gliaEnv.snackBar.present = { _, _, _, _, _, _, _ in
             calls.append(.presentSnackBar)
         }
+        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
         let sdk = Glia(environment: gliaEnv)
         try sdk.configure(with: .mock(), theme: .mock(), completion: { _ in })
 
@@ -102,6 +110,10 @@ extension CallVisualizerTests {
         gliaEnv.snackBar.present = { _, _, _, _, _, _, _ in
             calls.append(.presentSnackBar)
         }
+        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
         let sdk = Glia(environment: gliaEnv)
         try sdk.configure(with: .mock(), theme: .mock(), completion: { _ in })
 
@@ -132,6 +144,10 @@ extension CallVisualizerTests {
         gliaEnv.callVisualizerPresenter = .init(presenter: { nil })
         gliaEnv.gcd.mainQueue.asyncIfNeeded = { $0() }
         gliaEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
+        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
         let sdk = Glia(environment: gliaEnv)
         sdk.environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             sdk.environment.coreSdk.getCurrentEngagement = {
@@ -165,6 +181,10 @@ extension CallVisualizerTests {
         gliaEnv.callVisualizerPresenter = .init(presenter: { nil })
         gliaEnv.gcd.mainQueue.asyncIfNeeded = { $0() }
         gliaEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
+        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
         let sdk = Glia(environment: gliaEnv)
         sdk.environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             sdk.environment.coreSdk.getCurrentEngagement = {
@@ -198,6 +218,10 @@ extension CallVisualizerTests {
         gliaEnv.callVisualizerPresenter = .init(presenter: { nil })
         gliaEnv.gcd.mainQueue.asyncIfNeeded = { $0() }
         gliaEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
+        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
         let sdk = Glia(environment: gliaEnv)
         sdk.environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             sdk.environment.coreSdk.getCurrentEngagement = {

--- a/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
+++ b/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
@@ -52,7 +52,6 @@ extension EngagementCoordinator.Environment {
         createFileUploadListModel: { _ in
             fail("\(Self.self).createFileUploadListModel")
             return .mock()
-
         },
         uploadSecureFile: { _, _, _ in
             fail("\(Self.self).uploadSecureFile")
@@ -96,9 +95,9 @@ extension EngagementCoordinator.Environment {
         cameraDeviceManager: { .failing },
         flipCameraButtonStyle: .nop,
         alertManager: .failing(viewFactory: .mock()),
-        queuesMonitor: .failing, 
-        pendingSecureConversationStatusUpdates: { _ in
-            fail("\(Self.self).pendingSecureConversationStatusUpdates")
+        queuesMonitor: .failing,
+        pendingSecureConversationStatus: { _ in
+            fail("\(Self.self).pendingSecureConversationStatus")
         },
         createEntryWidget: { _ in
             fail("\(Self.self).createEntryWidget")

--- a/GliaWidgetsTests/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/CoreSDKClient.Failing.swift
@@ -78,9 +78,19 @@ extension CoreSdkClient {
         subscribeForUnreadSCMessageCount: { _ in
             fail("\(Self.self).subscribeForUnreadSCMessageCount")
             return ""
-        }, 
-        pendingSecureConversationStatusUpdates: { _ in
-            fail("\(Self.self).pendingSecureConversationStatusUpdates")
+        },
+        pendingSecureConversationStatus: { _ in
+            fail("\(Self.self).pendingSecureConversationStatus")
+        },
+        observePendingSecureConversationStatus: { _ in
+            fail("\(Self.self).observePendingSecureConversationStatus")
+            return nil
+        },
+        unsubscribeFromPendingSecureConversationStatus: { _ in
+            fail("\(Self.self).unsubscribeFromPendingSecureConversationStatus")
+        },
+        unsubscribeFromUnreadCount: { _ in
+            fail("\(Self.self).unsubscribeFromUnreadCount")
         }
     )
 }

--- a/GliaWidgetsTests/SecureConversations/SecureConversations.PendingInteraction.Failing.swift
+++ b/GliaWidgetsTests/SecureConversations/SecureConversations.PendingInteraction.Failing.swift
@@ -1,0 +1,26 @@
+@testable import GliaWidgets
+
+extension SecureConversations.PendingInteraction.Environment {
+    static let failing = Self(
+        observePendingSecureConversationsStatus: { _ in
+            fail("\(Self.self).observePendingSecureConversationsStatus")
+            return nil
+        },
+        observeSecureConversationsUnreadMessageCount: { _ in
+            fail("\(Self.self).observeSecureConversationsUnreadMessageCount")
+            return nil
+        },
+        unsubscribeFromUnreadCount: { _ in
+            fail("\(Self.self).unsubscribeFromUnreadCount")
+        },
+        unsubscribeFromPendingStatus: { _ in
+            fail("\(Self.self).unsubscribeFromPendingStatus")
+        }
+    )
+}
+
+extension SecureConversations.PendingInteraction {
+    static func failing() -> Self {
+        .init(environment: .failing)
+    }
+}

--- a/GliaWidgetsTests/SecureConversations/SecureConversations.PendingInteractionTests.swift
+++ b/GliaWidgetsTests/SecureConversations/SecureConversations.PendingInteractionTests.swift
@@ -1,0 +1,60 @@
+@testable import GliaWidgets
+import XCTest
+
+final class SecureConversationsPendingInteractionTests: XCTestCase {
+    func test_hasPendingInteractionGetChangedBasedOnUnreadCountAndPendingStatus() throws {
+        var environment = SecureConversations.PendingInteraction.Environment.failing
+        let uuidGen = UUID.incrementing
+        var pendingCallback: ((Result<Bool, Error>) -> Void)?
+        environment.observePendingSecureConversationsStatus = { callback in
+            pendingCallback = callback
+            return uuidGen().uuidString
+        }
+        var unreadCountCallback: ((Result<Int?, Error>) -> Void)?
+        environment.observeSecureConversationsUnreadMessageCount = { callback in
+            unreadCountCallback = callback
+            return uuidGen().uuidString
+        }
+        environment.unsubscribeFromPendingStatus = { _ in }
+        environment.unsubscribeFromUnreadCount = { _ in }
+
+        let pendingInteraction = SecureConversations.PendingInteraction(environment: environment)
+        // Assert initial pending interaction is false.
+        XCTAssertFalse(pendingInteraction.hasPendingInteraction)
+        // Affect pending secure conversations value by setting it to `true` and assert `hasPendingInteraction`,
+        // then set it back to `false` and assert again.
+        try XCTUnwrap(pendingCallback)(.success(true))
+        XCTAssertTrue(pendingInteraction.hasPendingInteraction)
+        try XCTUnwrap(pendingCallback)(.success(false))
+        XCTAssertFalse(pendingInteraction.hasPendingInteraction)
+        // Affect unread count value by setting it to `1` and assert `hasPendingInteraction`,
+        // then set it back to `0` and `nil` and assert again.
+        try XCTUnwrap(unreadCountCallback)(.success(1))
+        XCTAssertTrue(pendingInteraction.hasPendingInteraction)
+        try XCTUnwrap(unreadCountCallback)(.success(0))
+        try XCTUnwrap(unreadCountCallback)(.success(nil))
+        XCTAssertFalse(pendingInteraction.hasPendingInteraction)
+    }
+
+    func test_unsubscribeIsCalledOnDeinit() {
+        enum Call {
+            case unsubscribeFromPendingStatus
+            case unsubscribeFromUnreadCount
+        }
+        var calls: [Call] = []
+        var environment = SecureConversations.PendingInteraction.Environment.failing
+        let uuidGen = UUID.incrementing
+        environment.observePendingSecureConversationsStatus = { _ in uuidGen().uuidString }
+        environment.observeSecureConversationsUnreadMessageCount = { _ in uuidGen().uuidString }
+        environment.unsubscribeFromPendingStatus = { _ in
+            calls.append(.unsubscribeFromPendingStatus)
+        }
+        environment.unsubscribeFromUnreadCount = { _ in
+            calls.append(.unsubscribeFromUnreadCount)
+        }
+        var pendingInteraction = SecureConversations.PendingInteraction(environment: environment)
+        pendingInteraction = .mock()
+        _ = pendingInteraction
+        XCTAssertEqual(calls, [.unsubscribeFromUnreadCount, .unsubscribeFromPendingStatus])
+    }
+}

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+EngagementLauncher.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+EngagementLauncher.swift
@@ -4,7 +4,7 @@ import XCTest
 extension GliaTests {
     func test_getEngagementLauncherDoesNotThrowErrorWithCorrectConfiguration() throws {
         let sdk = makeConfigurableSDK()
-        
+
         try sdk.configure(
             with: .mock(),
             theme: .mock()
@@ -14,25 +14,25 @@ extension GliaTests {
             try sdk.getEngagementLauncher(queueIds: [])
         )
     }
-    
+
     func test_startChatUsingEngagementLauncherWithCorrectConfiguration() throws {
         let sdk = makeConfigurableSDK()
-        
+
         try sdk.configure(
             with: .mock(),
             theme: .mock()
         ) { _ in }
-        
+
         let engagementLauncher = try sdk.getEngagementLauncher(queueIds: [])
-        
+
         try engagementLauncher.startChat()
 
         XCTAssertEqual(sdk.engagement, .chat)
     }
-    
+
     func test_startAudioCallUsingEngagementLauncherWithCorrectConfiguration() throws {
         let sdk = makeConfigurableSDK()
-        
+
         try sdk.configure(
             with: .mock(),
             theme: .mock()
@@ -47,14 +47,14 @@ extension GliaTests {
     
     func test_startVideoCallUsingEngagementLauncherWithCorrectConfiguration() throws {
         let sdk = makeConfigurableSDK()
-        
+
         try sdk.configure(
             with: .mock(),
             theme: .mock()
         ) { _ in }
-        
+
         let engagementLauncher = try sdk.getEngagementLauncher(queueIds: [])
-        
+
         try engagementLauncher.startVideoCall()
 
         XCTAssertEqual(sdk.engagement, .videoCall)
@@ -67,9 +67,9 @@ extension GliaTests {
             with: .mock(),
             theme: .mock()
         ) { _ in }
-        
+
         let engagementLauncher = try sdk.getEngagementLauncher(queueIds: [])
-        
+
         try engagementLauncher.startSecureMessaging()
 
         XCTAssertEqual(sdk.engagement, .messaging(.welcome))
@@ -100,7 +100,11 @@ private extension GliaTests {
         }
         sdkEnv.coreSdk.getCurrentEngagement = { nil }
         sdkEnv.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
-        sdkEnv.coreSdk.pendingSecureConversationStatusUpdates = { _ in }
+        sdkEnv.coreSdk.pendingSecureConversationStatus = { _ in }
+        sdkEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        sdkEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        sdkEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        sdkEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
         let window = UIWindow(frame: .zero)
         window.makeKeyAndVisible()
         sdkEnv.uiApplication.windows = { [window] }

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+RestoreEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+RestoreEngagement.swift
@@ -22,12 +22,16 @@ extension GliaTests {
         sdkEnv.coreSdk.createLogger = { _ in logger }
         let siteMock = try CoreSdkClient.Site.mock()
         sdkEnv.coreSdk.fetchSiteConfigurations = { callback in callback(.success(siteMock)) }
-        sdkEnv.coreSdk.pendingSecureConversationStatusUpdates = { _ in }
+        sdkEnv.coreSdk.pendingSecureConversationStatus = { _ in }
         sdkEnv.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
         sdkEnv.conditionalCompilation.isDebug = { true }
         sdkEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
+        sdkEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        sdkEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        sdkEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        sdkEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
 
         let window = UIWindow(frame: .zero)
         window.rootViewController = .init()

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
@@ -23,8 +23,12 @@ extension GliaTests {
         logger.prefixedClosure = { _ in logger }
         logger.infoClosure = { _, _, _, _ in }
         sdkEnv.coreSdk.createLogger = { _ in logger }
-        sdkEnv.coreSdk.pendingSecureConversationStatusUpdates = { _ in }
+        sdkEnv.coreSdk.pendingSecureConversationStatus = { _ in }
         sdkEnv.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
+        sdkEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        sdkEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        sdkEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        sdkEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
         sdkEnv.conditionalCompilation.isDebug = { true }
         sdkEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
@@ -54,6 +58,10 @@ extension GliaTests {
         gliaEnv.conditionalCompilation.isDebug = { false }
         gliaEnv.coreSdk.createLogger = { _ in logger }
         gliaEnv.coreSdk.localeProvider.getRemoteString = { _ in nil }
+        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
         let sdk = Glia(environment: gliaEnv)
         sdk.queuesMonitor = .mock()
         sdk.environment.conditionalCompilation.isDebug = { true }
@@ -83,7 +91,7 @@ extension GliaTests {
         logger.prefixedClosure = { _ in logger }
         logger.configureLocalLogLevelClosure = { _ in }
         logger.configureRemoteLogLevelClosure = { _ in }
-        environment.coreSdk.pendingSecureConversationStatusUpdates = { _ in }
+        environment.coreSdk.pendingSecureConversationStatus = { _ in }
         environment.coreSdk.createLogger = { _ in logger }
         environment.conditionalCompilation.isDebug = { false }
         environment.createRootCoordinator = { _, _, _, _, _, _, _ in
@@ -96,6 +104,10 @@ extension GliaTests {
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
         environment.coreSdk.getCurrentEngagement = { nil }
         environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
         try sdk.configure(
@@ -140,9 +152,13 @@ extension GliaTests {
             completion(.success(()))
         }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
-        environment.coreSdk.pendingSecureConversationStatusUpdates = { _ in }
+        environment.coreSdk.pendingSecureConversationStatus = { _ in }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
         environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
 
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
@@ -190,9 +206,13 @@ extension GliaTests {
             completion(.success(()))
         }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
-        environment.coreSdk.pendingSecureConversationStatusUpdates = { _ in }
+        environment.coreSdk.pendingSecureConversationStatus = { _ in }
         environment.coreSdk.getCurrentEngagement = { nil }
         environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
 
         var logger = CoreSdkClient.Logger.failing
         logger.configureLocalLogLevelClosure = { _ in }
@@ -256,8 +276,12 @@ extension GliaTests {
         }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
-        environment.coreSdk.pendingSecureConversationStatusUpdates = { _ in }
+        environment.coreSdk.pendingSecureConversationStatus = { _ in }
         environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
 
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
@@ -309,8 +333,12 @@ extension GliaTests {
         }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
-        environment.coreSdk.pendingSecureConversationStatusUpdates = { _ in }
+        environment.coreSdk.pendingSecureConversationStatus = { _ in }
         environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
 
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
@@ -358,7 +386,7 @@ extension GliaTests {
             )
         }
 
-        environment.coreSdk.pendingSecureConversationStatusUpdates = { _ in }
+        environment.coreSdk.pendingSecureConversationStatus = { _ in }
         environment.coreSdk.localeProvider.getRemoteString = { _ in "" }
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
@@ -366,6 +394,10 @@ extension GliaTests {
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.getCurrentEngagement = { nil }
         environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
 
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
@@ -418,13 +450,17 @@ extension GliaTests {
         }
 
         environment.coreSdk.localeProvider.getRemoteString = { _ in "" }
-        environment.coreSdk.pendingSecureConversationStatusUpdates = { _ in }
+        environment.coreSdk.pendingSecureConversationStatus = { _ in }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
         environment.coreSdk.getCurrentEngagement = { nil }
         environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
 
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
@@ -461,14 +497,23 @@ extension GliaTests {
         }
 
         environment.coreSdk.localeProvider.getRemoteString = { _ in "" }
-        environment.coreSdk.pendingSecureConversationStatusUpdates = { $0(.success(true)) }
+        environment.coreSdk.pendingSecureConversationStatus = { $0(.success(true)) }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
+        let uuIdGen = UUID.incrementing
         environment.coreSdk.getCurrentEngagement = { nil }
-        environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
-
+        environment.coreSdk.subscribeForUnreadSCMessageCount = {
+            $0(.success(0))
+            return uuIdGen().uuidString
+        }
+        environment.coreSdk.observePendingSecureConversationStatus = {
+            $0(.success(true))
+            return uuIdGen().uuidString
+        }
+        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
         try sdk.configure(
@@ -502,13 +547,17 @@ extension GliaTests {
         }
 
         environment.coreSdk.localeProvider.getRemoteString = { _ in "" }
-        environment.coreSdk.pendingSecureConversationStatusUpdates = { $0(.success(false)) }
+        environment.coreSdk.pendingSecureConversationStatus = { $0(.success(false)) }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
         environment.coreSdk.getCurrentEngagement = { nil }
         environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
 
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
@@ -542,13 +591,23 @@ extension GliaTests {
         }
 
         environment.coreSdk.localeProvider.getRemoteString = { _ in "" }
-        environment.coreSdk.pendingSecureConversationStatusUpdates = { $0(.success(true)) }
+        environment.coreSdk.pendingSecureConversationStatus = { $0(.success(true)) }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
+        let uuIdGen = UUID.incrementing
         environment.coreSdk.getCurrentEngagement = { nil }
-        environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.subscribeForUnreadSCMessageCount = { callback in
+            callback(.success(0))
+            return uuIdGen().uuidString
+        }
+        environment.coreSdk.observePendingSecureConversationStatus = { callback in
+            callback(.success(true))
+            return uuIdGen().uuidString
+        }
+        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
 
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -14,6 +14,10 @@ final class GliaTests: XCTestCase {
         environment.coreSdk.createLogger = { _ in logger }
         environment.print = .mock
         environment.conditionalCompilation.isDebug = { false }
+        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
 
         let sdk = Glia(environment: environment)
         sdk.endEngagement { result in
@@ -39,6 +43,10 @@ final class GliaTests: XCTestCase {
         environment.coreSdk.createLogger = { _ in logger }
         environment.print = .mock
         environment.conditionalCompilation.isDebug = { false }
+        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
 
         let sdk = Glia(environment: environment)
         sdk.interactor = .mock()
@@ -60,6 +68,11 @@ final class GliaTests: XCTestCase {
         logger.configureRemoteLogLevelClosure = { _ in }
         environment.coreSdk.createLogger = { _ in logger }
         environment.conditionalCompilation.isDebug = { false }
+        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
+
         let sdk = Glia(environment: environment)
         XCTAssertNotNil(sdk.messageRenderer)
 
@@ -89,6 +102,10 @@ final class GliaTests: XCTestCase {
         gliaEnv.callVisualizerPresenter = .init(presenter: { nil })
         gliaEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
         gliaEnv.coreSdk.fetchSiteConfigurations = { _ in }
+        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
         let sdk = Glia(environment: gliaEnv)
         sdk.onEvent = {
             calls.append(.onEvent($0))
@@ -126,6 +143,10 @@ final class GliaTests: XCTestCase {
             completion(.success(()))
         }
         gliaEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
+        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
 
         let sdk = Glia(environment: gliaEnv)
         sdk.onEvent = {
@@ -163,6 +184,10 @@ final class GliaTests: XCTestCase {
             completion(.success(()))
         }
         gliaEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
+        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
 
         let sdk = Glia(environment: gliaEnv)
         sdk.onEvent = {
@@ -209,6 +234,10 @@ final class GliaTests: XCTestCase {
             completion(.success(()))
         }
         gliaEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
+        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
 
         let sdk = Glia(environment: gliaEnv)
         sdk.onEvent = {
@@ -253,6 +282,10 @@ final class GliaTests: XCTestCase {
             completion(.success(()))
         }
         gliaEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
+        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
 
         let sdk = Glia(environment: gliaEnv)
         sdk.onEvent = {
@@ -280,6 +313,10 @@ final class GliaTests: XCTestCase {
         environment.coreSdk.createLogger = { _ in logger }
         environment.conditionalCompilation.isDebug = { false }
         environment.coreSdk.getCurrentEngagement = { .mock() }
+        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
         let sdk = Glia(environment: environment)
 
         XCTAssertThrowsError(try sdk.configure(
@@ -303,6 +340,10 @@ final class GliaTests: XCTestCase {
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
+        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
         let sdk = Glia(environment: environment)
         try sdk.configure(
             with: .mock(),
@@ -332,6 +373,10 @@ final class GliaTests: XCTestCase {
         environment.coreSdk.getCurrentEngagement = { .mock() }
         environment.print = .mock
         environment.conditionalCompilation.isDebug = { false }
+        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
         let sdk = Glia(environment: environment)
 
         var resultingError: Error?
@@ -355,6 +400,10 @@ final class GliaTests: XCTestCase {
         logger.configureRemoteLogLevelClosure = { _ in }
         environment.coreSdk.createLogger = { _ in logger }
         environment.conditionalCompilation.isDebug = { false }
+        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
         let sdk = Glia(environment: environment)
         let coordinator = EngagementCoordinator.mock()
         let delegate = GliaViewControllerDelegateMock()
@@ -379,6 +428,10 @@ final class GliaTests: XCTestCase {
         logger.configureRemoteLogLevelClosure = { _ in }
         environment.coreSdk.createLogger = { _ in logger }
         environment.conditionalCompilation.isDebug = { false }
+        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
         let sdk = Glia(environment: environment)
         let coordinator = EngagementCoordinator.mock()
         let delegate = GliaViewControllerDelegateMock()
@@ -403,6 +456,10 @@ final class GliaTests: XCTestCase {
         logger.configureRemoteLogLevelClosure = { _ in }
         environment.coreSdk.createLogger = { _ in logger }
         environment.conditionalCompilation.isDebug = { false }
+        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
 
         XCTAssertFalse(Glia(environment: environment).isConfigured)
     }
@@ -420,6 +477,10 @@ final class GliaTests: XCTestCase {
         }
         environment.conditionalCompilation.isDebug = { true }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
+        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
         let sdk = Glia(environment: environment)
         try sdk.configure(
             with: .mock(),
@@ -442,6 +503,10 @@ final class GliaTests: XCTestCase {
         }
         environment.conditionalCompilation.isDebug = { true }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
+        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
         let sdk = Glia(environment: environment)
         try sdk.configure(
             with: .mock(),
@@ -469,6 +534,10 @@ final class GliaTests: XCTestCase {
                 throw CoreSdkClient.GliaCoreError.mock()
             }
         }
+        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
         let sdk = Glia(environment: environment)
 
         try sdk.configure(
@@ -496,6 +565,10 @@ final class GliaTests: XCTestCase {
         environment.coreSDKConfigurator.configureWithConfiguration = { _, _ in
             throw CoreSdkClient.GliaCoreError.mock()
         }
+        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
         let sdk = Glia(environment: environment)
         try? sdk.configure(
             with: .mock(),
@@ -517,13 +590,16 @@ final class GliaTests: XCTestCase {
         }
         environment.conditionalCompilation.isDebug = { true }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
-        environment.coreSdk.pendingSecureConversationStatusUpdates = { _ in }
+        environment.coreSdk.pendingSecureConversationStatus = { _ in }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
         environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
         var engCoordEnvironment = EngagementCoordinator.Environment.engagementCoordEnvironmentWithKeyWindow
         engCoordEnvironment.fileManager = .mock
         environment.createRootCoordinator = { _, _, _, _, _, _, _ in EngagementCoordinator.mock(environment: engCoordEnvironment) }
-
+        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
         enum Call {
@@ -569,6 +645,10 @@ final class GliaTests: XCTestCase {
             callback(.success(()))
         }
         gliaEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
+        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
         let sdk = Glia(environment: gliaEnv)
         try sdk.configure(
             with: .mock(),
@@ -646,6 +726,10 @@ final class GliaTests: XCTestCase {
             completion(.success(()))
         }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
+        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
         let sdk = Glia(environment: environment)
         let configuration = Configuration.mock()
 
@@ -666,31 +750,49 @@ final class GliaTests: XCTestCase {
     func test_hasPendingInteractionIfPendingSecureConversationExists() {
         var gliaEnv = Glia.Environment.failing
         var logger = CoreSdkClient.Logger.failing
+        let uuidGen = UUID.incrementing
         logger.configureLocalLogLevelClosure = { _ in }
         logger.configureRemoteLogLevelClosure = { _ in }
         gliaEnv.coreSdk.createLogger = { _ in logger }
-        gliaEnv.coreSdk.pendingSecureConversationStatusUpdates = { $0(.success(true)) }
-        gliaEnv.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
         gliaEnv.conditionalCompilation.isDebug = { true }
+        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { callback in
+            callback(.success(0))
+            return uuidGen().uuidString
+        }
+        gliaEnv.coreSdk.observePendingSecureConversationStatus = { callback in
+            callback(.success(true))
+            return uuidGen().uuidString
+        }
+        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
 
         let sdk = Glia(environment: gliaEnv)
 
-        XCTAssertTrue(sdk.hasPendingInteraction)
+        XCTAssertTrue(sdk.pendingInteraction.hasPendingInteraction)
     }
 
     func test_hasPendingInteractionIfUnreadMessagesExist() {
         var gliaEnv = Glia.Environment.failing
         var logger = CoreSdkClient.Logger.failing
+        let uuidGen = UUID.incrementing
         logger.configureLocalLogLevelClosure = { _ in }
         logger.configureRemoteLogLevelClosure = { _ in }
         gliaEnv.coreSdk.createLogger = { _ in logger }
-        gliaEnv.coreSdk.pendingSecureConversationStatusUpdates = { $0(.success(false)) }
-        gliaEnv.coreSdk.getSecureUnreadMessageCount = { $0(.success(3)) }
         gliaEnv.conditionalCompilation.isDebug = { true }
+        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { callback in
+            callback(.success(3))
+            return uuidGen().uuidString
+        }
+        gliaEnv.coreSdk.observePendingSecureConversationStatus = { callback in
+            callback(.success(false))
+            return uuidGen().uuidString
+        }
+        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
 
         let sdk = Glia(environment: gliaEnv)
 
-        XCTAssertTrue(sdk.hasPendingInteraction)
+        XCTAssertTrue(sdk.pendingInteraction.hasPendingInteraction)
     }
 
     func test_hasPendingInteractionIfNoUnreadMessageAndPendingSecureConversationExist() {
@@ -699,12 +801,16 @@ final class GliaTests: XCTestCase {
         logger.configureLocalLogLevelClosure = { _ in }
         logger.configureRemoteLogLevelClosure = { _ in }
         gliaEnv.coreSdk.createLogger = { _ in logger }
-        gliaEnv.coreSdk.pendingSecureConversationStatusUpdates = { $0(.success(false)) }
+        gliaEnv.coreSdk.pendingSecureConversationStatus = { $0(.success(false)) }
         gliaEnv.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
         gliaEnv.conditionalCompilation.isDebug = { true }
+        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
+        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
+        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
 
         let sdk = Glia(environment: gliaEnv)
 
-        XCTAssertFalse(sdk.hasPendingInteraction)
+        XCTAssertFalse(sdk.pendingInteraction.hasPendingInteraction)
     }
 }


### PR DESCRIPTION
MOB-3850

**What was solved?**
Introduce 'PendingInteraction' model to determine pending interaction for SC 2.0.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
