### PR TITLE
Address unavailability banner showing up for SC flow

### DIFF
--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.ChatWithTranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.ChatWithTranscriptModel.swift
@@ -70,10 +70,10 @@ extension SecureConversations.ChatWithTranscriptModel {
         }
     }
 
-    var isSecureConversationsAvailable: Bool {
+    var isSendMessageAvailable: Bool {
         switch self {
         case .chat:
-            false
+            true
         case let .transcript(model):
             model.isSecureConversationsAvailable
         }

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
@@ -266,11 +266,12 @@ final class ChatViewController: EngagementViewController, PopoverPresenter {
             // For regular chat engagement bottom banner is hidden.
             chatView.setSecureMessagingBottomBannerHidden(true)
             chatView.setSecureMessagingTopBannerHidden(true)
+            chatView.setSendingMessageUnavailabilityBannerHidden(viewModel.isSendMessageAvailable)
         case let .secureTranscript(needsTextInputEnabled):
             chatView.props = .init(header: props.secureTranscript)
             // Instead of hiding text input, we need to disable it and corresponding buttons.
             chatView.messageEntryView.isEnabled = needsTextInputEnabled
-            chatView.setSendingMessageUnavailabilityBannerHidden(viewModel.isSecureConversationsAvailable)
+            chatView.setSendingMessageUnavailabilityBannerHidden(viewModel.isSendMessageAvailable)
             // For secure messaging bottom banner is visible.
             chatView.setSecureMessagingBottomBannerHidden(false)
             chatView.setSecureMessagingTopBannerHidden(false)

--- a/GliaWidgetsTests/SecureConversations/SecureConversations.ChatWithTranscriptModel/SecureConversations.ChatWithTranscriptModelTests.swift
+++ b/GliaWidgetsTests/SecureConversations/SecureConversations.ChatWithTranscriptModel/SecureConversations.ChatWithTranscriptModelTests.swift
@@ -81,8 +81,13 @@ final class SecureConversationsChatWithTranscriptModelTests: XCTestCase {
                 interactor: .mock()
             )
         )
-        
+    
         XCTAssertNil(chatViewModel.entryWidget)
         XCTAssertNotNil(transcriptViewModel.entryWidget)
+    }
+
+    func test_isSendMessageAvailableReturnsTrueForChatViewModel() {
+        let chatViewModel = Model.chat(.mock())
+        XCTAssertTrue(chatViewModel.isSendMessageAvailable)
     }
 }

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -968,7 +968,7 @@ class ChatViewModelTests: XCTestCase {
 
         let upload = FileUpload.mock()
         upload.state.value = .uploaded(file: try .mock())
-        var fileUploadListViewModelEnv = SecureConversations.FileUploadListViewModel.Environment.mock
+        let fileUploadListViewModelEnv = SecureConversations.FileUploadListViewModel.Environment.mock
         fileUploadListViewModelEnv.uploader.uploads = [upload]
         viewModelEnv.createFileUploadListModel = { _ in .mock(environment: fileUploadListViewModelEnv) }
         viewModelEnv.createSendMessagePayload = { .mock(content: $0, attachment: $1) }

--- a/GliaWidgetsTests/Sources/EngagementLauncher/EngagementLauncherTests.swift
+++ b/GliaWidgetsTests/Sources/EngagementLauncher/EngagementLauncherTests.swift
@@ -6,43 +6,43 @@ final class EngagementLauncherTests: XCTestCase {
 
     func test_startChat() throws {
         var chatEngagement: EngagementKind?
-        var engagementLauncher = EngagementLauncher { engagementKind, _ in
+        let engagementLauncher = EngagementLauncher { engagementKind, _ in
             chatEngagement = engagementKind
         }
-        
+
         try engagementLauncher.startChat()
-        
+
         XCTAssertEqual(chatEngagement, .chat)
     }
 
     func test_startAudioCall() throws {
         var chatEngagement: EngagementKind?
-        var engagementLauncher = EngagementLauncher { engagementKind, _ in
+        let engagementLauncher = EngagementLauncher { engagementKind, _ in
             chatEngagement = engagementKind
         }
-        
+
         try engagementLauncher.startAudioCall()
-        
+
         XCTAssertEqual(chatEngagement, .audioCall)
     }
-    
+
     func test_startVideoCall() throws {
         var chatEngagement: EngagementKind?
-        var engagementLauncher = EngagementLauncher { engagementKind, _ in
+        let engagementLauncher = EngagementLauncher { engagementKind, _ in
             chatEngagement = engagementKind
         }
-        
+
         try engagementLauncher.startVideoCall()
         
         XCTAssertEqual(chatEngagement, .videoCall)
     }
-    
+
     func test_startSecureMessaging() throws {
         var chatEngagement: EngagementKind?
-        var engagementLauncher = EngagementLauncher { engagementKind, _ in
+        let engagementLauncher = EngagementLauncher { engagementKind, _ in
             chatEngagement = engagementKind
         }
-        
+
         try engagementLauncher.startSecureMessaging()
         
         XCTAssertEqual(chatEngagement, .messaging(.welcome))

--- a/GliaWidgetsTests/Sources/EntryWidget/EntryWidgetTests.swift
+++ b/GliaWidgetsTests/Sources/EntryWidget/EntryWidgetTests.swift
@@ -215,14 +215,14 @@ class EntryWidgetTests: XCTestCase {
         }
         let queuesMonitor = QueuesMonitor(environment: queueMonitorEnvironment)
         queuesMonitor.fetchAndMonitorQueues(queuesIds: [mockQueueId])
-        
+
         var environment = EntryWidget.Environment.mock()
         environment.queuesMonitor = queuesMonitor
         environment.observeSecureUnreadMessageCount = { result in
             result(.success(5))
             return UUID.mock.uuidString
         }
-        var configuration = EntryWidget.Configuration.mock(filterSecureConversation: true)
+        let configuration = EntryWidget.Configuration.mock(filterSecureConversation: true)
         let entryWidget = EntryWidget(
             queueIds: [mockQueueId],
             configuration: configuration,


### PR DESCRIPTION
MOB-3834

**What was solved?**

Hide send message unavailability banner for SC flow.
**UPD:**
Updated logic for hiding unavailability banner for regular chat flow.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
