### PR TITLE
Update SC availability taking into account 'transferring' state

### DIFF
--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
@@ -146,8 +146,12 @@ extension SecureConversations {
             availability.checkSecureConversationsAvailability(for: environment.queueIds) { [weak self] result in
                 guard let self else { return }
                 switch result {
-                case let .success(.available(queueIds)):
+                case let .success(.available(.queues(queueIds))):
                     self.environment.queueIds = queueIds
+                    self.isSecureConversationsAvailable = true
+                    self.fileUploadListModel.isEnabled = true
+                case .success(.available(.transferred)):
+                    self.environment.queueIds = []
                     self.isSecureConversationsAvailable = true
                     self.fileUploadListModel.isEnabled = true
                 case .failure, .success(.unavailable(.emptyQueue)), .success(.unavailable(.unauthenticated)):

--- a/GliaWidgetsTests/SecureConversations/Availability.Environment.Failing.swift
+++ b/GliaWidgetsTests/SecureConversations/Availability.Environment.Failing.swift
@@ -10,6 +10,10 @@ extension SecureConversations.Availability.Environment {
             return false
         },
         log: .failing,
-        queuesMonitor: .failing
+        queuesMonitor: .failing,
+        getCurrentEngagement: {
+            fail("\(Self.self).getCurrentEngagement")
+            return .mock()
+        }
     )
 }

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+GVA.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+GVA.swift
@@ -153,7 +153,8 @@ extension SecureConversationsTranscriptModelTests {
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
             log: logger,
-            queuesMonitor: .mock()
+            queuesMonitor: .mock(),
+            getCurrentEngagement: { .mock() }
         )
 
         let viewModel = TranscriptModel(
@@ -200,7 +201,8 @@ private extension SecureConversationsTranscriptModelTests {
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
             log: logger,
-            queuesMonitor: .mock()
+            queuesMonitor: .mock(),
+            getCurrentEngagement: { .mock() }
         )
 
         return TranscriptModel(

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+MessageRetry.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+MessageRetry.swift
@@ -140,7 +140,8 @@ private extension SecureConversationsTranscriptModelTests {
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
             log: logger,
-            queuesMonitor: .mock()
+            queuesMonitor: .mock(),
+            getCurrentEngagement: { .mock() }
         )
 
         return TranscriptModel(

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+ResponseCard.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+ResponseCard.swift
@@ -48,7 +48,8 @@ private extension SecureConversationsTranscriptModelTests {
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
             log: logger,
-            queuesMonitor: .mock()
+            queuesMonitor: .mock(),
+            getCurrentEngagement: { .mock() }
         )
 
         return TranscriptModel(

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+URLs.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+URLs.swift
@@ -92,7 +92,8 @@ private extension SecureConversationsTranscriptModelTests {
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
             log: logger,
-            queuesMonitor: .mock()
+            queuesMonitor: .mock(),
+            getCurrentEngagement: { .mock() }
         )
 
         return TranscriptModel(

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests.swift
@@ -21,7 +21,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
             log: logger,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            getCurrentEngagement: { .mock() }
         )
         let viewModel = TranscriptModel(
             isCustomCardSupported: false,
@@ -52,7 +53,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             listQueues: modelEnv.listQueues,
             isAuthenticated: { false },
             log: logger,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            getCurrentEngagement: { .mock() }
         )
         let viewModel = TranscriptModel(
             isCustomCardSupported: false,
@@ -87,7 +89,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            getCurrentEngagement: { .mock() }
         )
 
         let viewModel = TranscriptModel(
@@ -135,7 +138,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            getCurrentEngagement: { .mock() }
         )
         let viewModel = TranscriptModel(
             isCustomCardSupported: false,
@@ -169,7 +173,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            getCurrentEngagement: { .mock() }
         )
         let viewModel = TranscriptModel(
             isCustomCardSupported: false,
@@ -217,7 +222,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            getCurrentEngagement: { .mock() }
         )
 
         let viewModel = TranscriptModel(
@@ -260,7 +266,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            getCurrentEngagement: { .mock() }
         )
 
         let viewModel = TranscriptModel(
@@ -299,7 +306,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            getCurrentEngagement: { .mock() }
         )
 
         let viewModel = TranscriptModel(
@@ -344,7 +352,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            getCurrentEngagement: { .mock() }
         )
 
         let viewModel = TranscriptModel(
@@ -385,7 +394,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            getCurrentEngagement: { .mock() }
         )
 
         let viewModel = TranscriptModel(
@@ -429,7 +439,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            getCurrentEngagement: { .mock() }
         )
 
         let viewModel = TranscriptModel(
@@ -470,7 +481,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             callback(.success(0))
         }
         modelEnv.startSocketObservation = {}
-        modelEnv.gcd.mainQueue.asyncAfterDeadline = { _, callback in }
+        modelEnv.gcd.mainQueue.asyncAfterDeadline = { _, _ in }
         modelEnv.loadChatMessagesFromHistory = { true }
         modelEnv.createEntryWidget = { _ in .mock() }
         let scheduler = CoreSdkClient.ReactiveSwift.TestScheduler()
@@ -480,7 +491,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            getCurrentEngagement: { .mock() }
         )
 
         let interactor: Interactor = .failing
@@ -547,7 +559,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            getCurrentEngagement: { .mock() }
         )
 
         let interactor: Interactor = .failing
@@ -611,6 +624,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         }
         availabilityEnv.isAuthenticated = { true }
         availabilityEnv.queuesMonitor = .mock(listQueues: availabilityEnv.listQueues)
+        availabilityEnv.getCurrentEngagement = { .mock() }
         let model = TranscriptModel(
             isCustomCardSupported: false,
             environment: modelEnvironment,
@@ -705,6 +719,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         }
         availabilityEnv.isAuthenticated = { true }
         availabilityEnv.queuesMonitor = .mock(listQueues: availabilityEnv.listQueues)
+        availabilityEnv.getCurrentEngagement = { .mock() }
         let model = TranscriptModel(
             isCustomCardSupported: false,
             environment: modelEnvironment,
@@ -729,7 +744,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnvironment.createFileUploadListModel = {
             .mock(environment: $0)
         }
-        modelEnvironment.createEntryWidget = { _ in .mock() } 
+        modelEnvironment.createEntryWidget = { _ in .mock() }
         var availabilityEnv = SecureConversations.Availability.Environment.failing
         availabilityEnv.log = logger
         availabilityEnv.listQueues = { callback in
@@ -737,6 +752,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         }
         availabilityEnv.isAuthenticated = { true }
         availabilityEnv.queuesMonitor = .mock(listQueues: availabilityEnv.listQueues)
+        availabilityEnv.getCurrentEngagement = { .mock() }
         let model = TranscriptModel(
             isCustomCardSupported: false,
             environment: modelEnvironment,
@@ -759,7 +775,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             XCTFail("Unexpected action: \(receivedAction)")
         }
     }
-    
+
     func testLoadHistoryAlsoInvokesSecureMarkMessagesAsReadIfShouldNotShowLeaveSecureConversationDialog() {
         var modelEnv = TranscriptModel.Environment.failing
         let fileUploadListModel = FileUploadListViewModel.mock()
@@ -790,7 +806,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            getCurrentEngagement: { .mock() }
         )
 
         let viewModel = TranscriptModel(
@@ -806,10 +823,10 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
 
         viewModel.start()
         scheduler.run()
-        
+
         XCTAssertEqual(calls, [.secureMarkMessagesAsRead])
     }
-    
+
     func testLoadHistoryNotInvokesSecureMarkMessagesAsReadIfShouldShowLeaveSecureConversationDialog() {
         var modelEnv = TranscriptModel.Environment.failing
         let fileUploadListModel = FileUploadListViewModel.mock()
@@ -840,7 +857,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            getCurrentEngagement: { .mock() }
         )
 
         let viewModel = TranscriptModel(
@@ -856,7 +874,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
 
         viewModel.start()
         scheduler.run()
-        
+
         XCTAssertTrue(calls.isEmpty)
     }
 
@@ -890,7 +908,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            getCurrentEngagement: { .mock() }
         )
 
         let viewModel = TranscriptModel(
@@ -903,7 +922,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             failedToDeliverStatusText: "",
             interactor: .failing
         )
-        
+
         viewModel.engagementAction = { action in
             if case .showAlert(let type) = action, case let .leaveCurrentConversation(_, declined) = type {
                 declined?()
@@ -912,10 +931,10 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
 
         viewModel.start()
         scheduler.run()
-        
+
         XCTAssertEqual(calls, [.secureMarkMessagesAsRead])
     }
-    
+
     func testReceiveMessageMarksMessagesAsRead() {
         enum Call: Equatable { case secureMarkMessagesAsRead }
         var calls: [Call] = []
@@ -950,7 +969,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             listQueues: modelEnv.listQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues)
+            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            getCurrentEngagement: { .mock() }
         )
 
         let viewModel = TranscriptModel(

--- a/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.Mock.swift
+++ b/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.Mock.swift
@@ -53,7 +53,8 @@ extension SecureConversations.Availability {
             listQueues: { _ in },
             isAuthenticated: { true },
             log: .mock,
-            queuesMonitor: .mock()
+            queuesMonitor: .mock(),
+            getCurrentEngagement: { .mock() }
         )
     )
 }

--- a/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModelSpec.swift
+++ b/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModelSpec.swift
@@ -265,7 +265,7 @@ extension SecureConversationsWelcomeViewModelTests {
         }
 
         viewModel = .init(environment: environment, availability: .mock)
-        viewModel.availabilityStatus = .available()
+        viewModel.availabilityStatus = .available(.queues(queueIds: []))
 
         if case .welcome(let props) = viewModel.props() {
             XCTAssertNotNil(props.filePickerButton)
@@ -335,7 +335,7 @@ extension SecureConversationsWelcomeViewModelTests {
     }
 
     func testSendMessageButtonStateFileUploads() {
-        viewModel.availabilityStatus = .available()
+        viewModel.availabilityStatus = .available(.queues(queueIds: []))
         let uploadFile: FileUpload.Environment.UploadFile = .toSecureMessaging { file, progress, completion in
             completion(.failure(CoreSdkClient.GliaCoreError(reason: "")))
             return .mock
@@ -354,7 +354,7 @@ extension SecureConversationsWelcomeViewModelTests {
     }
 
     func testSendMessageButtonStateInProgressFileUpload() {
-        viewModel.availabilityStatus = .available()
+        viewModel.availabilityStatus = .available(.queues(queueIds: []))
         let fileUpload: FileUpload = .mock()
         fileUpload.startUpload()
         viewModel.fileUploadListModel.environment.uploader.uploads = [fileUpload]
@@ -367,7 +367,7 @@ extension SecureConversationsWelcomeViewModelTests {
     }
 
     func testSendMessageButtonStateEmptyText() {
-        viewModel.availabilityStatus = .available()
+        viewModel.availabilityStatus = .available(.queues(queueIds: []))
         viewModel.messageText = ""
 
         if case .welcome(let props) = viewModel.props() {
@@ -378,7 +378,7 @@ extension SecureConversationsWelcomeViewModelTests {
     }
 
     func testSendMessageButtonStateSuccessfulUpload() {
-        viewModel.availabilityStatus = .available()
+        viewModel.availabilityStatus = .available(.queues(queueIds: []))
         viewModel.fileUploadListModel.environment.uploader = FileUploader(maximumUploads: 100, environment: .mock)
         viewModel.messageText = ""
 
@@ -390,7 +390,7 @@ extension SecureConversationsWelcomeViewModelTests {
     }
 
     func testSendMessageButtonStateNoQueues() {
-        viewModel.availabilityStatus = .available()
+        viewModel.availabilityStatus = .available(.queues(queueIds: []))
         viewModel.messageText = "text"
         viewModel.fileUploadListModel.environment.uploader = FileUploader(maximumUploads: 100, environment: .mock)
         viewModel.environment.queueIds = []
@@ -403,7 +403,7 @@ extension SecureConversationsWelcomeViewModelTests {
     }
 
     func testSendMessageButtonStateLoadingMessageRequestState() {
-        viewModel.availabilityStatus = .available()
+        viewModel.availabilityStatus = .available(.queues(queueIds: []))
         viewModel.messageText = "text"
         viewModel.fileUploadListModel.environment.uploader = FileUploader(maximumUploads: 100, environment: .mock)
         viewModel.environment.queueIds = [""]
@@ -417,7 +417,7 @@ extension SecureConversationsWelcomeViewModelTests {
     }
 
     func testSendMessageButtonStateWaitingMessageRequestState() {
-        viewModel.availabilityStatus = .available()
+        viewModel.availabilityStatus = .available(.queues(queueIds: []))
         viewModel.messageText = "text"
         viewModel.fileUploadListModel.environment.uploader = FileUploader(maximumUploads: 100, environment: .mock)
         viewModel.environment.queueIds = [""]
@@ -623,7 +623,7 @@ extension SecureConversationsWelcomeViewModelTests {
 
         viewModel = .init(environment: .mock(queueIds: [uuid]), availability: availability)
 
-        XCTAssertEqual(viewModel.availabilityStatus, .available())
+        XCTAssertEqual(viewModel.availabilityStatus, .available(.queues(queueIds: [])))
     }
 
     func testAvailabilityUnavailableEmptyQueues() {

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -467,7 +467,8 @@ class ChatViewModelTests: XCTestCase {
             listQueues: transcriptModelEnv.listQueues,
             isAuthenticated: { true },
             log: logger,
-            queuesMonitor: .mock()
+            queuesMonitor: .mock(),
+            getCurrentEngagement: { .mock() }
         )
         let transcriptModel = TranscriptModel(
             isCustomCardSupported: false,


### PR DESCRIPTION
MOB-3654

**What was solved?**
Add 'transferring' and 'engagement.capabilities.text == true' to be used for SC availability.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
