### PR TITLE
Handle ongoing engagement in EntryWidget

### DIFF
--- a/GliaWidgets/Localization.swift
+++ b/GliaWidgets/Localization.swift
@@ -453,6 +453,14 @@ internal enum Localization {
         }
       }
     }
+    internal enum CallVisualizer {
+      /// Screen sharing in progress
+      internal static var desciption: String { Localization.tr("Localizable", "entry_widget.call_visualizer.desciption", fallback: "Screen sharing in progress") }
+      internal enum Button {
+        /// Call Visualizer
+        internal static var label: String { Localization.tr("Localizable", "entry_widget.call_visualizer.button.label", fallback: "Call Visualizer") }
+      }
+    }
     internal enum EmptyState {
       /// We are here to assist you during our business hours.
       internal static var description: String { Localization.tr("Localizable", "entry_widget.empty_state.description", fallback: "We are here to assist you during our business hours.") }
@@ -487,6 +495,16 @@ internal enum Localization {
       internal enum Accessibility {
         /// Loading indicator. Waiting for available options.
         internal static var label: String { Localization.tr("Localizable", "entry_widget.loading.accessibility.label", fallback: "Loading indicator. Waiting for available options.") }
+      }
+    }
+    internal enum OngoingEngagement {
+      /// Ongoing • Tap to return
+      internal static var description: String { Localization.tr("Localizable", "entry_widget.ongoing_engagement.description", fallback: "Ongoing • Tap to return") }
+      internal enum Button {
+        internal enum Accessibility {
+          /// Returns to ongoing engagement
+          internal static var hint: String { Localization.tr("Localizable", "entry_widget.ongoing_engagement.button.accessibility.hint", fallback: "Returns to ongoing engagement") }
+        }
       }
     }
     internal enum SecureMessaging {

--- a/GliaWidgets/Public/Glia/Glia+EntryWidget.swift
+++ b/GliaWidgets/Public/Glia/Glia+EntryWidget.swift
@@ -27,6 +27,10 @@ extension Glia {
                 hasPendingInteraction: { [weak self] in
                     guard let self else { return false }
                     return pendingInteraction?.hasPendingInteraction ?? false
+                },
+                currentInteractor: { [weak self] in
+                    guard let self else { return nil }
+                    return interactor
                 }
             )
         )

--- a/GliaWidgets/Resources/en.lproj/Localizable.strings
+++ b/GliaWidgets/Resources/en.lproj/Localizable.strings
@@ -262,9 +262,13 @@
 "entry_widget.secure_messaging.button.label" = "Secure Messaging";
 "entry_widget.secure_messaging.button.description" = "Start a conversation, we’ll get back to you";
 "entry_widget.secure_messaging.button.accessibility.hint" = "Starts messaging with us";
+"entry_widget.call_visualizer.button.label" = "Call Visualizer";
 "entry_widget.empty_state.title" = "Support team is currently offline";
 "entry_widget.empty_state.description" = "We are here to assist you during our business hours.";
 "entry_widget.error_state.title" = "Could not load the contacts";
 "entry_widget.error_state.description" = "We could not load the contacts at this time. This may be due to a temporary syncing issue or network problem.";
 "entry_widget.error_state.try_again.button.label" = "Try again";
 "entry_widget.loading.accessibility.label" = "Loading indicator. Waiting for available options.";
+"entry_widget.ongoing_engagement.description" = "Ongoing • Tap to return";
+"entry_widget.call_visualizer.desciption" = "The support team can provide interactive assistance";
+"entry_widget.ongoing_engagement.button.accessibility.hint" = "Returns to ongoing engagement";

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
@@ -788,6 +788,8 @@ extension SecureConversations.TranscriptModel {
                 kind = .chat
             case .secureMessaging:
                 kind = .messaging(.welcome)
+            case .callVisualizer:
+                return
             }
             self?.environment.switchToEngagement(kind)
         }))

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.Environment.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.Environment.swift
@@ -10,6 +10,7 @@ extension EntryWidget {
         var log: CoreSdkClient.Logger
         var isAuthenticated: () -> Bool
         var hasPendingInteraction: () -> Bool
+        var currentInteractor: () -> Interactor?
     }
 }
 
@@ -25,7 +26,8 @@ extension EntryWidget.Environment {
             theme: .mock(),
             log: .mock,
             isAuthenticated: { true },
-            hasPendingInteraction: { false }
+            hasPendingInteraction: { false },
+            currentInteractor: { .mock() }
         )
     }
 }

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.MediaTypeItem.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.MediaTypeItem.swift
@@ -64,6 +64,15 @@ extension EntryWidget {
                     hintline: Localization.EntryWidget.SecureMessaging.Button.Accessibility.hint,
                     image: Asset.mcEnvelope.image
                 )
+            case .callVisualizer:
+                self.init(
+                    type: type,
+                    badgeCount: 0,
+                    headline: "Call Visualizer",
+                    subheadline: "",
+                    hintline: "",
+                    image: Asset.screensharing.image
+                )
             }
         }
     }
@@ -73,6 +82,7 @@ extension EntryWidget {
         case audio
         case chat
         case secureMessaging
+        case callVisualizer
 
         var description: String {
             switch self {
@@ -80,6 +90,7 @@ extension EntryWidget {
             case .audio: return "audio"
             case .chat: return "chat"
             case .secureMessaging: return "secureMessaging"
+            case .callVisualizer: return "callVisualizer"
             }
         }
     }

--- a/GliaWidgets/Sources/EntryWidget/EntryWidgetViewModel.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidgetViewModel.swift
@@ -46,5 +46,14 @@ extension EntryWidgetView {
         func onTryAgainTapped() {
             retryMonitoring?()
         }
+
+        func ongoingEngagementLabel(for engagementType: EntryWidget.EngagementType) -> String {
+            switch engagementType {
+            case .video, .audio, .chat, .secureMessaging:
+                return style.mediaTypeItem.ongoingCoreEngagementMessage
+            case .callVisualizer:
+                return style.mediaTypeItem.ongoingCallVisualizerMessage
+            }
+        }
     }
 }

--- a/GliaWidgets/Sources/EntryWidget/MediaTypeItem/MediaTypeItemStyle.Accessibility.swift
+++ b/GliaWidgets/Sources/EntryWidget/MediaTypeItem/MediaTypeItemStyle.Accessibility.swift
@@ -15,22 +15,28 @@ extension EntryWidgetStyle.MediaTypeItemStyle {
         /// The accessibility hint for secure messaging media type.
         public var secureMessagingHint: String
 
+        /// The accessibility hint for call visualizer.
+        public var callVisualizerHint: String
+
         /// - Parameters:
         ///   - chatHint: The accessibility hint for chat media type.
         ///   - audioHint: The accessibility hint for audio media type.
         ///   - videoHint: The accessibility hint for video media type.
         ///   - secureMessagingHint: The accessibility hint for secure messaging media type.
+        ///   - callVisualizer: The accessibility hint for call visualizer.
         ///
         public init(
             chatHint: String,
             audioHint: String,
             videoHint: String,
-            secureMessagingHint: String
+            secureMessagingHint: String,
+            callVisualizerHint: String
         ) {
             self.chatHint = chatHint
             self.audioHint = audioHint
             self.videoHint = videoHint
             self.secureMessagingHint = secureMessagingHint
+            self.callVisualizerHint = callVisualizerHint
         }
 
         func hint(for item: EntryWidget.MediaTypeItem) -> String {
@@ -43,6 +49,8 @@ extension EntryWidgetStyle.MediaTypeItemStyle {
                 return videoHint
             case .secureMessaging:
                 return secureMessagingHint
+            case .callVisualizer:
+                return callVisualizerHint
             }
         }
     }
@@ -54,6 +62,7 @@ extension EntryWidgetStyle.MediaTypeItemStyle.Accessibility {
         chatHint: "",
         audioHint: "",
         videoHint: "",
-        secureMessagingHint: ""
+        secureMessagingHint: "",
+        callVisualizerHint: ""
     )
 }

--- a/GliaWidgets/Sources/EntryWidget/MediaTypeItem/MediaTypeItemStyle.Mock.swift
+++ b/GliaWidgets/Sources/EntryWidget/MediaTypeItem/MediaTypeItemStyle.Mock.swift
@@ -7,6 +7,7 @@ extension EntryWidgetStyle.MediaTypeItemStyle {
         audioTitle: String = "Audio",
         videoTitle: String = "Video",
         secureMessagingTitle: String = "Secure messaging",
+        callVisualizerTitle: String = "Call visualizer",
         titleFont: UIFont = .systemFont(ofSize: 16),
         titleColor: UIColor = .black,
         titleTextStyle: UIFont.TextStyle = .body,
@@ -23,13 +24,18 @@ extension EntryWidgetStyle.MediaTypeItemStyle {
         iconColor: ColorType = .fill(color: .blue),
         backgroundColor: ColorType = .fill(color: .white),
         loading: LoadingStyle = .init(loadingTintColor: .fill(color: .gray)),
-        accessibility: Accessibility = .unsupported
+        accessibility: Accessibility = .unsupported,
+        ongoingCoreEngagementMessage: String = "Ongoing • Tap to return",
+        ongoingCallVisualizerMessage: String = "Screen sharing in progress",
+        ongoingEngagementMessageFont: UIFont = UIFont.systemFont(ofSize: 14, weight: .medium),
+        ongoingEngagementMessageColor: UIColor = Color.primary
     ) -> Self {
         Self(
             chatTitle: chatTitle,
             audioTitle: audioTitle,
             videoTitle: videoTitle,
             secureMessagingTitle: secureMessagingTitle,
+            callVisualizerTitle: callVisualizerTitle,
             titleFont: titleFont,
             titleColor: titleColor,
             titleTextStyle: titleTextStyle,
@@ -46,7 +52,11 @@ extension EntryWidgetStyle.MediaTypeItemStyle {
             iconColor: iconColor,
             backgroundColor: backgroundColor,
             loading: loading,
-            accessibility: accessibility
+            accessibility: accessibility,
+            ongoingCoreEngagementMessage: ongoingCoreEngagementMessage,
+            ongoingCallVisualizerMessage: ongoingCallVisualizerMessage,
+            ongoingEngagementMessageFont: ongoingEngagementMessageFont,
+            ongoingEngagementMessageColor: ongoingEngagementMessageColor
         )
     }
 }

--- a/GliaWidgets/Sources/EntryWidget/MediaTypeItem/MediaTypeItemStyle.swift
+++ b/GliaWidgets/Sources/EntryWidget/MediaTypeItem/MediaTypeItemStyle.swift
@@ -14,6 +14,9 @@ extension EntryWidgetStyle {
         /// The title for secure messaging media type.
         public var secureMessagingTitle: String
 
+        /// The title for call visualizer media type.
+        public var callVisualizerTitle: String
+
         /// Font of the headline text.
         public var titleFont: UIFont
 
@@ -65,6 +68,18 @@ extension EntryWidgetStyle {
         /// Accessibility properties for EntryWidget MediaType Item.
         public var accessibility: Accessibility
 
+        /// The ongoing core engagement message string
+        public var ongoingCoreEngagementMessage: String
+
+        /// The ongoing call visualizer message string
+        public var ongoingCallVisualizerMessage: String
+
+        /// The ongoing engagement message font
+        public var ongoingEngagementMessageFont: UIFont
+
+        /// The ongoing engagement message color
+        public var ongoingEngagementMessageColor: UIColor
+
         /// - Parameters:
         ///   - chatTitle: Title for chat media type.
         ///   - audioTitle: Title for audio media type.
@@ -92,6 +107,7 @@ extension EntryWidgetStyle {
             audioTitle: String,
             videoTitle: String,
             secureMessagingTitle: String,
+            callVisualizerTitle: String,
             titleFont: UIFont,
             titleColor: UIColor,
             titleTextStyle: UIFont.TextStyle,
@@ -108,12 +124,17 @@ extension EntryWidgetStyle {
             iconColor: ColorType,
             backgroundColor: ColorType,
             loading: LoadingStyle,
-            accessibility: Accessibility
+            accessibility: Accessibility,
+            ongoingCoreEngagementMessage: String,
+            ongoingCallVisualizerMessage: String,
+            ongoingEngagementMessageFont: UIFont,
+            ongoingEngagementMessageColor: UIColor
         ) {
             self.chatTitle = chatTitle
             self.audioTitle = audioTitle
             self.videoTitle = videoTitle
             self.secureMessagingTitle = secureMessagingTitle
+            self.callVisualizerTitle = callVisualizerTitle
             self.titleFont = titleFont
             self.titleColor = titleColor
             self.titleTextStyle = titleTextStyle
@@ -131,6 +152,10 @@ extension EntryWidgetStyle {
             self.backgroundColor = backgroundColor
             self.loading = loading
             self.accessibility = accessibility
+            self.ongoingCoreEngagementMessage = ongoingCoreEngagementMessage
+            self.ongoingCallVisualizerMessage = ongoingCallVisualizerMessage
+            self.ongoingEngagementMessageFont = ongoingEngagementMessageFont
+            self.ongoingEngagementMessageColor = ongoingEngagementMessageColor
         }
 
         func title(for item: EntryWidget.MediaTypeItem) -> String {
@@ -143,6 +168,8 @@ extension EntryWidgetStyle {
                 return videoTitle
             case .secureMessaging:
                 return secureMessagingTitle
+            case .callVisualizer:
+                return callVisualizerTitle
             }
         }
 
@@ -156,6 +183,10 @@ extension EntryWidgetStyle {
                 return videoMessage
             case .secureMessaging:
                 return secureMessagingMessage
+            case .callVisualizer:
+                // This will not be used, because EntryWidget will show
+                // ongoing engagement message there
+                return ""
             }
         }
     }

--- a/GliaWidgets/Sources/Interactor/Interactor.swift
+++ b/GliaWidgets/Sources/Interactor/Interactor.swift
@@ -58,7 +58,7 @@ class Interactor {
     }
 
     let visitorContext: Configuration.VisitorContext?
-    var currentEngagement: CoreSdkClient.Engagement?
+    @Published var currentEngagement: CoreSdkClient.Engagement?
 
     private var observers = [() -> (AnyObject?, EventHandler)]()
 
@@ -329,20 +329,24 @@ extension Interactor: CoreSdkClient.Interactable {
 
     var onAudioStreamAdded: CoreSdkClient.AudioStreamAddedBlock {
         return { [weak self] stream, error in
+            guard let self else { return }
             if let stream = stream {
-                self?.notify(.audioStreamAdded(stream))
+                notify(.audioStreamAdded(stream))
+                currentEngagement = environment.coreSdk.getCurrentEngagement()
             } else if let error = error {
-                self?.notify(.audioStreamError(error))
+                notify(.audioStreamError(error))
             }
         }
     }
 
     var onVideoStreamAdded: CoreSdkClient.VideoStreamAddedBlock {
         return { [weak self] stream, error in
+            guard let self else { return }
             if let stream = stream {
-                self?.notify(.videoStreamAdded(stream))
+                notify(.videoStreamAdded(stream))
+                currentEngagement = environment.coreSdk.getCurrentEngagement()
             } else if let error = error {
-                self?.notify(.videoStreamError(error))
+                notify(.videoStreamError(error))
             }
         }
     }

--- a/GliaWidgets/Sources/Theme/Theme.EntryWidget.swift
+++ b/GliaWidgets/Sources/Theme/Theme.EntryWidget.swift
@@ -11,7 +11,8 @@ extension Theme {
             chatHint: Localization.EntryWidget.LiveChat.Button.Accessibility.hint,
             audioHint: Localization.EntryWidget.Audio.Button.Accessibility.hint,
             videoHint: Localization.EntryWidget.Video.Button.Accessibility.hint,
-            secureMessagingHint: Localization.EntryWidget.SecureMessaging.Button.Accessibility.hint
+            secureMessagingHint: Localization.EntryWidget.SecureMessaging.Button.Accessibility.hint,
+            callVisualizerHint: Localization.EntryWidget.OngoingEngagement.Button.Accessibility.hint
         )
 
         let mediaTypeItem: EntryWidgetStyle.MediaTypeItemStyle = .init(
@@ -19,6 +20,7 @@ extension Theme {
             audioTitle: Localization.EntryWidget.Audio.Button.label,
             videoTitle: Localization.EntryWidget.Video.Button.label,
             secureMessagingTitle: Localization.EntryWidget.SecureMessaging.Button.label,
+            callVisualizerTitle: Localization.EntryWidget.CallVisualizer.Button.label,
             titleFont: font.bodyText,
             titleColor: color.baseDark,
             titleTextStyle: .body,
@@ -35,7 +37,11 @@ extension Theme {
             iconColor: .fill(color: color.primary),
             backgroundColor: .fill(color: color.baseLight),
             loading: loading,
-            accessibility: mediaTypeAccessibility
+            accessibility: mediaTypeAccessibility,
+            ongoingCoreEngagementMessage: Localization.EntryWidget.OngoingEngagement.description,
+            ongoingCallVisualizerMessage: Localization.EntryWidget.CallVisualizer.desciption,
+            ongoingEngagementMessageFont: font.mediumSubtitle2,
+            ongoingEngagementMessageColor: color.primary
         )
 
         let backgroundColor: ColorType = .fill(color: color.baseLight)
@@ -59,7 +65,7 @@ extension Theme {
             backgroundColor: backgroundColor,
             cornerRadius: 24,
             poweredBy: poweredBy,
-            dividerColor: color.baseNeutral,
+            dividerColor: color.baseNormal,
             errorTitle: Localization.EntryWidget.ErrorState.title,
             errorTitleFont: font.header3,
             errorTitleStyle: .body,

--- a/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
@@ -122,7 +122,6 @@ class EngagementViewModel: CommonEngagementModel {
                 )
             )
             engagementDelegate?(.finished)
-
         case .ended(let reason) where reason == .byOperator:
             interactor.currentEngagement?.getSurvey(completion: { [weak self] result in
                 guard let self = self else { return }

--- a/GliaWidgetsTests/Sources/EntryWidget/EntryWidgetTests.swift
+++ b/GliaWidgetsTests/Sources/EntryWidget/EntryWidgetTests.swift
@@ -231,4 +231,124 @@ class EntryWidgetTests: XCTestCase {
 
         XCTAssertEqual(entryWidget.availableEngagementTypes, [.video, .audio, .chat])
     }
+
+    func test_ongoingEngagementViewStateIsShownWhenCoreEngagementIsChat() {
+        let mockQueueId = "mockQueueId"
+        let mockQueue = Queue.mock(id: mockQueueId, media: [.messaging, .audio])
+
+        var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
+        queueMonitorEnvironment.listQueues = { completion in
+            completion([mockQueue], nil)
+        }
+        queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
+            completion(.success(mockQueue))
+            return UUID.mock.uuidString
+        }
+        var environment = EntryWidget.Environment.mock()
+        environment.isAuthenticated = { false }
+        environment.queuesMonitor = QueuesMonitor(environment: queueMonitorEnvironment)
+        let interactor: Interactor = .mock()
+        interactor.currentEngagement = .mock()
+        environment.currentInteractor = { interactor }
+
+        let entryWidget = EntryWidget(
+            queueIds: [mockQueueId],
+            configuration: .default,
+            environment: environment
+        )
+
+        entryWidget.show(in: .init())
+
+        XCTAssertEqual(entryWidget.viewState, .ongoingEngagement(.chat))
+    }
+
+    func test_ongoingEngagementViewStateIsShownWhenCoreEngagementIsAudio() {
+        let mockQueueId = "mockQueueId"
+        let mockQueue = Queue.mock(id: mockQueueId, media: [.messaging, .audio])
+
+        var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
+        queueMonitorEnvironment.listQueues = { completion in
+            completion([mockQueue], nil)
+        }
+        queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
+            completion(.success(mockQueue))
+            return UUID.mock.uuidString
+        }
+        var environment = EntryWidget.Environment.mock()
+        environment.isAuthenticated = { false }
+        environment.queuesMonitor = QueuesMonitor(environment: queueMonitorEnvironment)
+        let interactor: Interactor = .mock()
+        interactor.currentEngagement = .mock(media: .init(audio: .twoWay, video: nil))
+        environment.currentInteractor = { interactor }
+
+        let entryWidget = EntryWidget(
+            queueIds: [mockQueueId],
+            configuration: .default,
+            environment: environment
+        )
+
+        entryWidget.show(in: .init())
+
+        XCTAssertEqual(entryWidget.viewState, .ongoingEngagement(.audio))
+    }
+
+    func test_ongoingEngagementViewStateIsShownWhenCoreEngagementIsVideo() {
+        let mockQueueId = "mockQueueId"
+        let mockQueue = Queue.mock(id: mockQueueId, media: [.messaging, .audio])
+
+        var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
+        queueMonitorEnvironment.listQueues = { completion in
+            completion([mockQueue], nil)
+        }
+        queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
+            completion(.success(mockQueue))
+            return UUID.mock.uuidString
+        }
+        var environment = EntryWidget.Environment.mock()
+        environment.isAuthenticated = { false }
+        environment.queuesMonitor = QueuesMonitor(environment: queueMonitorEnvironment)
+        let interactor: Interactor = .mock()
+        interactor.currentEngagement = .mock(media: .init(audio: .twoWay, video: .twoWay))
+        environment.currentInteractor = { interactor }
+
+        let entryWidget = EntryWidget(
+            queueIds: [mockQueueId],
+            configuration: .default,
+            environment: environment
+        )
+
+        entryWidget.show(in: .init())
+
+        XCTAssertEqual(entryWidget.viewState, .ongoingEngagement(.video))
+    }
+
+    func test_ongoingEngagementViewStateIsShownWhenCallVisualizer() {
+        let mockQueueId = "mockQueueId"
+        let mockQueue = Queue.mock(id: mockQueueId, media: [.messaging, .audio])
+
+        var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
+        queueMonitorEnvironment.listQueues = { completion in
+            completion([mockQueue], nil)
+        }
+        queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
+            completion(.success(mockQueue))
+            return UUID.mock.uuidString
+        }
+        var environment = EntryWidget.Environment.mock()
+        environment.isAuthenticated = { false }
+        environment.queuesMonitor = QueuesMonitor(environment: queueMonitorEnvironment)
+        let interactor: Interactor = .mock()
+        interactor.currentEngagement = .mock(source: .callVisualizer)
+        environment.currentInteractor = { interactor }
+
+        let entryWidget = EntryWidget(
+            queueIds: [mockQueueId],
+            configuration: .default,
+            environment: environment
+        )
+
+        entryWidget.show(in: .init())
+
+        XCTAssertEqual(entryWidget.viewState, .ongoingEngagement(.callVisualizer))
+    }
 }


### PR DESCRIPTION
**What was solved?**
This PR handles ongoing engagement in EntryWidget for both core engagements and call visualizer.

MOB-3806
**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
