### PR TITLE
Create PendingInteraction model after configuration

### DIFF
--- a/GliaWidgets/Public/Glia/Glia+EngagementSetup.swift
+++ b/GliaWidgets/Public/Glia/Glia+EngagementSetup.swift
@@ -142,7 +142,7 @@ extension Glia {
     ) {
         let engagementLaunching: EngagementCoordinator.EngagementLaunching
 
-        switch (pendingInteraction.hasPendingInteraction, engagementKind) {
+        switch (pendingInteraction?.hasPendingInteraction ?? false, engagementKind) {
         case (false, _):
             // if there is no pending Secure Conversation, open regular flow.
             engagementLaunching = .direct(kind: engagementKind)

--- a/GliaWidgets/Public/Glia/Glia+EntryWidget.swift
+++ b/GliaWidgets/Public/Glia/Glia+EntryWidget.swift
@@ -26,7 +26,7 @@ extension Glia {
                 isAuthenticated: environment.isAuthenticated,
                 hasPendingInteraction: { [weak self] in
                     guard let self else { return false }
-                    return pendingInteraction.hasPendingInteraction
+                    return pendingInteraction?.hasPendingInteraction ?? false
                 }
             )
         )

--- a/GliaWidgets/Public/GliaError.swift
+++ b/GliaWidgets/Public/GliaError.swift
@@ -30,4 +30,7 @@ public enum GliaError: Error {
 
     /// Internal error.
     case internalError
+
+    /// Internal event subscription failure.
+    case internalEventSubscriptionFailure
 }

--- a/GliaWidgetsTests/SecureConversations/SecureConversations.PendingInteraction.Failing.swift
+++ b/GliaWidgetsTests/SecureConversations/SecureConversations.PendingInteraction.Failing.swift
@@ -20,7 +20,7 @@ extension SecureConversations.PendingInteraction.Environment {
 }
 
 extension SecureConversations.PendingInteraction {
-    static func failing() -> Self {
-        .init(environment: .failing)
+    static func failing() throws -> Self {
+        try .init(environment: .failing)
     }
 }

--- a/GliaWidgetsTests/SecureConversations/SecureConversations.PendingInteractionTests.swift
+++ b/GliaWidgetsTests/SecureConversations/SecureConversations.PendingInteractionTests.swift
@@ -18,7 +18,7 @@ final class SecureConversationsPendingInteractionTests: XCTestCase {
         environment.unsubscribeFromPendingStatus = { _ in }
         environment.unsubscribeFromUnreadCount = { _ in }
 
-        let pendingInteraction = SecureConversations.PendingInteraction(environment: environment)
+        let pendingInteraction = try SecureConversations.PendingInteraction(environment: environment)
         // Assert initial pending interaction is false.
         XCTAssertFalse(pendingInteraction.hasPendingInteraction)
         // Affect pending secure conversations value by setting it to `true` and assert `hasPendingInteraction`,
@@ -36,7 +36,7 @@ final class SecureConversationsPendingInteractionTests: XCTestCase {
         XCTAssertFalse(pendingInteraction.hasPendingInteraction)
     }
 
-    func test_unsubscribeIsCalledOnDeinit() {
+    func test_unsubscribeIsCalledOnDeinit() throws {
         enum Call {
             case unsubscribeFromPendingStatus
             case unsubscribeFromUnreadCount
@@ -52,8 +52,8 @@ final class SecureConversationsPendingInteractionTests: XCTestCase {
         environment.unsubscribeFromUnreadCount = { _ in
             calls.append(.unsubscribeFromUnreadCount)
         }
-        var pendingInteraction = SecureConversations.PendingInteraction(environment: environment)
-        pendingInteraction = .mock()
+        var pendingInteraction = try SecureConversations.PendingInteraction(environment: environment)
+        pendingInteraction = try .mock()
         _ = pendingInteraction
         XCTAssertEqual(calls, [.unsubscribeFromUnreadCount, .unsubscribeFromPendingStatus])
     }


### PR DESCRIPTION
Make sure PendingInteraction model is created after configuration to prevent subscription for unread message count and pending SC status from failure, because 'pubsub' is created only when Core SDK is configured.

MOB-3871

**What was solved?**

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
