### PR TITLE
Create interface for resuming call visualizer

### DIFF
--- a/GliaWidgets/Public/Glia/Glia+EntryWidget.swift
+++ b/GliaWidgets/Public/Glia/Glia+EntryWidget.swift
@@ -31,6 +31,10 @@ extension Glia {
                 currentInteractor: { [weak self] in
                     guard let self else { return nil }
                     return interactor
+                },
+                onCallVisualizerResume: { [weak self] in
+                    guard let self else { return }
+                    callVisualizer.resume()
                 }
             )
         )

--- a/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
+++ b/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
@@ -83,6 +83,10 @@ public final class CallVisualizer {
             by: .embedded(container, onEngagementAccepted: onEngagementAccepted)
         )
     }
+
+    public func resume() {
+        coordinator.resume()
+    }
 }
 
 // MARK: - Internal

--- a/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
@@ -10,17 +10,20 @@ extension CallVisualizer {
             self.bubbleView = environment.viewFactory.makeBubbleView()
 
             bubbleView.tap = { [weak self] in
-                guard let self = self else { return }
-                if self.videoCallCoordinator == nil {
-                    self.showEndScreenSharingViewController()
-                } else {
-                    self.resumeVideoCallViewController()
-                }
-                environment.eventHandler(.maximized)
+                self?.resume()
             }
             bubbleView.pan = { [weak self] translation in
                 self?.updateBubblePosition(translation: translation)
             }
+        }
+
+        func resume() {
+            if self.videoCallCoordinator == nil {
+                self.showEndScreenSharingViewController()
+            } else {
+                self.resumeVideoCallViewController()
+            }
+            environment.eventHandler(.maximized)
         }
 
         func showVisitorCodeViewController(by presentation: Presentation) {

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.Environment.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.Environment.swift
@@ -11,6 +11,7 @@ extension EntryWidget {
         var isAuthenticated: () -> Bool
         var hasPendingInteraction: () -> Bool
         var currentInteractor: () -> Interactor?
+        var onCallVisualizerResume: () -> Void
     }
 }
 
@@ -27,7 +28,8 @@ extension EntryWidget.Environment {
             log: .mock,
             isAuthenticated: { true },
             hasPendingInteraction: { false },
-            currentInteractor: { .mock() }
+            currentInteractor: { .mock() },
+            onCallVisualizerResume: {}
         )
     }
 }

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
@@ -114,6 +114,31 @@ extension EntryWidget {
 
         return appliedHeight
     }
+
+    func mediaTypeSelected(_ mediaTypeItem: MediaTypeItem) {
+        if let configurationAction = configuration.mediaTypeSelected {
+            configurationAction(mediaTypeItem)
+            return
+        }
+        hideViewIfNecessary {
+            do {
+                switch mediaTypeItem.type {
+                case .chat:
+                    try self.environment.engagementLauncher.startChat()
+                case .audio:
+                    try self.environment.engagementLauncher.startAudioCall()
+                case .video:
+                    try self.environment.engagementLauncher.startVideoCall()
+                case .secureMessaging:
+                    try self.environment.engagementLauncher.startSecureMessaging()
+                case .callVisualizer:
+                    self.environment.onCallVisualizerResume()
+                }
+            } catch {
+                self.viewState = .error
+            }
+        }
+    }
 }
 
 // MARK: - Private methods
@@ -187,31 +212,6 @@ private extension EntryWidget {
         }
 
         return Array(availableMediaTypes).sorted(by: { $0.rawValue < $1.rawValue })
-    }
-
-    func mediaTypeSelected(_ mediaTypeItem: MediaTypeItem) {
-        if let configurationAction = configuration.mediaTypeSelected {
-            configurationAction(mediaTypeItem)
-            return
-        }
-        hideViewIfNecessary {
-            do {
-                switch mediaTypeItem.type {
-                case .chat:
-                    try self.environment.engagementLauncher.startChat()
-                case .audio:
-                    try self.environment.engagementLauncher.startAudioCall()
-                case .video:
-                    try self.environment.engagementLauncher.startVideoCall()
-                case .secureMessaging:
-                    try self.environment.engagementLauncher.startSecureMessaging()
-                case .callVisualizer:
-                    break
-                }
-            } catch {
-                self.viewState = .error
-            }
-        }
     }
 
     func hideViewIfNecessary(completion: @escaping () -> Void) {

--- a/Podfile
+++ b/Podfile
@@ -18,7 +18,7 @@ target 'TestingApp' do
 end
 
 target 'GliaWidgets' do
-  pod 'GliaCoreSDK', '1.5.8'
+  pod 'GliaCoreSDK', '2.0.4'
   swiftlint
 end
 


### PR DESCRIPTION
**What was solved?**

Up until now Call Visualizer screen sharing or video call screen could
only be opened through bubble tap. Entry Widget requires to open Call
Visualizer by a tap on call visualizer media type, if CV session is ongoing. This PR allows to do just that, by providing an interface to
resume the view.

MOB-3887
**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [X] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
