### PR TITLE
Fill area under message entry with same bg color as message entry

### DIFF
--- a/GliaWidgets/Sources/Theme/Theme+Chat.swift
+++ b/GliaWidgets/Sources/Theme/Theme+Chat.swift
@@ -350,7 +350,7 @@ extension Theme {
             placeholderFont: font.bodyText,
             placeholderColor: color.baseShade,
             separatorColor: color.baseShade,
-            backgroundColor: color.baseLight,
+            backgroundColor: color.baseNeutral,
             mediaButton: mediaButton,
             sendButton: sendButton,
             uploadList: uploadListStyle,

--- a/GliaWidgets/Sources/View/Chat/ChatView.DefineLayout.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatView.DefineLayout.swift
@@ -96,5 +96,13 @@ extension ChatView {
 
         bringSubviewToFront(entryWidgetOverlayView)
         bringSubviewToFront(entryWidgetContainerView)
+
+        constraints += [
+            messageEntryBottomArea.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
+            messageEntryBottomArea.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor),
+            messageEntryBottomArea.topAnchor.constraint(equalTo: messageEntryView.bottomAnchor),
+            messageEntryBottomArea.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor)
+        ]
+        insertSubview(messageEntryBottomArea, at: 0)
     }
 }

--- a/GliaWidgets/Sources/View/Chat/ChatView.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatView.swift
@@ -31,6 +31,15 @@ class ChatView: EngagementView {
     let secureMessagingBottomBannerView = SecureMessagingBottomBannerView().makeView()
     let sendingMessageUnavailabilityBannerView = SendingMessageUnavailableBannerView().makeView()
 
+    // Instead of modifying message entry view's layout to resize, covering bottom safe area,
+    // thus affecting existing layout calculations, we add additional view just for that,
+    // keeping background color for it reactively in sync with message entry view's one.
+    lazy var messageEntryBottomArea = UIView().makeView { [weak messageEntryView] area in
+        messageEntryView?.publisher(for: \.backgroundColor).sink { [weak area] newColor in
+            area?.backgroundColor = newColor
+        }.store(in: &cancelBag)
+    }
+
     let style: ChatStyle
     let environment: Environment
 


### PR DESCRIPTION
MOB-3889

**What was solved?**
With recent changes for SC 2.0 design, area under message entry must be of the same color as message entry background color. This is specifically important for message entry disabled state.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
<img src="https://github.com/user-attachments/assets/fdf2c259-4a15-45fd-bfed-e4b82e0a2f20" width="428" height="926">


