### PR TITLE
Handle `follow_up` end reason

### DIFF
--- a/GliaWidgets/Sources/Interactor/Interactor.swift
+++ b/GliaWidgets/Sources/Interactor/Interactor.swift
@@ -384,7 +384,7 @@ extension Interactor: CoreSdkClient.Interactable {
         switch reason {
         case .visitorHungUp:
             state = .ended(.byVisitor)
-        case .operatorHungUp:
+        case .operatorHungUp, .followUp:
             state = .ended(.byOperator)
         case .error:
             state = .ended(.byError)

--- a/GliaWidgetsTests/Sources/InteractorTests.swift
+++ b/GliaWidgetsTests/Sources/InteractorTests.swift
@@ -395,7 +395,32 @@ class InteractorTests: XCTestCase {
 
         XCTAssertEqual(callbacks, [.ended])
     }
-    
+
+    func test_endWithFollowUpSetsStateToEnded() throws {
+        enum Callback: Equatable {
+            case ended
+        }
+
+        var callbacks: [Callback] = []
+        var interactorEnv = Interactor.Environment.failing
+        interactorEnv.gcd = .mock
+        let interactor = Interactor.mock(environment: interactorEnv)
+        interactor.addObserver(self) { event in
+            switch event {
+            case .stateChanged(let state):
+                if case .ended = state {
+                    callbacks.append(.ended)
+                }
+            default:
+                return
+            }
+        }
+
+        interactor.end(with: .followUp)
+
+        XCTAssertEqual(callbacks, [.ended])
+    }
+
     func test_sendMessageCallsCoreSdkSendMessageWithAttachment() throws {
         enum Callback: Equatable {
             case sendMessageWithAttachment

--- a/Podfile
+++ b/Podfile
@@ -18,7 +18,7 @@ target 'TestingApp' do
 end
 
 target 'GliaWidgets' do
-  pod 'GliaCoreSDK', '2.0.4'
+  pod 'GliaCoreSDK'
   swiftlint
 end
 


### PR DESCRIPTION
MOB-3900

**What was solved?**
This PR adds handling of `follow_up` end reason the same way as `operator_hung_up`

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.