### PR TITLE
Fix keeping wrong interactor state after CV engagement

### DIFF
--- a/GliaWidgets/Sources/Interactor/Interactor.swift
+++ b/GliaWidgets/Sources/Interactor/Interactor.swift
@@ -58,7 +58,7 @@ class Interactor {
     }
 
     let visitorContext: Configuration.VisitorContext?
-    @Published var currentEngagement: CoreSdkClient.Engagement?
+    @Published private(set) var currentEngagement: CoreSdkClient.Engagement?
 
     private var observers = [() -> (AnyObject?, EventHandler)]()
 
@@ -417,3 +417,11 @@ extension InteractorState: Equatable {
         }
     }
 }
+
+#if DEBUG
+extension Interactor {
+    func setCurrentEngagement(_ engagement: CoreSdkClient.Engagement?) {
+        currentEngagement = engagement
+    }
+}
+#endif

--- a/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator+SurveyTests.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator+SurveyTests.swift
@@ -11,7 +11,7 @@ class EngagementCoordinatorSurveyTests: XCTestCase {
             media: .init(audio: .none, video: .oneWay)
         )
         let interactor = Interactor.mock(environment: .init(coreSdk: coreSdkClient, queuesMonitor: .mock(), gcd: .failing, log: .failing))
-        interactor.currentEngagement = engagement
+        interactor.setCurrentEngagement(engagement)
         var alertManagerEnv = AlertManager.Environment.failing()
         var log = CoreSdkClient.Logger.failing
         log.prefixedClosure = { _ in log }

--- a/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinatorTests.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinatorTests.swift
@@ -114,7 +114,8 @@ final class EngagementCoordinatorTests: XCTestCase {
 
     func test_endChatWithSurvey() throws {
         let survey: CoreSdkClient.Survey = try .mock()
-        coordinator.interactor.currentEngagement = .mock(fetchSurvey: { _, completion in completion(.success(survey)) })
+        let engagement: CoreSdkClient.Engagement = .mock(fetchSurvey: { _, completion in completion(.success(survey)) })
+        coordinator.interactor.setCurrentEngagement(engagement)
         coordinator.end()
 
         let surveyViewController = coordinator.gliaPresenter.topMostViewController as? Survey.ViewController
@@ -131,7 +132,8 @@ final class EngagementCoordinatorTests: XCTestCase {
         let survey: CoreSdkClient.Survey = try .mock()
         coordinator.start()
 
-        coordinator.interactor.currentEngagement = .mock(fetchSurvey: { _, completion in completion(.success(survey)) })
+        let engagement: CoreSdkClient.Engagement = .mock(fetchSurvey: { _, completion in completion(.success(survey)) })
+        coordinator.interactor.setCurrentEngagement(engagement)
         coordinator.end(surveyPresentation: .doNotPresentSurvey)
 
         XCTAssertEqual(coordinator.navigationPresenter.viewControllers.count, 0)

--- a/GliaWidgetsTests/Sources/EntryWidget/EntryWidgetTests.swift
+++ b/GliaWidgetsTests/Sources/EntryWidget/EntryWidgetTests.swift
@@ -248,7 +248,7 @@ class EntryWidgetTests: XCTestCase {
         environment.isAuthenticated = { false }
         environment.queuesMonitor = QueuesMonitor(environment: queueMonitorEnvironment)
         let interactor: Interactor = .mock()
-        interactor.currentEngagement = .mock()
+        interactor.setCurrentEngagement(.mock())
         environment.currentInteractor = { interactor }
 
         let entryWidget = EntryWidget(
@@ -278,7 +278,7 @@ class EntryWidgetTests: XCTestCase {
         environment.isAuthenticated = { false }
         environment.queuesMonitor = QueuesMonitor(environment: queueMonitorEnvironment)
         let interactor: Interactor = .mock()
-        interactor.currentEngagement = .mock(media: .init(audio: .twoWay, video: nil))
+        interactor.setCurrentEngagement(.mock(media: .init(audio: .twoWay, video: nil)))
         environment.currentInteractor = { interactor }
 
         let entryWidget = EntryWidget(
@@ -308,7 +308,7 @@ class EntryWidgetTests: XCTestCase {
         environment.isAuthenticated = { false }
         environment.queuesMonitor = QueuesMonitor(environment: queueMonitorEnvironment)
         let interactor: Interactor = .mock()
-        interactor.currentEngagement = .mock(media: .init(audio: .twoWay, video: .twoWay))
+        interactor.setCurrentEngagement(.mock(media: .init(audio: .twoWay, video: .twoWay)))
         environment.currentInteractor = { interactor }
 
         let entryWidget = EntryWidget(
@@ -338,7 +338,7 @@ class EntryWidgetTests: XCTestCase {
         environment.isAuthenticated = { false }
         environment.queuesMonitor = QueuesMonitor(environment: queueMonitorEnvironment)
         let interactor: Interactor = .mock()
-        interactor.currentEngagement = .mock(source: .callVisualizer)
+        interactor.setCurrentEngagement(.mock(source: .callVisualizer))
         environment.currentInteractor = { interactor }
 
         let entryWidget = EntryWidget(
@@ -371,7 +371,7 @@ class EntryWidgetTests: XCTestCase {
         var environment = EntryWidget.Environment.mock()
         environment.queuesMonitor = QueuesMonitor(environment: queueMonitorEnvironment)
         let interactor: Interactor = .mock()
-        interactor.currentEngagement = .mock(source: .callVisualizer)
+        interactor.setCurrentEngagement(.mock(source: .callVisualizer))
         environment.currentInteractor = { interactor }
         environment.onCallVisualizerResume = {
             calls.append(.onCallVisualizerResume)

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -157,7 +157,7 @@ final class GliaTests: XCTestCase {
             theme: .mock()
         ) { _ in }
 
-        sdk.environment.coreSdk.getCurrentEngagement = { .mock(source: .callVisualizer) }
+        sdk.interactor?.setCurrentEngagement(.mock(source: .callVisualizer))
         sdk.interactor?.state = .ended(.byOperator)
 
         XCTAssertEqual(calls, [.onEvent(.ended)])
@@ -202,7 +202,7 @@ final class GliaTests: XCTestCase {
 
         XCTAssertEqual(calls, [])
 
-        sdk.environment.coreSdk.getCurrentEngagement = { .mock(source: .callVisualizer) }
+        sdk.interactor?.setCurrentEngagement(.mock(source: .callVisualizer))
         sdk.interactor?.state = .ended(.byOperator)
 
         /// Since interactor is created only after visitor code is requested, 
@@ -247,7 +247,7 @@ final class GliaTests: XCTestCase {
             with: .mock(),
             theme: .mock()
         ) { _ in }
-        sdk.environment.coreSdk.getCurrentEngagement = { .mock(source: .callVisualizer) }
+        sdk.interactor?.setCurrentEngagement(.mock(source: .callVisualizer))
 
         sdk.callVisualizer.coordinator.showEndScreenSharingViewController()
         sdk.interactor?.state = .ended(.byOperator)
@@ -295,7 +295,7 @@ final class GliaTests: XCTestCase {
             with: .mock(),
             theme: .mock()
         ) { _ in }
-        sdk.environment.coreSdk.getCurrentEngagement = { .mock(source: .callVisualizer) }
+        sdk.interactor?.setCurrentEngagement(.mock(source: .callVisualizer))
 
         sdk.callVisualizer.coordinator.showVideoCallViewController()
         sdk.interactor?.state = .ended(.byOperator)
@@ -654,7 +654,7 @@ final class GliaTests: XCTestCase {
             with: .mock(),
             theme: .mock()
         ) { _ in }
-        sdk.environment.coreSdk.getCurrentEngagement = { .mock(source: .callVisualizer) }
+        sdk.interactor?.setCurrentEngagement(.mock(source: .callVisualizer))
         sdk.onEvent = { event in
             switch event {
             case .ended:


### PR DESCRIPTION
MOB-3901

**What was solved?**
After having CV engagement if visitor starts Live engagement, SDK immediately shows Engagement Ended dialog.
This PR fixes this behaviour.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.