### PR TITLE
Fix handling engagement ended flow

### DIFF
--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -437,10 +437,7 @@ public class Glia {
             return
         }
 
-        interactor?.endSession(
-            success: { completion(.success(())) },
-            failure: { completion(.failure($0)) }
-        )
+        interactor?.endSession(completion: completion)
     }
 
     /// List all queues of the configured site. It is also possible to monitor queues changes with

--- a/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
+++ b/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
@@ -107,14 +107,8 @@ extension CallVisualizer {
 
     func endSession() {
         coordinator.end()
-        environment.interactorProviding()?.endSession(
-            success: { [weak self] in
-                self?.delegate?(.engagementEnded)
-            },
-            failure: { [weak self] _ in
-                self?.delegate?(.engagementEnded)
-            }
-        )
+        environment.interactorProviding()?.cleanup()
+        delegate?(.engagementEnded)
     }
 
     func handleRestoredEngagement() {
@@ -132,7 +126,7 @@ extension CallVisualizer {
     func startObservingInteractorEvents() {
         environment.interactorProviding()?.addObserver(self) { [weak self] event in
             if case .stateChanged(.ended(.byOperator)) = event,
-               let endedEngagement = self?.environment.interactorProviding()?.currentEngagement,
+               let endedEngagement = self?.environment.interactorProviding()?.endedEngagement,
                endedEngagement.source == .callVisualizer {
                 self?.endSession()
                 self?.environment.log.prefixed(Self.self).info("Call visualizer engagement ended")

--- a/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
@@ -217,10 +217,7 @@ extension CallVisualizer.Coordinator {
 
 extension CallVisualizer.Coordinator {
     func declineEngagement() {
-        environment.interactorProviding?.endEngagement(
-            success: {},
-            failure: { _ in }
-        )
+        environment.interactorProviding?.endEngagement { _ in }
         end()
     }
 

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
@@ -199,7 +199,7 @@ extension EngagementCoordinator {
             }
         }
 
-        guard let engagement = interactor.currentEngagement, surveyPresentation == .presentSurvey else {
+        guard let engagement = interactor.endedEngagement, surveyPresentation == .presentSurvey else {
             dismissGliaViewController()
             return
         }

--- a/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
@@ -60,7 +60,7 @@ class EngagementViewModel: CommonEngagementModel {
 
     func viewWillAppear() {
         if interactor.state == .ended(.byOperator) {
-            interactor.currentEngagement?.getSurvey { [weak self] result in
+            interactor.endedEngagement?.getSurvey { [weak self] result in
                 guard let self = self else { return }
                 switch result {
                 case .success(let survey) where survey != nil:
@@ -121,9 +121,8 @@ class EngagementViewModel: CommonEngagementModel {
                     operatorImageUrl: nil
                 )
             )
-            engagementDelegate?(.finished)
         case .ended(let reason) where reason == .byOperator:
-            interactor.currentEngagement?.getSurvey(completion: { [weak self] result in
+            interactor.endedEngagement?.getSurvey(completion: { [weak self] result in
                 guard let self = self else { return }
                 guard case .success(let survey) = result, survey == nil else {
                     self.endSession()
@@ -174,12 +173,10 @@ class EngagementViewModel: CommonEngagementModel {
     }
 
     func endSession() {
-        interactor.endSession { [weak self] in
-            self?.engagementDelegate?(.finished)
-        } failure: { [weak self] _ in
+        interactor.endSession { [weak self] _ in
             self?.engagementDelegate?(.finished)
         }
-        self.screenShareHandler.stop(nil)
+        screenShareHandler.stop(nil)
     }
 
     func conditionallyEndSession() {

--- a/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator+SurveyTests.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator+SurveyTests.swift
@@ -11,7 +11,7 @@ class EngagementCoordinatorSurveyTests: XCTestCase {
             media: .init(audio: .none, video: .oneWay)
         )
         let interactor = Interactor.mock(environment: .init(coreSdk: coreSdkClient, queuesMonitor: .mock(), gcd: .failing, log: .failing))
-        interactor.setCurrentEngagement(engagement)
+        interactor.setEndedEngagement(engagement)
         var alertManagerEnv = AlertManager.Environment.failing()
         var log = CoreSdkClient.Logger.failing
         log.prefixedClosure = { _ in log }

--- a/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinatorTests.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinatorTests.swift
@@ -115,7 +115,7 @@ final class EngagementCoordinatorTests: XCTestCase {
     func test_endChatWithSurvey() throws {
         let survey: CoreSdkClient.Survey = try .mock()
         let engagement: CoreSdkClient.Engagement = .mock(fetchSurvey: { _, completion in completion(.success(survey)) })
-        coordinator.interactor.setCurrentEngagement(engagement)
+        coordinator.interactor.setEndedEngagement(engagement)
         coordinator.end()
 
         let surveyViewController = coordinator.gliaPresenter.topMostViewController as? Survey.ViewController

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -157,7 +157,7 @@ final class GliaTests: XCTestCase {
             theme: .mock()
         ) { _ in }
 
-        sdk.interactor?.setCurrentEngagement(.mock(source: .callVisualizer))
+        sdk.interactor?.setEndedEngagement(.mock(source: .callVisualizer))
         sdk.interactor?.state = .ended(.byOperator)
 
         XCTAssertEqual(calls, [.onEvent(.ended)])
@@ -202,7 +202,7 @@ final class GliaTests: XCTestCase {
 
         XCTAssertEqual(calls, [])
 
-        sdk.interactor?.setCurrentEngagement(.mock(source: .callVisualizer))
+        sdk.interactor?.setEndedEngagement(.mock(source: .callVisualizer))
         sdk.interactor?.state = .ended(.byOperator)
 
         /// Since interactor is created only after visitor code is requested, 
@@ -247,9 +247,9 @@ final class GliaTests: XCTestCase {
             with: .mock(),
             theme: .mock()
         ) { _ in }
-        sdk.interactor?.setCurrentEngagement(.mock(source: .callVisualizer))
 
         sdk.callVisualizer.coordinator.showEndScreenSharingViewController()
+        sdk.interactor?.setEndedEngagement(.mock(source: .callVisualizer))
         sdk.interactor?.state = .ended(.byOperator)
 
         XCTAssertEqual(calls, [.onEvent(.minimized), .onEvent(.ended)])
@@ -295,9 +295,9 @@ final class GliaTests: XCTestCase {
             with: .mock(),
             theme: .mock()
         ) { _ in }
-        sdk.interactor?.setCurrentEngagement(.mock(source: .callVisualizer))
 
         sdk.callVisualizer.coordinator.showVideoCallViewController()
+        sdk.interactor?.setEndedEngagement(.mock(source: .callVisualizer))
         sdk.interactor?.state = .ended(.byOperator)
 
         XCTAssertEqual(calls, [.onEvent(.maximized), .onEvent(.minimized), .onEvent(.ended)])
@@ -654,7 +654,7 @@ final class GliaTests: XCTestCase {
             with: .mock(),
             theme: .mock()
         ) { _ in }
-        sdk.interactor?.setCurrentEngagement(.mock(source: .callVisualizer))
+        sdk.interactor?.setEndedEngagement(.mock(source: .callVisualizer))
         sdk.onEvent = { event in
             switch event {
             case .ended:

--- a/GliaWidgetsTests/Sources/InteractorTests.swift
+++ b/GliaWidgetsTests/Sources/InteractorTests.swift
@@ -214,11 +214,15 @@ class InteractorTests: XCTestCase {
         var callbacks: [Callback] = []
         let interactor = Interactor.mock(environment: .failing)
 
-        interactor.endSession(
-            success: { callbacks.append(.success) },
-            failure: { XCTFail($0.reason) }
-        )
-        
+        interactor.endSession { result in
+            switch result {
+            case .success:
+                callbacks.append(.success)
+            case let .failure(error):
+                XCTFail(error.localizedDescription)
+            }
+        }
+
         XCTAssertEqual(callbacks, [.success])
     }
 
@@ -244,11 +248,15 @@ class InteractorTests: XCTestCase {
             }
         }
         
-        interactor.endSession(
-            success: { callbacks.append(.success) },
-            failure: { XCTFail($0.reason) }
-        )
-        
+        interactor.endSession { result in
+            switch result {
+            case .success:
+                callbacks.append(.success)
+            case let .failure(error):
+                XCTFail(error.localizedDescription)
+            }
+        }
+
         XCTAssertEqual(callbacks, [.stateChangedToEnded, .success])
     }
 
@@ -268,11 +276,15 @@ class InteractorTests: XCTestCase {
         let interactor = Interactor.mock(environment: interactorEnv)
         
         interactor.state = .enqueued(.mock)
-        interactor.endSession(
-            success: {},
-            failure: { XCTFail($0.reason) }
-        )
-        
+        interactor.endSession { result in
+            switch result {
+            case .success:
+                break
+            case let .failure(error):
+                XCTFail(error.localizedDescription)
+            }
+        }
+
         XCTAssertEqual(callbacks, [.cancelQueueCalled])
     }
     
@@ -291,11 +303,15 @@ class InteractorTests: XCTestCase {
         let interactor = Interactor.mock(environment: interactorEnv)
         
         interactor.state = .engaged(.mock())
-        interactor.endSession(
-            success: {},
-            failure: { XCTFail($0.reason) }
-        )
-        
+        interactor.endSession { result in
+            switch result {
+            case .success:
+                break
+            case let .failure(error):
+                XCTFail(error.localizedDescription)
+            }
+        }
+
         XCTAssertEqual(callbacks, [.endEngagementCalled])
     }
     
@@ -316,8 +332,7 @@ class InteractorTests: XCTestCase {
 
         interactor.exitQueue(
             ticket: .mock,
-            success: {},
-            failure: { XCTFail($0.reason) }
+            completion: { _ in }
         )
 
         XCTAssertEqual(callbacks, [.cancelQueueTicket])
@@ -336,10 +351,14 @@ class InteractorTests: XCTestCase {
         interactorEnv.log.prefixedClosure = { _ in interactorEnv.log }
         let interactor = Interactor.mock(environment: interactorEnv)
 
-        interactor.endEngagement(
-            success: {},
-            failure: { XCTFail($0.reason) }
-        )
+        interactor.endEngagement { result in
+            switch result {
+            case .success:
+                break
+            case let .failure(error):
+                XCTFail(error.localizedDescription)
+            }
+        }
 
         XCTAssertEqual(callbacks, [.endEngagement])
     }
@@ -541,7 +560,7 @@ class InteractorTests: XCTestCase {
         let interactor = Interactor.mock(environment: interactorEnv)
         interactor.state = .engaged(.mock())
 
-        interactor.endSession(success: {}, failure: { _ in })
+        interactor.endSession { _ in }
 
         XCTAssertEqual(interactor.state, .ended(.byVisitor))
     }


### PR DESCRIPTION
MOB-3897

**What was solved?**
This PR introduces `endedEngagement` property in Interactor for storing engagement ended by operator to fetch a survey

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.