### PR TITLE
[WIP] Show Engagement Ended dialog globally

### DIFF
--- a/GliaWidgets/Sources/ViewController/EngagementViewController.swift
+++ b/GliaWidgets/Sources/ViewController/EngagementViewController.swift
@@ -62,9 +62,14 @@ class EngagementViewController: UIViewController {
                     accepted: accepted,
                     declined: declined
                 )
-            case let.showAlert(type):
+            case let .showAlert(type):
+                var placement: AlertPlacement = .root(self)
+                // Need to show Engagement Ended dialog even over integrator's screens.
+                if case .operatorEndedEngagement = type {
+                    placement = .global
+                }
                 self.environment.alertManager.present(
-                    in: .root(self),
+                    in: placement,
                     as: type
                 )
             }

--- a/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
@@ -58,21 +58,7 @@ class EngagementViewModel: CommonEngagementModel {
 
     func viewDidAppear() {}
 
-    func viewWillAppear() {
-        if interactor.state == .ended(.byOperator) {
-            interactor.endedEngagement?.getSurvey { [weak self] result in
-                guard let self = self else { return }
-                switch result {
-                case .success(let survey) where survey != nil:
-                    return
-                default:
-                    self.engagementAction?(.showAlert(.operatorEndedEngagement(action: { [weak self] in
-                        self?.endSession()
-                    })))
-                }
-            }
-        }
-    }
+    func viewWillAppear() {}
 
     func start() {}
 


### PR DESCRIPTION
MOB-3905

**What was solved?**
This PR:
- sets `AlertPlacement` for Engagement Ended dialog presenting;
- removes handling of ended engagement on `EngagementViewModel.viewWillApper`.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.