### PR TITLE
Remove bubble related toggles from initial screen in TestingApp

### DIFF
--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -123,8 +123,8 @@ public class Glia {
     var loggerPhase: LoggerPhase
     var queuesMonitor: QueuesMonitor
     var alertManager: AlertManager
-    // We need to store `features` via `configure` or deprecated `startEngagement` methods
-    // to use it when engagement gets restored for Direct ID authentication flow.
+    // We need to store `features` via `configure` method to use it
+    // when engagement gets restored for Direct ID authentication flow.
     var features: Features?
 
     private(set) var configuration: Configuration?

--- a/TestingApp/Main.storyboard
+++ b/TestingApp/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -21,7 +21,7 @@
                                 <rect key="frame" x="0.0" y="48" width="414" height="814"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="A3Y-Xf-Ufg">
-                                        <rect key="frame" x="0.0" y="16" width="414" height="1500"/>
+                                        <rect key="frame" x="0.0" y="16" width="414" height="1415.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Configuration" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4l1-DH-Wkd">
                                                 <rect key="frame" x="155.5" y="0.0" width="103.5" height="20.5"/>
@@ -83,53 +83,8 @@
                                                     </switch>
                                                 </subviews>
                                             </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalCentering" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="S6U-rq-MZq">
-                                                <rect key="frame" x="68.5" y="162" width="277" height="69.5"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dgu-6M-S4x">
-                                                        <rect key="frame" x="0.0" y="0.0" width="277" height="32.5"/>
-                                                        <string key="text">Enable temporary ability to overwrite bubble visibility from `configure` (Glia Settings) via deprecated 'startEngagement' method:</string>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="9"/>
-                                                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="e2o-i0-a3l">
-                                                        <rect key="frame" x="0.0" y="38.5" width="277" height="31"/>
-                                                        <subviews>
-                                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="mt6-x7-Rlc">
-                                                                <rect key="frame" x="0.0" y="0.0" width="139.5" height="31"/>
-                                                                <subviews>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enable Overwrite" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l87-py-Raq">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="88.5" height="31"/>
-                                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="10"/>
-                                                                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                        <nil key="highlightedColor"/>
-                                                                    </label>
-                                                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="d3A-aT-6lw">
-                                                                        <rect key="frame" x="90.5" y="0.0" width="51" height="31"/>
-                                                                    </switch>
-                                                                </subviews>
-                                                            </stackView>
-                                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="MTv-mu-eKw">
-                                                                <rect key="frame" x="159.5" y="0.0" width="117.5" height="31"/>
-                                                                <subviews>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Show bubble" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="j5D-JP-3Fi">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="66.5" height="31"/>
-                                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="10"/>
-                                                                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                        <nil key="highlightedColor"/>
-                                                                    </label>
-                                                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uZf-AD-CGp">
-                                                                        <rect key="frame" x="68.5" y="0.0" width="51" height="31"/>
-                                                                    </switch>
-                                                                </subviews>
-                                                            </stackView>
-                                                        </subviews>
-                                                    </stackView>
-                                                </subviews>
-                                            </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="qwv-F0-vOF">
-                                                <rect key="frame" x="74" y="246.5" width="266" height="30"/>
+                                                <rect key="frame" x="74" y="162" width="266" height="30"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zmv-pl-N2H">
                                                         <rect key="frame" x="0.0" y="0.0" width="68" height="30"/>
@@ -167,13 +122,13 @@
                                                 </subviews>
                                             </stackView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="EntryWidget" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Ba-8k-E2g">
-                                                <rect key="frame" x="160" y="291.5" width="94.5" height="20.5"/>
+                                                <rect key="frame" x="160" y="207" width="94.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lRB-te-9Yv">
-                                                <rect key="frame" x="100" y="327" width="214" height="34.5"/>
+                                                <rect key="frame" x="100" y="242.5" width="214" height="34.5"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3hO-Oq-9Lh" userLabel="Contact Us">
                                                         <rect key="frame" x="0.0" y="0.0" width="107" height="34.5"/>
@@ -196,13 +151,13 @@
                                                 </subviews>
                                             </stackView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Utils" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fwb-CM-wR2">
-                                                <rect key="frame" x="190" y="376.5" width="34" height="20.5"/>
+                                                <rect key="frame" x="190" y="292" width="34" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="P9U-ba-KVy">
-                                                <rect key="frame" x="179.5" y="412" width="55" height="30"/>
+                                                <rect key="frame" x="179.5" y="327.5" width="55" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_resume_button"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="mbg-qw-hCC"/>
@@ -213,7 +168,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0wb-9L-Csn">
-                                                <rect key="frame" x="161" y="457" width="92" height="30"/>
+                                                <rect key="frame" x="161" y="372.5" width="92" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_clearSession_button"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="wht-81-BI4"/>
@@ -224,7 +179,7 @@
                                                 </connections>
                                             </button>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Dmx-9D-42U">
-                                                <rect key="frame" x="88.5" y="502" width="237.5" height="95"/>
+                                                <rect key="frame" x="88.5" y="417.5" width="237.5" height="95"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Authentication during engagement" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JXc-IZ-au3">
                                                         <rect key="frame" x="0.0" y="0.0" width="237.5" height="18"/>
@@ -271,7 +226,7 @@
                                                 </subviews>
                                             </stackView>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ojd-PF-wje">
-                                                <rect key="frame" x="119" y="612" width="176" height="30"/>
+                                                <rect key="frame" x="119" y="527.5" width="176" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_secureConversations_button"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="Nk7-ud-fyb"/>
@@ -284,7 +239,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3Ys-xS-zdq">
-                                                <rect key="frame" x="126" y="657" width="162" height="30"/>
+                                                <rect key="frame" x="126" y="572.5" width="162" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_endEngagement_button"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="QkV-yj-Sti"/>
@@ -295,7 +250,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tYL-hF-sF1">
-                                                <rect key="frame" x="152" y="702" width="110" height="30"/>
+                                                <rect key="frame" x="152" y="617.5" width="110" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_visitorInfo_button"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
@@ -305,7 +260,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PbA-Oy-bDr">
-                                                <rect key="frame" x="113.5" y="747" width="187" height="30"/>
+                                                <rect key="frame" x="113.5" y="662.5" width="187" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_sensitiveData_button"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
@@ -315,13 +270,13 @@
                                                 </connections>
                                             </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="UI customization" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E1e-uA-HuC">
-                                                <rect key="frame" x="143.5" y="792" width="127.5" height="20.5"/>
+                                                <rect key="frame" x="143.5" y="707.5" width="127.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ezc-iY-PbB">
-                                                <rect key="frame" x="141" y="827.5" width="132" height="30"/>
+                                                <rect key="frame" x="141" y="743" width="132" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="main_endEngagement_button"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="Nef-0j-qW7"/>
@@ -332,13 +287,13 @@
                                                 </connections>
                                             </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VisitorCode" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tI8-TQ-jWA">
-                                                <rect key="frame" x="162.5" y="872.5" width="89" height="20.5"/>
+                                                <rect key="frame" x="162.5" y="788" width="89" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="1gR-qB-lno">
-                                                <rect key="frame" x="90.5" y="908" width="233" height="30"/>
+                                                <rect key="frame" x="90.5" y="823.5" width="233" height="30"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YnU-rR-gCc">
                                                         <rect key="frame" x="0.0" y="0.0" width="88" height="30"/>
@@ -367,7 +322,7 @@
                                                 </subviews>
                                             </stackView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7mi-et-ybT">
-                                                <rect key="frame" x="0.0" y="953" width="414" height="200"/>
+                                                <rect key="frame" x="0.0" y="868.5" width="414" height="200"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="200" id="GaG-7F-RUb"/>
@@ -375,7 +330,7 @@
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pXZ-8Z-cyU">
-                                                <rect key="frame" x="0.0" y="1168" width="414" height="332"/>
+                                                <rect key="frame" x="0.0" y="1083.5" width="414" height="332"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="332" id="eEb-6T-YAJ"/>
@@ -384,8 +339,6 @@
                                             </view>
                                         </subviews>
                                         <constraints>
-                                            <constraint firstItem="qwv-F0-vOF" firstAttribute="top" secondItem="S6U-rq-MZq" secondAttribute="bottom" constant="15" id="8qB-zt-dYV"/>
-                                            <constraint firstItem="S6U-rq-MZq" firstAttribute="top" secondItem="CoL-67-2P6" secondAttribute="bottom" constant="15" id="BRy-s9-qgS"/>
                                             <constraint firstAttribute="trailing" secondItem="7mi-et-ybT" secondAttribute="trailing" id="DkY-DC-Zat"/>
                                             <constraint firstItem="pXZ-8Z-cyU" firstAttribute="leading" secondItem="A3Y-Xf-Ufg" secondAttribute="leading" id="F7u-Bw-OEA"/>
                                             <constraint firstAttribute="trailing" secondItem="pXZ-8Z-cyU" secondAttribute="trailing" id="VYp-52-I9C"/>
@@ -417,12 +370,10 @@
                         <outlet property="authenticationBehaviorSegmentedControl" destination="kH0-DZ-F2e" id="m54-z8-Emh"/>
                         <outlet property="autoConfigureSdkToggle" destination="rZ7-2H-jwc" id="nAr-zX-vTy"/>
                         <outlet property="configureButton" destination="4yC-lN-tH2" id="sAf-jg-YTC"/>
-                        <outlet property="enablingOverwriteBubbleSwitch" destination="d3A-aT-6lw" id="Tg3-18-rBG"/>
                         <outlet property="entryWidgetView" destination="pXZ-8Z-cyU" id="gbD-kc-o3J"/>
                         <outlet property="refreshAccessTokenButton" destination="5zf-Ur-3od" id="O5Q-56-XDi"/>
                         <outlet property="secureConversationsButton" destination="ojd-PF-wje" id="kN8-zY-QYl"/>
                         <outlet property="toggleAuthenticateButton" destination="pHy-59-v7T" id="9rO-74-dfE"/>
-                        <outlet property="togglingStartEngBubbleSwitch" destination="uZf-AD-CGp" id="UD2-Q9-CkE"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/TestingApp/ViewController/ViewController.swift
+++ b/TestingApp/ViewController/ViewController.swift
@@ -17,23 +17,6 @@ class ViewController: UIViewController {
     @UserDefaultsStored(key: "features", defaultValue: Features.all, coder: .rawRepresentable())
     private(set) var features: Features
 
-    // If not `nil`, this value will be passed to deprecated
-    // `Glia.sharedInstance.startEngagement(engagementKind:in:features:sceneProvider:)`
-    // overwriting `features` passed initially to `Glia.sharedInstance.configure` method.
-    // If not set, non-deprecated `startEngagement` will be called,
-    // using `features` passed to `configure` under the hood.
-    private var startEngagementFeatures: Features? {
-        switch (enablingOverwriteBubbleSwitch.isOn, togglingStartEngBubbleSwitch.isOn) {
-        case (false, _):
-            return nil
-        case (true, true):
-            var features = self.features
-            return features.insert(.bubbleView).memberAfterInsert
-        case (true, false):
-            return self.features.subtracting(.bubbleView)
-        }
-    }
-
     let visitorInfoModel = VisitorInfoModel(
         environment: .init(
             fetchVisitorInfo: GliaCore.sharedInstance.fetchVisitorInfo,
@@ -53,7 +36,6 @@ class ViewController: UIViewController {
         view.backgroundColor = .white
         setupPushHandler()
         configureAuthenticationBehaviorToggleAccessibility()
-        setupStartEngagementBubbleSwitches()
     }
 
     // MARK: - IBOutlets
@@ -70,14 +52,6 @@ class ViewController: UIViewController {
     var authenticationBehavior: Authentication.Behavior {
         authenticationBehaviorSegmentedControl.selectedSegmentIndex == 0 ? .forbiddenDuringEngagement : .allowedDuringEngagement
     }
-
-    // Switch control that enables call of deprecated
-    // `Glia.sharedInstance.startEngagement(engagementKind:in:features:sceneProvider:)`
-    // method with passed `startEngagementFeatures` as `features` parameter.
-    @IBOutlet weak var enablingOverwriteBubbleSwitch: UISwitch!
-    // Switch control that toggles bubble visibility via deprecated
-    // `Glia.sharedInstance.startEngagement(engagementKind:in:features:sceneProvider:)`
-    @IBOutlet weak var togglingStartEngBubbleSwitch: UISwitch!
 
     // MARK: - IBActions
 
@@ -213,33 +187,5 @@ private extension ViewController {
                 break
             }
         }
-    }
-
-    func renderStartEngagementBubbleSwitches() {
-        if let startEngagementFeatures {
-            self.enablingOverwriteBubbleSwitch.isOn = true
-            self.togglingStartEngBubbleSwitch.isEnabled = true
-            self.togglingStartEngBubbleSwitch.isOn = startEngagementFeatures.contains(.bubbleView)
-        } else {
-            self.enablingOverwriteBubbleSwitch.isOn = false
-            self.togglingStartEngBubbleSwitch.isEnabled = false
-        }
-    }
-
-    func setupStartEngagementBubbleSwitches() {
-        [self.enablingOverwriteBubbleSwitch, self.togglingStartEngBubbleSwitch]
-            .forEach { uiSwitch in
-                uiSwitch.addTarget(
-                    self,
-                    action: #selector(handleStartEngagementBubbleSwitchChange),
-                    for: .valueChanged
-                )
-            }
-        renderStartEngagementBubbleSwitches()
-    }
-
-    @objc
-    func handleStartEngagementBubbleSwitchChange(_: UISwitch) {
-        renderStartEngagementBubbleSwitches()
     }
 }


### PR DESCRIPTION
MOB-3907

**What was solved?**
This PR revert changes introduced in [PR](https://github.com/salemove/ios-sdk-widgets/pull/1025/files):
- Removes bubble related controls from initial screen;
- Updates comments/documentation for `var features: Features?` in `Glia` instance.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.
 
 
![Simulator Screenshot - iPhone 15 Pro - 2024-12-30 at 16 46 26](https://github.com/user-attachments/assets/0320656f-242b-49aa-9deb-9aad06461190)