### PR TITLE
Log ongoing engagement event in Entry Widget

### DIFF
--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
@@ -148,6 +148,7 @@ private extension EntryWidget {
         unreadSecureMessagesCount: Int?
     ) {
         if let ongoingEngagement {
+            environment.log.info("Preparing items based on ongoing engagement")
             if ongoingEngagement.source == .callVisualizer {
                 viewState = .ongoingEngagement(.callVisualizer)
             } else if ongoingEngagement.source == .coreEngagement {


### PR DESCRIPTION
**What was solved?**
Both platforms now also log when ongoing engagement

MOB-3909
**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
