### PR TITLE
Update image preview screen logs to align with Android

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -985,7 +985,7 @@
 		C0D6CA512C19BB5600D4709B /* SurveyViewController.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA502C19BB5600D4709B /* SurveyViewController.Environment.swift */; };
 		C0D6CA532C19BC0300D4709B /* FilePreviewView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA522C19BC0300D4709B /* FilePreviewView.Environment.swift */; };
 		C0D6CA552C19BCDB00D4709B /* SecureConversations.FilePreviewView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA542C19BCDB00D4709B /* SecureConversations.FilePreviewView.Environment.swift */; };
-		C0D6CA572C19BDCD00D4709B /* FilePickerViewModel.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA562C19BDCD00D4709B /* FilePickerViewModel.Environment.swift */; };
+		C0D6CA572C19BDCD00D4709B /* QuickLookViewModel.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA562C19BDCD00D4709B /* QuickLookViewModel.Environment.swift */; };
 		C0D6CA592C19BE9D00D4709B /* FilePickerController.Envrionment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA582C19BE9D00D4709B /* FilePickerController.Envrionment.swift */; };
 		C0D6CA5B2C19BF1D00D4709B /* SecureConversations.ConfirmationViewModel.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA5A2C19BF1D00D4709B /* SecureConversations.ConfirmationViewModel.Environment.swift */; };
 		C0D6CA5D2C19C07200D4709B /* ConnectOperatorView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6CA5C2C19C07200D4709B /* ConnectOperatorView.Environment.swift */; };
@@ -2076,7 +2076,7 @@
 		C0D6CA502C19BB5600D4709B /* SurveyViewController.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyViewController.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA522C19BC0300D4709B /* FilePreviewView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewView.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA542C19BCDB00D4709B /* SecureConversations.FilePreviewView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.FilePreviewView.Environment.swift; sourceTree = "<group>"; };
-		C0D6CA562C19BDCD00D4709B /* FilePickerViewModel.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePickerViewModel.Environment.swift; sourceTree = "<group>"; };
+		C0D6CA562C19BDCD00D4709B /* QuickLookViewModel.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLookViewModel.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA582C19BE9D00D4709B /* FilePickerController.Envrionment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePickerController.Envrionment.swift; sourceTree = "<group>"; };
 		C0D6CA5A2C19BF1D00D4709B /* SecureConversations.ConfirmationViewModel.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.ConfirmationViewModel.Environment.swift; sourceTree = "<group>"; };
 		C0D6CA5C2C19C07200D4709B /* ConnectOperatorView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectOperatorView.Environment.swift; sourceTree = "<group>"; };
@@ -2497,7 +2497,6 @@
 			isa = PBXGroup;
 			children = (
 				1A2DA71E25EF720400032611 /* FilePickerViewModel.swift */,
-				C0D6CA562C19BDCD00D4709B /* FilePickerViewModel.Environment.swift */,
 			);
 			path = FilePicker;
 			sourceTree = "<group>";
@@ -5342,6 +5341,7 @@
 			isa = PBXGroup;
 			children = (
 				C49A29DA2614A22600819269 /* QuickLookViewModel.swift */,
+				C0D6CA562C19BDCD00D4709B /* QuickLookViewModel.Environment.swift */,
 			);
 			path = QuickLook;
 			sourceTree = "<group>";
@@ -6640,7 +6640,7 @@
 				7594093D298D376B008B173A /* RemoteConfiguration+AssetsBuilder.swift in Sources */,
 				AF552ED72BECDCDF00FD5653 /* UIButton+Extensions.swift in Sources */,
 				9A3E1D9B27B73246005634EB /* FoundationBased.Mock.swift in Sources */,
-				C0D6CA572C19BDCD00D4709B /* FilePickerViewModel.Environment.swift in Sources */,
+				C0D6CA572C19BDCD00D4709B /* QuickLookViewModel.Environment.swift in Sources */,
 				75FF151427F3A2D600FE7BE2 /* Theme.Survey.swift in Sources */,
 				C0D6CA272C18743E00D4709B /* CallDurationCounter.Environment.swift in Sources */,
 				84681AA32A66D90000DD7406 /* AdjustedTouchAreaButton.swift in Sources */,

--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
@@ -172,10 +172,7 @@ extension SecureConversations {
         private func presentFilePickerController(with pickerEvent: Command<FilePickerEvent>) {
             let observable = ObservableValue<FilePickerEvent>(with: .none)
             observable.addObserver(self, update: { event, _ in pickerEvent(event) })
-            let viewModel = FilePickerViewModel(
-                pickerEvent: observable,
-                environment: .create(with: environment)
-            )
+            let viewModel = FilePickerViewModel(pickerEvent: observable)
             viewModel.delegate = { [weak self] event in
                 switch event {
                 case .finished:

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
@@ -112,10 +112,7 @@ class ChatCoordinator: SubFlowCoordinator, FlowCoordinator {
     }
 
     private func presentFilePickerController(with pickerEvent: ObservableValue<FilePickerEvent>) {
-        let viewModel = FilePickerViewModel(
-            pickerEvent: pickerEvent,
-            environment: .create(with: environment)
-        )
+        let viewModel = FilePickerViewModel(pickerEvent: pickerEvent)
         viewModel.delegate = { [weak self] event in
             switch event {
             case .finished:
@@ -132,7 +129,7 @@ class ChatCoordinator: SubFlowCoordinator, FlowCoordinator {
     }
 
     private func presentQuickLookController(with file: LocalFile) {
-        let viewModel = QuickLookViewModel(file: file)
+        let viewModel = QuickLookViewModel(file: file, environment: .create(with: environment))
         viewModel.delegate = { [weak self] event in
             switch event {
             case .finished:

--- a/GliaWidgets/Sources/ViewController/Common/FilePicker/FilePickerController.swift
+++ b/GliaWidgets/Sources/ViewController/Common/FilePicker/FilePickerController.swift
@@ -8,10 +8,7 @@ final class FilePickerController: NSObject {
         documentPicker.modalPresentationStyle = .fullScreen
         let urls = environment.fileManager.urlsForDirectoryInDomainMask(.documentDirectory, .userDomainMask)
         documentPicker.directoryURL = urls.first
-        viewModel.environment.log.prefixed(Self.self).info(
-            "Create File Preview screen",
-            function: "\(\FilePickerController.viewController)"
-        )
+
         return documentPicker
     }
 
@@ -24,10 +21,6 @@ final class FilePickerController: NSObject {
     ) {
         self.viewModel = viewModel
         self.environment = environment
-    }
-
-    deinit {
-        viewModel.environment.log.prefixed(Self.self).info("Destroy File Preview screen")
     }
 }
 

--- a/GliaWidgets/Sources/ViewController/Common/QuickLook/QuickLookController.swift
+++ b/GliaWidgets/Sources/ViewController/Common/QuickLook/QuickLookController.swift
@@ -5,6 +5,10 @@ final class QuickLookController: NSObject {
         let controller = QLPreviewController()
         controller.dataSource = self
         controller.delegate = self
+        viewModel.environment.log.prefixed(Self.self).info(
+            "Create Image Preview screen",
+            function: "\(\FilePickerController.viewController)"
+        )
         return controller
     }
 
@@ -12,6 +16,10 @@ final class QuickLookController: NSObject {
 
     init(viewModel: QuickLookViewModel) {
         self.viewModel = viewModel
+    }
+
+    deinit {
+        viewModel.environment.log.prefixed(Self.self).info("Destroy Image Preview screen")
     }
 }
 

--- a/GliaWidgets/Sources/ViewModel/Common/FilePicker/FilePickerViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Common/FilePicker/FilePickerViewModel.swift
@@ -45,16 +45,13 @@ class FilePickerViewModel: ViewModel {
     let allowedFiles: FileTypes
 
     private let pickerEvent: ObservableValue<FilePickerEvent>
-    var environment: Environment
 
     init(
         pickerEvent: ObservableValue<FilePickerEvent>,
-        allowedFiles: FileTypes = .default,
-        environment: Environment
+        allowedFiles: FileTypes = .default
     ) {
         self.pickerEvent = pickerEvent
         self.allowedFiles = allowedFiles
-        self.environment = environment
     }
 
     func event(_ event: Event) {

--- a/GliaWidgets/Sources/ViewModel/Common/QuickLook/QuickLookViewModel.Environment.swift
+++ b/GliaWidgets/Sources/ViewModel/Common/QuickLook/QuickLookViewModel.Environment.swift
@@ -1,16 +1,12 @@
 import Foundation
 
-extension FilePickerViewModel {
+extension QuickLookViewModel {
     struct Environment {
         var log: CoreSdkClient.Logger
     }
 }
 
-extension FilePickerViewModel.Environment {
-    static func create(with environment: SecureConversations.Coordinator.Environment) -> Self {
-        .init(log: environment.log)
-    }
-
+extension QuickLookViewModel.Environment {
     static func create(with environment: ChatCoordinator.Environment) -> Self {
         .init(log: environment.log)
     }

--- a/GliaWidgets/Sources/ViewModel/Common/QuickLook/QuickLookViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Common/QuickLook/QuickLookViewModel.swift
@@ -16,13 +16,15 @@ class QuickLookViewModel: ViewModel {
     var delegate: ((DelegateEvent) -> Void)?
 
     private let items: [QLPreviewItem]
+    var environment: Environment
 
-    init(files: [LocalFile]) {
+    init(files: [LocalFile], environment: Environment) {
         self.items = files.map { $0.url as NSURL }
+        self.environment = environment
     }
 
-    convenience init(file: LocalFile) {
-        self.init(files: [file])
+    convenience init(file: LocalFile, environment: Environment) {
+        self.init(files: [file], environment: environment)
     }
 
     func event(_ event: Event) {


### PR DESCRIPTION
**What was solved?**
This PR updates image preview screen logs to align with Android

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

