### PR TITLE
Do not cancel enqueuing if new enqueue is the same engagement type

### DIFF
--- a/GliaWidgets/Public/Glia/Glia+EngagementSetup.swift
+++ b/GliaWidgets/Public/Glia/Glia+EngagementSetup.swift
@@ -61,6 +61,14 @@ extension Glia {
         viewFactory: ViewFactory,
         ongoingEngagementMediaStreams: Engagement.Media?
     ) throws {
+        /// If during enqueued state the visitor initiates another engagement, we avoid cancelling the queue
+        /// ticket and adding a new one, by monitoring the new engagement kind. If the engagement kind matches
+        /// the current enqueued engagement kind, then we resume the old, and do not start a new one
+        if case let .enqueued(_, enqueudEngagementKind) = interactor.state, enqueudEngagementKind == engagementKind, let rootCoordinator {
+            rootCoordinator.maximize()
+            return
+        }
+
         if let engagement = environment.coreSdk.getCurrentEngagement() {
             if engagement.source == .callVisualizer {
                 throw GliaError.callVisualizerEngagementExists

--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -37,6 +37,10 @@ extension EngagementKind {
             return false
         }
     }
+
+    var mediaType: CoreSdkClient.MediaType {
+        .init(engagementKind: self)
+    }
 }
 
 extension SecureConversations {

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -341,3 +341,20 @@ extension CoreSdkClient {
         var currentCameraDevice: () -> GliaCoreSDK.CameraDevice?
     }
 }
+
+extension CoreSdkClient.MediaType {
+    init(engagementKind: EngagementKind) {
+        switch engagementKind {
+        case .none:
+            self = .unknown
+        case .chat:
+            self = .text
+        case .audioCall:
+            self = .audio
+        case .videoCall:
+            self = .video
+        case .messaging:
+            self = .messaging
+        }
+    }
+}

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
@@ -265,7 +265,7 @@ extension ChatViewController {
 
         fileUploadListModel.environment.uploader.uploads.append(fileUploadWithError)
         fileUploadWithError.state.value = .error(FileUpload.Error.fileTooBig)
-        chatViewModel.interactor.state = .enqueueing(.text)
+        chatViewModel.interactor.state = .enqueueing(.chat)
         chatViewModel.action?(.sendButtonDisabled(false))
         chatViewModel.action?(.updateUnreadMessageIndicator(itemCount: 5))
         chatViewModel.action?(.setChoiceCardInputModeEnabled(false))

--- a/GliaWidgets/Sources/ViewController/GliaViewController.Mock.swift
+++ b/GliaWidgets/Sources/ViewController/GliaViewController.Mock.swift
@@ -2,12 +2,14 @@
 extension GliaViewController {
     static func mock(
         bubbleView: BubbleView = .mock(),
-        delegate: GliaViewControllerDelegate? = nil,
+        delegate: ((GliaViewControllerEvent) -> Void)? = nil,
+        sceneProvider: SceneProvider? = .none,
         features: Features = .all
     ) -> GliaViewController {
         .init(
             bubbleView: bubbleView,
             delegate: delegate,
+            sceneProvider: sceneProvider,
             features: features,
             environment: .init(
                 uiApplication: .mock,

--- a/GliaWidgets/Sources/ViewController/GliaViewController.swift
+++ b/GliaWidgets/Sources/ViewController/GliaViewController.swift
@@ -9,16 +9,12 @@ public enum GliaViewControllerEvent {
     case maximized
 }
 
-public protocol GliaViewControllerDelegate: AnyObject {
-    func event(_ event: GliaViewControllerEvent)
-}
-
 class GliaViewController: UIViewController {
     var bubbleKind: BubbleKind = .userImage(url: nil) {
         didSet { bubbleWindow?.bubbleKind = bubbleKind }
     }
 
-    private weak var delegate: GliaViewControllerDelegate?
+    private var delegate: ((GliaViewControllerEvent) -> Void)?
     private let bubbleView: BubbleView?
     private var bubbleWindow: BubbleWindow?
     private var sceneProvider: SceneProvider?
@@ -27,24 +23,9 @@ class GliaViewController: UIViewController {
     private let environment: Environment
 
     init(
-        bubbleView: BubbleView,
-        delegate: GliaViewControllerDelegate?,
-        features: Features,
-        environment: Environment
-    ) {
-        self.bubbleView = bubbleView
-        self.delegate = delegate
-        self.features = features
-        self.environment = environment
-        super.init(nibName: nil, bundle: nil)
-        setup()
-    }
-
-    @available(iOS 13.0, *)
-    init(
         bubbleView: BubbleView?,
-        delegate: GliaViewControllerDelegate?,
-        sceneProvider: SceneProvider,
+        delegate: ((GliaViewControllerEvent) -> Void)?,
+        sceneProvider: SceneProvider? = .none,
         features: Features,
         environment: Environment
     ) {
@@ -75,7 +56,7 @@ class GliaViewController: UIViewController {
             },
             completion: { [weak self] _ in
                 self?.bubbleWindow = nil
-                self?.delegate?.event(.maximized)
+                self?.delegate?(.maximized)
             }
         )
     }
@@ -87,7 +68,7 @@ class GliaViewController: UIViewController {
 
     func minimize(animated: Bool) {
         environment.log.prefixed(Self.self).info("Bubble: show application-only bubble")
-        defer { delegate?.event(.minimized) }
+        defer { delegate?(.minimized) }
         guard let bubbleView = bubbleView else {
             return
         }
@@ -132,7 +113,6 @@ class GliaViewController: UIViewController {
         }
     }
 
-    @available(iOS 13.0, *)
     private func windowScene() -> UIWindowScene? {
         if let windowScene = sceneProvider?.windowScene() {
             return windowScene

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+GVA.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+GVA.swift
@@ -60,7 +60,7 @@ extension ChatViewModel {
 
             case .enqueueing, .ended, .none:
                 self.handle(pendingMessage: outgoingMessage)
-                self.enqueue(mediaType: .text)
+                self.enqueue(engagementKind: .chat)
             }
         }
     }

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -153,7 +153,7 @@ class ChatViewModel: EngagementViewModel {
             // or in case if engagement has been restored.
 
             if history.isEmpty || self.environment.getCurrentEngagement() != nil {
-                self.interactor.state = .enqueueing(.text)
+                self.interactor.state = .enqueueing(.chat)
             }
         }
     }
@@ -478,7 +478,7 @@ extension ChatViewModel {
 
         case .enqueueing, .ended, .none:
             handle(pendingMessage: outgoingMessage)
-            interactor.state = .enqueueing(.text)
+            interactor.state = .enqueueing(.chat)
         }
 
         messageText = ""

--- a/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
@@ -62,9 +62,9 @@ class EngagementViewModel: CommonEngagementModel {
 
     func start() {}
 
-    func enqueue(mediaType: CoreSdkClient.MediaType) {
+    func enqueue(engagementKind: EngagementKind) {
         interactor.enqueueForEngagement(
-            mediaType: mediaType,
+            engagementKind: engagementKind,
             success: {},
             failure: { [weak self] error in
                 self?.handleError(error)
@@ -123,15 +123,15 @@ class EngagementViewModel: CommonEngagementModel {
                     )
                 })))
             })
-        case let .enqueueing(mediaType):
+        case let .enqueueing(engagementKind):
             environment.fetchSiteConfigurations { [weak self] result in
                 guard let self else { return }
                 switch result {
                 case let .success(site):
                     if site.mobileConfirmDialogEnabled == false || self.interactor.skipLiveObservationConfirmations {
-                        self.enqueue(mediaType: mediaType)
+                        self.enqueue(engagementKind: engagementKind)
                     } else {
-                        self.showLiveObservationConfirmation(in: mediaType)
+                        self.showLiveObservationConfirmation(in: engagementKind)
                     }
                 case let .failure(error):
                     self.engagementAction?(.showAlert(.error(
@@ -226,13 +226,13 @@ private extension EngagementViewModel {
 // MARK: Live Observation
 
 extension EngagementViewModel {
-    private func showLiveObservationConfirmation(in mediaType: CoreSdkClient.MediaType) {
+    private func showLiveObservationConfirmation(in engagementKind: EngagementKind) {
         engagementAction?(.showLiveObservationConfirmation(
             link: { [weak self] link in
                 self?.engagementDelegate?(.openLink(link))
             },
             accepted: { [weak self] in
-                self?.enqueue(mediaType: mediaType)
+                self?.enqueue(engagementKind: engagementKind)
             },
             declined: { [weak self] in
                 self?.endSession()

--- a/GliaWidgetsTests/Sources/CallViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/CallViewModelTests.swift
@@ -430,7 +430,7 @@ class CallViewModelTests: XCTestCase {
                 XCTFail()
             }
         }
-        interactor.state = .enqueueing(.audio)
+        interactor.state = .enqueueing(.audioCall)
         XCTAssertEqual(calls, [.showLiveObservationAlert])
     }
 
@@ -464,9 +464,9 @@ class CallViewModelTests: XCTestCase {
                 XCTFail()
             }
         }
-        interactor.state = .enqueueing(.audio)
+        interactor.state = .enqueueing(.audioCall)
         alertConfig?.accepted()
-        XCTAssertEqual(interactor.state, .enqueued(.mock))
+        XCTAssertEqual(interactor.state, .enqueued(.mock, .audioCall))
     }
 
     func test_liveObservationDeclineTriggersNone() throws {
@@ -503,7 +503,7 @@ class CallViewModelTests: XCTestCase {
                 XCTFail()
             }
         }
-        interactor.state = .enqueueing(.audio)
+        interactor.state = .enqueueing(.audioCall)
         alertConfig?.declined()
         XCTAssertEqual(interactor.state, .ended(.byVisitor))
         XCTAssertTrue(calls.isEmpty)

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Gva.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Gva.swift
@@ -127,8 +127,8 @@ extension ChatViewModelTests {
         env.createSendMessagePayload = { _, _ in .mock() }
         viewModel = .mock(interactor: interactorMock, environment: env)
         viewModel.gvaOptionAction(for: option)()
-        viewModel.interactor.state = .enqueueing(.text)
-        XCTAssertEqual(interactorMock.state, .enqueueing(.text))
+        viewModel.interactor.state = .enqueueing(.chat)
+        XCTAssertEqual(interactorMock.state, .enqueueing(.chat))
     }
 
     func test_broadcastEventAction() {

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -78,7 +78,7 @@ class ChatViewModelTests: XCTestCase {
 
     func test_secureTranscriptChatTypeCases() throws {
         let viewModel: ChatViewModel = .mock(chatType: .secureTranscript(upgradedFromChat: false))
-        viewModel.update(for: .enqueueing(.text))
+        viewModel.update(for: .enqueueing(.chat))
         XCTAssertEqual(viewModel.queueOperatorSection.itemCount, 0)
         viewModel.handle(pendingMessage: .mock())
         XCTAssertEqual(viewModel.queueOperatorSection.itemCount, 1)
@@ -86,7 +86,7 @@ class ChatViewModelTests: XCTestCase {
 
     func test_authenticatedChatTypeCases() throws {
         let viewModel: ChatViewModel = .mock(chatType: .authenticated)
-        viewModel.update(for: .enqueueing(.text))
+        viewModel.update(for: .enqueueing(.chat))
         XCTAssertEqual(viewModel.queueOperatorSection.itemCount, 1)
         viewModel.handle(pendingMessage: .mock())
         XCTAssertEqual(viewModel.queueOperatorSection.itemCount, 1)
@@ -94,7 +94,7 @@ class ChatViewModelTests: XCTestCase {
 
     func test_nonAuthenticatedChatTypeCases() throws {
         let viewModel: ChatViewModel = .mock(chatType: .nonAuthenticated)
-        viewModel.update(for: .enqueueing(.text))
+        viewModel.update(for: .enqueueing(.chat))
         XCTAssertEqual(viewModel.queueOperatorSection.itemCount, 1)
         viewModel.handle(pendingMessage: .mock())
         XCTAssertEqual(viewModel.queueOperatorSection.itemCount, 1)
@@ -141,7 +141,7 @@ class ChatViewModelTests: XCTestCase {
         let mockOperator: CoreSdkClient.Operator = .mock()
 
         XCTAssertEqual(0, viewModel.numberOfItems(in: queueSectionIndex))
-        viewModel.update(for: .enqueueing(.text))
+        viewModel.update(for: .enqueueing(.chat))
         XCTAssertEqual(1, viewModel.numberOfItems(in: queueSectionIndex))
         viewModel.update(for: .engaged(mockOperator))
         XCTAssertEqual(0, viewModel.numberOfItems(in: queueSectionIndex))
@@ -260,7 +260,7 @@ class ChatViewModelTests: XCTestCase {
         let viewModel = ChatViewModel.mock(interactor: interactor, environment: viewModelEnv)
 
         // When
-        viewModel.update(for: .enqueueing(.text))
+        viewModel.update(for: .enqueueing(.chat))
 
         // Then
         XCTAssertEqual(calls, [])
@@ -722,7 +722,7 @@ class ChatViewModelTests: XCTestCase {
         let viewModel: ChatViewModel = .mock(interactor: interactor, environment: viewModelEnv)
         viewModel.isViewLoaded = true
         viewModel.start()
-        viewModel.interactor.state = .enqueueing(.text)
+        viewModel.interactor.state = .enqueueing(.chat)
         interactor.state = .engaged(.mock())
         viewModel.invokeSetTextAndSendMessage(text: "Mock send message.")
         viewModel.interactorEvent(.receivedMessage(.mock(id: expectedMessageId)))
@@ -789,7 +789,7 @@ class ChatViewModelTests: XCTestCase {
                 XCTFail()
             }
         }
-        interactor.state = .enqueueing(.audio)
+        interactor.state = .enqueueing(.audioCall)
         XCTAssertEqual(calls, [.showLiveObservationAlert])
     }
 
@@ -824,9 +824,9 @@ class ChatViewModelTests: XCTestCase {
                 XCTFail()
             }
         }
-        interactor.state = .enqueueing(.audio)
+        interactor.state = .enqueueing(.audioCall)
         alertConfig?.accepted()
-        XCTAssertEqual(interactor.state, .enqueued(.mock))
+        XCTAssertEqual(interactor.state, .enqueued(.mock, .audioCall))
     }
 
     func test_liveObservationDeclineTriggersNone() throws {
@@ -863,7 +863,7 @@ class ChatViewModelTests: XCTestCase {
                 XCTFail()
             }
         }
-        interactor.state = .enqueueing(.audio)
+        interactor.state = .enqueueing(.audioCall)
         alertConfig?.declined()
         XCTAssertEqual(interactor.state, .ended(.byVisitor))
         XCTAssertTrue(calls.isEmpty)

--- a/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinatorCallTests.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinatorCallTests.swift
@@ -11,7 +11,7 @@ extension EngagementCoordinatorTests {
         let viewController = coordinator.navigationPresenter.viewControllers.first as? CallViewController
 
         XCTAssertNotNil(viewController)
-        XCTAssertEqual(coordinator.interactor.state, .enqueueing(.audio))
+        XCTAssertEqual(coordinator.interactor.state, .enqueueing(.audioCall))
     }
 
     func test_video() {
@@ -21,7 +21,7 @@ extension EngagementCoordinatorTests {
         let viewController = coordinator.navigationPresenter.viewControllers.first as? CallViewController
 
         XCTAssertNotNil(viewController)
-        XCTAssertEqual(coordinator.interactor.state, .enqueueing(.video))
+        XCTAssertEqual(coordinator.interactor.state, .enqueueing(.videoCall))
     }
 
     // MARK: - Delegate

--- a/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinatorTests.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinatorTests.swift
@@ -44,7 +44,7 @@ final class EngagementCoordinatorTests: XCTestCase {
 
         coordinator.start()
 
-        XCTAssertEqual(coordinator.interactor.state, .enqueueing(.audio))
+        XCTAssertEqual(coordinator.interactor.state, .enqueueing(.audioCall))
         let viewController = coordinator.navigationPresenter.viewControllers.first as? CallViewController
         XCTAssertNotNil(viewController)
         XCTAssertNotNil(coordinator.gliaViewController)
@@ -63,7 +63,7 @@ final class EngagementCoordinatorTests: XCTestCase {
 
         coordinator.start()
 
-        XCTAssertEqual(coordinator.interactor.state, .enqueueing(.video))
+        XCTAssertEqual(coordinator.interactor.state, .enqueueing(.videoCall))
         let viewController = coordinator.navigationPresenter.viewControllers.first as? CallViewController
         XCTAssertNotNil(viewController)
         XCTAssertNotNil(coordinator.gliaViewController)
@@ -165,7 +165,7 @@ final class EngagementCoordinatorTests: XCTestCase {
 
         coordinator.start()
 
-        coordinator.interactor.state = .enqueueing(.text)
+        coordinator.interactor.state = .enqueueing(.chat)
 
         let chatCoordinator = coordinator.coordinators.last as? ChatCoordinator
         chatCoordinator?.delegate?(.back)

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+EngagementLauncher.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+EngagementLauncher.swift
@@ -74,6 +74,46 @@ extension GliaTests {
 
         XCTAssertEqual(sdk.engagement, .messaging(.welcome))
     }
+
+    func test_testEnqueuingToChatWhenAlreadyEnqueuedToChat() throws {
+        enum Call {
+            case maximaize
+        }
+        var calls: [Call] = []
+
+        let sdk = makeConfigurableSDK()
+
+        try sdk.configure(
+            with: .mock(),
+            theme: .mock()
+        ) { _ in }
+
+        let interactor: Interactor = .mock()
+        interactor.state = .enqueued(.mock, .chat)
+
+        sdk.interactor = interactor
+        sdk.rootCoordinator = .mock(interactor: interactor)
+        sdk.rootCoordinator?.gliaViewController = GliaViewController.mock(delegate: { event in
+            switch event {
+            case .maximized:
+                calls.append(.maximaize)
+            default:
+                break
+            }
+        })
+
+        try sdk.resolveEngagementState(
+            engagementKind: .chat,
+            sceneProvider: .none,
+            configuration: .mock(),
+            interactor: interactor,
+            features: .all,
+            viewFactory: .mock(),
+            ongoingEngagementMediaStreams: .none
+        )
+
+        XCTAssertEqual(calls, [.maximaize])
+    }
 }
 
 private extension GliaTests {

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -407,7 +407,9 @@ final class GliaTests: XCTestCase {
         let sdk = Glia(environment: environment)
         let coordinator = EngagementCoordinator.mock()
         let delegate = GliaViewControllerDelegateMock()
-        let gliaVC = GliaViewController.mock(delegate: delegate)
+        let gliaVC = GliaViewController.mock(delegate: { event in
+            delegate.event(event)
+        })
         coordinator.gliaViewController = gliaVC
         sdk.rootCoordinator = coordinator
 
@@ -435,7 +437,9 @@ final class GliaTests: XCTestCase {
         let sdk = Glia(environment: environment)
         let coordinator = EngagementCoordinator.mock()
         let delegate = GliaViewControllerDelegateMock()
-        let gliaVC = GliaViewController.mock(delegate: delegate)
+        let gliaVC = GliaViewController.mock(delegate: { event in
+            delegate.event(event)
+        })
         coordinator.gliaViewController = gliaVC
         sdk.rootCoordinator = coordinator
 

--- a/GliaWidgetsTests/Sources/Glia/Mocks/GliaViewControllerDelegateMock.swift
+++ b/GliaWidgetsTests/Sources/Glia/Mocks/GliaViewControllerDelegateMock.swift
@@ -1,7 +1,7 @@
 @testable import GliaWidgets
 import Foundation
 
-final class GliaViewControllerDelegateMock: GliaViewControllerDelegate {
+final class GliaViewControllerDelegateMock {
     var invokedEventCall = false
     var invokedEventCallCount = 0
     var invokedEventCallParameter: GliaViewControllerEvent?


### PR DESCRIPTION
**What was solved?**
Currently, if the visitor is enqueuing and decides to initiate engagement again, then that will cancel their queue ticket and create a new one. This is really bad from a UX perspective because a person would potentially lose a great spot in a long queue, even though their reason was to just resume the existing one.

The new solution would check for the engagement kind and if the current one matches the new one, then instead of canceling the old, the old one is resumed.

There were technical difficulties to achieve that because currently, the SDK converts EngagementKind to simplified mediaType, which makes this upgrade impossible. This PR improves the approach significantly and allows the SDK to rely on EngagementKind as long as possible and only use mediaType when absolutely needed. This PR lays a pathway forward to continue removing mediaType from places where EngagementKind is sufficient.

MOB-3931
**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
