### PR TITLE
Log error if application unable to open deeplink in Chat

### DIFF
--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
@@ -399,7 +399,10 @@ extension SecureConversations.TranscriptModel {
     }
 
     func linkTapped(_ url: URL) {
-        guard environment.uiApplication.canOpenURL(url) else { return }
+        guard environment.uiApplication.canOpenURL(url) else {
+            environment.log.prefixed(Self.self).error("No dialer uri - \(url)")
+            return
+        }
         environment.uiApplication.open(url)
     }
 

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -796,7 +796,10 @@ extension ChatViewModel {
     }
 
     func linkTapped(_ url: URL) {
-        guard environment.uiApplication.canOpenURL(url) else { return }
+        guard environment.uiApplication.canOpenURL(url) else {
+            environment.log.prefixed(Self.self).error("No dialer uri - \(url)")
+            return
+        }
         environment.uiApplication.open(url)
     }
 

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+URLs.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+URLs.swift
@@ -71,6 +71,25 @@ extension SecureConversationsTranscriptModelTests {
 
         XCTAssertEqual(calls, [.canOpen(mockUrl), .open(mockUrl)])
     }
+    
+    func test_handleUrlThatCanNotBeOpenedShouldLog() throws {
+        enum Call: Equatable { case canOpen(URL), log }
+        var calls: [Call] = []
+        let viewModel = createViewModel()
+        viewModel.environment.uiApplication.canOpenURL = { url in
+            calls.append(.canOpen(url))
+            return false
+        }
+        viewModel.environment.log.prefixedClosure = { prefix in
+            calls.append(.log)
+            return .mock
+        }
+
+        let linkUrl = try XCTUnwrap(URL(string: "https://mock.mock"))
+        viewModel.linkTapped(linkUrl)
+
+        XCTAssertEqual(calls, [.canOpen(linkUrl), .log])
+    }
 }
 
 private extension SecureConversationsTranscriptModelTests {


### PR DESCRIPTION
**What was solved?**
This PR logs error if application unable to open deeplink in Chat.

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [X] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.
