### PR TITLE
Show SnackBar if there is ongoing Call Visualizer

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -195,6 +195,7 @@
 		2198B7AC2CAEB14D002C442B /* QueuesMonitor.Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2198B7AB2CAEB14D002C442B /* QueuesMonitor.Live.swift */; };
 		2198B7AE2CB035A6002C442B /* QueuesMonitor.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2198B7AD2CB035A6002C442B /* QueuesMonitor.Environment.swift */; };
 		21BADEBB2D2D7F94000AD9CF /* MockConfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 21BADEBA2D2D7F94000AD9CF /* MockConfiguration.json */; };
+		21C07F7A2D39095F00AEBE3E /* Glia+SnackBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C07F792D39095F00AEBE3E /* Glia+SnackBar.swift */; };
 		23D69155F4F4C5043173EF05 /* Pods_GliaWidgets.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F7A5CDD05FB57D55971AA68A /* Pods_GliaWidgets.framework */; };
 		3100D929296E946600DEC9CE /* SecureConversations.ConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3100D924296E946600DEC9CE /* SecureConversations.ConfirmationView.swift */; };
 		3100D92A296E946600DEC9CE /* Theme+SecureConversationsConfirmation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3100D925296E946600DEC9CE /* Theme+SecureConversationsConfirmation.swift */; };
@@ -1281,6 +1282,7 @@
 		2198B7AB2CAEB14D002C442B /* QueuesMonitor.Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueuesMonitor.Live.swift; sourceTree = "<group>"; };
 		2198B7AD2CB035A6002C442B /* QueuesMonitor.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueuesMonitor.Environment.swift; sourceTree = "<group>"; };
 		21BADEBA2D2D7F94000AD9CF /* MockConfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MockConfiguration.json; sourceTree = "<group>"; };
+		21C07F792D39095F00AEBE3E /* Glia+SnackBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Glia+SnackBar.swift"; sourceTree = "<group>"; };
 		235300A49A5836A51EB1C4E8 /* Pods-GliaWidgets.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GliaWidgets.release.xcconfig"; path = "Target Support Files/Pods-GliaWidgets/Pods-GliaWidgets.release.xcconfig"; sourceTree = "<group>"; };
 		2797F86D83B9055FAD6E596E /* Pods-SnapshotTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SnapshotTests.debug.xcconfig"; path = "Target Support Files/Pods-SnapshotTests/Pods-SnapshotTests.debug.xcconfig"; sourceTree = "<group>"; };
 		3100D924296E946600DEC9CE /* SecureConversations.ConfirmationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecureConversations.ConfirmationView.swift; sourceTree = "<group>"; };
@@ -3850,6 +3852,7 @@
 				AFC7ABB72C2D93A0006F15AA /* Glia+RestoreEngagement.swift */,
 				215A258F2CA44D8A0013023E /* Glia+EngagementLauncher.swift */,
 				C0F7EA3B2CA581E70038019C /* Glia+EntryWidget.swift */,
+				21C07F792D39095F00AEBE3E /* Glia+SnackBar.swift */,
 			);
 			path = Glia;
 			sourceTree = "<group>";
@@ -6506,6 +6509,7 @@
 				9A8130BF27D7AEF700220BBD /* FileUpload.Mock.swift in Sources */,
 				C0175A1D2A5D4226001FACDE /* ChatView.TableView.swift in Sources */,
 				9A8130BD27D7A53300220BBD /* FileUpload.Environment.Mock.swift in Sources */,
+				21C07F7A2D39095F00AEBE3E /* Glia+SnackBar.swift in Sources */,
 				1A60AFB22566821B00E53F53 /* Asset.swift in Sources */,
 				C05AB01C295F416700AA381F /* VisitorCodeCloseButtonProperties.swift in Sources */,
 				C09047862B7E2CC9003C437C /* QuickReplyButtonStyle.RemoteConfig.swift in Sources */,

--- a/GliaWidgets/Localization.swift
+++ b/GliaWidgets/Localization.swift
@@ -454,8 +454,8 @@ internal enum Localization {
       }
     }
     internal enum CallVisualizer {
-      /// Screen sharing in progress
-      internal static var desciption: String { Localization.tr("Localizable", "entry_widget.call_visualizer.desciption", fallback: "Screen sharing in progress") }
+      /// You are already in contact with the support team
+      internal static var description: String { Localization.tr("Localizable", "entry_widget.call_visualizer.description", fallback: "You are already in contact with the support team") }
       internal enum Button {
         /// Call Visualizer
         internal static var label: String { Localization.tr("Localizable", "entry_widget.call_visualizer.button.label", fallback: "Call Visualizer") }

--- a/GliaWidgets/Public/Glia/Glia+EngagementSetup.swift
+++ b/GliaWidgets/Public/Glia/Glia+EngagementSetup.swift
@@ -71,6 +71,10 @@ extension Glia {
 
         if let engagement = environment.coreSdk.getCurrentEngagement() {
             if engagement.source == .callVisualizer {
+                showSnackBar(
+                    with: Localization.EntryWidget.CallVisualizer.description,
+                    style: viewFactory.theme.snackBar
+                )
                 throw GliaError.callVisualizerEngagementExists
             } else {
                 if let rootCoordinator {

--- a/GliaWidgets/Public/Glia/Glia+RestoreEngagement.swift
+++ b/GliaWidgets/Public/Glia/Glia+RestoreEngagement.swift
@@ -47,29 +47,15 @@ extension Glia {
             self.rootCoordinator?.minimize()
         }
 
-        func showSnackBarMessage() {
-            environment.snackBar.showSnackBarMessage(
-                text: viewFactory.theme.snackBar.text,
-                style: viewFactory.theme.snackBar,
-                topMostViewController: GliaPresenter(
-                    environment: .create(
-                        with: self.environment,
-                        log: self.loggerPhase.logger,
-                        sceneProvider: nil
-                    )
-                ).topMostViewController,
-                timerProviding: environment.timerProviding,
-                gcd: environment.gcd,
-                notificationCenter: environment.notificationCenter
-            )
-        }
-
         func showSnackBarIfNeeded() {
-            environment.coreSdk.fetchSiteConfigurations { result in
+            environment.coreSdk.fetchSiteConfigurations { [weak self] result in
                 guard case let .success(site) = result else { return }
                 guard site.mobileObservationEnabled == true else { return }
                 guard site.mobileObservationIndicationEnabled == true else { return }
-                showSnackBarMessage()
+                self?.showSnackBar(
+                    with: viewFactory.theme.snackBar.text,
+                    style: viewFactory.theme.snackBar
+                )
             }
         }
 

--- a/GliaWidgets/Public/Glia/Glia+SnackBar.swift
+++ b/GliaWidgets/Public/Glia/Glia+SnackBar.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+extension Glia {
+    /// Shows snackbar over all application's views.
+    ///
+    /// - Parameters:
+    ///   - message: A text message that will be displayed on snackbar.
+    ///   - style: A style which will be applied for snackbar.
+    ///
+    func showSnackBar(with message: String, style: Theme.SnackBarStyle) {
+        environment.snackBar.showSnackBarMessage(
+            text: message,
+            style: style,
+            topMostViewController: GliaPresenter(
+                environment: .create(
+                    with: self.environment,
+                    log: self.loggerPhase.logger,
+                    sceneProvider: nil
+                )
+            ).topMostViewController,
+            timerProviding: environment.timerProviding,
+            gcd: environment.gcd,
+            notificationCenter: environment.notificationCenter
+        )
+    }
+}

--- a/GliaWidgets/Resources/en.lproj/Localizable.strings
+++ b/GliaWidgets/Resources/en.lproj/Localizable.strings
@@ -270,5 +270,6 @@
 "entry_widget.error_state.try_again.button.label" = "Try again";
 "entry_widget.loading.accessibility.label" = "Loading indicator. Waiting for available options.";
 "entry_widget.ongoing_engagement.description" = "Ongoing • Tap to return";
-"entry_widget.call_visualizer.desciption" = "The support team can provide interactive assistance";
 "entry_widget.ongoing_engagement.button.accessibility.hint" = "Returns to ongoing engagement";
+"entry_widget.call_visualizer.description" = "You are already in contact with the support team";
+"entry_widget.call_visualizer.button.label" = "Call Visualizer";

--- a/GliaWidgets/Sources/Theme/Theme.EntryWidget.swift
+++ b/GliaWidgets/Sources/Theme/Theme.EntryWidget.swift
@@ -39,7 +39,7 @@ extension Theme {
             loading: loading,
             accessibility: mediaTypeAccessibility,
             ongoingCoreEngagementMessage: Localization.EntryWidget.OngoingEngagement.description,
-            ongoingCallVisualizerMessage: Localization.EntryWidget.CallVisualizer.desciption,
+            ongoingCallVisualizerMessage: Localization.EntryWidget.CallVisualizer.description,
             ongoingEngagementMessageFont: font.mediumSubtitle2,
             ongoingEngagementMessageColor: color.primary
         )

--- a/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar+Presenter.swift
+++ b/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar+Presenter.swift
@@ -42,12 +42,12 @@ extension SnackBar {
             hostingController.view.backgroundColor = .clear
 
             hostingController.view.translatesAutoresizingMaskIntoConstraints = false
-             NSLayoutConstraint.activate([
+            NSLayoutConstraint.activate([
                 hostingController.view.topAnchor.constraint(greaterThanOrEqualTo: parent.view.topAnchor),
                 hostingController.view.bottomAnchor.constraint(equalTo: parent.view.bottomAnchor, constant: 64),
                 hostingController.view.leadingAnchor.constraint(equalTo: parent.view.leadingAnchor),
                 hostingController.view.trailingAnchor.constraint(equalTo: parent.view.trailingAnchor)
-             ])
+            ])
         }
 
         func remove() {
@@ -62,19 +62,21 @@ extension SnackBar {
         ) {
             serialQueue.addOperation(
                 .init { [weak self] done in
-                    self?.hostingController.rootView.offset = offset
-                    self?.updatePublisher.send(.appear(text))
+                    guard let self else {
+                        done()
+                        return
+                    }
+                    self.hostingController.rootView.offset = offset
+                    self.updatePublisher.send(.appear(text))
 
-                    self?.timer?.invalidate()
+                    self.timer?.invalidate()
 
-                    self?.timer = self?.environment.timerProviding.scheduledTimer(
+                    self.timer = self.environment.timerProviding.scheduledTimer(
                         withTimeInterval: 3,
                         repeats: false
-                    ) { [weak self] _ in
-                        self?.updatePublisher.send(.disappear)
-                        self?.environment.gcd.mainQueue.asyncAfterDeadline(.now() + 0.5) { [weak self] in
-                            self?.remove()
-                        }
+                    ) { _ in
+                        self.updatePublisher.send(.disappear)
+                        self.environment.gcd.mainQueue.asyncAfterDeadline(.now() + 0.5, self.remove)
                         done()
                     }
                 }

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
@@ -49,6 +49,11 @@ extension GliaTests {
     }
 
     func testStartEngagementThrowsErrorDuringActiveCallVisualizerEngagement() throws {
+        enum Call {
+            case presentSnackBar
+        }
+        var calls: [Call] = []
+        var snackBarMessage: String?
         var logger = CoreSdkClient.Logger.failing
         logger.configureLocalLogLevelClosure = { _ in }
         logger.configureRemoteLogLevelClosure = { _ in }
@@ -69,6 +74,14 @@ extension GliaTests {
         sdk.environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
+        let window = UIWindow(frame: .zero)
+        window.rootViewController = UIViewController()
+        window.makeKeyAndVisible()
+        sdk.environment.uiApplication.windows = { [window] }
+        sdk.environment.snackBar.present = { message, _, _, _, _, _, _ in
+            snackBarMessage = message
+            calls.append(.presentSnackBar)
+        }
 
         try sdk.configure(
             with: .mock(),
@@ -82,6 +95,8 @@ extension GliaTests {
         ) { error in
             XCTAssertEqual(error as? GliaError, GliaError.callVisualizerEngagementExists)
         }
+        XCTAssertEqual(calls, [.presentSnackBar])
+        XCTAssertEqual(snackBarMessage, Localization.EntryWidget.CallVisualizer.description)
     }
 
     func testStartEngagementWithNoQueueIds() throws {


### PR DESCRIPTION
**What was solved?**
This PR shows ShackBar if there is ongoing Call Visualizer

**Release notes:**

 - [X] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [X] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
![Simulator Screenshot - iPhone 15 Pro - 2025-01-16 at 11 11 09](https://github.com/user-attachments/assets/4c4ccfb3-b13f-4d6a-90f6-742295241676)
