### PR TITLE
Show only one available engagement type in Entry Widget when queueing

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -5244,19 +5244,19 @@
 		C0F3DE352C69F4A700DE6D7B /* EntryWidget */ = {
 			isa = PBXGroup;
 			children = (
-				216D31192CFE25630019CA9E /* MediaTypeItems */,
-				216D31182CFE25570019CA9E /* MediaTypeItem */,
 				C0F7EA372CA1D6D40038019C /* CustomPresentationController.swift */,
 				216D31022CEF83A90019CA9E /* EntryWidget.Builder.swift */,
-				C0F3DE362C69F51D00DE6D7B /* EntryWidget.swift */,
+				C0F7EA392CA1D7050038019C /* EntryWidget.Configuration.swift */,
 				2100B47B2CB66B6500AC7527 /* EntryWidget.Environment.swift */,
 				C0F3DE3E2C6E176A00DE6D7B /* EntryWidget.MediaTypeItem.swift */,
 				C0F3DE382C69FC2100DE6D7B /* EntryWidget.Presentation.swift */,
-				C0F7EA392CA1D7050038019C /* EntryWidget.Configuration.swift */,
-				C0F3DE442C6E3D7C00DE6D7B /* EntryWidgetStyle.swift */,
+				C0F3DE362C69F51D00DE6D7B /* EntryWidget.swift */,
 				C034EEEC2CAAB525002650B8 /* EntryWidgetStyle.RemoteConfig.swift */,
+				C0F3DE442C6E3D7C00DE6D7B /* EntryWidgetStyle.swift */,
 				C0F3DE3A2C6E0DD900DE6D7B /* EntryWidgetView.swift */,
 				C0F3DE3C2C6E170600DE6D7B /* EntryWidgetViewModel.swift */,
+				216D31182CFE25570019CA9E /* MediaTypeItem */,
+				216D31192CFE25630019CA9E /* MediaTypeItems */,
 			);
 			path = EntryWidget;
 			sourceTree = "<group>";

--- a/GliaWidgets/Sources/Interactor/Interactor.swift
+++ b/GliaWidgets/Sources/Interactor/Interactor.swift
@@ -70,7 +70,7 @@ class Interactor {
 
     private var observers = [() -> (AnyObject?, EventHandler)]()
 
-    var state: InteractorState = .none {
+    @Published var state: InteractorState = .none {
         didSet {
             if oldValue != state {
                 notify(.stateChanged(state))

--- a/GliaWidgets/Sources/View/Chat/ChatView.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatView.swift
@@ -6,6 +6,7 @@ extension ChatView {
     }
 }
 
+// swiftlint:disable file_length
 class ChatView: EngagementView {
     let tableAndIndicatorStack = UIStackView()
     let tableView = UITableView()
@@ -509,7 +510,13 @@ extension ChatView {
         guard let entryWidget else {
             return
         }
-        let isAnyEngagementTypeAvailable = entryWidget.$availableEngagementTypes
+        let isAnyEngagementTypeAvailable = entryWidget.$viewState
+            .map {
+                if case let .mediaTypes(availableMediaTypes) = $0 {
+                    return availableMediaTypes
+                }
+                return []
+            }
             .map { !$0.isEmpty }
         isAnyEngagementTypeAvailable
             .filter { !$0 }
@@ -1001,3 +1008,4 @@ extension ChatView {
         return .gvaPersistentButton(view)
     }
 }
+// swiftlint:enable file_length

--- a/GliaWidgetsTests/Sources/EntryWidget/EntryWidgetTests.swift
+++ b/GliaWidgetsTests/Sources/EntryWidget/EntryWidgetTests.swift
@@ -149,7 +149,7 @@ class EntryWidgetTests: XCTestCase {
         XCTAssertEqual(envCalls, [.start(.messaging(.welcome))])
     }
     
-    func test_availableEngagementTypesSortedWithNoFilters() {
+    func test_mediaTypesSortedWithNoFilters() {
         let mockQueueId = "mockQueueId"
         let mockQueue = Queue.mock(id: mockQueueId, media: [.messaging, .audio, .video, .text])
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
@@ -173,10 +173,13 @@ class EntryWidgetTests: XCTestCase {
             environment: environment
         )
 
-        XCTAssertEqual(entryWidget.availableEngagementTypes, [.video, .audio, .chat, .secureMessaging])
+        XCTAssertEqual(
+            entryWidget.viewState,
+            .mediaTypes([.init(type: .video), .init(type: .audio), .init(type: .chat), .init(type: .secureMessaging, badgeCount: 5)])
+        )
     }
     
-    func test_availableEngagementTypesSortedAndFilteredIfUserNotAuthenticated() {
+    func test_mediaTypesSortedAndFilteredIfUserNotAuthenticated() {
         let mockQueueId = "mockQueueId"
         let mockQueue = Queue.mock(id: mockQueueId, media: [.messaging, .audio, .video, .text])
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
@@ -203,10 +206,13 @@ class EntryWidgetTests: XCTestCase {
             environment: environment
         )
 
-        XCTAssertEqual(entryWidget.availableEngagementTypes, [.video, .audio, .chat])
+        XCTAssertEqual(
+            entryWidget.viewState,
+            .mediaTypes([.init(type: .video), .init(type: .audio), .init(type: .chat)])
+        )
     }
     
-    func test_availableEngagementTypesSortedAndFilteredSecureConversation() {
+    func test_mediaTypesSortedAndFilteredSecureConversation() {
         let mockQueueId = "mockQueueId"
         let mockQueue = Queue.mock(id: mockQueueId, media: [.messaging, .audio, .video, .text])
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
@@ -229,7 +235,10 @@ class EntryWidgetTests: XCTestCase {
             environment: environment
         )
 
-        XCTAssertEqual(entryWidget.availableEngagementTypes, [.video, .audio, .chat])
+        XCTAssertEqual(
+            entryWidget.viewState,
+            .mediaTypes([.init(type: .video), .init(type: .audio), .init(type: .chat)])
+        )
     }
 
     func test_ongoingEngagementViewStateIsShownWhenCoreEngagementIsChat() {
@@ -350,6 +359,108 @@ class EntryWidgetTests: XCTestCase {
         entryWidget.show(in: .init())
 
         XCTAssertEqual(entryWidget.viewState, .ongoingEngagement(.callVisualizer))
+    }
+
+    func test_ongoingEngagementViewStateIsShownWhenEnqueuedToChat() {
+        var environment = EntryWidget.Environment.mock()
+        let interactor: Interactor = .mock()
+        interactor.state = .enqueued(.mock, .chat)
+        environment.currentInteractor = { interactor }
+
+        let entryWidget = EntryWidget(
+            queueIds: [],
+            configuration: .default,
+            environment: environment
+        )
+
+        entryWidget.show(in: .init())
+
+        XCTAssertEqual(entryWidget.viewState, .ongoingEngagement(.chat))
+    }
+
+    func test_ongoingEngagementViewStateIsShownWhenEnqueuedToAudio() {
+        var environment = EntryWidget.Environment.mock()
+        let interactor: Interactor = .mock()
+        interactor.state = .enqueued(.mock, .audioCall)
+        environment.currentInteractor = { interactor }
+
+        let entryWidget = EntryWidget(
+            queueIds: [],
+            configuration: .default,
+            environment: environment
+        )
+
+        entryWidget.show(in: .init())
+
+        XCTAssertEqual(entryWidget.viewState, .ongoingEngagement(.audio))
+    }
+
+    func test_ongoingEngagementViewStateIsShownWhenEnqueuedToVideo() {
+        var environment = EntryWidget.Environment.mock()
+        let interactor: Interactor = .mock()
+        interactor.state = .enqueued(.mock, .videoCall)
+        environment.currentInteractor = { interactor }
+
+        let entryWidget = EntryWidget(
+            queueIds: [],
+            configuration: .default,
+            environment: environment
+        )
+
+        entryWidget.show(in: .init())
+
+        XCTAssertEqual(entryWidget.viewState, .ongoingEngagement(.video))
+    }
+    
+    func test_ongoingEngagementViewStateIsShownWhenEnqueueingToChat() {
+        var environment = EntryWidget.Environment.mock()
+        let interactor: Interactor = .mock()
+        interactor.state = .enqueueing(.chat)
+        environment.currentInteractor = { interactor }
+
+        let entryWidget = EntryWidget(
+            queueIds: [],
+            configuration: .default,
+            environment: environment
+        )
+
+        entryWidget.show(in: .init())
+
+        XCTAssertEqual(entryWidget.viewState, .ongoingEngagement(.chat))
+    }
+
+    func test_ongoingEngagementViewStateIsShownWhenEnqueueingToAudio() {
+        var environment = EntryWidget.Environment.mock()
+        let interactor: Interactor = .mock()
+        interactor.state = .enqueueing(.audioCall)
+        environment.currentInteractor = { interactor }
+
+        let entryWidget = EntryWidget(
+            queueIds: [],
+            configuration: .default,
+            environment: environment
+        )
+
+        entryWidget.show(in: .init())
+
+        XCTAssertEqual(entryWidget.viewState, .ongoingEngagement(.audio))
+    }
+
+    func test_ongoingEngagementViewStateIsShownWhenEnqueueingToVideo() {
+        var environment = EntryWidget.Environment.mock()
+        let interactor: Interactor = .mock()
+        interactor.state = .enqueueing(.videoCall)
+        environment.currentInteractor = { interactor }
+
+        let entryWidget = EntryWidget(
+            queueIds: [],
+            configuration: .default,
+            environment: environment
+        )
+
+        entryWidget.show(in: .init())
+
+        XCTAssertEqual(entryWidget.viewState, .ongoingEngagement(.video))
     }
 
     func test_callVisualizerResumeCallbackBeingCalled() {


### PR DESCRIPTION
**What was solved?**
Show only one available engagement type in Entry Widget when queueing
When visitor is enqueued, instead of showing all the options in EntryWidget,
We show only the one that the visitor is enqueued to.

MOB-3950
**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
