### PR TITLE
Improve the mark messages as read logic

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -257,6 +257,11 @@
 		31FF0DD12B5A89A600834AFB /* CallCoordinator.Environment.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FF0DD02B5A89A600834AFB /* CallCoordinator.Environment.Mock.swift */; };
 		470A2A18BEAC7BE3FC48E99F /* Pods_TestingApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC2C9ED342FA5228B7E8BCEE /* Pods_TestingApp.framework */; };
 		476B3340DAE8B9D71834B216 /* Pods_SnapshotTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7BF80688D6DD761AADD4A046 /* Pods_SnapshotTests.framework */; };
+		492F2E632D4CF6B3003465D9 /* Combine.Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 492F2E622D4CF6B3003465D9 /* Combine.Interface.swift */; };
+		492F2E652D4CF890003465D9 /* Combine.Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = 492F2E642D4CF890003465D9 /* Combine.Live.swift */; };
+		492F2E672D4D18E5003465D9 /* Combine.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 492F2E662D4D18E5003465D9 /* Combine.Mock.swift */; };
+		492F2E692D4D1C0E003465D9 /* Combine.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 492F2E682D4D1C0E003465D9 /* Combine.Failing.swift */; };
+		498ABBD52D47E77C001AE866 /* ApplicationVisibilityTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498ABBD42D47E77C001AE866 /* ApplicationVisibilityTracker.swift */; };
 		540DA2E4F381F57717A466E8 /* Pods_GliaWidgetsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B97A8A0B9AD30D0AB8666042 /* Pods_GliaWidgetsTests.framework */; };
 		6B2BFCE2274297F100B68506 /* SettingsSwitchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B2BFCE1274297F100B68506 /* SettingsSwitchCell.swift */; };
 		6B48213E2735873300F2900A /* Feature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B48213D2735873300F2900A /* Feature.swift */; };
@@ -1342,6 +1347,11 @@
 		31FF0DCA2B5907C600834AFB /* ChatCoordinator.Environment.Mock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatCoordinator.Environment.Mock.swift; sourceTree = "<group>"; };
 		31FF0DCE2B5A88F500834AFB /* CallCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallCoordinatorTests.swift; sourceTree = "<group>"; };
 		31FF0DD02B5A89A600834AFB /* CallCoordinator.Environment.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallCoordinator.Environment.Mock.swift; sourceTree = "<group>"; };
+		492F2E622D4CF6B3003465D9 /* Combine.Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Combine.Interface.swift; sourceTree = "<group>"; };
+		492F2E642D4CF890003465D9 /* Combine.Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Combine.Live.swift; sourceTree = "<group>"; };
+		492F2E662D4D18E5003465D9 /* Combine.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Combine.Mock.swift; sourceTree = "<group>"; };
+		492F2E682D4D1C0E003465D9 /* Combine.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Combine.Failing.swift; sourceTree = "<group>"; };
+		498ABBD42D47E77C001AE866 /* ApplicationVisibilityTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationVisibilityTracker.swift; sourceTree = "<group>"; };
 		6B2BFCE1274297F100B68506 /* SettingsSwitchCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSwitchCell.swift; sourceTree = "<group>"; };
 		6B48213D2735873300F2900A /* Feature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature.swift; sourceTree = "<group>"; };
 		6E60DD5527146C9D001422EF /* AlertViewController+SingleAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AlertViewController+SingleAction.swift"; sourceTree = "<group>"; };
@@ -2450,6 +2460,7 @@
 				AF6291142B0818DE00D3D76B /* SwiftBased.Failing.swift */,
 				AFF9542B2ADDA10600C277E0 /* CoreSDKConfigurator.Failing.swift */,
 				AF1C197F2B14FE9F00F8810F /* ConditionalCompilationClient.Failing.swift */,
+				492F2E682D4D1C0E003465D9 /* Combine.Failing.swift */,
 			);
 			path = GliaWidgetsTests;
 			sourceTree = "<group>";
@@ -3128,6 +3139,7 @@
 		1A63B2EF257A3EF100508478 /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				498ABBD62D4909C1001AE866 /* State */,
 				8464297E2A45A1D900943BD6 /* OfferPresenter */,
 				8464297B2A459E3500943BD6 /* Replaceble */,
 				1A5892AF2608C66300E183CC /* QuickLook */,
@@ -3701,6 +3713,14 @@
 				31758EBE2B5E9E22007BBD9F /* VideoCallCoordinatorTests.swift */,
 			);
 			path = Coordinator;
+			sourceTree = "<group>";
+		};
+		498ABBD62D4909C1001AE866 /* State */ = {
+			isa = PBXGroup;
+			children = (
+				498ABBD42D47E77C001AE866 /* ApplicationVisibilityTracker.swift */,
+			);
+			path = State;
 			sourceTree = "<group>";
 		};
 		69BB38CE6B54F4C95ED474B6 /* Pods */ = {
@@ -5109,6 +5129,9 @@
 			isa = PBXGroup;
 			children = (
 				C0AF097C2D4B747700699E83 /* AnyPublisher.mock.swift */,
+				492F2E622D4CF6B3003465D9 /* Combine.Interface.swift */,
+				492F2E642D4CF890003465D9 /* Combine.Live.swift */,
+				492F2E662D4D18E5003465D9 /* Combine.Mock.swift */,
 			);
 			path = Combine;
 			sourceTree = "<group>";
@@ -6019,6 +6042,7 @@
 				C0F3DE3B2C6E0DD900DE6D7B /* EntryWidgetView.swift in Sources */,
 				C090474C2B7E210C003C437C /* FileUploadStyle.EnabledDisabledState.Equatable.swift in Sources */,
 				C09047402B7E1FBC003C437C /* MessageCenterFileUploadStyle.swift in Sources */,
+				492F2E632D4CF6B3003465D9 /* Combine.Interface.swift in Sources */,
 				9A8130BB27D7A41000220BBD /* FileUpload.Environment.Interface.swift in Sources */,
 				C09046AB2B7D0967003C437C /* WelcomeStyle.SendButton.DisabledStyle.Accessibility.swift in Sources */,
 				84520BE72B1769AB00F97617 /* ChatViewController.Environment.swift in Sources */,
@@ -6291,6 +6315,7 @@
 				2188DEDF2CEE2C3F00FA3BEF /* SecureMessagingBottomBannerViewStyle.swift in Sources */,
 				2188DED22CECC3D400FA3BEF /* SecureMessagingTopBannerView.swift in Sources */,
 				C09046752B7CFFCB003C437C /* ConfirmationStyle.CheckMessageButtonStyle.Accessibility.swift in Sources */,
+				492F2E672D4D18E5003465D9 /* Combine.Mock.swift in Sources */,
 				845E2F85283FA90200C04D56 /* Theme.Survey.ValidationError.Accessibility.swift in Sources */,
 				9AB3402B28002EE9006E0FE2 /* ChatCallUpgradeStyle.Accessibility.swift in Sources */,
 				9A1992E327D6669900161AAE /* UIKitBased.Interface.swift in Sources */,
@@ -6469,6 +6494,7 @@
 				1A5F8182258B4F0E00A605DA /* OutgoingMessage.swift in Sources */,
 				AFA2FDF428907F0C00428E6D /* BubbleView.Mock.swift in Sources */,
 				84D5B9602A14DF2400807F92 /* QuickLookBased.Interface.swift in Sources */,
+				498ABBD52D47E77C001AE866 /* ApplicationVisibilityTracker.swift in Sources */,
 				AF552EDB2BEE783500FD5653 /* FlipCameraButtonStyle.Accessibility.swift in Sources */,
 				3115D45C29A4FD3F00D99561 /* SecureConversations.Availability.swift in Sources */,
 				9A19926E27D3BB7800161AAE /* Theme.Mock.swift in Sources */,
@@ -6588,6 +6614,7 @@
 				C09047002B7E13BB003C437C /* Theme.Survey.OptionButton.RemoteConfig.swift in Sources */,
 				C09046872B7D03C4003C437C /* WelcomeStyle.CheckMessagesButtonStyle.Accessibility.swift in Sources */,
 				C09047422B7E1FDF003C437C /* MessageCenterFileUploadStyle.RemoteConfig.swift in Sources */,
+				492F2E652D4CF890003465D9 /* Combine.Live.swift in Sources */,
 				1A1E30A325F8E4A400850E68 /* FileSystemStorage.swift in Sources */,
 				75940944298D378A008B173A /* CoreSDKClient.Interface.swift in Sources */,
 				C0D2F08529A4E7CB00803B47 /* HeaderStyle.Mock.swift in Sources */,
@@ -6804,6 +6831,7 @@
 				31758EC12B5E9E22007BBD9F /* CallVisualizer.VideoCallCoordinator.Environment.Mock.swift in Sources */,
 				84551A952D478BD800C55DA2 /* CoreSdkClientTests.swift in Sources */,
 				31758EC02B5E9E22007BBD9F /* VideoCallCoordinatorTests.swift in Sources */,
+				492F2E692D4D1C0E003465D9 /* Combine.Failing.swift in Sources */,
 				9AE05CB32805C9D900871321 /* ChatViewModel.Environment.Failing.swift in Sources */,
 				7552DFB12A6FB7DF0093519B /* ChatMessageTests.swift in Sources */,
 				31CCE3E82BCE8F3A00F92535 /* VideoCallCoordinatorTests.swift in Sources */,

--- a/GliaWidgets/Public/Glia/Glia+EngagementSetup.swift
+++ b/GliaWidgets/Public/Glia/Glia+EngagementSetup.swift
@@ -195,6 +195,7 @@ extension Glia {
             environment: .create(
                 with: environment,
                 loggerPhase: loggerPhase,
+                markUnreadMessagesDelay: { self.markUnreadMessagesDelay },
                 maximumUploads: { self.maximumUploads },
                 viewFactory: viewFactory,
                 alertManager: alertManager,

--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -78,6 +78,7 @@ public protocol SceneProvider: AnyObject {
 
 private extension Glia {
     static let maximumUploads = 25
+    static let markUnreadMessagesDelaySeconds = 6
 }
 
 /// Glia's engagement interface.
@@ -104,6 +105,8 @@ public class Glia {
         }
         return value
     }()
+
+    lazy var markUnreadMessagesDelay: DispatchQueue.SchedulerTimeType.Stride = .seconds(Self.markUnreadMessagesDelaySeconds)
 
     public lazy var callVisualizer = CallVisualizer(
         environment: .create(

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.Environment.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.Environment.swift
@@ -36,6 +36,9 @@ extension SecureConversations.TranscriptModel {
         var createEntryWidget: EntryWidgetBuilder
         var switchToEngagement: Command<EngagementKind>
         var topBannerItemsStyle: EntryWidgetStyle.MediaTypeItemsStyle
+        var notificationCenter: FoundationBased.NotificationCenter
+        var markUnreadMessagesDelay: () -> DispatchQueue.SchedulerTimeType.Stride
+        var combineScheduler: CombineBased.CombineScheduler
     }
 }
 
@@ -79,7 +82,10 @@ extension SecureConversations.TranscriptModel.Environment {
             leaveCurrentSecureConversation: environment.leaveCurrentSecureConversation,
             createEntryWidget: environment.createEntryWidget,
             switchToEngagement: environment.switchToEngagement,
-            topBannerItemsStyle: viewFactory.theme.chat.secureMessagingExpandedTopBannerItemsStyle
+            topBannerItemsStyle: viewFactory.theme.chat.secureMessagingExpandedTopBannerItemsStyle,
+            notificationCenter: environment.notificationCenter,
+            markUnreadMessagesDelay: environment.markUnreadMessagesDelay,
+            combineScheduler: environment.combineScheduler
        )
     }
 }
@@ -121,7 +127,10 @@ extension SecureConversations.TranscriptModel.Environment {
         createEntryWidget: @escaping EntryWidgetBuilder = { _ in .mock() },
         switchToEngagement: Command<EngagementKind> = .nop,
         // swiftlint:disable:next line_length
-        secureMessagingExpandedTopBannerItemsStyle: EntryWidgetStyle.MediaTypeItemsStyle = Theme().chatStyle.secureMessagingExpandedTopBannerItemsStyle
+        secureMessagingExpandedTopBannerItemsStyle: EntryWidgetStyle.MediaTypeItemsStyle = Theme().chatStyle.secureMessagingExpandedTopBannerItemsStyle,
+        notificationCenter: FoundationBased.NotificationCenter = .mock,
+        markUnreadMessagesDelay: @escaping () -> DispatchQueue.SchedulerTimeType.Stride = { .mock },
+        combineScheduler: CombineBased.CombineScheduler = .mock
     ) -> Self {
         Self(
             fetchFile: fetchFile,
@@ -157,7 +166,10 @@ extension SecureConversations.TranscriptModel.Environment {
             leaveCurrentSecureConversation: leaveCurrentSecureConversation,
             createEntryWidget: createEntryWidget,
             switchToEngagement: switchToEngagement,
-            topBannerItemsStyle: secureMessagingExpandedTopBannerItemsStyle
+            topBannerItemsStyle: secureMessagingExpandedTopBannerItemsStyle,
+            notificationCenter: notificationCenter,
+            markUnreadMessagesDelay: markUnreadMessagesDelay,
+            combineScheduler: combineScheduler
         )
     }
 }

--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.Environment.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.Environment.swift
@@ -55,6 +55,8 @@ extension SecureConversations.Coordinator {
         var shouldShowLeaveSecureConversationDialog: Bool
         var leaveCurrentSecureConversation: Cmd
         var switchToEngagement: Command<EngagementKind>
+        var markUnreadMessagesDelay: () -> DispatchQueue.SchedulerTimeType.Stride
+        var combineScheduler: CombineBased.CombineScheduler
     }
 }
 
@@ -126,7 +128,9 @@ extension SecureConversations.Coordinator.Environment {
             createEntryWidget: environment.createEntryWidget,
             shouldShowLeaveSecureConversationDialog: shouldShowLeaveSecureConversationDialog,
             leaveCurrentSecureConversation: leaveCurrentSecureConversation,
-            switchToEngagement: switchToEngagement
+            switchToEngagement: switchToEngagement,
+            markUnreadMessagesDelay: environment.markUnreadMessagesDelay,
+            combineScheduler: environment.combineScheduler
         )
     }
 }

--- a/GliaWidgets/Sources/Combine/Combine.Interface.swift
+++ b/GliaWidgets/Sources/Combine/Combine.Interface.swift
@@ -1,0 +1,11 @@
+import Foundation
+import Combine
+
+enum CombineBased {
+    struct CombineScheduler {
+        var main: () -> Scheduler
+        var global: () -> Scheduler
+    }
+
+    typealias Scheduler = DispatchQueue
+}

--- a/GliaWidgets/Sources/Combine/Combine.Live.swift
+++ b/GliaWidgets/Sources/Combine/Combine.Live.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+extension CombineBased.CombineScheduler {
+    static let live = Self(
+        main: { DispatchQueue.main },
+        global: { DispatchQueue.global() }
+    )
+}

--- a/GliaWidgets/Sources/Combine/Combine.Mock.swift
+++ b/GliaWidgets/Sources/Combine/Combine.Mock.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension CombineBased.CombineScheduler {
+    // Till we don't have a mock tools for Combine, we will use the live scheduler
+    // Once MOB-4008 is ready, we can use AnyScheduler here.
+    static let mock = live
+}

--- a/GliaWidgets/Sources/Coordinators/Call/CallCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/Call/CallCoordinator.Environment.swift
@@ -31,6 +31,9 @@ extension CallCoordinator {
         var flipCameraButtonStyle: FlipCameraButtonStyle
         var alertManager: AlertManager
         var isAuthenticated: () -> Bool
+        var secureMarkMessagesAsRead: CoreSdkClient.SecureMarkMessagesAsRead
+        var markUnreadMessagesDelay: () -> DispatchQueue.SchedulerTimeType.Stride
+        var combineScheduler: CombineBased.CombineScheduler
     }
 }
 
@@ -65,7 +68,10 @@ extension CallCoordinator.Environment {
             cameraDeviceManager: environment.cameraDeviceManager,
             flipCameraButtonStyle: environment.flipCameraButtonStyle,
             alertManager: environment.alertManager,
-            isAuthenticated: environment.isAuthenticated
+            isAuthenticated: environment.isAuthenticated,
+            secureMarkMessagesAsRead: environment.secureMarkMessagesAsRead,
+            markUnreadMessagesDelay: environment.markUnreadMessagesDelay,
+            combineScheduler: environment.combineScheduler
         )
     }
 }

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
@@ -47,6 +47,8 @@ extension ChatCoordinator {
         var shouldShowLeaveSecureConversationDialog: Bool
         var leaveCurrentSecureConversation: Cmd
         var switchToEngagement: Command<EngagementKind>
+        var markUnreadMessagesDelay: () -> DispatchQueue.SchedulerTimeType.Stride
+        var combineScheduler: CombineBased.CombineScheduler
     }
 }
 
@@ -103,7 +105,9 @@ extension ChatCoordinator.Environment {
             createEntryWidget: environment.createEntryWidget,
             shouldShowLeaveSecureConversationDialog: shouldShowLeaveSecureConversationDialog,
             leaveCurrentSecureConversation: leaveCurrentSecureConversation,
-            switchToEngagement: switchToEngagement
+            switchToEngagement: switchToEngagement,
+            markUnreadMessagesDelay: environment.markUnreadMessagesDelay,
+            combineScheduler: environment.combineScheduler
         )
     }
 
@@ -153,7 +157,9 @@ extension ChatCoordinator.Environment {
             createEntryWidget: environment.createEntryWidget,
             shouldShowLeaveSecureConversationDialog: environment.shouldShowLeaveSecureConversationDialog,
             leaveCurrentSecureConversation: environment.leaveCurrentSecureConversation,
-            switchToEngagement: environment.switchToEngagement
+            switchToEngagement: environment.switchToEngagement,
+            markUnreadMessagesDelay: environment.markUnreadMessagesDelay,
+            combineScheduler: environment.combineScheduler
         )
     }
 }

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
@@ -29,6 +29,7 @@ extension EngagementCoordinator.Environment {
         getSecureUnreadMessageCount: { _ in },
         messagesWithUnreadCountLoaderScheduler: CoreSdkClient.reactiveSwiftDateSchedulerMock,
         secureMarkMessagesAsRead: { _ in .mock },
+        markUnreadMessagesDelay: { .mock },
         downloadSecureFile: { _, _, _ in .mock },
         isAuthenticated: { false },
         startSocketObservation: {},
@@ -48,7 +49,8 @@ extension EngagementCoordinator.Environment {
         queuesMonitor: .mock(),
         pendingSecureConversationStatus: { $0(.success(false)) },
         createEntryWidget: { _ in .mock() },
-        dismissManager: .init { _, _, _ in }
+        dismissManager: .init { _, _, _ in },
+        combineScheduler: .mock
     )
 }
 #endif

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
@@ -30,6 +30,7 @@ extension EngagementCoordinator {
         var getSecureUnreadMessageCount: CoreSdkClient.GetSecureUnreadMessageCount
         var messagesWithUnreadCountLoaderScheduler: CoreSdkClient.ReactiveSwift.DateScheduler
         var secureMarkMessagesAsRead: CoreSdkClient.SecureMarkMessagesAsRead
+        var markUnreadMessagesDelay: () -> DispatchQueue.SchedulerTimeType.Stride
         var downloadSecureFile: CoreSdkClient.DownloadSecureFile
         var isAuthenticated: () -> Bool
         var startSocketObservation: CoreSdkClient.StartSocketObservation
@@ -48,6 +49,7 @@ extension EngagementCoordinator {
         var pendingSecureConversationStatus: CoreSdkClient.PendingSecureConversationStatus
         var createEntryWidget: EntryWidgetBuilder
         var dismissManager: GliaPresenter.DismissManager
+        var combineScheduler: CombineBased.CombineScheduler
     }
 }
 
@@ -55,6 +57,7 @@ extension EngagementCoordinator.Environment {
     static func create(
         with environment: Glia.Environment,
         loggerPhase: Glia.LoggerPhase,
+        markUnreadMessagesDelay: @escaping () -> DispatchQueue.SchedulerTimeType.Stride,
         maximumUploads: @escaping () -> Int,
         viewFactory: ViewFactory,
         alertManager: AlertManager,
@@ -90,6 +93,7 @@ extension EngagementCoordinator.Environment {
             getSecureUnreadMessageCount: environment.coreSdk.getSecureUnreadMessageCount,
             messagesWithUnreadCountLoaderScheduler: environment.messagesWithUnreadCountLoaderScheduler,
             secureMarkMessagesAsRead: environment.coreSdk.secureMarkMessagesAsRead,
+            markUnreadMessagesDelay: markUnreadMessagesDelay,
             downloadSecureFile: environment.coreSdk.downloadSecureFile,
             isAuthenticated: environment.isAuthenticated,
             startSocketObservation: environment.coreSdk.startSocketObservation,
@@ -107,7 +111,8 @@ extension EngagementCoordinator.Environment {
             queuesMonitor: queuesMonitor,
             pendingSecureConversationStatus: environment.coreSdk.pendingSecureConversationStatus,
             createEntryWidget: createEntryWidget,
-            dismissManager: environment.dismissManager
+            dismissManager: environment.dismissManager,
+            combineScheduler: environment.combineScheduler
         )
     }
 }

--- a/GliaWidgets/Sources/GCD/GCD.Mock.swift
+++ b/GliaWidgets/Sources/GCD/GCD.Mock.swift
@@ -29,3 +29,7 @@ extension GCD.MainQueue {
         }
     )
 }
+
+extension DispatchQueue.SchedulerTimeType.Stride {
+    static let mock = Self.zero
+}

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Interface.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Interface.swift
@@ -55,6 +55,7 @@ extension Glia {
         var cameraDeviceManager: CoreSdkClient.GetCameraDeviceManageable
         var isAuthenticated: () -> Bool
         var dismissManager: GliaPresenter.DismissManager
+        var combineScheduler: CombineBased.CombineScheduler
     }
 }
 

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Live.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Live.swift
@@ -56,7 +56,8 @@ extension Glia.Environment {
         },
         dismissManager: .init { viewController, animated, completion in
             viewController.dismiss(animated: animated, completion: completion)
-        }
+        },
+        combineScheduler: .live
     )
 }
 

--- a/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Mock.swift
+++ b/GliaWidgets/Sources/GliaEnvironment/Glia.Environment.Mock.swift
@@ -35,7 +35,8 @@ extension Glia.Environment {
         processInfo: .mock(),
         cameraDeviceManager: { .mock },
         isAuthenticated: { false },
-        dismissManager: .init { _, _, _ in }
+        dismissManager: .init { _, _, _ in },
+        combineScheduler: .mock
     )
 }
 

--- a/GliaWidgets/Sources/ViewController/Common/State/ApplicationVisibilityTracker.swift
+++ b/GliaWidgets/Sources/ViewController/Common/State/ApplicationVisibilityTracker.swift
@@ -1,0 +1,74 @@
+import UIKit
+import Combine
+
+protocol ApplicationVisibilityTracker: AnyObject {
+    func isAppVisiblePublisher(
+        for applicationState: UIApplication.State,
+        notificationCenter: FoundationBased.NotificationCenter,
+        resumeToForegroundDelay: DispatchQueue.SchedulerTimeType.Stride,
+        delayScheduler: CombineBased.Scheduler
+    ) -> AnyPublisher<Void, Never>
+
+    func isViewVisiblePublisher(
+        for applicationState: UIApplication.State,
+        notificationCenter: FoundationBased.NotificationCenter,
+        isViewVisiblePublisher: AnyPublisher<Bool, Never>,
+        resumeToForegroundDelay: DispatchQueue.SchedulerTimeType.Stride,
+        delayScheduler: CombineBased.Scheduler
+    ) -> AnyPublisher<Void, Never>
+}
+
+extension ApplicationVisibilityTracker {
+    func isAppVisiblePublisher(
+        for applicationState: UIApplication.State,
+        notificationCenter: FoundationBased.NotificationCenter,
+        resumeToForegroundDelay: DispatchQueue.SchedulerTimeType.Stride,
+        delayScheduler: CombineBased.Scheduler
+    ) -> AnyPublisher<Void, Never> {
+        return isViewVisiblePublisher(
+            for: applicationState,
+            notificationCenter: notificationCenter,
+            isViewVisiblePublisher: Just(true).eraseToAnyPublisher(),
+            resumeToForegroundDelay: resumeToForegroundDelay,
+            delayScheduler: delayScheduler
+        )
+    }
+
+    func isViewVisiblePublisher(
+        for applicationState: UIApplication.State,
+        notificationCenter: FoundationBased.NotificationCenter,
+        isViewVisiblePublisher: AnyPublisher<Bool, Never>,
+        resumeToForegroundDelay: DispatchQueue.SchedulerTimeType.Stride,
+        delayScheduler: CombineBased.Scheduler
+    ) -> AnyPublisher<Void, Never> {
+        return Publishers.Merge3(
+            Just(applicationState == .active),
+            notificationCenter
+                .publisherForNotification(UIApplication.willEnterForegroundNotification)
+                .map { _ in true },
+            notificationCenter
+                .publisherForNotification(UIApplication.didEnterBackgroundNotification)
+                .map { _ in false }
+        )
+            .combineLatest(isViewVisiblePublisher)
+            .map { isApplicationForeground, isViewVisible in
+                return isApplicationForeground && isViewVisible
+            }
+            .removeDuplicates()
+            .map {
+                if $0 {
+                    return Just(true)
+                        .delay(for: resumeToForegroundDelay, scheduler: delayScheduler)
+                        .eraseToAnyPublisher()
+                } else {
+                    return Just(false)
+                        .eraseToAnyPublisher()
+                }
+            }
+            .switchToLatest()
+            .filter { $0 }
+            .first()
+            .map { _ in }
+            .eraseToAnyPublisher()
+    }
+}

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Environment.Interface.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Environment.Interface.swift
@@ -29,6 +29,10 @@ extension EngagementViewModel {
         var flipCameraButtonStyle: FlipCameraButtonStyle
         var alertManager: AlertManager
         var isAuthenticated: () -> Bool
+        var notificationCenter: FoundationBased.NotificationCenter
+        var secureMarkMessagesAsRead: CoreSdkClient.SecureMarkMessagesAsRead
+        var markUnreadMessagesDelay: () -> DispatchQueue.SchedulerTimeType.Stride
+        var combineScheduler: CombineBased.CombineScheduler
     }
 }
 
@@ -64,7 +68,11 @@ extension EngagementViewModel.Environment {
             cameraDeviceManager: environment.cameraDeviceManager,
             flipCameraButtonStyle: environment.flipCameraButtonStyle,
             alertManager: environment.alertManager,
-            isAuthenticated: environment.isAuthenticated
+            isAuthenticated: environment.isAuthenticated,
+            notificationCenter: environment.notificationCenter,
+            secureMarkMessagesAsRead: environment.secureMarkMessagesAsRead,
+            markUnreadMessagesDelay: environment.markUnreadMessagesDelay,
+            combineScheduler: environment.combineScheduler
         )
     }
 
@@ -99,7 +107,11 @@ extension EngagementViewModel.Environment {
             cameraDeviceManager: environment.cameraDeviceManager,
             flipCameraButtonStyle: environment.flipCameraButtonStyle,
             alertManager: environment.alertManager,
-            isAuthenticated: environment.isAuthenticated
+            isAuthenticated: environment.isAuthenticated,
+            notificationCenter: environment.notificationCenter,
+            secureMarkMessagesAsRead: environment.secureMarkMessagesAsRead,
+            markUnreadMessagesDelay: environment.markUnreadMessagesDelay,
+            combineScheduler: environment.combineScheduler
         )
     }
 }

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Environment.Mock.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Environment.Mock.swift
@@ -36,7 +36,11 @@ extension ChatViewModel.Environment {
         cameraDeviceManager: { .mock },
         flipCameraButtonStyle: .nop,
         alertManager: .mock(),
-        isAuthenticated: { false }
+        isAuthenticated: { false },
+        notificationCenter: .mock,
+        secureMarkMessagesAsRead: { _ in .mock },
+        markUnreadMessagesDelay: { .mock },
+        combineScheduler: .mock
     )
 }
 #endif

--- a/GliaWidgetsTests/Combine.Failing.swift
+++ b/GliaWidgetsTests/Combine.Failing.swift
@@ -1,0 +1,14 @@
+@testable import GliaWidgets
+
+extension CombineBased.CombineScheduler {
+    static let failing = Self(
+        main: {
+            fail("\(Self.self).main")
+            return mock.main()
+        },
+        global: {
+            fail("\(Self.self).global")
+            return mock.global()
+        }
+    )
+}

--- a/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
+++ b/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
@@ -69,6 +69,10 @@ extension EngagementCoordinator.Environment {
             fail("\(Self.self).secureMarkMessagesAsRead")
             return .mock
         },
+        markUnreadMessagesDelay: {
+            fail("\(Self.self).markUnreadMessagesDelay")
+            return .mock
+        },
         downloadSecureFile: { _, _, _ in
             fail("\(Self.self).downloadSecureFile")
             return .mock
@@ -107,6 +111,7 @@ extension EngagementCoordinator.Environment {
             fail("\(Self.self).createEntryWidget")
             return .mock()
         },
-        dismissManager: .failing
+        dismissManager: .failing,
+        combineScheduler: .failing
     )
 }

--- a/GliaWidgetsTests/Glia.Environment.Failing.swift
+++ b/GliaWidgetsTests/Glia.Environment.Failing.swift
@@ -72,7 +72,8 @@ extension Glia.Environment {
         },
         dismissManager: .init { _, _, _ in
             fail("\(Self.self).dismissManager")
-        }
+        },
+        combineScheduler: .failing
     )
 }
 

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModel.Environment.Failing.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModel.Environment.Failing.swift
@@ -88,6 +88,12 @@ extension SecureConversations.TranscriptModel.Environment {
         switchToEngagement: .init { _ in
             fail("\(Self.self).switchToEngagement")
         },
-        topBannerItemsStyle: .mock()
+        topBannerItemsStyle: .mock(),
+        notificationCenter: .failing,
+        markUnreadMessagesDelay: {
+            fail("\(Self.self).markUnreadMessagesDelay")
+            return .mock
+        },
+        combineScheduler: .failing
     )
 }

--- a/GliaWidgetsTests/SecureConversations/Coordinator/SecureConversations.Coordinator.Environment.Mock.swift
+++ b/GliaWidgetsTests/SecureConversations/Coordinator/SecureConversations.Coordinator.Environment.Mock.swift
@@ -58,6 +58,8 @@ extension SecureConversations.Coordinator.Environment {
         createEntryWidget: { _ in .mock() },
         shouldShowLeaveSecureConversationDialog: false,
         leaveCurrentSecureConversation: .nop,
-        switchToEngagement: .nop
+        switchToEngagement: .nop,
+        markUnreadMessagesDelay: { .mock },
+        combineScheduler: .mock
     )
 }

--- a/GliaWidgetsTests/Sources/Coordinators/Call/CallCoordinator.Environment.Mock.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/Call/CallCoordinator.Environment.Mock.swift
@@ -31,6 +31,9 @@ extension CallCoordinator.Environment {
         cameraDeviceManager: { .mock },
         flipCameraButtonStyle: .nop,
         alertManager: .mock(),
-        isAuthenticated: { false }
+        isAuthenticated: { false },
+        secureMarkMessagesAsRead: { _ in .mock },
+        markUnreadMessagesDelay: { .mock },
+        combineScheduler: .mock
     )
 }

--- a/GliaWidgetsTests/Sources/Coordinators/Chat/ChatCoordinator.Environment.Mock.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/Chat/ChatCoordinator.Environment.Mock.swift
@@ -47,6 +47,8 @@ extension ChatCoordinator.Environment {
         createEntryWidget: { _ in .mock() },
         shouldShowLeaveSecureConversationDialog: false,
         leaveCurrentSecureConversation: .nop,
-        switchToEngagement: .nop
+        switchToEngagement: .nop,
+        markUnreadMessagesDelay: { .mock },
+        combineScheduler: .mock
     )
 }

--- a/GliaWidgetsTests/ViewModel/Chat/ChatViewModel.Environment.Failing.swift
+++ b/GliaWidgetsTests/ViewModel/Chat/ChatViewModel.Environment.Failing.swift
@@ -63,7 +63,11 @@ extension ChatViewModel.Environment {
             isAuthenticated: {
                 fail("\(Self.self).isAuthenticated")
                 return false
-            }
+            },
+            notificationCenter: .mock,
+            secureMarkMessagesAsRead: { _ in .mock },
+            markUnreadMessagesDelay: { .mock },
+            combineScheduler: .failing
         )
     }
 }


### PR DESCRIPTION
**What was solved?**
New messages should be marked as read when:
1. We have new messages when the history loaded after a visitor opened the chat (transcript) screen or a visitor gets a new SC or Live Engagement message from an Operator; and
2. (Not ready) It is an ongoing secure conversation or an ongoing engagement on_end equals retain; and
3. The visitor has stayed on the chat (transcript) screen for at least 6 seconds after the new message; and
4. The leave current SC dialog has not shown for at least 6 seconds after the new message.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
