### PR TITLE
Restore bubble when SC Live Upgrade happens

### DIFF
--- a/GliaWidgets/Public/Glia/Glia+EngagementSetup.swift
+++ b/GliaWidgets/Public/Glia/Glia+EngagementSetup.swift
@@ -209,6 +209,11 @@ extension Glia {
         case .ended:
             rootCoordinator = nil
             onEvent?(.ended)
+        case .closed:
+            rootCoordinator = nil
+            // If engagement was started/restored while visitor was
+            // on SecureConversation Confirmation screen, we need to restore the bubble.
+            restoreOngoingEngagementIfPresent()
         case .minimized:
             onEvent?(.minimized)
         case .maximized:

--- a/GliaWidgets/Public/Glia/Glia+RestoreEngagement.swift
+++ b/GliaWidgets/Public/Glia/Glia+RestoreEngagement.swift
@@ -1,6 +1,31 @@
 import Foundation
 
 extension Glia {
+    /// Used to restore a bubble for Secure Conversation engagement:
+    /// - started by accepting engagement request;
+    /// - started by Outbound message;
+    /// - restored from Follow Up.
+    func restoreOngoingEngagementIfPresent() {
+        guard let interactor, let configuration else { return }
+
+        guard
+            let currentEngagement = self.environment.coreSdk.getCurrentEngagement(),
+            currentEngagement.source == .coreEngagement
+        else { return }
+
+        // Restore only if rootCoordinator is `nil`, meaning Glia screen is not set up.
+        guard rootCoordinator == nil else { return }
+
+        restoreOngoingEngagement(
+            configuration: configuration,
+            currentEngagement: currentEngagement,
+            interactor: interactor,
+            features: features ?? [],
+            maximize: false
+        )
+        loggerPhase.logger.prefixed(Self.self).info("Engagement was restored")
+    }
+
     func restoreOngoingEngagement(
         configuration: Configuration,
         currentEngagement: CoreSdkClient.Engagement,

--- a/GliaWidgets/Public/Glia/Glia.OpaqueAuthentication.swift
+++ b/GliaWidgets/Public/Glia/Glia.OpaqueAuthentication.swift
@@ -85,6 +85,11 @@ extension Glia {
 
                 let prevEngagementIsNotPresent = self?.environment.coreSdk.getCurrentEngagement() == nil
 
+                // We need to unsubscribe from listening to Interactor events
+                // until authentication is finished to avoid
+                // calling engagement restoration twice.
+                self?.stopObservingInteractorEvents()
+
                 auth.authenticate(
                     with: .init(rawValue: idToken),
                     externalAccessToken: accessToken.map { .init(rawValue: $0) }
@@ -116,6 +121,9 @@ extension Glia {
                                     features: self?.features
                                 )
                             }
+                            // We need to subscribe on Interactor events
+                            // once authentication if finished.
+                            self?.startObservingInteractorEvents()
                         case .failure:
                             break
                         }

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
@@ -188,6 +188,8 @@ extension EngagementCoordinator {
             break
         }
 
+        let engagementEnded = interactor.state.isEnded
+
         let dismissGliaViewController: () -> Void = { [weak self] in
             self?.dismissGliaViewController(animated: true) { [weak self] in
                 self?.delegateEvent(.minimized)
@@ -195,7 +197,15 @@ extension EngagementCoordinator {
                 self?.navigationPresenter.setViewControllers([], animated: false)
                 self?.removeAllCoordinators()
                 self?.engagementLaunching = .direct(kind: .none)
-                self?.delegate?(.ended)
+                // If engagement was ended then pass `ended` event. This
+                // initiates sending `ended` event to integrators.
+                // Otherwise, pass `closed` meaning that Glia screen was closed
+                // without having an engagement. This does not send `ended` event to integrators.
+                if engagementEnded {
+                    self?.delegate?(.ended)
+                } else {
+                    self?.delegate?(.closed)
+                }
             }
         }
 
@@ -687,7 +697,10 @@ extension EngagementCoordinator {
     enum DelegateEvent: Equatable {
         case started
         case engagementChanged(EngagementKind)
+        // Glia screen is closed after once an engagement is ended
         case ended
+        // Glia screen is closed without having an engagement
+        case closed
         case minimized
         case maximized
     }

--- a/GliaWidgets/Sources/Interactor/Interactor.swift
+++ b/GliaWidgets/Sources/Interactor/Interactor.swift
@@ -6,6 +6,11 @@ enum InteractorState {
     case enqueued(CoreSdkClient.QueueTicket, EngagementKind)
     case engaged(CoreSdkClient.Operator?)
     case ended(EndEngagementReason)
+
+    var isEnded: Bool {
+        guard case .ended = self else { return false }
+        return true
+    }
 }
 
 enum EndEngagementReason {

--- a/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinatorTests.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinatorTests.swift
@@ -9,11 +9,6 @@ final class EngagementCoordinatorTests: XCTestCase {
         coordinator = createCoordinator()
     }
 
-    override func tearDown() {
-        coordinator.end()
-        coordinator = nil
-    }
-
     // Start
 
     func test_startText() throws {
@@ -134,6 +129,7 @@ final class EngagementCoordinatorTests: XCTestCase {
 
         let engagement: CoreSdkClient.Engagement = .mock(fetchSurvey: { _, completion in completion(.success(survey)) })
         coordinator.interactor.setCurrentEngagement(engagement)
+        coordinator.interactor.state = .ended(.byVisitor)
         coordinator.end(surveyPresentation: .doNotPresentSurvey)
 
         XCTAssertEqual(coordinator.navigationPresenter.viewControllers.count, 0)
@@ -240,6 +236,21 @@ final class EngagementCoordinatorTests: XCTestCase {
         let flowCoordinator = coordinator.coordinators.last
 
         XCTAssertNil(flowCoordinator)
+    }
+
+    func test_closeCoordinatorWithoutHavingEngagement() throws {
+        var calledEvents: [EngagementCoordinator.DelegateEvent] = []
+
+        coordinator.delegate = { event in
+            calledEvents.append(event)
+        }
+
+        coordinator.start()
+
+        let chatCoordinator = coordinator.coordinators.last as? ChatCoordinator
+        chatCoordinator?.delegate?(.finished)
+
+        XCTAssertEqual(calledEvents.last, .closed)
     }
 }
 

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+RestoreEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+RestoreEngagement.swift
@@ -68,4 +68,65 @@ extension GliaTests {
         try XCTAssertTrue(XCTUnwrap(sdk.interactor?.skipLiveObservationConfirmations))
         XCTAssertEqual(calls, [.snackBarPresent])
     }
+
+    func test_restoreOngoingSecureConversationEngagement() throws {
+        var sdkEnv = Glia.Environment.failing
+        sdkEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
+        sdkEnv.createRootCoordinator = { _, _, _, engagementLaunching, _, _, _ in
+            EngagementCoordinator.mock(
+                engagementLaunching: engagementLaunching,
+                screenShareHandler: .mock,
+                environment: .engagementCoordEnvironmentWithKeyWindow
+            )
+        }
+        sdkEnv.print.printClosure = { _, _, _ in }
+        var logger = CoreSdkClient.Logger.failing
+        logger.configureLocalLogLevelClosure = { _ in }
+        logger.configureRemoteLogLevelClosure = { _ in }
+        logger.prefixedClosure = { _ in logger }
+        logger.infoClosure = { _, _, _, _ in }
+        sdkEnv.coreSdk.createLogger = { _ in logger }
+        let siteMock = try CoreSdkClient.Site.mock()
+        sdkEnv.coreSdk.fetchSiteConfigurations = { callback in callback(.success(siteMock)) }
+        sdkEnv.coreSdk.pendingSecureConversationStatus = { _ in }
+        sdkEnv.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
+        sdkEnv.conditionalCompilation.isDebug = { true }
+        sdkEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
+            completion(.success(()))
+        }
+        let uuidGen = UUID.incrementing
+        sdkEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in uuidGen().uuidString }
+        sdkEnv.coreSdk.observePendingSecureConversationStatus = { _ in uuidGen().uuidString }
+        sdkEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        sdkEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        sdkEnv.gcd.mainQueue.async = { $0() }
+
+        let window = UIWindow(frame: .zero)
+        window.rootViewController = .init()
+        window.makeKeyAndVisible()
+        sdkEnv.uiApplication.windows = { [window] }
+        enum Call {
+            case snackBarPresent
+        }
+
+        var calls: [Call] = []
+        sdkEnv.snackBar.present = { _, _, _, _, _, _, _ in
+            calls.append(.snackBarPresent)
+        }
+
+        let sdk = Glia(environment: sdkEnv)
+        try sdk.configure(with: .mock(), features: .all) { _ in }
+        sdk.environment.coreSdk.getCurrentEngagement = { .mock() }
+        sdk.stringProvidingPhase = .configured { _ in
+            return ""
+        }
+        guard let interactor = sdk.interactor else {
+            XCTFail("Interactor missing")
+            return
+        }
+        interactor.state = .engaged(.mock())
+
+        XCTAssertNotNil(sdk.rootCoordinator?.gliaViewController)
+        XCTAssertEqual(calls, [.snackBarPresent])
+    }
 }


### PR DESCRIPTION
MOB-3951

**What was solved?**
This PR introduces:
- the logic for restoring the bubble for the cases when SC engagement gets:
	- restored from Follow Up;
	- started using Outbound Message feature;
	- started while visitor is on SecureConversation.Confirmation screen
- unit tests

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.