### PR TITLE
Fix `skipLiveObservationConfirmations` value after restored engagement

### DIFF
--- a/GliaWidgets/Public/Glia/Glia+EngagementSetup.swift
+++ b/GliaWidgets/Public/Glia/Glia+EngagementSetup.swift
@@ -93,6 +93,11 @@ extension Glia {
             }
         }
 
+        // This value can be set to `true` if engagement restoring happened.
+        // To prevent missing Live Observation Confirmation dialog to be shown
+        // for further engagements, we need to default this value again.
+        interactor.skipLiveObservationConfirmations = false
+
         startRootCoordinator(
             with: interactor,
             viewFactory: viewFactory,

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
@@ -770,7 +770,9 @@ extension SecureConversations.TranscriptModel {
             ),
             showPoweredBy: false,
             filterSecureConversation: true,
-            mediaTypeSelected: .init(closure: entryWidgetMediaTypeSelected),
+            mediaTypeSelected: .init { [weak self] mediaType in
+                self?.entryWidgetMediaTypeSelected(mediaType)
+            },
             mediaTypeItemsStyle: environment.topBannerItemsStyle
         )
     }


### PR DESCRIPTION
MOB-3964

**What was solved?**
Restoring engagement on configuration step or during authentication turns `skipLiveObservationConfirmations` value to `true` to prevent displaying the dialog. This value never turns back to default value, which is `false` without re-configuring the SDK. This commit fixes it.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.