### PR TITLE
Restore Video Call Visualizer on enqueuing if it is running

### DIFF
--- a/GliaWidgets/Public/Glia/Glia+EngagementLauncher.swift
+++ b/GliaWidgets/Public/Glia/Glia+EngagementLauncher.swift
@@ -41,7 +41,7 @@ extension Glia {
                 interactor: getInteractor(),
                 queueIds: queueIds
             )
-            try self.resolveEngagementState(
+            self.resolveEngagementState(
                 engagementKind: engagementKind,
                 sceneProvider: sceneProvider,
                 configuration: parameters.configuration,

--- a/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
+++ b/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
@@ -118,6 +118,13 @@ extension CallVisualizer {
     func observeScreenSharingHandlerState() {
         coordinator.observeScreenSharingHandlerState()
     }
+
+    func restoreVideoIfPossible() {
+        guard let engagement = environment.getCurrentEngagement(), engagement.source == .callVisualizer && engagement.mediaStreams.video != nil else {
+            return
+        }
+        coordinator.restoreVideoCall()
+    }
 }
 
 // MARK: - Interactor Events

--- a/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
@@ -163,6 +163,14 @@ extension CallVisualizer.Coordinator {
             self.showSnackBarMessage(text: self.environment.viewFactory.theme.snackBar.text)
         }
     }
+
+    func restoreVideoCall() {
+        if videoCallCoordinator != nil {
+            resumeVideoCallViewController()
+        } else {
+            showVideoCallViewController()
+        }
+    }
 }
 
 // MARK: - Video screen

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+EngagementLauncher.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+EngagementLauncher.swift
@@ -102,7 +102,7 @@ extension GliaTests {
             }
         })
 
-        try sdk.resolveEngagementState(
+        sdk.resolveEngagementState(
             engagementKind: .chat,
             sceneProvider: .none,
             configuration: .mock(),
@@ -115,7 +115,7 @@ extension GliaTests {
         XCTAssertEqual(calls, [.maximize])
     }
     
-    func test_testEnqueuingWhenCallVisualizaerIsActive() throws {
+    func test_testEnqueuingChatWhenCallVisualizerIsActiveShouldShowSnackbar() throws {
         enum Call {
             case presentSnackBar
         }
@@ -133,7 +133,7 @@ extension GliaTests {
 
         sdk.interactor = interactor
         sdk.environment.coreSdk.getCurrentEngagement = {
-            return .mock(source: .callVisualizer)
+            .mock(source: .callVisualizer)
         }
         sdk.rootCoordinator = .mock(interactor: interactor)
         sdk.rootCoordinator?.gliaViewController = .mock()
@@ -142,21 +142,221 @@ extension GliaTests {
             calls.append(.presentSnackBar)
         }
 
-        XCTAssertThrowsError(
-            try sdk.resolveEngagementState(
-                engagementKind: .chat,
-                sceneProvider: .none,
-                configuration: .mock(),
-                interactor: interactor,
-                features: .all,
-                viewFactory: .mock(),
-                ongoingEngagementMediaStreams: .none
-            )
-        ) { error in
-            XCTAssertEqual(error as? GliaError, GliaError.callVisualizerEngagementExists)
-        }
+        sdk.resolveEngagementState(
+            engagementKind: .chat,
+            sceneProvider: .none,
+            configuration: .mock(),
+            interactor: interactor,
+            features: .all,
+            viewFactory: .mock(),
+            ongoingEngagementMediaStreams: .none
+        )
+
         XCTAssertEqual(calls, [.presentSnackBar])
         XCTAssertEqual(snackBarMessage, Localization.EntryWidget.CallVisualizer.description)
+    }
+    
+    func test_testEnqueuingAudioWhenCallVisualizerIsActiveShouldShowSnackbar() throws {
+        enum Call {
+            case presentSnackBar
+        }
+        var calls: [Call] = []
+        var snackBarMessage: String?
+
+        let sdk = makeConfigurableSDK()
+
+        try sdk.configure(
+            with: .mock(),
+            theme: .mock()
+        ) { _ in }
+
+        let interactor: Interactor = .mock()
+
+        sdk.interactor = interactor
+        sdk.environment.coreSdk.getCurrentEngagement = {
+            .mock(source: .callVisualizer)
+        }
+        sdk.rootCoordinator = .mock(interactor: interactor)
+        sdk.rootCoordinator?.gliaViewController = .mock()
+        sdk.environment.snackBar.present = { message, _, _, _, _, _, _ in
+            snackBarMessage = message
+            calls.append(.presentSnackBar)
+        }
+
+        sdk.resolveEngagementState(
+            engagementKind: .audioCall,
+            sceneProvider: .none,
+            configuration: .mock(),
+            interactor: interactor,
+            features: .all,
+            viewFactory: .mock(),
+            ongoingEngagementMediaStreams: .none
+        )
+
+        XCTAssertEqual(calls, [.presentSnackBar])
+        XCTAssertEqual(snackBarMessage, Localization.EntryWidget.CallVisualizer.description)
+    }
+    
+    func test_testEnqueuingVideoWhenCallVisualizerIsActiveShouldShowSnackbar() throws {
+        enum Call {
+            case presentSnackBar
+        }
+        var calls: [Call] = []
+        var snackBarMessage: String?
+
+        let sdk = makeConfigurableSDK()
+
+        try sdk.configure(
+            with: .mock(),
+            theme: .mock()
+        ) { _ in }
+
+        let interactor: Interactor = .mock()
+
+        sdk.interactor = interactor
+        sdk.environment.coreSdk.getCurrentEngagement = {
+            .mock(source: .callVisualizer)
+        }
+        sdk.rootCoordinator = .mock(interactor: interactor)
+        sdk.rootCoordinator?.gliaViewController = .mock()
+        sdk.environment.snackBar.present = { message, _, _, _, _, _, _ in
+            snackBarMessage = message
+            calls.append(.presentSnackBar)
+        }
+
+        sdk.resolveEngagementState(
+            engagementKind: .videoCall,
+            sceneProvider: .none,
+            configuration: .mock(),
+            interactor: interactor,
+            features: .all,
+            viewFactory: .mock(),
+            ongoingEngagementMediaStreams: .none
+        )
+
+        XCTAssertEqual(calls, [.presentSnackBar])
+        XCTAssertEqual(snackBarMessage, Localization.EntryWidget.CallVisualizer.description)
+    }
+    
+    func test_testEnqueuingChatWhenVideoCallVisualizerIsActiveShouldRestoreVideo() throws {
+        enum Call {
+            case presentSnackBar
+        }
+        var calls: [Call] = []
+        var snackBarMessage: String?
+
+        let sdk = makeConfigurableSDK()
+
+        try sdk.configure(
+            with: .mock(),
+            theme: .mock()
+        ) { _ in }
+
+        let interactor: Interactor = .mock()
+
+        sdk.interactor = interactor
+        sdk.environment.coreSdk.getCurrentEngagement = {
+            .mock(source: .callVisualizer, media: .init(audio: nil, video: .oneWay))
+        }
+        sdk.rootCoordinator = .mock(interactor: interactor)
+        sdk.rootCoordinator?.gliaViewController = .mock()
+        sdk.environment.snackBar.present = { message, _, _, _, _, _, _ in
+            snackBarMessage = message
+            calls.append(.presentSnackBar)
+        }
+
+        sdk.resolveEngagementState(
+            engagementKind: .chat,
+            sceneProvider: .none,
+            configuration: .mock(),
+            interactor: interactor,
+            features: .all,
+            viewFactory: .mock(),
+            ongoingEngagementMediaStreams: .none
+        )
+
+        XCTAssertEqual(calls, [.presentSnackBar])
+        XCTAssertEqual(snackBarMessage, Localization.EntryWidget.CallVisualizer.description)
+    }
+    
+    func test_testEnqueuingAudioWhenVideoCallVisualizerIsActiveShouldRestoreVideo() throws {
+        enum Call {
+            case presentSnackBar
+        }
+        var calls: [Call] = []
+        var snackBarMessage: String?
+
+        let sdk = makeConfigurableSDK()
+
+        try sdk.configure(
+            with: .mock(),
+            theme: .mock()
+        ) { _ in }
+
+        let interactor: Interactor = .mock()
+
+        sdk.interactor = interactor
+        sdk.environment.coreSdk.getCurrentEngagement = {
+            .mock(source: .callVisualizer, media: .init(audio: nil, video: .oneWay))
+        }
+        sdk.rootCoordinator = .mock(interactor: interactor)
+        sdk.rootCoordinator?.gliaViewController = .mock()
+        sdk.environment.snackBar.present = { message, _, _, _, _, _, _ in
+            snackBarMessage = message
+            calls.append(.presentSnackBar)
+        }
+
+        sdk.resolveEngagementState(
+            engagementKind: .audioCall,
+            sceneProvider: .none,
+            configuration: .mock(),
+            interactor: interactor,
+            features: .all,
+            viewFactory: .mock(),
+            ongoingEngagementMediaStreams: .none
+        )
+
+        XCTAssertEqual(calls, [.presentSnackBar])
+        XCTAssertEqual(snackBarMessage, Localization.EntryWidget.CallVisualizer.description)
+    }
+    
+    func test_testEnqueuingVideoWhenVideoCallVisualizerIsActiveShouldRestoreVideo() throws {
+        let sdk = makeConfigurableSDK()
+
+        try sdk.configure(
+            with: .mock(),
+            theme: .mock()
+        ) { _ in }
+
+        let interactor: Interactor = .mock()
+
+        sdk.interactor = interactor
+        sdk.environment.coreSdk.getCurrentEngagement = {
+            .mock(source: .callVisualizer, media: .init(audio: nil, video: .oneWay))
+        }
+        sdk.rootCoordinator = .mock(interactor: interactor)
+        sdk.rootCoordinator?.gliaViewController = .mock()
+        sdk.environment.snackBar.present = { _, _, _, _, _, _, _ in
+        }
+        var callVisualizerEnv = CallVisualizer.Environment.mock
+        callVisualizerEnv.getCurrentEngagement = {
+            .mock(source: .callVisualizer, media: .init(audio: nil, video: .oneWay))
+        }
+        sdk.callVisualizer = .init(environment: callVisualizerEnv)
+        var calledEvents: [CallVisualizer.Coordinator.DelegateEvent] = []
+        sdk.callVisualizer.coordinator.environment.eventHandler = { calledEvents.append($0) }
+
+        sdk.resolveEngagementState(
+            engagementKind: .videoCall,
+            sceneProvider: .none,
+            configuration: .mock(),
+            interactor: interactor,
+            features: .all,
+            viewFactory: .mock(),
+            ongoingEngagementMediaStreams: .none
+        )
+
+        XCTAssertTrue(calledEvents.contains(.maximized))
     }
 }
 

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
@@ -48,7 +48,7 @@ extension GliaTests {
         XCTAssertNoThrow(try engagementLauncher.startChat())
     }
 
-    func testStartEngagementThrowsErrorDuringActiveCallVisualizerEngagement() throws {
+    func testStartEngagementShowsSnackBarDuringActiveCallVisualizerEngagement() throws {
         enum Call {
             case presentSnackBar
         }
@@ -89,12 +89,9 @@ extension GliaTests {
         ) { _ in }
         let engagementLauncher = try sdk.getEngagementLauncher(queueIds: ["queueID"])
         sdk.environment.coreSdk.getCurrentEngagement = { .mock(source: .callVisualizer) }
+ 
+        try engagementLauncher.startChat()
 
-        XCTAssertThrowsError(
-            try engagementLauncher.startChat()
-        ) { error in
-            XCTAssertEqual(error as? GliaError, GliaError.callVisualizerEngagementExists)
-        }
         XCTAssertEqual(calls, [.presentSnackBar])
         XCTAssertEqual(snackBarMessage, Localization.EntryWidget.CallVisualizer.description)
     }


### PR DESCRIPTION
**What was solved?**
This PR restores Video Call Visualizer on enqueuing if it is running

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [X] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.
