### PR TITLE
Erase interactor state on deauthenticate

### DIFF
--- a/GliaWidgets/Public/Glia/Glia.OpaqueAuthentication.swift
+++ b/GliaWidgets/Public/Glia/Glia.OpaqueAuthentication.swift
@@ -137,6 +137,8 @@ extension Glia {
                 auth.deauthenticate { result in
                     switch result {
                     case .success:
+                        // Erase interactor state.
+                        self?.interactor?.cleanup()
                         // Cleanup navigation and views.
                         self?.closeRootCoordinator()
                     case .failure:


### PR DESCRIPTION
MOB-3972

**What was solved?**
This PR introduces the logic erasing `interactor.state` to align its behaviour in case when deauthentication happended during trasferred SC.

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.