### PR TITLE
Make interactor as published property

### DIFF
--- a/GliaWidgets/Public/Glia/Glia+EntryWidget.swift
+++ b/GliaWidgets/Public/Glia/Glia+EntryWidget.swift
@@ -28,10 +28,7 @@ extension Glia {
                     guard let self else { return false }
                     return pendingInteraction?.hasPendingInteraction ?? false
                 },
-                currentInteractor: { [weak self] in
-                    guard let self else { return nil }
-                    return interactor
-                },
+                interactorPublisher: Glia.sharedInstance.$interactor.eraseToAnyPublisher(),
                 onCallVisualizerResume: { [weak self] in
                     guard let self else { return }
                     callVisualizer.resume()

--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -119,7 +119,7 @@ public class Glia {
         )
     )
     var rootCoordinator: EngagementCoordinator?
-    var interactor: Interactor?
+    @Published var interactor: Interactor?
     var environment: Environment
     var messageRenderer: MessageRenderer? = .webRenderer
     var theme: Theme

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.Environment.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.Environment.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 
 extension EntryWidget {
     struct Environment {
@@ -10,7 +11,7 @@ extension EntryWidget {
         var log: CoreSdkClient.Logger
         var isAuthenticated: () -> Bool
         var hasPendingInteraction: () -> Bool
-        var currentInteractor: () -> Interactor?
+        var interactorPublisher: AnyPublisher<Interactor?, Never>
         var onCallVisualizerResume: () -> Void
     }
 }
@@ -28,7 +29,7 @@ extension EntryWidget.Environment {
             log: .mock,
             isAuthenticated: { true },
             hasPendingInteraction: { false },
-            currentInteractor: { .mock() },
+            interactorPublisher: Just(nil).eraseToAnyPublisher(),
             onCallVisualizerResume: {}
         )
     }


### PR DESCRIPTION
**What was solved?**
If the integrator creates EntryWidget and then re-configures the SDK, EntryWidgets stops handling engagement states, because it owns an outdated interactor instance.
To solve this problem we need to re-subscribe on interactor.currentEngagement property once the SDK is reconfigured. This PR does that by making the interactor a published property. EntryWidget will always be up to date with the most recent interactor.

MOB-3965

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
