### PR TITLE
Show snack bar for enqueued engagements

### DIFF
--- a/GliaWidgetsTests/Sources/Glia/GliaTests+EngagementLauncher.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+EngagementLauncher.swift
@@ -114,7 +114,10 @@ extension GliaTests {
 
         XCTAssertEqual(calls, [.maximize])
     }
-    
+}
+
+// MARK: - Enqueuing engagement with ongoing CV
+extension GliaTests {
     func test_testEnqueuingChatWhenCallVisualizerIsActiveShouldShowSnackbar() throws {
         enum Call {
             case presentSnackBar
@@ -357,6 +360,255 @@ extension GliaTests {
         )
 
         XCTAssertTrue(calledEvents.contains(.maximized))
+    }
+}
+
+// MARK: - Enqueuing engagement with ongoing engagement
+private extension GliaTests {
+    func test_testEnqueuingChatWhenOngoingVideoEngagementExistsShouldShowSnackBar() throws {
+        enum Call {
+            case presentSnackBar
+        }
+        var calls: [Call] = []
+        var snackBarMessage: String?
+
+        let sdk = makeConfigurableSDK()
+
+        try sdk.configure(
+            with: .mock(),
+            theme: .mock()
+        ) { _ in }
+
+        let interactor: Interactor = .mock()
+
+        sdk.interactor = interactor
+        sdk.environment.coreSdk.getCurrentEngagement = {
+            .mock(source: .coreEngagement, media: .init(audio: nil, video: .oneWay))
+        }
+        sdk.rootCoordinator = .mock(interactor: interactor)
+        sdk.rootCoordinator?.gliaViewController = .mock()
+        sdk.environment.snackBar.present = { message, _, _, _, _, _, _ in
+            snackBarMessage = message
+            calls.append(.presentSnackBar)
+        }
+
+        sdk.resolveEngagementState(
+            engagementKind: .chat,
+            sceneProvider: .none,
+            configuration: .mock(),
+            interactor: interactor,
+            features: .all,
+            viewFactory: .mock(),
+            ongoingEngagementMediaStreams: .none
+        )
+
+        XCTAssertEqual(calls, [.presentSnackBar])
+        XCTAssertEqual(snackBarMessage, Localization.EntryWidget.CallVisualizer.description)
+    }
+
+    func test_testEnqueuingSCWhenOngoingVideoEngagementExistsShouldShowSnackBar() throws {
+        enum Call {
+            case presentSnackBar
+        }
+        var calls: [Call] = []
+        var snackBarMessage: String?
+
+        let sdk = makeConfigurableSDK()
+
+        try sdk.configure(
+            with: .mock(),
+            theme: .mock()
+        ) { _ in }
+
+        let interactor: Interactor = .mock()
+
+        sdk.interactor = interactor
+        sdk.environment.coreSdk.getCurrentEngagement = {
+            .mock(source: .coreEngagement, media: .init(audio: nil, video: .oneWay))
+        }
+        sdk.rootCoordinator = .mock(interactor: interactor)
+        sdk.rootCoordinator?.gliaViewController = .mock()
+        sdk.environment.snackBar.present = { message, _, _, _, _, _, _ in
+            snackBarMessage = message
+            calls.append(.presentSnackBar)
+        }
+
+        sdk.resolveEngagementState(
+            engagementKind: .messaging(.welcome),
+            sceneProvider: .none,
+            configuration: .mock(),
+            interactor: interactor,
+            features: .all,
+            viewFactory: .mock(),
+            ongoingEngagementMediaStreams: .none
+        )
+
+        XCTAssertEqual(calls, [.presentSnackBar])
+        XCTAssertEqual(snackBarMessage, Localization.EntryWidget.CallVisualizer.description)
+    }
+
+    func test_testEnqueuingChatWhenOngoingAudioEngagementExistsShouldShowSnackBar() throws {
+        enum Call {
+            case presentSnackBar
+        }
+        var calls: [Call] = []
+        var snackBarMessage: String?
+
+        let sdk = makeConfigurableSDK()
+
+        try sdk.configure(
+            with: .mock(),
+            theme: .mock()
+        ) { _ in }
+
+        let interactor: Interactor = .mock()
+
+        sdk.interactor = interactor
+        sdk.environment.coreSdk.getCurrentEngagement = {
+            .mock(source: .coreEngagement, media: .init(audio: .twoWay, video: nil))
+        }
+        sdk.rootCoordinator = .mock(interactor: interactor)
+        sdk.rootCoordinator?.gliaViewController = .mock()
+        sdk.environment.snackBar.present = { message, _, _, _, _, _, _ in
+            snackBarMessage = message
+            calls.append(.presentSnackBar)
+        }
+
+        sdk.resolveEngagementState(
+            engagementKind: .chat,
+            sceneProvider: .none,
+            configuration: .mock(),
+            interactor: interactor,
+            features: .all,
+            viewFactory: .mock(),
+            ongoingEngagementMediaStreams: .none
+        )
+
+        XCTAssertEqual(calls, [.presentSnackBar])
+        XCTAssertEqual(snackBarMessage, Localization.EntryWidget.CallVisualizer.description)
+    }
+    
+    func test_testEnqueuingSCWhenOngoingAudioEngagementExistsShouldShowSnackBar() throws {
+        enum Call {
+            case presentSnackBar
+        }
+        var calls: [Call] = []
+        var snackBarMessage: String?
+
+        let sdk = makeConfigurableSDK()
+
+        try sdk.configure(
+            with: .mock(),
+            theme: .mock()
+        ) { _ in }
+
+        let interactor: Interactor = .mock()
+
+        sdk.interactor = interactor
+        sdk.environment.coreSdk.getCurrentEngagement = {
+            .mock(source: .coreEngagement, media: .init(audio: .twoWay, video: nil))
+        }
+        sdk.rootCoordinator = .mock(interactor: interactor)
+        sdk.rootCoordinator?.gliaViewController = .mock()
+        sdk.environment.snackBar.present = { message, _, _, _, _, _, _ in
+            snackBarMessage = message
+            calls.append(.presentSnackBar)
+        }
+
+        sdk.resolveEngagementState(
+            engagementKind: .chat,
+            sceneProvider: .none,
+            configuration: .mock(),
+            interactor: interactor,
+            features: .all,
+            viewFactory: .mock(),
+            ongoingEngagementMediaStreams: .none
+        )
+
+        XCTAssertEqual(calls, [.presentSnackBar])
+        XCTAssertEqual(snackBarMessage, Localization.EntryWidget.CallVisualizer.description)
+    }
+    
+    func test_testEnqueuingAudioWhenOngoingChatEngagementExistsShouldShowSnackBar() throws {
+        enum Call {
+            case presentSnackBar
+        }
+        var calls: [Call] = []
+        var snackBarMessage: String?
+
+        let sdk = makeConfigurableSDK()
+
+        try sdk.configure(
+            with: .mock(),
+            theme: .mock()
+        ) { _ in }
+
+        let interactor: Interactor = .mock()
+
+        sdk.interactor = interactor
+        sdk.environment.coreSdk.getCurrentEngagement = {
+            .mock(source: .coreEngagement)
+        }
+        sdk.rootCoordinator = .mock(interactor: interactor)
+        sdk.rootCoordinator?.gliaViewController = .mock()
+        sdk.environment.snackBar.present = { message, _, _, _, _, _, _ in
+            snackBarMessage = message
+            calls.append(.presentSnackBar)
+        }
+
+        sdk.resolveEngagementState(
+            engagementKind: .audioCall,
+            sceneProvider: .none,
+            configuration: .mock(),
+            interactor: interactor,
+            features: .all,
+            viewFactory: .mock(),
+            ongoingEngagementMediaStreams: .none
+        )
+
+        XCTAssertEqual(calls, [.presentSnackBar])
+        XCTAssertEqual(snackBarMessage, Localization.EntryWidget.CallVisualizer.description)
+    }
+    
+    func test_testEnqueuingVideoWhenOngoingChatEngagementExistsShouldShowSnackBar() throws {
+        enum Call {
+            case presentSnackBar
+        }
+        var calls: [Call] = []
+        var snackBarMessage: String?
+
+        let sdk = makeConfigurableSDK()
+
+        try sdk.configure(
+            with: .mock(),
+            theme: .mock()
+        ) { _ in }
+
+        let interactor: Interactor = .mock()
+
+        sdk.interactor = interactor
+        sdk.environment.coreSdk.getCurrentEngagement = {
+            .mock(source: .coreEngagement)
+        }
+        sdk.rootCoordinator = .mock(interactor: interactor)
+        sdk.rootCoordinator?.gliaViewController = .mock()
+        sdk.environment.snackBar.present = { message, _, _, _, _, _, _ in
+            snackBarMessage = message
+            calls.append(.presentSnackBar)
+        }
+
+        sdk.resolveEngagementState(
+            engagementKind: .videoCall,
+            sceneProvider: .none,
+            configuration: .mock(),
+            interactor: interactor,
+            features: .all,
+            viewFactory: .mock(),
+            ongoingEngagementMediaStreams: .none
+        )
+
+        XCTAssertEqual(calls, [.presentSnackBar])
+        XCTAssertEqual(snackBarMessage, Localization.EntryWidget.CallVisualizer.description)
     }
 }
 

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
@@ -667,6 +667,11 @@ extension GliaTests {
 
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
+        let window = UIWindow(frame: .zero)
+        window.rootViewController = UIViewController()
+        window.makeKeyAndVisible()
+        sdk.environment.uiApplication.windows = { [window] }
+        sdk.environment.snackBar.present = { _, _, _, _, _, _, _ in }
         try sdk.configure(
             with: .mock(),
             theme: .mock()


### PR DESCRIPTION
**What was solved?**
This PR shows snack bar for enqueued engagements
- Snackbar shown for video/audio enqueueing if chat/SC running
- Snackbar shown for chat/SC enqueueing if video/audio running

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [X] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.
