### PR TITLE
Switch from Live Chat to SC on ended engagement with '.retain'

### DIFF
--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
@@ -208,6 +208,11 @@ extension ChatCoordinator {
             delegate?(.call)
         case .minimize:
             delegate?(.minimize)
+        // TODO: Cover with unit tests MOB-3989
+        case let .liveChatEngagementUpgradedToSecureMessaging(chatModel):
+            let transcriptModel = self.transcriptModel(with: { [weak controller] in controller })
+            controller?.swapAndBindViewModel(.transcript(transcriptModel))
+            transcriptModel.migrate(from: chatModel)
         }
     }
 

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
@@ -118,7 +118,7 @@ final class ChatViewController: EngagementViewController, PopoverPresenter {
             case .connected(let name, let imageUrl):
                 view?.setConnectState(.connected(name: name, imageUrl: imageUrl), animated: true)
                 view?.unreadMessageIndicatorView.setImage(fromUrl: imageUrl, animated: true)
-                view?.messageEntryView.isConnected = true
+                self.viewModel.action?(.setMessageEntryConnected(true))
             case .setMessageEntryEnabled(let enabled):
                 view?.messageEntryView.isEnabled = enabled
             case .setChoiceCardInputModeEnabled(let enabled):
@@ -195,6 +195,8 @@ final class ChatViewController: EngagementViewController, PopoverPresenter {
                 )
             case .switchToEngagement:
                 view?.hideEntryWidget()
+            case let .setMessageEntryConnected(isConnected):
+                view?.messageEntryView.isConnected = isConnected
             }
             self.renderProps()
         }

--- a/GliaWidgets/Sources/ViewController/EngagementViewController.swift
+++ b/GliaWidgets/Sources/ViewController/EngagementViewController.swift
@@ -54,6 +54,8 @@ class EngagementViewController: UIViewController {
             switch action {
             case .showEndButton:
                 view?.header.showEndButton()
+            case .showCloseButton:
+                view?.header.showCloseButton()
             case .showEndScreenShareButton:
                 view?.header.showEndScreenSharingButton()
             case let .showLiveObservationConfirmation(link, accepted, declined):

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+ViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+ViewModel.swift
@@ -57,6 +57,7 @@ extension ChatViewModel: ViewModel {
         case transcript(TranscriptAction)
         case showSnackBarView
         case switchToEngagement
+        case setMessageEntryConnected(Bool)
     }
 
     enum DelegateEvent {
@@ -71,6 +72,7 @@ extension ChatViewModel: ViewModel {
         case showFile(LocalFile)
         case call
         case minimize
+        case liveChatEngagementUpgradedToSecureMessaging(ChatViewModel)
     }
 
     enum StartAction {

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.InteractorChangedState.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.InteractorChangedState.swift
@@ -25,8 +25,9 @@ extension ChatViewModel {
             switch endedEngagement.actionOnEnd {
             case .showSurvey:
                 endSession()
-            // TODO: review '.retain' case in context of SC 2 transfer MOB-3978.
-            case .retain, .showEndedNotification:
+            case .retain:
+                delegate?(.liveChatEngagementUpgradedToSecureMessaging(self))
+            case .showEndedNotification:
                 handleOperatorEndedEngagement()
             case let .unknown(unhandledCase):
                 // TODO: log unhandled case MOB-3971

--- a/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
@@ -251,6 +251,7 @@ extension EngagementViewModel {
 
     enum Action {
         case showEndButton
+        case showCloseButton
         case showEndScreenShareButton
         case showLiveObservationConfirmation(
             link: (WebViewController.Link) -> Void,


### PR DESCRIPTION
**What was solved?**
Handle case when engagement is ended with 'actionOnEnd = .retain' by switching to SC from Live Chat, instead of ending engagement.

MOB-3978

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
