### PR TITLE
Replace InteractorProviding with InteractorPublisher

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -900,6 +900,7 @@
 		C090478A2B7E5C66003C437C /* AttachmentSourceListStyle.Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09047892B7E5C66003C437C /* AttachmentSourceListStyle.Equatable.swift */; };
 		C090478C2B7E5C8F003C437C /* FilePreviewStyle.Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C090478B2B7E5C8F003C437C /* FilePreviewStyle.Equatable.swift */; };
 		C096B40B297EBDE400F0C552 /* VisitorCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C096B40A297EBDE400F0C552 /* VisitorCodeTests.swift */; };
+		C0AF097D2D4B748300699E83 /* AnyPublisher.mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AF097C2D4B747700699E83 /* AnyPublisher.mock.swift */; };
 		C0B325E72AC5A8FA006BC430 /* AlertViewController+LiveObservationConfirmation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B325E62AC5A8FA006BC430 /* AlertViewController+LiveObservationConfirmation.swift */; };
 		C0C5BB772CAD4278001B2025 /* MediaTypeItemStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C5BB762CAD4259001B2025 /* MediaTypeItemStyle.swift */; };
 		C0C5BB792CAD42FD001B2025 /* MediaTypeItemStyle.RemoteConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C5BB782CAD42FD001B2025 /* MediaTypeItemStyle.RemoteConfig.swift */; };
@@ -1987,6 +1988,7 @@
 		C09047892B7E5C66003C437C /* AttachmentSourceListStyle.Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentSourceListStyle.Equatable.swift; sourceTree = "<group>"; };
 		C090478B2B7E5C8F003C437C /* FilePreviewStyle.Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewStyle.Equatable.swift; sourceTree = "<group>"; };
 		C096B40A297EBDE400F0C552 /* VisitorCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitorCodeTests.swift; sourceTree = "<group>"; };
+		C0AF097C2D4B747700699E83 /* AnyPublisher.mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyPublisher.mock.swift; sourceTree = "<group>"; };
 		C0B325E62AC5A8FA006BC430 /* AlertViewController+LiveObservationConfirmation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AlertViewController+LiveObservationConfirmation.swift"; sourceTree = "<group>"; };
 		C0C5BB762CAD4259001B2025 /* MediaTypeItemStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTypeItemStyle.swift; sourceTree = "<group>"; };
 		C0C5BB782CAD42FD001B2025 /* MediaTypeItemStyle.RemoteConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTypeItemStyle.RemoteConfig.swift; sourceTree = "<group>"; };
@@ -2825,6 +2827,7 @@
 		1A60AFC12566857200E53F53 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				C0AF097B2D4B746E00699E83 /* Combine */,
 				2198B7AA2CAEB13E002C442B /* QueuesMonitor */,
 				215A25922CA44D900013023E /* EngagementLauncher */,
 				C0F3DE352C69F4A700DE6D7B /* EntryWidget */,
@@ -5099,6 +5102,14 @@
 			path = CallVisualizer;
 			sourceTree = "<group>";
 		};
+		C0AF097B2D4B746E00699E83 /* Combine */ = {
+			isa = PBXGroup;
+			children = (
+				C0AF097C2D4B747700699E83 /* AnyPublisher.mock.swift */,
+			);
+			path = Combine;
+			sourceTree = "<group>";
+		};
 		C0D2F0292991213B00803B47 /* VideoCall */ = {
 			isa = PBXGroup;
 			children = (
@@ -6193,6 +6204,7 @@
 				C0D6CA212C185F1000D4709B /* AlertTypeComposer.Environment.swift in Sources */,
 				75940982298D38C2008B173A /* VisitorCodeCoordinator+Environment.swift in Sources */,
 				C09047682B7E23EC003C437C /* ChatFileDownloadErrorStateStyle.RemoteConfig.swift in Sources */,
+				C0AF097D2D4B748300699E83 /* AnyPublisher.mock.swift in Sources */,
 				75CF8D6129B3F1E400CB1524 /* Configuration.Mock.swift in Sources */,
 				84EFB05D28AA992D0005E270 /* WebMessageCardView.swift in Sources */,
 				315BAB1E29ADFED800FF284B /* ConfirmationStyle.CheckMessagesButtonStyle.swift in Sources */,

--- a/GliaWidgets/Public/Glia/Glia+EntryWidget.swift
+++ b/GliaWidgets/Public/Glia/Glia+EntryWidget.swift
@@ -28,7 +28,7 @@ extension Glia {
                     guard let self else { return false }
                     return pendingInteraction?.hasPendingInteraction ?? false
                 },
-                interactorPublisher: Glia.sharedInstance.$interactor.eraseToAnyPublisher(),
+                interactorPublisher: $interactor.eraseToAnyPublisher(),
                 onCallVisualizerResume: { [weak self] in
                     guard let self else { return }
                     callVisualizer.resume()

--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -1,4 +1,5 @@
 import GliaCoreSDK
+import Combine
 import UIKit
 
 /// Engagement media type.
@@ -107,7 +108,7 @@ public class Glia {
     public lazy var callVisualizer = CallVisualizer(
         environment: .create(
             with: environment,
-            interactorProviding: { [weak self] in self?.interactor },
+            interactorPublisher: $interactor.eraseToAnyPublisher(),
             engagedOperator: { [weak self] in
                 self?.environment.coreSdk.getNonTransferredSecureConversationEngagement()?.engagedOperator
             },
@@ -267,7 +268,7 @@ public class Glia {
                     do {
                         pendingInteraction = try .init(environment: .init(
                             client: environment.coreSdk,
-                            interactorProviding: { [weak self] in self?.interactor }
+                            interactorPublisher: Just(interactor).eraseToAnyPublisher()
                         ))
                         startObservingInteractorEvents()
                         completion(.success(()))

--- a/GliaWidgets/Sources/CallVisualizer/CallVisualizer.Environment.swift
+++ b/GliaWidgets/Sources/CallVisualizer/CallVisualizer.Environment.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 
 extension CallVisualizer {
     struct Environment {
@@ -12,7 +13,7 @@ extension CallVisualizer {
         var uiDevice: UIKitBased.UIDevice
         var notificationCenter: FoundationBased.NotificationCenter
         var requestVisitorCode: CoreSdkClient.RequestVisitorCode
-        var interactorProviding: () -> Interactor?
+        var interactorPublisher: AnyPublisher<Interactor?, Never>
         var callVisualizerPresenter: CallVisualizer.Presenter
         var bundleManaging: BundleManaging
         var screenShareHandler: ScreenShareHandler
@@ -37,7 +38,7 @@ extension CallVisualizer {
 extension CallVisualizer.Environment {
     static func create(
         with environment: Glia.Environment,
-        interactorProviding: @escaping () -> Interactor?,
+        interactorPublisher: AnyPublisher<Interactor?, Never>,
         engagedOperator: @escaping () -> CoreSdkClient.Operator?,
         theme: Theme,
         assetBuilder: @escaping () -> RemoteConfiguration.AssetsBuilder,
@@ -56,7 +57,7 @@ extension CallVisualizer.Environment {
             uiDevice: environment.uiDevice,
             notificationCenter: environment.notificationCenter,
             requestVisitorCode: environment.coreSdk.requestVisitorCode,
-            interactorProviding: interactorProviding,
+            interactorPublisher: interactorPublisher,
             callVisualizerPresenter: environment.callVisualizerPresenter,
             bundleManaging: environment.bundleManaging,
             screenShareHandler: environment.screenShareHandler,

--- a/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.Environment.swift
+++ b/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.Environment.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 
 extension CallVisualizer.Coordinator {
     struct Environment {
@@ -23,7 +24,7 @@ extension CallVisualizer.Coordinator {
         var orientationManager: OrientationManager
         var proximityManager: ProximityManager
         var log: CoreSdkClient.Logger
-        var interactorProviding: Interactor?
+        var interactorPublisher: AnyPublisher<Interactor?, Never>
         var fetchSiteConfigurations: CoreSdkClient.FetchSiteConfigurations
         var snackBar: SnackBar
         var cameraDeviceManager: CoreSdkClient.GetCameraDeviceManageable
@@ -59,7 +60,7 @@ extension CallVisualizer.Coordinator.Environment {
             orientationManager: environment.orientationManager,
             proximityManager: environment.proximityManager,
             log: environment.log,
-            interactorProviding: environment.interactorProviding(),
+            interactorPublisher: environment.interactorPublisher,
             fetchSiteConfigurations: environment.fetchSiteConfigurations,
             snackBar: environment.snackBar,
             cameraDeviceManager: environment.cameraDeviceManager,

--- a/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UIKit
+import Combine
 
 extension CallVisualizer {
     final class Coordinator {
@@ -15,12 +16,19 @@ extension CallVisualizer {
             bubbleView.pan = { [weak self] translation in
                 self?.updateBubblePosition(translation: translation)
             }
+
+            interactorSubscription = environment.interactorPublisher
+                .sink { [weak self] newInteractor in
+                    self?.activeInteractor = newInteractor
+                }
         }
 
         // MARK: - Private
         private var visitorCodeCoordinator: VisitorCodeCoordinator?
         private var screenSharingCoordinator: ScreenSharingCoordinator?
         private var videoCallCoordinator: VideoCallCoordinator?
+        private var interactorSubscription: AnyCancellable?
+        private(set) var activeInteractor: Interactor?
         private var state: State
         private let bubbleSize = CGSize(width: 60, height: 60)
         private let bubbleView: BubbleView
@@ -225,7 +233,7 @@ extension CallVisualizer.Coordinator {
 
 extension CallVisualizer.Coordinator {
     func declineEngagement() {
-        environment.interactorProviding?.endEngagement { _ in }
+        activeInteractor?.endEngagement { _ in }
         end()
     }
 

--- a/GliaWidgets/Sources/Combine/AnyPublisher.mock.swift
+++ b/GliaWidgets/Sources/Combine/AnyPublisher.mock.swift
@@ -1,0 +1,12 @@
+import Foundation
+import Combine
+
+extension AnyPublisher {
+    static func mock<T>() -> AnyPublisher<T, Never> {
+        return Empty().eraseToAnyPublisher()
+    }
+
+    static func mock<T>(_ value: T) -> AnyPublisher<T, Never> {
+        return Just(value).eraseToAnyPublisher()
+    }
+}

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.Environment.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.Environment.swift
@@ -29,7 +29,7 @@ extension EntryWidget.Environment {
             log: .mock,
             isAuthenticated: { true },
             hasPendingInteraction: { false },
-            interactorPublisher: Just(nil).eraseToAnyPublisher(),
+            interactorPublisher: .mock(nil),
             onCallVisualizerResume: {}
         )
     }

--- a/GliaWidgetsTests/CallVisualizer/ScreenSharing/Mocks/CallVisualizer.Environment.Mock.swift
+++ b/GliaWidgetsTests/CallVisualizer/ScreenSharing/Mocks/CallVisualizer.Environment.Mock.swift
@@ -12,7 +12,7 @@ extension CallVisualizer.Environment {
         uiDevice: .mock,
         notificationCenter: .mock,
         requestVisitorCode: { _ in .init() },
-        interactorProviding: { .mock() },
+        interactorPublisher: .mock(.mock()),
         callVisualizerPresenter: .init(presenter: { nil }),
         bundleManaging: .init { .main },
         screenShareHandler: .mock,

--- a/GliaWidgetsTests/SecureConversations/SecureConversations.PendingInteraction.Failing.swift
+++ b/GliaWidgetsTests/SecureConversations/SecureConversations.PendingInteraction.Failing.swift
@@ -1,4 +1,5 @@
 @testable import GliaWidgets
+import Combine
 
 extension SecureConversations.PendingInteraction.Environment {
     static let failing = Self(
@@ -15,11 +16,13 @@ extension SecureConversations.PendingInteraction.Environment {
         },
         unsubscribeFromPendingStatus: { _ in
             fail("\(Self.self).unsubscribeFromPendingStatus")
-        }, 
-        interactorProviding: {
-            fail("\(Self.self).interactorProviding")
-            return .failing
-        }
+        },
+        // InteractorPublisher cannot call fail because it is a
+        // computed property and will fail immediately upon
+        // initialization, meaning that it fails before the override.
+        // Instead we return a do-nothing publisher.
+        interactorPublisher: Empty<Interactor?, Never>(completeImmediately: false)
+            .eraseToAnyPublisher()
     )
 }
 

--- a/GliaWidgetsTests/SecureConversations/SecureConversations.PendingInteractionTests.swift
+++ b/GliaWidgetsTests/SecureConversations/SecureConversations.PendingInteractionTests.swift
@@ -1,4 +1,5 @@
 @testable import GliaWidgets
+import Combine
 import XCTest
 
 final class SecureConversationsPendingInteractionTests: XCTestCase {
@@ -6,6 +7,8 @@ final class SecureConversationsPendingInteractionTests: XCTestCase {
         var environment = SecureConversations.PendingInteraction.Environment.failing
         let uuidGen = UUID.incrementing
         var pendingCallback: ((Result<Bool, Error>) -> Void)?
+        let interactor = Interactor.mock()
+        environment.interactorPublisher = Just(interactor).eraseToAnyPublisher()
         environment.observePendingSecureConversationsStatus = { callback in
             pendingCallback = callback
             return uuidGen().uuidString
@@ -17,8 +20,7 @@ final class SecureConversationsPendingInteractionTests: XCTestCase {
         }
         environment.unsubscribeFromPendingStatus = { _ in }
         environment.unsubscribeFromUnreadCount = { _ in }
-        let interactor = Interactor.mock()
-        environment.interactorProviding = { interactor }
+
 
         let pendingInteraction = try SecureConversations.PendingInteraction(environment: environment)
         // Assert initial pending interaction is false.
@@ -60,7 +62,7 @@ final class SecureConversationsPendingInteractionTests: XCTestCase {
         environment.unsubscribeFromUnreadCount = { _ in
             calls.append(.unsubscribeFromUnreadCount)
         }
-        environment.interactorProviding = { .mock() }
+        environment.interactorPublisher = .mock(.mock())
         var pendingInteraction = try SecureConversations.PendingInteraction(environment: environment)
         pendingInteraction = try .mock()
         _ = pendingInteraction

--- a/GliaWidgetsTests/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.Environment.Mock.swift
+++ b/GliaWidgetsTests/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.Environment.Mock.swift
@@ -24,6 +24,7 @@ extension CallVisualizer.Coordinator.Environment {
         orientationManager: .mock(),
         proximityManager: .mock,
         log: .mock,
+        interactorPublisher: .mock(.mock()),
         fetchSiteConfigurations: { completion in },
         snackBar: .mock,
         cameraDeviceManager: { .mock },


### PR DESCRIPTION
**What was solved?**
After Interactor was refactored to be Published property, interactorProviding was replaced with interactorPublisher using Combine

MOB-3982

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
