### PR TITLE
Ignore transferred SC in EntryWidget

### DIFF
--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
@@ -350,7 +350,8 @@ private extension EntryWidget {
 
         if ongoingEngagement.source == .callVisualizer {
             return .ongoingEngagement(.callVisualizer)
-        } else if ongoingEngagement.source == .coreEngagement {
+        } else if ongoingEngagement.source == .coreEngagement,
+                  ongoingEngagement.isTransferredSecureConversation == false {
             if ongoingEngagement.mediaStreams.video != nil {
                 return .ongoingEngagement(.video)
             } else if ongoingEngagement.mediaStreams.audio != nil {


### PR DESCRIPTION
MOB-3992

**What was solved?**
Since transferred SC behaves as Secure Conversation queue ticket, we don't need to take it into account during evaluating EntryWidget's viewState.

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.