### PR TITLE
Add test covering migration from Chat to SC

### DIFF
--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
@@ -835,7 +835,6 @@ extension SecureConversations.TranscriptModel {
 }
 
 extension SecureConversations.TranscriptModel {
-    // TODO: Cover with unit tests MOB-3989
     func migrate(from chatModel: ChatViewModel) {
         sections = chatModel.sections
         // There's a possibility where migration to SC (this actually doesn't seem to work ATM, needs checking (MOB-3988)).

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
@@ -208,7 +208,6 @@ extension ChatCoordinator {
             delegate?(.call)
         case .minimize:
             delegate?(.minimize)
-        // TODO: Cover with unit tests MOB-3989
         case let .liveChatEngagementUpgradedToSecureMessaging(chatModel):
             let transcriptModel = self.transcriptModel(with: { [weak controller] in controller })
             controller?.swapAndBindViewModel(.transcript(transcriptModel))


### PR DESCRIPTION
Add unit test that ensures that 'ChatCoordinator' calls 'migrate' on 'TranscriptModel' and asserts migration related properties.

MOB-3989

**What was solved?**

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
