### PR TITLE
Fix Chat state during Transferred SC

### DIFF
--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.LeaveConversation.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.LeaveConversation.swift
@@ -2,20 +2,33 @@ import Foundation
 
 extension SecureConversations.TranscriptModel {
     func showLeaveConversationDialogIfNeeded() {
-        if environment.shouldShowLeaveSecureConversationDialog {
-            let action = EngagementViewModel.Action.showAlert(
-                .leaveCurrentConversation(
-                    confirmed: { [weak self] in
-                        self?.environment.leaveCurrentSecureConversation()
-                    }, declined: { [weak self] in
-                        guard let self else {
-                            return
-                        }
-                        self.markMessagesAsRead(with: self.hasUnreadMessages)
-                    }
-                )
-            )
-            engagementAction?(action)
+        func handleInteractorState() {
+            switch environment.interactor.state {
+                // If engagement has been started
+                // we signal perform upgrade.
+            case .engaged:
+                delegate?(.upgradeToChatEngagement(self))
+            case .none, .enqueueing, .ended, .enqueued:
+                environment.interactor.addObserver(self) { [weak self] event in
+                    self?.handleInteractorEvent(event)
+                }
+            }
         }
+        guard environment.shouldShowLeaveSecureConversationDialog else {
+            handleInteractorState()
+            return
+        }
+        let action = EngagementViewModel.Action.showAlert(
+            .leaveCurrentConversation(
+                confirmed: { [weak self] in
+                    self?.environment.leaveCurrentSecureConversation()
+                }, declined: { [weak self] in
+                    guard let self else { return }
+                    handleInteractorState()
+                    markMessagesAsRead(with: self.hasUnreadMessages)
+                }
+            )
+        )
+        engagementAction?(action)
     }
 }

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
@@ -575,17 +575,6 @@ extension SecureConversations.TranscriptModel {
                     let props = button.options.compactMap { [weak self] in self?.quickReplyOption($0) }
                     self.action?(.quickReplyPropsUpdated(.shown(props)))
                 }
-
-                switch self.environment.interactor.state {
-                    // If engagement has been started
-                    // we signal perform upgrade.
-                case .engaged:
-                    self.delegate?(.upgradeToChatEngagement(self))
-                case .none, .enqueueing, .ended, .enqueued:
-                    self.environment.interactor.addObserver(self) { [weak self] event in
-                        self?.handleInteractorEvent(event)
-                    }
-                }
             case .failure:
                 completion([])
             }

--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
@@ -208,7 +208,8 @@ extension SecureConversations.Coordinator {
             isWindowVisible: environment.isWindowVisible,
             startAction: .startEngagement,
             environment: .create(with: environment),
-            startWithSecureTranscriptFlow: true
+            startWithSecureTranscriptFlow: true,
+            skipTransferredSCHandling: false
         )
 
         coordinator.delegate = { [weak self] event in

--- a/GliaWidgets/Sources/Coordinators/Call/CallCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/Call/CallCoordinator.Environment.swift
@@ -30,6 +30,7 @@ extension CallCoordinator {
         var cameraDeviceManager: CoreSdkClient.GetCameraDeviceManageable
         var flipCameraButtonStyle: FlipCameraButtonStyle
         var alertManager: AlertManager
+        var isAuthenticated: () -> Bool
     }
 }
 
@@ -63,7 +64,8 @@ extension CallCoordinator.Environment {
             snackBar: environment.snackBar,
             cameraDeviceManager: environment.cameraDeviceManager,
             flipCameraButtonStyle: environment.flipCameraButtonStyle,
-            alertManager: environment.alertManager
+            alertManager: environment.alertManager,
+            isAuthenticated: environment.isAuthenticated
         )
     }
 }

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+GVA.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+GVA.swift
@@ -52,15 +52,15 @@ extension ChatViewModel {
             let outgoingMessage = OutgoingMessage(payload: payload)
 
             switch self.interactor.state {
-            case .engaged:
-                self.sendMessage(outgoingMessage)
-
             case .enqueued:
                 self.handle(pendingMessage: outgoingMessage)
 
-            case .enqueueing, .ended, .none:
+            case .engaged where shouldForceEnqueueing, .enqueueing, .ended, .none:
                 self.handle(pendingMessage: outgoingMessage)
                 self.enqueue(engagementKind: .chat)
+
+            case .engaged:
+                self.sendMessage(outgoingMessage)
             }
         }
     }

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Environment.Interface.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Environment.Interface.swift
@@ -28,6 +28,7 @@ extension EngagementViewModel {
         var cameraDeviceManager: CoreSdkClient.GetCameraDeviceManageable
         var flipCameraButtonStyle: FlipCameraButtonStyle
         var alertManager: AlertManager
+        var isAuthenticated: () -> Bool
     }
 }
 
@@ -62,7 +63,8 @@ extension EngagementViewModel.Environment {
             log: environment.log,
             cameraDeviceManager: environment.cameraDeviceManager,
             flipCameraButtonStyle: environment.flipCameraButtonStyle,
-            alertManager: environment.alertManager
+            alertManager: environment.alertManager,
+            isAuthenticated: environment.isAuthenticated
         )
     }
 
@@ -96,7 +98,8 @@ extension EngagementViewModel.Environment {
             log: environment.log,
             cameraDeviceManager: environment.cameraDeviceManager,
             flipCameraButtonStyle: environment.flipCameraButtonStyle,
-            alertManager: environment.alertManager
+            alertManager: environment.alertManager,
+            isAuthenticated: environment.isAuthenticated
         )
     }
 }

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Environment.Mock.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Environment.Mock.swift
@@ -35,7 +35,8 @@ extension ChatViewModel.Environment {
         log: .mock,
         cameraDeviceManager: { .mock },
         flipCameraButtonStyle: .nop,
-        alertManager: .mock()
+        alertManager: .mock(),
+        isAuthenticated: { false }
     )
 }
 #endif

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.InteractorChangedState.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.InteractorChangedState.swift
@@ -7,6 +7,18 @@ extension ChatViewModel {
             break
         case .engaged:
             environment.log.prefixed(Self.self).info("New engagement loaded")
+            // Engaged state for non-transferred SC engagement when
+            // ChatType is `.secureTranscript(upgradedFromChat: true)` means
+            // that SC QueueTicket is accepted by operator. In this case we need to
+            // switch ChatType to authenticated. For better reliability `isAuthenticated` check was added.
+            if interactor.currentEngagement?.isTransferredSecureConversation == false,
+               case .secureTranscript(let upgradedFromChat) = chatType,
+               upgradedFromChat == true {
+                let chatType: ChatType = environment.isAuthenticated() ? .authenticated : .nonAuthenticated
+                setChatType(chatType)
+                action?(.refreshAll)
+            }
+
         case .ended(.byOperator):
             func handleOperatorEndedEngagement() {
                 engagementAction?(.showAlert(.operatorEndedEngagement(action: { [weak self] in

--- a/GliaWidgetsTests/Sources/Coordinators/Call/CallCoordinator.Environment.Mock.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/Call/CallCoordinator.Environment.Mock.swift
@@ -30,6 +30,7 @@ extension CallCoordinator.Environment {
         snackBar: .mock,
         cameraDeviceManager: { .mock },
         flipCameraButtonStyle: .nop,
-        alertManager: .mock()
+        alertManager: .mock(),
+        isAuthenticated: { false }
     )
 }

--- a/GliaWidgetsTests/ViewModel/Chat/ChatViewModel.Environment.Failing.swift
+++ b/GliaWidgetsTests/ViewModel/Chat/ChatViewModel.Environment.Failing.swift
@@ -59,7 +59,11 @@ extension ChatViewModel.Environment {
             log: .failing,
             cameraDeviceManager: { .failing },
             flipCameraButtonStyle: .nop,
-            alertManager: .mock()
+            alertManager: .mock(),
+            isAuthenticated: {
+                fail("\(Self.self).isAuthenticated")
+                return false
+            }
         )
     }
 }


### PR DESCRIPTION
MOB-3973

**What was solved?**
This PR:
- fixes enqueueing to Live engagement during Transferred SC;
- fixes Chat UI for case when SC queue ticket created by Transferred SC gets accepted by operator;
- fixes chatType for the case if visitor leaves current conversation in favour of Live engagement;
- adds unit tests;

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.