### PR TITLE
Implement EngagementLauncher enqueuing logic

### DIFF
--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
@@ -364,7 +364,7 @@ private extension EntryWidget {
     }
 
     func resolveViewState(for interactorState: InteractorState) -> EntryWidget.ViewState? {
-        guard let engagementKind = interactorState.enqueiengEngagementKind else {
+        guard let engagementKind = interactorState.enqueueingEngagementKind else {
             return nil
         }
 
@@ -420,17 +420,6 @@ extension EntryWidget {
         case offline
         case error
         case ongoingEngagement(EngagementType)
-    }
-}
-
-private extension InteractorState {
-    var enqueiengEngagementKind: EngagementKind? {
-        switch self {
-        case .enqueued(_, let engagementKind), .enqueueing(let engagementKind):
-            return engagementKind
-        case .none, .engaged, .ended:
-            return nil
-        }
     }
 }
 

--- a/GliaWidgets/Sources/Interactor/Interactor.swift
+++ b/GliaWidgets/Sources/Interactor/Interactor.swift
@@ -11,6 +11,15 @@ enum InteractorState {
         guard case .ended = self else { return false }
         return true
     }
+
+    var enqueueingEngagementKind: EngagementKind? {
+        switch self {
+        case .enqueued(_, let engagementKind), .enqueueing(let engagementKind):
+            return engagementKind
+        case .none, .engaged, .ended:
+            return nil
+        }
+    }
 }
 
 enum EndEngagementReason {

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+EngagementLauncher.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+EngagementLauncher.swift
@@ -74,509 +74,105 @@ extension GliaTests {
 
         XCTAssertEqual(sdk.engagement, .messaging(.welcome))
     }
-
-    func test_testEnqueuingToChatWhenAlreadyEnqueuedToChat() throws {
-        enum Call {
-            case maximize
-        }
-        var calls: [Call] = []
-
-        let sdk = makeConfigurableSDK()
-
-        try sdk.configure(
-            with: .mock(),
-            theme: .mock()
-        ) { _ in }
-
-        let interactor: Interactor = .mock()
-        interactor.state = .enqueued(.mock, .chat)
-
-        sdk.interactor = interactor
-        sdk.rootCoordinator = .mock(interactor: interactor)
-        sdk.rootCoordinator?.gliaViewController = GliaViewController.mock(delegate: { event in
-            switch event {
-            case .maximized:
-                calls.append(.maximize)
-            default:
-                break
-            }
-        })
-
-        sdk.resolveEngagementState(
-            engagementKind: .chat,
-            sceneProvider: .none,
-            configuration: .mock(),
-            interactor: interactor,
-            features: .all,
-            viewFactory: .mock(),
-            ongoingEngagementMediaStreams: .none
-        )
-
-        XCTAssertEqual(calls, [.maximize])
-    }
 }
 
 // MARK: - Enqueuing engagement with ongoing CV
 extension GliaTests {
     func test_testEnqueuingChatWhenCallVisualizerIsActiveShouldShowSnackbar() throws {
-        enum Call {
-            case presentSnackBar
-        }
-        var calls: [Call] = []
-        var snackBarMessage: String?
+        try testSnackBarPresentation(ongoingEngagement: .mock(source: .callVisualizer), enqueueingEngagement: .chat)
+    }
 
-        let sdk = makeConfigurableSDK()
-
-        try sdk.configure(
-            with: .mock(),
-            theme: .mock()
-        ) { _ in }
-
-        let interactor: Interactor = .mock()
-
-        sdk.interactor = interactor
-        sdk.environment.coreSdk.getCurrentEngagement = {
-            .mock(source: .callVisualizer)
-        }
-        sdk.rootCoordinator = .mock(interactor: interactor)
-        sdk.rootCoordinator?.gliaViewController = .mock()
-        sdk.environment.snackBar.present = { message, _, _, _, _, _, _ in
-            snackBarMessage = message
-            calls.append(.presentSnackBar)
-        }
-
-        sdk.resolveEngagementState(
-            engagementKind: .chat,
-            sceneProvider: .none,
-            configuration: .mock(),
-            interactor: interactor,
-            features: .all,
-            viewFactory: .mock(),
-            ongoingEngagementMediaStreams: .none
-        )
-
-        XCTAssertEqual(calls, [.presentSnackBar])
-        XCTAssertEqual(snackBarMessage, Localization.EntryWidget.CallVisualizer.description)
+    func test_testEnqueuingSCWhenCallVisualizerIsActiveShouldShowSnackbar() throws {
+        try testSnackBarPresentation(ongoingEngagement: .mock(source: .callVisualizer), enqueueingEngagement: .messaging(.welcome))
     }
     
     func test_testEnqueuingAudioWhenCallVisualizerIsActiveShouldShowSnackbar() throws {
-        enum Call {
-            case presentSnackBar
-        }
-        var calls: [Call] = []
-        var snackBarMessage: String?
-
-        let sdk = makeConfigurableSDK()
-
-        try sdk.configure(
-            with: .mock(),
-            theme: .mock()
-        ) { _ in }
-
-        let interactor: Interactor = .mock()
-
-        sdk.interactor = interactor
-        sdk.environment.coreSdk.getCurrentEngagement = {
-            .mock(source: .callVisualizer)
-        }
-        sdk.rootCoordinator = .mock(interactor: interactor)
-        sdk.rootCoordinator?.gliaViewController = .mock()
-        sdk.environment.snackBar.present = { message, _, _, _, _, _, _ in
-            snackBarMessage = message
-            calls.append(.presentSnackBar)
-        }
-
-        sdk.resolveEngagementState(
-            engagementKind: .audioCall,
-            sceneProvider: .none,
-            configuration: .mock(),
-            interactor: interactor,
-            features: .all,
-            viewFactory: .mock(),
-            ongoingEngagementMediaStreams: .none
-        )
-
-        XCTAssertEqual(calls, [.presentSnackBar])
-        XCTAssertEqual(snackBarMessage, Localization.EntryWidget.CallVisualizer.description)
+        try testSnackBarPresentation(ongoingEngagement: .mock(source: .callVisualizer), enqueueingEngagement: .audioCall)
     }
     
     func test_testEnqueuingVideoWhenCallVisualizerIsActiveShouldShowSnackbar() throws {
-        enum Call {
-            case presentSnackBar
-        }
-        var calls: [Call] = []
-        var snackBarMessage: String?
-
-        let sdk = makeConfigurableSDK()
-
-        try sdk.configure(
-            with: .mock(),
-            theme: .mock()
-        ) { _ in }
-
-        let interactor: Interactor = .mock()
-
-        sdk.interactor = interactor
-        sdk.environment.coreSdk.getCurrentEngagement = {
-            .mock(source: .callVisualizer)
-        }
-        sdk.rootCoordinator = .mock(interactor: interactor)
-        sdk.rootCoordinator?.gliaViewController = .mock()
-        sdk.environment.snackBar.present = { message, _, _, _, _, _, _ in
-            snackBarMessage = message
-            calls.append(.presentSnackBar)
-        }
-
-        sdk.resolveEngagementState(
-            engagementKind: .videoCall,
-            sceneProvider: .none,
-            configuration: .mock(),
-            interactor: interactor,
-            features: .all,
-            viewFactory: .mock(),
-            ongoingEngagementMediaStreams: .none
-        )
-
-        XCTAssertEqual(calls, [.presentSnackBar])
-        XCTAssertEqual(snackBarMessage, Localization.EntryWidget.CallVisualizer.description)
+        try testSnackBarPresentation(ongoingEngagement: .mock(source: .callVisualizer), enqueueingEngagement: .videoCall)
     }
     
-    func test_testEnqueuingChatWhenVideoCallVisualizerIsActiveShouldRestoreVideo() throws {
-        enum Call {
-            case presentSnackBar
-        }
-        var calls: [Call] = []
-        var snackBarMessage: String?
+    func test_testEnqueuingChatWhenVideoCallVisualizerIsActiveShouldShowSnackbar() throws {
+        try testSnackBarPresentation(ongoingEngagement: .mock(source: .callVisualizer, media: .init(audio: nil, video: .oneWay)), enqueueingEngagement: .chat)
+    }
 
-        let sdk = makeConfigurableSDK()
-
-        try sdk.configure(
-            with: .mock(),
-            theme: .mock()
-        ) { _ in }
-
-        let interactor: Interactor = .mock()
-
-        sdk.interactor = interactor
-        sdk.environment.coreSdk.getCurrentEngagement = {
-            .mock(source: .callVisualizer, media: .init(audio: nil, video: .oneWay))
-        }
-        sdk.rootCoordinator = .mock(interactor: interactor)
-        sdk.rootCoordinator?.gliaViewController = .mock()
-        sdk.environment.snackBar.present = { message, _, _, _, _, _, _ in
-            snackBarMessage = message
-            calls.append(.presentSnackBar)
-        }
-
-        sdk.resolveEngagementState(
-            engagementKind: .chat,
-            sceneProvider: .none,
-            configuration: .mock(),
-            interactor: interactor,
-            features: .all,
-            viewFactory: .mock(),
-            ongoingEngagementMediaStreams: .none
-        )
-
-        XCTAssertEqual(calls, [.presentSnackBar])
-        XCTAssertEqual(snackBarMessage, Localization.EntryWidget.CallVisualizer.description)
+    func test_testEnqueuingSCWhenVideoCallVisualizerIsActiveShouldShowSnackbar() throws {
+        try testSnackBarPresentation(ongoingEngagement: .mock(source: .callVisualizer, media: .init(audio: nil, video: .oneWay)), enqueueingEngagement: .messaging(.welcome))
     }
     
-    func test_testEnqueuingAudioWhenVideoCallVisualizerIsActiveShouldRestoreVideo() throws {
-        enum Call {
-            case presentSnackBar
-        }
-        var calls: [Call] = []
-        var snackBarMessage: String?
-
-        let sdk = makeConfigurableSDK()
-
-        try sdk.configure(
-            with: .mock(),
-            theme: .mock()
-        ) { _ in }
-
-        let interactor: Interactor = .mock()
-
-        sdk.interactor = interactor
-        sdk.environment.coreSdk.getCurrentEngagement = {
-            .mock(source: .callVisualizer, media: .init(audio: nil, video: .oneWay))
-        }
-        sdk.rootCoordinator = .mock(interactor: interactor)
-        sdk.rootCoordinator?.gliaViewController = .mock()
-        sdk.environment.snackBar.present = { message, _, _, _, _, _, _ in
-            snackBarMessage = message
-            calls.append(.presentSnackBar)
-        }
-
-        sdk.resolveEngagementState(
-            engagementKind: .audioCall,
-            sceneProvider: .none,
-            configuration: .mock(),
-            interactor: interactor,
-            features: .all,
-            viewFactory: .mock(),
-            ongoingEngagementMediaStreams: .none
-        )
-
-        XCTAssertEqual(calls, [.presentSnackBar])
-        XCTAssertEqual(snackBarMessage, Localization.EntryWidget.CallVisualizer.description)
+    func test_testEnqueuingAudioWhenVideoCallVisualizerIsActiveShouldShowSnackbar() throws {
+        try testSnackBarPresentation(ongoingEngagement: .mock(source: .callVisualizer, media: .init(audio: nil, video: .oneWay)), enqueueingEngagement: .audioCall)
     }
     
     func test_testEnqueuingVideoWhenVideoCallVisualizerIsActiveShouldRestoreVideo() throws {
-        let sdk = makeConfigurableSDK()
+        var calledCVEvents: [CallVisualizer.Coordinator.DelegateEvent] = []
 
-        try sdk.configure(
-            with: .mock(),
-            theme: .mock()
-        ) { _ in }
-
-        let interactor: Interactor = .mock()
-
-        sdk.interactor = interactor
-        sdk.environment.coreSdk.getCurrentEngagement = {
-            .mock(source: .callVisualizer, media: .init(audio: nil, video: .oneWay))
+        let sdk = try makeConfigurableSDK(ongoingEngagement: .mock(source: .callVisualizer, media: .init(audio: nil, video: .oneWay)), enqueueingEngagement: .videoCall) { sdk in
+            sdk.rootCoordinator?.gliaViewController = .mock()
+            sdk.environment.snackBar.present = { _, _, _, _, _, _, _ in
+            }
+            var callVisualizerEnv = CallVisualizer.Environment.mock
+            callVisualizerEnv.getCurrentEngagement = {
+                .mock(source: .callVisualizer, media: .init(audio: nil, video: .oneWay))
+            }
+            sdk.callVisualizer = .init(environment: callVisualizerEnv)
+            sdk.callVisualizer.coordinator.environment.eventHandler = { calledCVEvents.append($0) }
         }
-        sdk.rootCoordinator = .mock(interactor: interactor)
-        sdk.rootCoordinator?.gliaViewController = .mock()
-        sdk.environment.snackBar.present = { _, _, _, _, _, _, _ in
-        }
-        var callVisualizerEnv = CallVisualizer.Environment.mock
-        callVisualizerEnv.getCurrentEngagement = {
-            .mock(source: .callVisualizer, media: .init(audio: nil, video: .oneWay))
-        }
-        sdk.callVisualizer = .init(environment: callVisualizerEnv)
-        var calledEvents: [CallVisualizer.Coordinator.DelegateEvent] = []
-        sdk.callVisualizer.coordinator.environment.eventHandler = { calledEvents.append($0) }
-
-        sdk.resolveEngagementState(
-            engagementKind: .videoCall,
-            sceneProvider: .none,
-            configuration: .mock(),
-            interactor: interactor,
-            features: .all,
-            viewFactory: .mock(),
-            ongoingEngagementMediaStreams: .none
-        )
-
-        XCTAssertTrue(calledEvents.contains(.maximized))
+        XCTAssertTrue(calledCVEvents.contains(.maximized))
     }
 }
 
 // MARK: - Enqueuing engagement with ongoing engagement
 private extension GliaTests {
     func test_testEnqueuingChatWhenOngoingVideoEngagementExistsShouldShowSnackBar() throws {
-        enum Call {
-            case presentSnackBar
-        }
-        var calls: [Call] = []
-        var snackBarMessage: String?
-
-        let sdk = makeConfigurableSDK()
-
-        try sdk.configure(
-            with: .mock(),
-            theme: .mock()
-        ) { _ in }
-
-        let interactor: Interactor = .mock()
-
-        sdk.interactor = interactor
-        sdk.environment.coreSdk.getCurrentEngagement = {
-            .mock(source: .coreEngagement, media: .init(audio: nil, video: .oneWay))
-        }
-        sdk.rootCoordinator = .mock(interactor: interactor)
-        sdk.rootCoordinator?.gliaViewController = .mock()
-        sdk.environment.snackBar.present = { message, _, _, _, _, _, _ in
-            snackBarMessage = message
-            calls.append(.presentSnackBar)
-        }
-
-        sdk.resolveEngagementState(
-            engagementKind: .chat,
-            sceneProvider: .none,
-            configuration: .mock(),
-            interactor: interactor,
-            features: .all,
-            viewFactory: .mock(),
-            ongoingEngagementMediaStreams: .none
-        )
-
-        XCTAssertEqual(calls, [.presentSnackBar])
-        XCTAssertEqual(snackBarMessage, Localization.EntryWidget.CallVisualizer.description)
+        try testSnackBarPresentation(ongoingEngagement: .mock(source: .coreEngagement, media: .init(audio: nil, video: .oneWay)), enqueueingEngagement: .chat)
     }
 
     func test_testEnqueuingSCWhenOngoingVideoEngagementExistsShouldShowSnackBar() throws {
-        enum Call {
-            case presentSnackBar
-        }
-        var calls: [Call] = []
-        var snackBarMessage: String?
-
-        let sdk = makeConfigurableSDK()
-
-        try sdk.configure(
-            with: .mock(),
-            theme: .mock()
-        ) { _ in }
-
-        let interactor: Interactor = .mock()
-
-        sdk.interactor = interactor
-        sdk.environment.coreSdk.getCurrentEngagement = {
-            .mock(source: .coreEngagement, media: .init(audio: nil, video: .oneWay))
-        }
-        sdk.rootCoordinator = .mock(interactor: interactor)
-        sdk.rootCoordinator?.gliaViewController = .mock()
-        sdk.environment.snackBar.present = { message, _, _, _, _, _, _ in
-            snackBarMessage = message
-            calls.append(.presentSnackBar)
-        }
-
-        sdk.resolveEngagementState(
-            engagementKind: .messaging(.welcome),
-            sceneProvider: .none,
-            configuration: .mock(),
-            interactor: interactor,
-            features: .all,
-            viewFactory: .mock(),
-            ongoingEngagementMediaStreams: .none
-        )
-
-        XCTAssertEqual(calls, [.presentSnackBar])
-        XCTAssertEqual(snackBarMessage, Localization.EntryWidget.CallVisualizer.description)
+        try testSnackBarPresentation(ongoingEngagement: .mock(source: .coreEngagement, media: .init(audio: nil, video: .twoWay)), enqueueingEngagement: .messaging(.welcome))
     }
 
     func test_testEnqueuingChatWhenOngoingAudioEngagementExistsShouldShowSnackBar() throws {
-        enum Call {
-            case presentSnackBar
-        }
-        var calls: [Call] = []
-        var snackBarMessage: String?
-
-        let sdk = makeConfigurableSDK()
-
-        try sdk.configure(
-            with: .mock(),
-            theme: .mock()
-        ) { _ in }
-
-        let interactor: Interactor = .mock()
-
-        sdk.interactor = interactor
-        sdk.environment.coreSdk.getCurrentEngagement = {
-            .mock(source: .coreEngagement, media: .init(audio: .twoWay, video: nil))
-        }
-        sdk.rootCoordinator = .mock(interactor: interactor)
-        sdk.rootCoordinator?.gliaViewController = .mock()
-        sdk.environment.snackBar.present = { message, _, _, _, _, _, _ in
-            snackBarMessage = message
-            calls.append(.presentSnackBar)
-        }
-
-        sdk.resolveEngagementState(
-            engagementKind: .chat,
-            sceneProvider: .none,
-            configuration: .mock(),
-            interactor: interactor,
-            features: .all,
-            viewFactory: .mock(),
-            ongoingEngagementMediaStreams: .none
-        )
-
-        XCTAssertEqual(calls, [.presentSnackBar])
-        XCTAssertEqual(snackBarMessage, Localization.EntryWidget.CallVisualizer.description)
+        try testSnackBarPresentation(ongoingEngagement: .mock(source: .coreEngagement, media: .init(audio: .twoWay, video: nil)), enqueueingEngagement: .chat)
     }
     
     func test_testEnqueuingSCWhenOngoingAudioEngagementExistsShouldShowSnackBar() throws {
-        enum Call {
-            case presentSnackBar
-        }
-        var calls: [Call] = []
-        var snackBarMessage: String?
-
-        let sdk = makeConfigurableSDK()
-
-        try sdk.configure(
-            with: .mock(),
-            theme: .mock()
-        ) { _ in }
-
-        let interactor: Interactor = .mock()
-
-        sdk.interactor = interactor
-        sdk.environment.coreSdk.getCurrentEngagement = {
-            .mock(source: .coreEngagement, media: .init(audio: .twoWay, video: nil))
-        }
-        sdk.rootCoordinator = .mock(interactor: interactor)
-        sdk.rootCoordinator?.gliaViewController = .mock()
-        sdk.environment.snackBar.present = { message, _, _, _, _, _, _ in
-            snackBarMessage = message
-            calls.append(.presentSnackBar)
-        }
-
-        sdk.resolveEngagementState(
-            engagementKind: .chat,
-            sceneProvider: .none,
-            configuration: .mock(),
-            interactor: interactor,
-            features: .all,
-            viewFactory: .mock(),
-            ongoingEngagementMediaStreams: .none
-        )
-
-        XCTAssertEqual(calls, [.presentSnackBar])
-        XCTAssertEqual(snackBarMessage, Localization.EntryWidget.CallVisualizer.description)
+        try testSnackBarPresentation(ongoingEngagement: .mock(source: .coreEngagement, media: .init(audio: .twoWay, video: nil)), enqueueingEngagement: .messaging(.welcome))
     }
     
     func test_testEnqueuingAudioWhenOngoingChatEngagementExistsShouldShowSnackBar() throws {
+        try testSnackBarPresentation(ongoingEngagement: .mock(source: .coreEngagement), enqueueingEngagement: .audioCall)
+    }
+    
+    func test_testEnqueuingVideoWhenOngoingChatEngagementExistsShouldShowSnackBar() throws {
+        try testSnackBarPresentation(ongoingEngagement: .mock(source: .coreEngagement), enqueueingEngagement: .videoCall)
+    }
+    
+    func testSnackBarPresentation(ongoingEngagement: CoreSdkClient.Engagement, enqueueingEngagement: EngagementKind) throws {
         enum Call {
             case presentSnackBar
         }
         var calls: [Call] = []
         var snackBarMessage: String?
 
-        let sdk = makeConfigurableSDK()
-
-        try sdk.configure(
-            with: .mock(),
-            theme: .mock()
-        ) { _ in }
-
-        let interactor: Interactor = .mock()
-
-        sdk.interactor = interactor
-        sdk.environment.coreSdk.getCurrentEngagement = {
-            .mock(source: .coreEngagement)
+        let sdk = try makeConfigurableSDK(ongoingEngagement: ongoingEngagement, enqueueingEngagement: enqueueingEngagement) { sdk in
+            sdk.environment.snackBar.present = { message, _, _, _, _, _, _ in
+                snackBarMessage = message
+                calls.append(.presentSnackBar)
+            }
         }
-        sdk.rootCoordinator = .mock(interactor: interactor)
-        sdk.rootCoordinator?.gliaViewController = .mock()
-        sdk.environment.snackBar.present = { message, _, _, _, _, _, _ in
-            snackBarMessage = message
-            calls.append(.presentSnackBar)
-        }
-
-        sdk.resolveEngagementState(
-            engagementKind: .audioCall,
-            sceneProvider: .none,
-            configuration: .mock(),
-            interactor: interactor,
-            features: .all,
-            viewFactory: .mock(),
-            ongoingEngagementMediaStreams: .none
-        )
 
         XCTAssertEqual(calls, [.presentSnackBar])
         XCTAssertEqual(snackBarMessage, Localization.EntryWidget.CallVisualizer.description)
     }
     
-    func test_testEnqueuingVideoWhenOngoingChatEngagementExistsShouldShowSnackBar() throws {
-        enum Call {
-            case presentSnackBar
-        }
-        var calls: [Call] = []
-        var snackBarMessage: String?
-
+    func makeConfigurableSDK(
+        ongoingEngagement: CoreSdkClient.Engagement,
+        enqueueingEngagement: EngagementKind,
+        extendedConfigure: @escaping (Glia) -> ()
+    ) throws -> Glia {
         let sdk = makeConfigurableSDK()
 
         try sdk.configure(
@@ -588,17 +184,15 @@ private extension GliaTests {
 
         sdk.interactor = interactor
         sdk.environment.coreSdk.getCurrentEngagement = {
-            .mock(source: .coreEngagement)
+            ongoingEngagement
         }
         sdk.rootCoordinator = .mock(interactor: interactor)
         sdk.rootCoordinator?.gliaViewController = .mock()
-        sdk.environment.snackBar.present = { message, _, _, _, _, _, _ in
-            snackBarMessage = message
-            calls.append(.presentSnackBar)
-        }
+
+        extendedConfigure(sdk)
 
         sdk.resolveEngagementState(
-            engagementKind: .videoCall,
+            engagementKind: enqueueingEngagement,
             sceneProvider: .none,
             configuration: .mock(),
             interactor: interactor,
@@ -607,8 +201,154 @@ private extension GliaTests {
             ongoingEngagementMediaStreams: .none
         )
 
+        return sdk
+    }
+}
+
+// MARK: - Enqueuing engagement with enqueued engagement
+extension GliaTests {
+    func test_testEnqueuingChatWhenEnqueuedChatEngagementExistsShouldMaximizeBubble() throws {
+        try testBubbleRestoration(enqueueingEngagementKind: .chat, engagementToEnqueue: .chat)
+    }
+    
+    func test_testEnqueuingMessagingWhenEnqueuedChatEngagementExistsShouldMaximizeBubble() throws {
+        try testBubbleRestoration(enqueueingEngagementKind: .messaging(.welcome), engagementToEnqueue: .chat)
+    }
+    
+    func test_testEnqueuingChatWhenEnqueuedMessagingEngagementExistsShouldMaximizeBubble() throws {
+        try testBubbleRestoration(enqueueingEngagementKind: .chat, engagementToEnqueue: .messaging(.welcome))
+    }
+    
+    func test_testEnqueuingMessagingWhenEnqueuedMessagingEngagementExistsShouldMaximizeBubble() throws {
+        try testBubbleRestoration(enqueueingEngagementKind: .messaging(.welcome), engagementToEnqueue: .messaging(.welcome))
+    }
+    
+    func test_testEnqueuingChatWhenEnqueuedAudioEngagementExistsShouldShowSnackBar() throws {
+        try testSnackBarPresentation(enqueueingEngagementKind: .chat, engagementToEnqueue: .audioCall)
+    }
+    
+    func test_testEnqueuingMessagingWhenEnqueuedAudioEngagementExistsShouldShowSnackBar() throws {
+        try testSnackBarPresentation(enqueueingEngagementKind: .messaging(.welcome), engagementToEnqueue: .audioCall)
+    }
+    
+    func test_testEnqueuingChatWhenEnqueuedVideoEngagementExistsShouldShowSnackBar() throws {
+        try testSnackBarPresentation(enqueueingEngagementKind: .chat, engagementToEnqueue: .videoCall)
+    }
+    
+    func test_testEnqueuingMessagingWhenEnqueuedVideoEngagementExistsShouldShowSnackBar() throws {
+        try testSnackBarPresentation(enqueueingEngagementKind: .chat, engagementToEnqueue: .videoCall)
+    }
+    
+    func test_testEnqueuingAudioWhenEnqueuedAudioEngagementExistsShouldMaximizeBubble() throws {
+        try testBubbleRestoration(enqueueingEngagementKind: .audioCall, engagementToEnqueue: .audioCall)
+    }
+    
+    func test_testEnqueuingVideoWhenEnqueuedAudioEngagementExistsShouldMaximizeBubble() throws {
+        try testBubbleRestoration(enqueueingEngagementKind: .videoCall, engagementToEnqueue: .audioCall)
+    }
+    
+    func test_testEnqueuingAudioWhenEnqueuedVideoEngagementExistsShouldMaximizeBubble() throws {
+        try testBubbleRestoration(enqueueingEngagementKind: .audioCall, engagementToEnqueue: .videoCall)
+    }
+    
+    func test_testEnqueuingVideoWhenEnqueuedVideoEngagementExistsShouldMaximizeBubble() throws {
+        try testBubbleRestoration(enqueueingEngagementKind: .videoCall, engagementToEnqueue: .videoCall)
+    }
+    
+    func test_testEnqueuingAudioWhenEnqueuedChatEngagementExistsShouldShowSnackBar() throws {
+        try testSnackBarPresentation(enqueueingEngagementKind: .audioCall, engagementToEnqueue: .chat)
+    }
+    
+    func test_testEnqueuingVideoWhenEnqueuedChatEngagementExistsShouldShowSnackBar() throws {
+        try testSnackBarPresentation(enqueueingEngagementKind: .videoCall, engagementToEnqueue: .chat)
+    }
+    
+    func test_testEnqueuingAudioWhenEnqueuedMessagingEngagementExistsShouldShowSnackBar() throws {
+        try testSnackBarPresentation(enqueueingEngagementKind: .audioCall, engagementToEnqueue: .messaging(.welcome))
+    }
+    
+    func test_testEnqueuingVideoWhenEnqueuedMessagingEngagementExistsShouldShowSnackBar() throws {
+        try testSnackBarPresentation(enqueueingEngagementKind: .videoCall, engagementToEnqueue: .messaging(.welcome))
+    }
+    
+    private func testBubbleRestoration(
+        enqueueingEngagementKind: EngagementKind,
+        engagementToEnqueue: EngagementKind
+    ) throws {
+        let delegate = GliaViewControllerDelegateMock()
+        
+        let sdk = try makeConfigurableSDK(
+            enqueueingEngagementKind: enqueueingEngagementKind,
+            engagementToEnqueue: engagementToEnqueue
+        ) { sdk in
+            let coordinator = EngagementCoordinator.mock()
+            let gliaVC = GliaViewController.mock(delegate: { event in
+                delegate.event(event)
+            })
+            coordinator.gliaViewController = gliaVC
+            sdk.rootCoordinator = coordinator
+        }
+        
+        XCTAssertEqual(delegate.invokedEventCallParameter, .maximized)
+        XCTAssertEqual(delegate.invokedEventCallParameterList, [.maximized])
+    }
+    
+    private func testSnackBarPresentation(
+        enqueueingEngagementKind: EngagementKind,
+        engagementToEnqueue: EngagementKind
+    ) throws {
+        enum Call {
+            case presentSnackBar
+        }
+        var calls: [Call] = []
+        var snackBarMessage: String?
+        
+        let sdk = try makeConfigurableSDK(
+            enqueueingEngagementKind: enqueueingEngagementKind,
+            engagementToEnqueue: engagementToEnqueue
+        ) { sdk in
+            sdk.environment.snackBar.present = { message, _, _, _, _, _, _ in
+                snackBarMessage = message
+                calls.append(.presentSnackBar)
+            }
+        }
+        
         XCTAssertEqual(calls, [.presentSnackBar])
         XCTAssertEqual(snackBarMessage, Localization.EntryWidget.CallVisualizer.description)
+    }
+    
+    private func makeConfigurableSDK(
+        enqueueingEngagementKind: EngagementKind,
+        engagementToEnqueue: EngagementKind,
+        extendedConfigure: @escaping (Glia) -> ()
+    ) throws -> Glia {
+        let sdk = makeConfigurableSDK()
+
+        try sdk.configure(
+            with: .mock(),
+            theme: .mock()
+        ) { _ in }
+
+        let interactor: Interactor = .mock()
+
+        sdk.interactor = interactor
+        sdk.interactor?.state = .enqueueing(enqueueingEngagementKind)
+        sdk.rootCoordinator = .mock(interactor: interactor)
+        sdk.rootCoordinator?.gliaViewController = .mock()
+
+        extendedConfigure(sdk)
+
+        sdk.resolveEngagementState(
+            engagementKind: engagementToEnqueue,
+            sceneProvider: .none,
+            configuration: .mock(),
+            interactor: interactor,
+            features: .all,
+            viewFactory: .mock(),
+            ongoingEngagementMediaStreams: .none
+        )
+
+        return sdk
     }
 }
 


### PR DESCRIPTION
**What was solved?**
This PR implements EngagementLauncher enqueuing logic
- Show already in contact snackbar for chat/SC enqueueing if audio/video already enqueued
- Maximize bubble for chat/SC enqueueing if chat/SC already enqueued
- Show already in contact snackbar for audio/video enqueueing if chat/SC already enqueued
- Maximize bubble for audio/video enqueueing if audio/video already enqueued

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [X] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
