### PR TITLE
Fix restoring engagement when `hasPendingInteraction` is `true`

### DIFF
--- a/GliaWidgets/Public/Glia/Glia+EngagementSetup.swift
+++ b/GliaWidgets/Public/Glia/Glia+EngagementSetup.swift
@@ -171,6 +171,9 @@ extension Glia {
             // then open ChatTranscript screen.
             engagementLaunching = .direct(kind: .messaging(.chatTranscript))
 
+        case (true, .messaging(.chatTranscript)):
+            engagementLaunching = .direct(kind: .messaging(.chatTranscript))
+
         case (true, _):
             // if there is pending Secure Conversation and requested `EngagementKind` is not messaging,
             // then open ChatTranscript screen and present Leave Current Conversation dialog.

--- a/GliaWidgets/Public/Glia/Glia+RestoreEngagement.swift
+++ b/GliaWidgets/Public/Glia/Glia+RestoreEngagement.swift
@@ -58,11 +58,16 @@ extension Glia {
             video: nil
         )
 
+        var engagementKind = EngagementKind(media: ongoingEngagementMediaStreams)
+        if pendingInteraction?.hasPendingInteraction == true {
+            engagementKind = .messaging(.chatTranscript)
+        }
+
         startRootCoordinator(
             with: interactor,
             viewFactory: viewFactory,
             sceneProvider: nil,
-            engagementKind: EngagementKind(media: ongoingEngagementMediaStreams),
+            engagementKind: engagementKind,
             features: features,
             maximize: maximize
         )

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
@@ -10,7 +10,7 @@ extension EngagementCoordinator {
     /// one of `[.chat, . audioCall, .videoCall]`, then `EngagementCoordinator` opens
     /// ChatTranscript screen and shows Leave Engagement Dialog. Then if user presses "Leave" button,
     /// `EngagementCoordinator` replaces current screen with the one corresponding to initial `EngagementKind`.
-    enum EngagementLaunching {
+    enum EngagementLaunching: Equatable {
         case direct(kind: EngagementKind)
         case indirect(kind: EngagementKind, initialKind: EngagementKind)
 

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+RestoreEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+RestoreEngagement.swift
@@ -200,4 +200,63 @@ extension GliaTests {
 
         XCTAssertNil(sdk.rootCoordinator?.gliaViewController)
     }
+
+    func test_sdkRestoresMessagingWhenOngoingEngagementExistsAndPendingInteractionIsTrue() throws {
+        var sdkEnv = Glia.Environment.failing
+        sdkEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
+        var launching: EngagementCoordinator.EngagementLaunching?
+        sdkEnv.createRootCoordinator = { _, _, _, engagementLaunching, _, _, _ in
+            launching = engagementLaunching
+            return EngagementCoordinator.mock(
+                engagementLaunching: engagementLaunching,
+                screenShareHandler: .mock,
+                environment: .engagementCoordEnvironmentWithKeyWindow
+            )
+        }
+        sdkEnv.print.printClosure = { _, _, _ in }
+        var logger = CoreSdkClient.Logger.failing
+        logger.configureLocalLogLevelClosure = { _ in }
+        logger.configureRemoteLogLevelClosure = { _ in }
+        logger.prefixedClosure = { _ in logger }
+        logger.infoClosure = { _, _, _, _ in }
+        sdkEnv.coreSdk.createLogger = { _ in logger }
+        let siteMock = try CoreSdkClient.Site.mock()
+        sdkEnv.coreSdk.fetchSiteConfigurations = { callback in callback(.success(siteMock)) }
+        sdkEnv.coreSdk.pendingSecureConversationStatus = { _ in }
+        sdkEnv.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
+        sdkEnv.conditionalCompilation.isDebug = { true }
+        sdkEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
+            completion(.success(()))
+        }
+        sdkEnv.snackBar.present = { _, _, _, _, _, _, _ in }
+        let uuidGen = UUID.incrementing
+        sdkEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in uuidGen().uuidString }
+        sdkEnv.coreSdk.observePendingSecureConversationStatus = { callback in
+            callback(.success(true))
+            return uuidGen().uuidString
+        }
+        sdkEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
+        sdkEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        sdkEnv.gcd.mainQueue.async = { $0() }
+
+        let window = UIWindow(frame: .zero)
+        window.rootViewController = .init()
+        window.makeKeyAndVisible()
+        sdkEnv.uiApplication.windows = { [window] }
+
+        let sdk = Glia(environment: sdkEnv)
+        try sdk.configure(with: .mock(), features: .all) { _ in }
+        sdk.environment.coreSdk.getCurrentEngagement = { .mock() }
+        sdk.stringProvidingPhase = .configured { _ in
+            return ""
+        }
+        guard let interactor = sdk.interactor else {
+            XCTFail("Interactor missing")
+            return
+        }
+        interactor.state = .engaged(.mock())
+
+        XCTAssertNotNil(sdk.rootCoordinator?.gliaViewController)
+        XCTAssertEqual(launching, .direct(kind: .messaging(.chatTranscript)))
+    }
 }


### PR DESCRIPTION
MOB-4003

**What was solved?**
PR fixes restoring engagement when `hasPendingInteraction` is `true`

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
