### PR TITLE
Fix viewModel migration on `retain`

### DIFF
--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.Environment.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.Environment.swift
@@ -31,8 +31,12 @@ extension SecureConversations.TranscriptModel {
         var createSendMessagePayload: CoreSdkClient.CreateSendMessagePayload
         var log: CoreSdkClient.Logger
         var maximumUploads: () -> Int
-        var shouldShowLeaveSecureConversationDialog: Bool
-        var leaveCurrentSecureConversation: Cmd
+        var shouldShowLeaveSecureConversationDialog: () -> Bool
+        /// The value returning by the command corresponds to decision made by visitor
+        /// whether to leave current conversation:
+        /// - `true` - visitor decided to leave the conversation;
+        /// - `false` - visitor decided to stay;
+        var leaveCurrentSecureConversation: Command<Bool>
         var createEntryWidget: EntryWidgetBuilder
         var switchToEngagement: Command<EngagementKind>
         var topBannerItemsStyle: EntryWidgetStyle.MediaTypeItemsStyle
@@ -122,8 +126,8 @@ extension SecureConversations.TranscriptModel.Environment {
         createSendMessagePayload: @escaping CoreSdkClient.CreateSendMessagePayload = { _, _ in .mock() },
         log: CoreSdkClient.Logger = .mock,
         maximumUploads: @escaping () -> Int = { .zero },
-        shouldShowLeaveSecureConversationDialog: Bool = false,
-        leaveCurrentSecureConversation: Cmd = .nop,
+        shouldShowLeaveSecureConversationDialog: @escaping () -> Bool = { false },
+        leaveCurrentSecureConversation: Command<Bool> = .nop,
         createEntryWidget: @escaping EntryWidgetBuilder = { _ in .mock() },
         switchToEngagement: Command<EngagementKind> = .nop,
         // swiftlint:disable:next line_length

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.LeaveConversation.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.LeaveConversation.swift
@@ -14,16 +14,17 @@ extension SecureConversations.TranscriptModel {
                 }
             }
         }
-        guard environment.shouldShowLeaveSecureConversationDialog else {
+        guard environment.shouldShowLeaveSecureConversationDialog() else {
             handleInteractorState()
             return
         }
         let action = EngagementViewModel.Action.showAlert(
             .leaveCurrentConversation(
                 confirmed: { [weak self] in
-                    self?.environment.leaveCurrentSecureConversation()
+                    self?.environment.leaveCurrentSecureConversation(true)
                 }, declined: { [weak self] in
                     guard let self else { return }
+                    environment.leaveCurrentSecureConversation(false)
                     handleInteractorState()
                     markMessagesAsRead(with: self.hasUnreadMessages)
                 }

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
@@ -574,7 +574,7 @@ extension SecureConversations.TranscriptModel {
                 self.action?(.scrollToBottom(animated: false))
                 completion(messagesWithUnreadCount.messages)
                 markMessagesAsRead(
-                    with: self.hasUnreadMessages && !environment.shouldShowLeaveSecureConversationDialog
+                    with: self.hasUnreadMessages && !environment.shouldShowLeaveSecureConversationDialog()
                 )
 
                 if let item = items.last, case .gvaQuickReply(_, let button, _, _) = item.kind {
@@ -901,6 +901,7 @@ extension SecureConversations.TranscriptModel {
         // Since we only need to start socket observation,
         // we skip chat transcript loading.
         start(isTranscriptFetchNeeded: false)
+        showLeaveConversationDialogIfNeeded()
     }
 
     func clearSections(_ sections: [Section<ChatItem>]) {

--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.Environment.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.Environment.swift
@@ -52,8 +52,12 @@ extension SecureConversations.Coordinator {
         var alertManager: AlertManager
         var queuesMonitor: QueuesMonitor
         var createEntryWidget: EntryWidgetBuilder
-        var shouldShowLeaveSecureConversationDialog: Bool
-        var leaveCurrentSecureConversation: Cmd
+        var shouldShowLeaveSecureConversationDialog: () -> Bool
+        /// The value returning by the command corresponds to decision made by visitor
+        /// whether to leave current conversation:
+        /// - `true` - visitor decided to leave the conversation;
+        /// - `false` - visitor decided to stay;
+        var leaveCurrentSecureConversation: Command<Bool>
         var switchToEngagement: Command<EngagementKind>
         var markUnreadMessagesDelay: () -> DispatchQueue.SchedulerTimeType.Stride
         var combineScheduler: CombineBased.CombineScheduler
@@ -71,8 +75,8 @@ extension SecureConversations.Coordinator.Environment {
         screenShareHandler: ScreenShareHandler,
         isWindowVisible: ObservableValue<Bool>,
         interactor: Interactor,
-        shouldShowLeaveSecureConversationDialog: Bool,
-        leaveCurrentSecureConversation: Cmd,
+        shouldShowLeaveSecureConversationDialog: @escaping () -> Bool,
+        leaveCurrentSecureConversation: Command<Bool>,
         switchToEngagement: Command<EngagementKind>
     ) -> Self {
         .init(

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
@@ -44,8 +44,12 @@ extension ChatCoordinator {
         var alertManager: AlertManager
         var queuesMonitor: QueuesMonitor
         var createEntryWidget: EntryWidgetBuilder
-        var shouldShowLeaveSecureConversationDialog: Bool
-        var leaveCurrentSecureConversation: Cmd
+        var shouldShowLeaveSecureConversationDialog: () -> Bool
+        /// The value returning by the command corresponds to decision made by visitor
+        /// whether to leave current conversation:
+        /// - `true` - visitor decided to leave the conversation;
+        /// - `false` - visitor decided to stay;
+        var leaveCurrentSecureConversation: Command<Bool>
         var switchToEngagement: Command<EngagementKind>
         var markUnreadMessagesDelay: () -> DispatchQueue.SchedulerTimeType.Stride
         var combineScheduler: CombineBased.CombineScheduler
@@ -56,8 +60,8 @@ extension ChatCoordinator.Environment {
     static func create(
         with environment: EngagementCoordinator.Environment,
         interactor: Interactor,
-        shouldShowLeaveSecureConversationDialog: Bool,
-        leaveCurrentSecureConversation: Cmd,
+        shouldShowLeaveSecureConversationDialog: @escaping () -> Bool,
+        leaveCurrentSecureConversation: Command<Bool>,
         switchToEngagement: Command<EngagementKind>
     ) -> Self {
         .init(

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModel.Environment.Failing.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModel.Environment.Failing.swift
@@ -77,8 +77,8 @@ extension SecureConversations.TranscriptModel.Environment {
             fail("\(Self.self).maximumUploads")
             return 2
         },
-        shouldShowLeaveSecureConversationDialog: false,
-        leaveCurrentSecureConversation: .init {
+        shouldShowLeaveSecureConversationDialog: { false },
+        leaveCurrentSecureConversation: .init { _ in
             fail("\(Self.self).leaveCurrentSecureConversation")
         },
         createEntryWidget: { _ in

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests.swift
@@ -811,7 +811,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             expectation.fulfill()
             return .mock
         }
-        modelEnv.shouldShowLeaveSecureConversationDialog = false
+        modelEnv.shouldShowLeaveSecureConversationDialog = { false }
         modelEnv.markUnreadMessagesDelay = { .zero }
         modelEnv.notificationCenter.publisherForNotification = { _ in
             Empty<Notification, Never>().eraseToAnyPublisher()
@@ -872,7 +872,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             expectation.fulfill()
             return .mock
         }
-        modelEnv.shouldShowLeaveSecureConversationDialog = true
+        modelEnv.shouldShowLeaveSecureConversationDialog = { true }
         modelEnv.markUnreadMessagesDelay = { .zero }
 
         let availabilityEnv = SecureConversations.Availability.Environment(
@@ -929,7 +929,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             expectation.fulfill()
             return .mock
         }
-        modelEnv.shouldShowLeaveSecureConversationDialog = true
+        modelEnv.shouldShowLeaveSecureConversationDialog = { true }
+        modelEnv.leaveCurrentSecureConversation = .nop
         modelEnv.markUnreadMessagesDelay = { .zero }
         modelEnv.notificationCenter.publisherForNotification = { _ in
             Empty<Notification, Never>().eraseToAnyPublisher()
@@ -998,7 +999,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.fetchChatHistory = { completion in
             completion(.success([.mock()]))
         }
-        modelEnv.shouldShowLeaveSecureConversationDialog = false
+        modelEnv.shouldShowLeaveSecureConversationDialog = { false }
         let scheduler = CoreSdkClient.ReactiveSwift.TestScheduler()
         modelEnv.messagesWithUnreadCountLoaderScheduler = scheduler
         modelEnv.interactor = interactor

--- a/GliaWidgetsTests/SecureConversations/Coordinator/SecureConversations.Coordinator.Environment.Mock.swift
+++ b/GliaWidgetsTests/SecureConversations/Coordinator/SecureConversations.Coordinator.Environment.Mock.swift
@@ -56,7 +56,7 @@ extension SecureConversations.Coordinator.Environment {
         alertManager: .mock(),
         queuesMonitor: .mock(),
         createEntryWidget: { _ in .mock() },
-        shouldShowLeaveSecureConversationDialog: false,
+        shouldShowLeaveSecureConversationDialog: { false },
         leaveCurrentSecureConversation: .nop,
         switchToEngagement: .nop,
         markUnreadMessagesDelay: { .mock },

--- a/GliaWidgetsTests/Sources/Coordinators/Chat/ChatCoordinator.Environment.Mock.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/Chat/ChatCoordinator.Environment.Mock.swift
@@ -45,7 +45,7 @@ extension ChatCoordinator.Environment {
         alertManager: .mock(),
         queuesMonitor: .mock(), 
         createEntryWidget: { _ in .mock() },
-        shouldShowLeaveSecureConversationDialog: false,
+        shouldShowLeaveSecureConversationDialog: { false },
         leaveCurrentSecureConversation: .nop,
         switchToEngagement: .nop,
         markUnreadMessagesDelay: { .mock },

--- a/GliaWidgetsTests/Sources/Coordinators/Chat/ChatCoordinatorTests.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/Chat/ChatCoordinatorTests.swift
@@ -514,6 +514,38 @@ final class ChatCoordinatorTests: XCTestCase {
         }
 
         XCTAssertEqual(chatModel.isViewLoaded, transcriptModel.isViewLoaded)
+        enum Call {
+            case setChoiceCardInputModeEnabled
+            case appendRows
+            case refreshAll
+            case scrollToBottom
+            case updateItemsUserImage
+        }
+
+        var calls: [Call] = []
+
+        // Check if TranscriptModel subscribed on interactor events
+        transcriptModel.action = { action in
+            switch action {
+            case .appendRows:
+                calls.append(.appendRows)
+            case .refreshAll:
+                calls.append(.refreshAll)
+            case .updateItemsUserImage:
+                calls.append(.updateItemsUserImage)
+            case .setChoiceCardInputModeEnabled:
+                calls.append(.setChoiceCardInputModeEnabled)
+            case .scrollToBottom:
+                calls.append(.scrollToBottom)
+            default:
+                XCTFail("Unexpected action \(action)")
+            }
+        }
+        transcriptModel.environment.interactor.receive(message: .mock(sender: .init(type: .operator)))
+
+        XCTAssertEqual(calls, [
+            .appendRows, .updateItemsUserImage, .setChoiceCardInputModeEnabled, .scrollToBottom
+        ])
     }
 
     func test_chatTypeWhenSkipTransferredSCHandlingIsFalseAndTransferredScExists() {

--- a/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinatorSecureConversationsTests.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinatorSecureConversationsTests.swift
@@ -75,9 +75,31 @@ extension EngagementCoordinatorTests {
 
         XCTAssertEqual(coordinator.engagementLaunching.currentKind, .messaging(.chatTranscript))
         XCTAssertEqual(coordinator.engagementLaunching.initialKind, .videoCall)
+        XCTAssertTrue(subCoordinator.coordinatorEnvironment.shouldShowLeaveSecureConversationDialog())
 
-        subCoordinator.coordinatorEnvironment.leaveCurrentSecureConversation()
+        subCoordinator.coordinatorEnvironment.leaveCurrentSecureConversation(true)
 
         XCTAssertEqual(coordinator.engagementLaunching.currentKind, .videoCall)
+        XCTAssertFalse(subCoordinator.coordinatorEnvironment.shouldShowLeaveSecureConversationDialog())
+    }
+
+    // MARK: - Leave Conversation
+    func test_leaveCurrentConversationDeclineSetsEngagementKindToMessaging() throws {
+        coordinator = createCoordinator(with: .indirect(
+            kind: .messaging(.chatTranscript),
+            initialKind: .videoCall
+        ))
+        coordinator.start()
+
+        let subCoordinator = try XCTUnwrap(coordinator.coordinators.first as? SecureConversations.Coordinator)
+
+        XCTAssertEqual(coordinator.engagementLaunching.currentKind, .messaging(.chatTranscript))
+        XCTAssertEqual(coordinator.engagementLaunching.initialKind, .videoCall)
+        XCTAssertTrue(subCoordinator.coordinatorEnvironment.shouldShowLeaveSecureConversationDialog())
+
+        subCoordinator.coordinatorEnvironment.leaveCurrentSecureConversation(false)
+
+        XCTAssertEqual(coordinator.engagementLaunching.currentKind, .messaging(.chatTranscript))
+        XCTAssertFalse(subCoordinator.coordinatorEnvironment.shouldShowLeaveSecureConversationDialog())
     }
 }


### PR DESCRIPTION
MOB-4007

**What was solved?**
This PR:
- fixes TranscriptModel subscribing on interactor events on LiveChat-to-SC migration;
- fixes shouldShowLeaveSecureConversationDialog value calculation;
- adds unit tests

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.