### PR TITLE
Add observing of hasPendingInteraction in EntryWidget

### DIFF
--- a/GliaWidgets/Public/Glia/Glia+EntryWidget.swift
+++ b/GliaWidgets/Public/Glia/Glia+EntryWidget.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 
 extension Glia {
     /// Retrieves an instance of `EntryWidget`.
@@ -24,10 +25,12 @@ extension Glia {
                 theme: theme,
                 log: loggerPhase.logger,
                 isAuthenticated: environment.isAuthenticated,
-                hasPendingInteraction: { [weak self] in
-                    guard let self else { return false }
-                    return pendingInteraction?.hasPendingInteraction ?? false
-                },
+                hasPendingInteractionPublisher: { [weak self] in
+                    guard let self, let pendingInteraction else {
+                        return Just(false).eraseToAnyPublisher()
+                    }
+                    return pendingInteraction.$hasPendingInteraction.eraseToAnyPublisher()
+                }(),
                 interactorPublisher: $interactor.eraseToAnyPublisher(),
                 onCallVisualizerResume: { [weak self] in
                     guard let self else { return }

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.Environment.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.Environment.swift
@@ -10,7 +10,7 @@ extension EntryWidget {
         var theme: Theme
         var log: CoreSdkClient.Logger
         var isAuthenticated: () -> Bool
-        var hasPendingInteraction: () -> Bool
+        var hasPendingInteractionPublisher: AnyPublisher<Bool, Never>
         var interactorPublisher: AnyPublisher<Interactor?, Never>
         var onCallVisualizerResume: () -> Void
     }
@@ -28,7 +28,7 @@ extension EntryWidget.Environment {
             theme: .mock(),
             log: .mock,
             isAuthenticated: { true },
-            hasPendingInteraction: { false },
+            hasPendingInteractionPublisher: .mock(false),
             interactorPublisher: .mock(nil),
             onCallVisualizerResume: {}
         )


### PR DESCRIPTION
MOB-4030

**What was solved?**
This PR introduces:
- subscription for `hasPendingInteraction` value;
- the logic for adding Messaging into the available media types in EntryWidget in case when `hasPendingInteraction` is `true`, even if it's unsupported by queue.
- unit test

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**