### PR TITLE
Fix Queue update subscription issue

### DIFF
--- a/GliaWidgets.podspec
+++ b/GliaWidgets.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   }
   s.exclude_files         = ['GliaWidgets/Window/**']
 
-  s.dependency 'GliaCoreSDK', '2.0.9'
+  s.dependency 'GliaCoreSDK', '2.0.1'
 end

--- a/GliaWidgets.podspec
+++ b/GliaWidgets.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   }
   s.exclude_files         = ['GliaWidgets/Window/**']
 
-  s.dependency 'GliaCoreSDK', '2.0.1'
+  s.dependency 'GliaCoreSDK', '2.0.10'
 end

--- a/GliaWidgets/Public/Glia/Glia+EngagementLauncher.swift
+++ b/GliaWidgets/Public/Glia/Glia+EngagementLauncher.swift
@@ -23,6 +23,9 @@ extension Glia {
                 loggerPhase.logger.prefixed(Self.self).warning("Interactor is missing")
                 throw GliaError.sdkIsNotConfigured
             }
+            // Interactor is initialized during configuration, which means that queueIds need
+            // to be set in interactor when EngagementLauncher is requested.
+            interactor.setQueuesIds(queueIds)
             return interactor
         }
 
@@ -38,8 +41,7 @@ extension Glia {
             guard let self else { return }
             let parameters = try getEngagementParameters(
                 configuration: getConfiguration(),
-                interactor: getInteractor(),
-                queueIds: queueIds
+                interactor: getInteractor()
             )
             self.resolveEngagementState(
                 engagementKind: engagementKind,

--- a/GliaWidgets/Public/Glia/Glia+EngagementSetup.swift
+++ b/GliaWidgets/Public/Glia/Glia+EngagementSetup.swift
@@ -5,13 +5,8 @@ extension Glia {
     /// Set up and returns parameters needed to start or restore engagement
     func getEngagementParameters(
         configuration: Configuration,
-        interactor: Interactor,
-        queueIds: [String] = []
+        interactor: Interactor
     ) -> EngagementParameters {
-        // Interactor is initialized during configuration, which means that queueIds need
-        // to be set in interactor when startEngagement is called.
-        interactor.setQueuesIds(queueIds)
-
         // It is assumed that `features` to be provided from `configure` or via deprecated `startEngagement` method.
         let features = self.features ?? []
 

--- a/GliaWidgets/SecureConversations/SecureConversations.Availability.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Availability.swift
@@ -17,7 +17,7 @@ extension SecureConversations {
                 environment.log.warning("Queue ID array for Secure Messaging contains invalid queue IDs: \(invalidIds).")
             }
 
-            environment.queuesMonitor.fetchAndMonitorQueues(queuesIds: queueIds) { result in
+            environment.queuesMonitor.fetchQueues(queuesIds: queueIds) { result in
                 switch result {
                 case .success(let queues):
                     self.checkQueues(fetchedQueues: queues, completion: completion)

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -471,14 +471,16 @@ extension CoreSdkClient.Queue {
         name: String = "",
         status: QueueStatus = .unknown,
         isDefault: Bool = false,
-        media: [MediaType] = []
+        media: [MediaType] = [],
+        lastUpdated: Date = Date()
     ) -> CoreSdkClient.Queue {
         CoreSdkClient.Queue(
             id: id,
             name: name,
             status: status,
             isDefault: isDefault,
-            media: media
+            media: media,
+            lastUpdated: lastUpdated
         )
     }
 }

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
@@ -230,14 +230,12 @@ private extension EntryWidget {
 
         viewModel.retryMonitoring = { [weak self] in
             self?.viewState = .loading
-            self?.environment.queuesMonitor.fetchAndMonitorQueues(queuesIds: self?.queueIds ?? [])
         }
 
         return viewModel
     }
 
     func showView(in parentView: UIView) {
-        self.environment.queuesMonitor.fetchAndMonitorQueues(queuesIds: self.queueIds)
         parentView.subviews.forEach { $0.removeFromSuperview() }
         let model = makeViewModel(showHeader: false)
         let view = makeView(model: model)
@@ -262,7 +260,6 @@ private extension EntryWidget {
     }
 
     func showSheet(in parentViewController: UIViewController) {
-        self.environment.queuesMonitor.fetchAndMonitorQueues(queuesIds: self.queueIds)
         let model = makeViewModel(showHeader: true)
         let view = makeView(model: model).accessibilityAction(.escape, {
             self.hide()
@@ -401,7 +398,7 @@ private extension EntryWidget {
         unreadSecureMessagesCount: Int?
     ) -> EntryWidget.ViewState {
         switch queuesMonitorState {
-        case .idle:
+        case .idle, .loading:
             return .loading
         case .updated(let queues):
             let availableEngagementTypes = resolveAvailableEngagementTypes(from: queues)

--- a/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModelSpec.swift
+++ b/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModelSpec.swift
@@ -610,7 +610,7 @@ extension SecureConversationsWelcomeViewModelTests {
         let uuid = UUID.mock.uuidString
         var availability = SecureConversations.Availability.mock
         availability.environment.listQueues = { completion in
-            let queue = CoreSdkClient.Queue(
+            let queue = CoreSdkClient.Queue.mock(
                 id: uuid,
                 name: "",
                 status: .open,
@@ -632,7 +632,7 @@ extension SecureConversationsWelcomeViewModelTests {
         let uuid = UUID.mock.uuidString
         var availability = SecureConversations.Availability.mock
         availability.environment.listQueues = { completion in
-            let queue = CoreSdkClient.Queue(
+            let queue = CoreSdkClient.Queue.mock(
                 id: uuid,
                 name: "",
                 status: .open,
@@ -676,7 +676,7 @@ extension SecureConversationsWelcomeViewModelTests {
         let uuid = UUID.mock.uuidString
         var availability = SecureConversations.Availability.mock
         availability.environment.listQueues = { completion in
-            let queue = CoreSdkClient.Queue(
+            let queue = CoreSdkClient.Queue.mock(
                 id: uuid,
                 name: "",
                 status: .open,

--- a/GliaWidgetsTests/Sources/QueuesMonitor/QueuesMonitorTests.swift
+++ b/GliaWidgetsTests/Sources/QueuesMonitor/QueuesMonitorTests.swift
@@ -71,7 +71,8 @@ class QueuesMonitorTests: XCTestCase {
             "Setting up queues. Using 1 default queues."
         ]
         var receivedLogMessage: [String] = []
-        let expectedObservedQueues = [Queue.mock(isDefault: true)]
+        let mockedQueue = Queue.mock(isDefault: true)
+        let expectedObservedQueues = [mockedQueue]
         let mockQueues = [expectedObservedQueues[0], Queue.mock()]
         monitor.environment.logger.infoClosure = { logMessage, _, _, _ in
             receivedLogMessage.append(logMessage as? String ?? "")
@@ -82,6 +83,7 @@ class QueuesMonitorTests: XCTestCase {
         }
         monitor.environment.subscribeForQueuesUpdates = { _, completion in
             envCalls.append(.subscribeForQueuesUpdates)
+            completion(.success(mockedQueue))
             return UUID().uuidString
         }
 

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
         ),
         .binaryTarget(
             name: "GliaCoreSDK",
-            url: "https://github.com/salemove/ios-bundle/releases/download/2.0.1/GliaCoreSDK.xcframework.zip",
+            url: "https://github.com/salemove/ios-bundle/releases/download/2.0.10/GliaCoreSDK.xcframework.zip",
             checksum: "ffa6b933d9e750420fc9f2b2768c023bf7655b6a545135b4cd1041074c586b48"
         ),
         .binaryTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -35,8 +35,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "GliaCoreSDK",
-            url: "https://github.com/salemove/ios-bundle/releases/download/2.0.9/GliaCoreSDK.xcframework.zip",
-            checksum: "263661f5d63ff5d01d8fce4b1eb2446ba10b04d613d7e2bbbb29af6e3f3c326c"
+            url: "https://github.com/salemove/ios-bundle/releases/download/2.0.1/GliaCoreSDK.xcframework.zip",
+            checksum: "ffa6b933d9e750420fc9f2b2768c023bf7655b6a545135b4cd1041074c586b48"
         ),
         .binaryTarget(
             name: "GliaWidgetsSDKXcf",

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
     - AccessibilitySnapshot/Core
     - SnapshotTesting (~> 1.0)
   - GliaCoreDependency (2.3.0)
-  - GliaCoreSDK (2.0.9):
+  - GliaCoreSDK (2.0.10):
     - GliaCoreDependency (= 2.3.0)
     - TwilioVoice (= 6.8.0)
     - WebRTC-lib (= 119.0.0)
@@ -34,7 +34,7 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   AccessibilitySnapshot: a91e4a69f870188b51f43863d9fc7269d07cdd93
   GliaCoreDependency: 37f48a5a32e2646617b87cbe9d4b30eedd123f6f
-  GliaCoreSDK: 65f8e2b4c8eee8267909704f3dcb81f3fa644344
+  GliaCoreSDK: 3ba903c4a8335d137844c22928d5f01b7f802c52
   SnapshotTesting: 6141c48b6aa76ead61431ca665c14ab9a066c53b
   SwiftLint: eb47480d47c982481592c195c221d11013a679cc
   TwilioVoice: 9563c9ad71b9ab7bbad0b59b67cfe4be96c75d23


### PR DESCRIPTION
MOB-4033

**What was solved?**
This commit introduces:
- single place for subscribing on queue updates - interactor;
- moves setting interactor.queueIds array into getEngagementLauncher method to make subscription as early as possible;
- removes all unnecessary subscription call;
- loading state for QueueMonitor, which prevents subscription duplicates while fetching queues;

ℹ️ Unit tests will be added later in MOB-4046 ticket

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**