### PR TITLE
Use 'replaceExisting' for 'Leave Current Conversation?' dialog

### DIFF
--- a/GliaWidgets/Sources/Coordinators/Call/CallCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Call/CallCoordinator.swift
@@ -68,7 +68,8 @@ private extension CallCoordinator {
             ),
             call: call,
             unreadMessages: unreadMessages,
-            startWith: startAction
+            startWith: startAction,
+            replaceExistingEnqueueing: false
         )
         viewModel.engagementDelegate = { [weak self] event in
             self?.handleEngagementViewModelEvent(event)

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -38,6 +38,7 @@ struct CoreSdkClient {
 
     typealias QueueForEngagement = (
         _ options: GliaCoreSDK.QueueForEngagementOptions,
+        _ replaceExisting: Bool,
         _ completion: @escaping (Result<GliaCoreSDK.QueueTicket, GliaCoreSDK.GliaCoreError>) -> Void
     ) -> Void
 

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
@@ -12,7 +12,7 @@ extension CoreSdkClient {
             configureWithConfiguration: GliaCore.sharedInstance.configure(with:completion:),
             configureWithInteractor: GliaCore.sharedInstance.configure(interactor:),
             listQueues: GliaCore.sharedInstance.listQueues(completion:),
-            queueForEngagement: { options, completion in
+            queueForEngagement: { options, replaceExisting, completion in
                 let options = QueueForEngagementOptions(
                     queueIds: options.queueIds,
                     visitorContext: options.visitorContext,
@@ -21,8 +21,7 @@ extension CoreSdkClient {
                     engagementOptions: options.engagementOptions
                 )
                 GliaCore.sharedInstance.queueForEngagement(
-                    // TODO: - Passing correct value will be implemented in MOB-4016
-                    using: options, replaceExisting: false, completion: completion
+                    using: options, replaceExisting: replaceExisting, completion: completion
                 )
             },
             requestMediaUpgradeWithOffer: GliaCore.sharedInstance.requestMediaUpgrade(offer:completion:),

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -13,7 +13,7 @@ extension CoreSdkClient {
         configureWithConfiguration: { _, _ in },
         configureWithInteractor: { _ in },
         listQueues: { _ in },
-        queueForEngagement: { _, _ in },
+        queueForEngagement: { _, _, _ in },
         requestMediaUpgradeWithOffer: { _, _ in },
         sendMessagePreview: { _, _ in },
         sendMessageWithMessagePayload: { _, _ in },

--- a/GliaWidgets/Sources/Interactor/Interactor.swift
+++ b/GliaWidgets/Sources/Interactor/Interactor.swift
@@ -141,6 +141,7 @@ extension Interactor {
 
     func enqueueForEngagement(
         engagementKind: EngagementKind,
+        replaceExisting: Bool,
         success: @escaping () -> Void,
         failure: @escaping (CoreSdkClient.SalemoveError) -> Void
     ) {
@@ -171,7 +172,8 @@ extension Interactor {
                 shouldCloseAllQueues: true,
                 mediaType: engagementKind.mediaType,
                 engagementOptions: options
-            )
+            ),
+            replaceExisting
         ) { [weak self] result in
             switch result {
             case .failure(let error):

--- a/GliaWidgets/Sources/ViewModel/Call/CallViewModel.Mock.swift
+++ b/GliaWidgets/Sources/ViewModel/Call/CallViewModel.Mock.swift
@@ -6,6 +6,7 @@ extension CallViewModel {
         call: Call = .init(.audio, environment: .mock),
         unreadMessages: ObservableValue<Int> = .init(with: .zero),
         startWith: StartAction = .engagement(mediaType: .audio),
+        replaceExistingEnqueueing: Bool = false,
         environment: CallViewModel.Environment = .mock
     ) -> CallViewModel {
         .init(
@@ -14,7 +15,8 @@ extension CallViewModel {
             environment: environment,
             call: call,
             unreadMessages: unreadMessages,
-            startWith: startWith
+            startWith: startWith,
+            replaceExistingEnqueueing: replaceExistingEnqueueing
         )
     }
 }

--- a/GliaWidgets/Sources/ViewModel/Call/CallViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Call/CallViewModel.swift
@@ -27,7 +27,8 @@ class CallViewModel: EngagementViewModel, ViewModel {
         environment: EngagementViewModel.Environment,
         call: Call,
         unreadMessages: ObservableValue<Int>,
-        startWith: StartAction
+        startWith: StartAction,
+        replaceExistingEnqueueing: Bool
     ) {
         self.call = call
         self.startWith = startWith
@@ -36,6 +37,7 @@ class CallViewModel: EngagementViewModel, ViewModel {
         super.init(
             interactor: interactor,
             screenShareHandler: screenShareHandler,
+            replaceExistingEnqueueing: replaceExistingEnqueueing,
             environment: environment
         )
         unreadMessages.addObserver(self) { [weak self] unreadCount, _ in

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+GVA.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+GVA.swift
@@ -57,7 +57,7 @@ extension ChatViewModel {
 
             case .engaged where shouldForceEnqueueing, .enqueueing, .ended, .none:
                 self.handle(pendingMessage: outgoingMessage)
-                self.enqueue(engagementKind: .chat)
+                self.enqueue(engagementKind: .chat, replaceExisting: false)
 
             case .engaged:
                 self.sendMessage(outgoingMessage)

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Mock.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Mock.swift
@@ -13,6 +13,7 @@ extension ChatViewModel {
         deliveredStatusText: String = "Delivered",
         failedToDeliverStatusText: String = "Failed",
         chatType: ChatViewModel.ChatType = .nonAuthenticated,
+        replaceExistingEnqueueing: Bool = false,
         environment: Environment = .mock,
         maximumUploads: () -> Int = { 2 }
     ) -> ChatViewModel {
@@ -28,6 +29,7 @@ extension ChatViewModel {
             deliveredStatusText: deliveredStatusText,
             failedToDeliverStatusText: failedToDeliverStatusText,
             chatType: chatType,
+            replaceExistingEnqueueing: replaceExistingEnqueueing,
             environment: environment,
             maximumUploads: maximumUploads
         )

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -77,6 +77,7 @@ class ChatViewModel: EngagementViewModel {
         deliveredStatusText: String,
         failedToDeliverStatusText: String,
         chatType: ChatType,
+        replaceExistingEnqueueing: Bool,
         environment: Environment,
         maximumUploads: () -> Int
     ) {
@@ -115,6 +116,7 @@ class ChatViewModel: EngagementViewModel {
         super.init(
             interactor: interactor,
             screenShareHandler: screenShareHandler,
+            replaceExistingEnqueueing: replaceExistingEnqueueing,
             environment: environment
         )
         unreadMessages.addObserver(self) { [weak self] unreadCount, _ in

--- a/GliaWidgetsTests/Sources/CallViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/CallViewModelTests.swift
@@ -25,7 +25,8 @@ class CallViewModelTests: XCTestCase {
             environment: .mock,
             call: call,
             unreadMessages: .init(with: 0),
-            startWith: .engagement(mediaType: .video)
+            startWith: .engagement(mediaType: .video),
+            replaceExistingEnqueueing: false
         )
 
         viewModel.action = {
@@ -117,7 +118,8 @@ class CallViewModelTests: XCTestCase {
             environment: .mock,
             call: call,
             unreadMessages: .init(with: 0),
-            startWith: .engagement(mediaType: .video)
+            startWith: .engagement(mediaType: .video), 
+            replaceExistingEnqueueing: false
         )
 
         let remoteVideoStream = CoreSdkClient.MockVideoStreamable.mock(
@@ -174,7 +176,8 @@ class CallViewModelTests: XCTestCase {
             environment: .mock,
             call: call,
             unreadMessages: .init(with: 0),
-            startWith: .engagement(mediaType: .video)
+            startWith: .engagement(mediaType: .video), 
+            replaceExistingEnqueueing: false
         )
 
         let remoteAudioStream = CoreSdkClient.MockAudioStreamable.mock(
@@ -259,7 +262,8 @@ class CallViewModelTests: XCTestCase {
             environment: .mock,
             call: call,
             unreadMessages: .init(with: 0),
-            startWith: .engagement(mediaType: .video)
+            startWith: .engagement(mediaType: .video), 
+            replaceExistingEnqueueing: false
         )
 
         viewModel.action = { action in
@@ -338,7 +342,8 @@ class CallViewModelTests: XCTestCase {
             environment: .mock,
             call: call,
             unreadMessages: .init(with: 0),
-            startWith: .engagement(mediaType: .video)
+            startWith: .engagement(mediaType: .video), 
+            replaceExistingEnqueueing: false
         )
 
         call.updateVideoStream(with: localVideoStream)
@@ -378,7 +383,8 @@ class CallViewModelTests: XCTestCase {
             environment: .mock,
             call: call,
             unreadMessages: .init(with: 0),
-            startWith: .engagement(mediaType: .video)
+            startWith: .engagement(mediaType: .video), 
+            replaceExistingEnqueueing: false
         )
 
         XCTAssertEqual(call.kind.value, .video(direction: .twoWay))
@@ -427,7 +433,7 @@ class CallViewModelTests: XCTestCase {
             case .showLiveObservationConfirmation:
                 calls.append(.showLiveObservationAlert)
             default:
-                XCTFail()
+                XCTFail("Unexpected action: \(action)")
             }
         }
         interactor.state = .enqueueing(.audioCall)
@@ -436,7 +442,7 @@ class CallViewModelTests: XCTestCase {
 
     func test_liveObservationAllowTriggersEnqueue() throws {
         var interactorEnv: Interactor.Environment = .mock
-        interactorEnv.coreSdk.queueForEngagement = { _, completion in
+        interactorEnv.coreSdk.queueForEngagement = { _, _, completion in
             completion(.success(.mock))
         }
 
@@ -461,7 +467,7 @@ class CallViewModelTests: XCTestCase {
                     declined: declined
                 )
             default:
-                XCTFail()
+                XCTFail("Unexpected action \(action).")
             }
         }
         interactor.state = .enqueueing(.audioCall)
@@ -475,7 +481,7 @@ class CallViewModelTests: XCTestCase {
         }
         var calls: [Call] = []
         var interactorEnv: Interactor.Environment = .mock
-        interactorEnv.coreSdk.queueForEngagement = { _, _ in
+        interactorEnv.coreSdk.queueForEngagement = { _, _, _ in
             calls.append(.queueForEngagement)
         }
 
@@ -500,7 +506,7 @@ class CallViewModelTests: XCTestCase {
                     declined: declined
                 )
             default:
-                XCTFail()
+                XCTFail("Unexpected action \(action).")
             }
         }
         interactor.state = .enqueueing(.audioCall)
@@ -527,7 +533,8 @@ class CallViewModelTests: XCTestCase {
             environment: env,
             call: .mock(),
             unreadMessages: .init(with: 0),
-            startWith: .engagement(mediaType: .video)
+            startWith: .engagement(mediaType: .video), 
+            replaceExistingEnqueueing: false
         )
 
         viewModel.event(.viewDidLoad)
@@ -569,7 +576,8 @@ class CallViewModelTests: XCTestCase {
             environment: .mock,
             call: call,
             unreadMessages: .init(with: 0),
-            startWith: .engagement(mediaType: .audio)
+            startWith: .engagement(mediaType: .audio), 
+            replaceExistingEnqueueing: false
         )
 
         let remoteAudioStream = CoreSdkClient.MockAudioStreamable.mock(
@@ -631,7 +639,8 @@ class CallViewModelTests: XCTestCase {
             environment: .mock,
             call: call,
             unreadMessages: .init(with: 0),
-            startWith: .engagement(mediaType: .video)
+            startWith: .engagement(mediaType: .video), 
+            replaceExistingEnqueueing: false
         )
 
         let localVideoStream = CoreSdkClient.MockVideoStreamable.mock(
@@ -682,7 +691,8 @@ class CallViewModelTests: XCTestCase {
             flipCameraButtonStyle: .nop,
             callback: { _ in
                 calls.append(.callback)
-            })
+            }
+        )
 
         XCTAssertEqual(calls, [.callback])
     }
@@ -721,7 +731,8 @@ class CallViewModelTests: XCTestCase {
                 if let accessibility = $0?.accessibility {
                     accessibilities.append(accessibility)
                 }
-            })
+            }
+        )
 
         let backCameraExpectedAccessibility = FlipCameraButton.Props.Accessibility(
             accessibilityLabel: style.accessibility.switchToFrontCameraAccessibilityLabel,
@@ -739,7 +750,8 @@ class CallViewModelTests: XCTestCase {
                 if let accessibility = $0?.accessibility {
                     accessibilities.append(accessibility)
                 }
-            })
+            }
+        )
 
         let frontCameraExpectedAccessibility = FlipCameraButton.Props.Accessibility(
             accessibilityLabel: style.accessibility.switchToBackCameraAccessibilityLabel,
@@ -772,7 +784,6 @@ class CallViewModelTests: XCTestCase {
 
         cameraDeviceManager.currentCameraDevice = { backCamera }
 
-
         var receivedAccessibilitiesWithCallbacks: [VideoStreamView.FlipCameraAccLabelWithTap?] = []
 
         CallViewModel.setFlipCameraButtonVisible(
@@ -782,7 +793,8 @@ class CallViewModelTests: XCTestCase {
             flipCameraButtonStyle: style,
             callback: {
                 receivedAccessibilitiesWithCallbacks.append($0)
-            })
+            }
+        )
 
         XCTAssertEqual(receivedAccessibilitiesWithCallbacks[0]?.tapCallback, nil)
         XCTAssertEqual(receivedAccessibilitiesWithCallbacks[0]?.accessibility, nil)
@@ -807,7 +819,8 @@ class CallViewModelTests: XCTestCase {
             flipCameraButtonStyle: style,
             callback: {
                 receivedAccessibilitiesWithCallbacks.append($0)
-            })
+            }
+        )
 
         XCTAssertEqual(receivedAccessibilitiesWithCallbacks[0]?.tapCallback, nil)
         XCTAssertEqual(receivedAccessibilitiesWithCallbacks[0]?.accessibility, nil)

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+CustomCard.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+CustomCard.swift
@@ -14,7 +14,7 @@ extension ChatViewModelTests {
             XCTFail("createSendMessagePayload should not be called")
         }
         interactorEnv.gcd.mainQueue.asyncIfNeeded = { _ in }
-        interactorEnv.coreSdk.queueForEngagement = { _, _ in }
+        interactorEnv.coreSdk.queueForEngagement = { _, _, _ in }
         interactorEnv.coreSdk.configureWithInteractor = { _ in }
         interactorEnv.coreSdk.sendMessageWithMessagePayload = { payload, _ in
             calls.append(.sendOption(payload.content, payload.attachment?.selectedOption))

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Gva.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Gva.swift
@@ -111,7 +111,7 @@ extension ChatViewModelTests {
             XCTFail("sendMessageWithMessagePayload should not be called")
         }
         interactorEnv.gcd.mainQueue.async = { _ in }
-        interactorEnv.coreSdk.queueForEngagement = { _, _ in }
+        interactorEnv.coreSdk.queueForEngagement = { _, _, _ in }
         interactorEnv.coreSdk.configureWithInteractor = { _ in }
         interactorEnv.log.infoClosure = { _, _, _, _ in }
         interactorEnv.log.prefixedClosure = { _ in interactorEnv.log }

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Transferring.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Transferring.swift
@@ -17,7 +17,7 @@ extension ChatViewModelTests {
             XCTFail("createSendMessagePayload should not be called")
         }
         interactorEnv.gcd.mainQueue.async = { $0() }
-        interactorEnv.coreSdk.queueForEngagement = { _, _ in }
+        interactorEnv.coreSdk.queueForEngagement = { _, _, _ in }
         interactorEnv.coreSdk.configureWithInteractor = { _ in }
         var log = interactorEnv.log
         log.prefixedClosure = { _ in log }

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -25,9 +25,10 @@ class ChatViewModelTests: XCTestCase {
             isCustomCardSupported: false,
             isWindowVisible: .init(with: true),
             startAction: .none,
-            deliveredStatusText: "Delivered", 
+            deliveredStatusText: "Delivered",
             failedToDeliverStatusText: "Failed",
             chatType: .nonAuthenticated,
+            replaceExistingEnqueueing: false,
             environment: .init(
                 fetchFile: { _, _, _ in },
                 downloadSecureFile: { _, _, _ in .mock },
@@ -690,7 +691,7 @@ class ChatViewModelTests: XCTestCase {
         interactor.environment.coreSdk.sendMessageWithMessagePayload = { _, completion in
             completion(.success(.mock(id: expectedMessageId)))
         }
-        interactor.environment.coreSdk.queueForEngagement = { _, completion in
+        interactor.environment.coreSdk.queueForEngagement = { _, _, completion in
             completion(.success(.mock))
         }
 
@@ -750,7 +751,7 @@ class ChatViewModelTests: XCTestCase {
             viewModel?.interactorEvent(.receivedMessage(.mock(id: expectedMessageId)))
             completion(.success(.mock(id: expectedMessageId)))
         }
-        interactor.environment.coreSdk.queueForEngagement = { _, completion in
+        interactor.environment.coreSdk.queueForEngagement = { _, _, completion in
             completion(.success(.mock))
         }
 
@@ -830,7 +831,7 @@ class ChatViewModelTests: XCTestCase {
 
     func test_liveObservationAllowTriggersEnqueue() throws {
         var interactorEnv: Interactor.Environment = .mock
-        interactorEnv.coreSdk.queueForEngagement = { _, completion in
+        interactorEnv.coreSdk.queueForEngagement = { _, _, completion in
             completion(.success(.mock))
         }
 
@@ -870,7 +871,7 @@ class ChatViewModelTests: XCTestCase {
         }
         var calls: [Call] = []
         var interactorEnv: Interactor.Environment = .mock
-        interactorEnv.coreSdk.queueForEngagement = { _, _ in
+        interactorEnv.coreSdk.queueForEngagement = { _, _, _ in
             calls.append(.queueForEngagement)
         }
 

--- a/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
@@ -11,7 +11,7 @@ extension CoreSdkClient {
         configureWithConfiguration: { _, _ in fail("\(Self.self).configureWithConfiguration") },
         configureWithInteractor: { _ in fail("\(Self.self).configureWithInteractor") },
         listQueues: { _ in fail("\(Self.self).listQueues") },
-        queueForEngagement: { _, _ in fail("\(Self.self).queueForEngagement") },
+        queueForEngagement: { _, _, _ in fail("\(Self.self).queueForEngagement") },
         requestMediaUpgradeWithOffer: { _, _ in fail("\(Self.self).requestMediaUpgradeWithOffer") },
         sendMessagePreview: { _, _ in fail("\(Self.self).sendMessagePreview") },
         sendMessageWithMessagePayload: { _, _ in fail("\(Self.self).sendMessageWithMessagePayload") },

--- a/GliaWidgetsTests/Sources/EngagementViewModel/EngagementViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/EngagementViewModel/EngagementViewModelTests.swift
@@ -5,7 +5,8 @@ final class EngagementViewModelTests: XCTestCase {
     func testHandleScreenSharingStatusShowsEndScreenSharingButton() {
         let viewModel = EngagementViewModel(
             interactor: .failing,
-            screenShareHandler: .mock,
+            screenShareHandler: .mock, 
+            replaceExistingEnqueueing: false,
             environment: .mock
         )
         enum Call { case showEndScreenShareButton }
@@ -26,7 +27,8 @@ final class EngagementViewModelTests: XCTestCase {
     func testHandleScreenSharingStatusShowsEndButton() {
         let viewModel = EngagementViewModel(
             interactor: .failing,
-            screenShareHandler: .mock,
+            screenShareHandler: .mock, 
+            replaceExistingEnqueueing: false,
             environment: .mock
         )
         enum Call { case showEndButton }
@@ -50,6 +52,7 @@ final class EngagementViewModelTests: XCTestCase {
         let viewModel = EngagementViewModel(
             interactor: interactor,
             screenShareHandler: .mock,
+            replaceExistingEnqueueing: false,
             environment: .mock
         )
         enum Call { case showCloseButton }


### PR DESCRIPTION
**What was solved?**
Add implementation of indicating if current queue ticket has to be replaced with another one in case of 'Leave Current Conversation?' dialog 'Leave' choice.

MOB-4018

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
