### PR TITLE
Update queues only if they are the most up to date

### DIFF
--- a/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.Live.swift
+++ b/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.Live.swift
@@ -121,7 +121,9 @@ private extension QueuesMonitor {
                 queues.append(queue)
                 return
             }
-            queues[indexToChange] = queue
+            if queue.lastUpdated > queues[indexToChange].lastUpdated {
+                queues[indexToChange] = queue
+            }
         }
     }
 


### PR DESCRIPTION
**What was solved?**
Update queues only if they are the most up to date. New property `lastUpdated` in queue allows the comparison of dates and only the latest will be added to the array.

MOB-4044
**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
