### PR TITLE
Refetch and restart queues monitoring if access token expires

### DIFF
--- a/GliaWidgets/Sources/Interactor/Interactor.swift
+++ b/GliaWidgets/Sources/Interactor/Interactor.swift
@@ -422,6 +422,11 @@ extension Interactor: CoreSdkClient.Interactable {
     }
 
     func fail(error: CoreSdkClient.SalemoveError) {
+        // Fail is called from CoreSDK when acces token expiration happens
+        // and it leads to fetchQueues failure that stops queues observing
+        // Also when token expires CoreSDK makes force deauthentication which
+        // allows to refetch the queues without errors
+        environment.queuesMonitor.fetchAndMonitorQueues(queuesIds: queueIds ?? [])
         notify(.error(error))
     }
 }

--- a/GliaWidgetsTests/Sources/ChatViewControllerTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewControllerTests.swift
@@ -56,6 +56,7 @@ class ChatViewControllerTests: XCTestCase {
         viewModelEnv.log.prefixedClosure = { _ in return .mock }
         let interactor = Interactor.failing
         interactor.environment.gcd.mainQueue.async = { $0() }
+        interactor.environment.queuesMonitor = .mock()
         let viewModel = ChatViewModel.mock(
             interactor: interactor,
             environment: viewModelEnv


### PR DESCRIPTION
**What was solved?**
This PR refetches and restart queues monitoring if access token expires

**Release notes:**

 - [X] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [X] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

