### PR TITLE
Throw error on `startSecureMessaging()` for unauthenticated visitor

### DIFF
--- a/GliaWidgets/Public/Glia/Glia+EngagementLauncher.swift
+++ b/GliaWidgets/Public/Glia/Glia+EngagementLauncher.swift
@@ -43,7 +43,7 @@ extension Glia {
                 configuration: getConfiguration(),
                 interactor: getInteractor()
             )
-            self.resolveEngagementState(
+            try self.resolveEngagementState(
                 engagementKind: engagementKind,
                 sceneProvider: sceneProvider,
                 configuration: parameters.configuration,

--- a/GliaWidgets/Public/Glia/Glia+EngagementSetup.swift
+++ b/GliaWidgets/Public/Glia/Glia+EngagementSetup.swift
@@ -47,7 +47,7 @@ extension Glia {
         features: Features,
         viewFactory: ViewFactory,
         ongoingEngagementMediaStreams: Engagement.Media?
-    ) {
+    ) throws {
         /// If during enqueued state the visitor initiates another engagement, we avoid cancelling the queue
         /// ticket and adding a new one, by monitoring the new engagement kind. If the engagement kind matches
         /// the current enqueued engagement kind, then we resume the old, and do not start a new one
@@ -61,6 +61,9 @@ extension Glia {
         }
 
         guard let currentEngagement = environment.coreSdk.getNonTransferredSecureConversationEngagement() else {
+            if case .messaging = engagementKind, !environment.isAuthenticated() {
+                throw GliaError.messagingIsNotSupportedForUnauthenticatedVisitor
+            }
             // This value can be set to `true` if engagement restoring happened.
             // To prevent missing Live Observation Confirmation dialog to be shown
             // for further engagements, we need to default this value again.

--- a/GliaWidgets/Public/GliaError.swift
+++ b/GliaWidgets/Public/GliaError.swift
@@ -33,4 +33,7 @@ public enum GliaError: Error {
 
     /// Internal event subscription failure.
     case internalEventSubscriptionFailure
+
+    /// Messaging is not supported for unauthenticated visitor
+    case messagingIsNotSupportedForUnauthenticatedVisitor
 }

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
@@ -593,6 +593,7 @@ extension GliaTests {
         environment.coreSdk.createLogger = { _ in logger }
         environment.print = .mock
         environment.conditionalCompilation.isDebug = { true }
+        environment.isAuthenticated = { true }
 
         let engagementKind = EngagementKind.messaging(.welcome)
         var engagementLaunching: EngagementCoordinator.EngagementLaunching = .direct(kind: engagementKind)


### PR DESCRIPTION
MOB-4038

**What was solved?**
SDK was opening Secure Message center and showing error Message Center Unavailable if visitor is unauthenticated. This PR adds the logic that throws an error on `startSecureMessaging` call instead.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.