### PR TITLE
Fix snackbar bottom padding if tabbar is present

### DIFF
--- a/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar+Presenter.swift
+++ b/GliaWidgets/SwiftUI/Components/SnackBarView/SnackBar+Presenter.swift
@@ -44,7 +44,7 @@ extension SnackBar {
             hostingController.view.translatesAutoresizingMaskIntoConstraints = false
             NSLayoutConstraint.activate([
                 hostingController.view.topAnchor.constraint(greaterThanOrEqualTo: parent.view.topAnchor),
-                hostingController.view.bottomAnchor.constraint(equalTo: parent.view.bottomAnchor, constant: 64),
+                hostingController.view.bottomAnchor.constraint(equalTo: parent.view.safeAreaLayoutGuide.bottomAnchor, constant: 64),
                 hostingController.view.leadingAnchor.constraint(equalTo: parent.view.leadingAnchor),
                 hostingController.view.trailingAnchor.constraint(equalTo: parent.view.trailingAnchor)
             ])


### PR DESCRIPTION
**What was solved?**
This PR fixes the issue where the snackbar is halfway hidden under the bottom of the screen, because of
wrong padding calculation. Safearea needs to be included in this calculation.

MOB-4051
**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
