### PR TITLE
Improve Transferred SC behaviour

### DIFF
--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
@@ -619,8 +619,10 @@ extension ChatViewController {
         interactorEnv.coreSdk.sendMessageWithMessagePayload = { _, completion in
             completion(.failure(.mock()))
         }
+        let interactor = Interactor.mock(environment: interactorEnv)
+        interactor.setCurrentEngagement(.mock())
         let chatViewModel = ChatViewModel.mock(
-            interactor: .mock(environment: interactorEnv),
+            interactor: interactor,
             failedToDeliverStatusText: "Failed to send. Tap on the message to retry.",
             environment: chatViewModelEnv
         )

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -179,7 +179,7 @@ class ChatViewModel: EngagementViewModel {
 
             action?(.queue)
             action?(.scrollToBottom(animated: true))
-        case .engaged(let engagedOperator):
+        case .engaged(let engagedOperator) where interactor.currentEngagement?.isTransferredSecureConversation == false:
             environment.log.prefixed(Self.self).info("Operator connected")
             let name = engagedOperator?.firstName
             let pictureUrl = engagedOperator?.picture?.url

--- a/GliaWidgetsTests/Sources/ChatViewControllerTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewControllerTests.swift
@@ -105,6 +105,7 @@ class ChatViewControllerTests: XCTestCase {
             return .mock
         }
         let interactor = Interactor.failing
+        interactor.setCurrentEngagement(.mock())
         interactor.environment.gcd.mainQueue.async = { $0() }
         let viewModel = ChatViewModel.mock(interactor: interactor, environment: viewModelEnv)
 

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Transferring.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Transferring.swift
@@ -38,7 +38,7 @@ extension ChatViewModelTests {
         env.fetchSiteConfigurations = { completion in
             completion(.success(site))
         }
-        env.getCurrentEngagement = { .mock() }
+        interactorMock.setCurrentEngagement(.mock())
         viewModel = .mock(interactor: interactorMock, environment: env)
 
         viewModel.action = { action in


### PR DESCRIPTION
MOB-4039

**What was solved?**
This PR adds the logic that skips showing LO indication banner and operator connected view on engaged state if there is transferred SC.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.