### PR TITLE
Update SC top banner visibility only based on EW state

### DIFF
--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
@@ -642,10 +642,6 @@ extension ChatViewController {
     }
 
     static func mockSecureMessagingBottomBannerView(theme: Theme = Theme.mock()) -> ChatViewController {
-        var chatViewModelEnv = ChatViewModel.Environment.mock
-        chatViewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
-        let chatViewModel = ChatViewModel.mock(environment: chatViewModelEnv)
-
         let transcriptModel = SecureConversations.TranscriptModel.init(
             isCustomCardSupported: false,
             environment: .mock(secureMessagingExpandedTopBannerItemsStyle: theme.chatStyle.secureMessagingExpandedTopBannerItemsStyle),
@@ -655,6 +651,7 @@ extension ChatViewController {
             interactor: .mock()
         )
 
+        transcriptModel.entryWidget?.viewState = .mediaTypes([.init(type: .chat)])
         return .init(viewModel: .transcript(transcriptModel), environment: .mock(viewFactory: .mock(theme: theme)))
     }
 

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
@@ -267,7 +267,6 @@ final class ChatViewController: EngagementViewController, PopoverPresenter {
             chatView.props = .init(header: props.chat)
             // For regular chat engagement bottom banner is hidden.
             chatView.setSecureMessagingBottomBannerHidden(true)
-            chatView.setSecureMessagingTopBannerHidden(true)
             chatView.setSendingMessageUnavailabilityBannerHidden(viewModel.isSendMessageAvailable)
         case let .secureTranscript(needsTextInputEnabled):
             chatView.props = .init(header: props.secureTranscript)
@@ -276,13 +275,11 @@ final class ChatViewController: EngagementViewController, PopoverPresenter {
             chatView.setSendingMessageUnavailabilityBannerHidden(viewModel.isSendMessageAvailable)
             // For secure messaging bottom banner is visible.
             chatView.setSecureMessagingBottomBannerHidden(false)
-            chatView.setSecureMessagingTopBannerHidden(false)
         case .chatToSecureTranscript:
             chatView.props = .init(header: props.secureTranscript)
             chatView.messageEntryView.isEnabled = true
             chatView.setSendingMessageUnavailabilityBannerHidden(true)
             chatView.setSecureMessagingBottomBannerHidden(false)
-            chatView.setSecureMessagingTopBannerHidden(false)
         }
     }
 


### PR DESCRIPTION
MOB-4029

**What was solved?**
Remove manual update of SC top banner visibility to avoid inconsistency. Now visibility is driven only by EW logic.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
