### PR TITLE
Skip Leave Current Conversation dialog showing

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -459,6 +459,7 @@
 		847D7FB82CEE019C00EA5C2D /* ViewController+ErrorHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847D7FB72CEE019C00EA5C2D /* ViewController+ErrorHandling.swift */; };
 		847D7FBA2CEE022200EA5C2D /* ViewController+Playbook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847D7FB92CEE022200EA5C2D /* ViewController+Playbook.swift */; };
 		847D7FBC2CEE038E00EA5C2D /* ViewController+UnifiedUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847D7FBB2CEE038E00EA5C2D /* ViewController+UnifiedUI.swift */; };
+		84803C102D64D349009BD762 /* SecureConversations.ShouldShowLeaveCurrentConversationSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84803C0F2D64D349009BD762 /* SecureConversations.ShouldShowLeaveCurrentConversationSource.swift */; };
 		8485704F2BEE3A0800CEBCC5 /* ChatViewTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8485704E2BEE3A0800CEBCC5 /* ChatViewTest.swift */; };
 		848570512BEE3CCC00CEBCC5 /* ChatStyle.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848570502BEE3CCC00CEBCC5 /* ChatStyle.Mock.swift */; };
 		848B8ADC2C0759C500E990E6 /* Theme.CustomCardContainerStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848B8ADB2C0759C500E990E6 /* Theme.CustomCardContainerStyle.swift */; };
@@ -1545,6 +1546,7 @@
 		847D7FB72CEE019C00EA5C2D /* ViewController+ErrorHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+ErrorHandling.swift"; sourceTree = "<group>"; };
 		847D7FB92CEE022200EA5C2D /* ViewController+Playbook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Playbook.swift"; sourceTree = "<group>"; };
 		847D7FBB2CEE038E00EA5C2D /* ViewController+UnifiedUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+UnifiedUI.swift"; sourceTree = "<group>"; };
+		84803C0F2D64D349009BD762 /* SecureConversations.ShouldShowLeaveCurrentConversationSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.ShouldShowLeaveCurrentConversationSource.swift; sourceTree = "<group>"; };
 		8485704E2BEE3A0800CEBCC5 /* ChatViewTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewTest.swift; sourceTree = "<group>"; };
 		848570502BEE3CCC00CEBCC5 /* ChatStyle.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStyle.Mock.swift; sourceTree = "<group>"; };
 		848B8ADB2C0759C500E990E6 /* Theme.CustomCardContainerStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.CustomCardContainerStyle.swift; sourceTree = "<group>"; };
@@ -3511,6 +3513,7 @@
 				C0D6CA142C184F1900D4709B /* SecureConversations.MessagesWithUnreadCountLoader.Environment.swift */,
 				3115D45B29A4FD3F00D99561 /* SecureConversations.Availability.swift */,
 				AFCDA7232CF8EC2C006E339B /* SecureConversations.PendingInteraction.swift */,
+				84803C0F2D64D349009BD762 /* SecureConversations.ShouldShowLeaveCurrentConversationSource.swift */,
 			);
 			path = SecureConversations;
 			sourceTree = "<group>";
@@ -6539,6 +6542,7 @@
 				84265DF02983E62100D65842 /* Theme+ScreenSharing.swift in Sources */,
 				6E9C01AD26D3B8B500EBE1D4 /* OperatorTypingIndicatorView.swift in Sources */,
 				C090469E2B7D075C003C437C /* WelcomeStyle.MessageTextViewActiveStyle.Accessibility.swift in Sources */,
+				84803C102D64D349009BD762 /* SecureConversations.ShouldShowLeaveCurrentConversationSource.swift in Sources */,
 				AF10ED8B29B7A4C000E85309 /* ChatViewModel+ChoiceCards.swift in Sources */,
 				7594097E298D38C2008B173A /* CallVisualizer.BubbleIcon.swift in Sources */,
 				C09047842B7E2A74003C437C /* CallButtonBarStyle.RemoteConfig.swift in Sources */,

--- a/GliaWidgets/Public/Glia/Glia+EngagementSetup.swift
+++ b/GliaWidgets/Public/Glia/Glia+EngagementSetup.swift
@@ -206,6 +206,9 @@ extension Glia {
                         queueIds: interactor.queueIds ?? [],
                         configuration: configuration
                     )
+                },
+                hasPendingInteraction: { [weak self] in
+                    self?.pendingInteraction?.hasPendingInteraction ?? false
                 }
             )
         )

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.Environment.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.Environment.swift
@@ -31,7 +31,7 @@ extension SecureConversations.TranscriptModel {
         var createSendMessagePayload: CoreSdkClient.CreateSendMessagePayload
         var log: CoreSdkClient.Logger
         var maximumUploads: () -> Int
-        var shouldShowLeaveSecureConversationDialog: () -> Bool
+        var shouldShowLeaveSecureConversationDialog: (SecureConversations.ShouldShowLeaveCurrentConversationSource) -> Bool
         /// The value returning by the command corresponds to decision made by visitor
         /// whether to leave current conversation:
         /// - `true` - visitor decided to leave the conversation;
@@ -126,7 +126,7 @@ extension SecureConversations.TranscriptModel.Environment {
         createSendMessagePayload: @escaping CoreSdkClient.CreateSendMessagePayload = { _, _ in .mock() },
         log: CoreSdkClient.Logger = .mock,
         maximumUploads: @escaping () -> Int = { .zero },
-        shouldShowLeaveSecureConversationDialog: @escaping () -> Bool = { false },
+        shouldShowLeaveSecureConversationDialog: @escaping (SecureConversations.ShouldShowLeaveCurrentConversationSource) -> Bool = { _ in false },
         leaveCurrentSecureConversation: Command<Bool> = .nop,
         createEntryWidget: @escaping EntryWidgetBuilder = { _ in .mock() },
         switchToEngagement: Command<EngagementKind> = .nop,

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.LeaveConversation.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.LeaveConversation.swift
@@ -14,7 +14,7 @@ extension SecureConversations.TranscriptModel {
                 }
             }
         }
-        guard environment.shouldShowLeaveSecureConversationDialog() else {
+        guard environment.shouldShowLeaveSecureConversationDialog(.transcriptOpened) else {
             handleInteractorState()
             return
         }

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
@@ -574,7 +574,7 @@ extension SecureConversations.TranscriptModel {
                 self.action?(.scrollToBottom(animated: false))
                 completion(messagesWithUnreadCount.messages)
                 markMessagesAsRead(
-                    with: self.hasUnreadMessages && !environment.shouldShowLeaveSecureConversationDialog()
+                    with: self.hasUnreadMessages && !environment.shouldShowLeaveSecureConversationDialog(.transcriptOpened)
                 )
 
                 if let item = items.last, case .gvaQuickReply(_, let button, _, _) = item.kind {
@@ -743,7 +743,7 @@ extension SecureConversations.TranscriptModel {
 
     private func entryWidgetMediaTypeSelected(_ item: EntryWidget.MediaTypeItem) {
         action?(.switchToEngagement)
-        engagementAction?(.showAlert(.leaveCurrentConversation { [weak self] in
+        let switchToEngagement = { [weak self] in
             let kind: EngagementKind
             switch item.type {
             case .video:
@@ -758,7 +758,14 @@ extension SecureConversations.TranscriptModel {
                 return
             }
             self?.environment.switchToEngagement(kind)
-        }))
+        }
+        if environment.shouldShowLeaveSecureConversationDialog(.entryWidgetTopBanner) {
+            engagementAction?(.showAlert(.leaveCurrentConversation {
+                switchToEngagement()
+            }))
+        } else {
+            switchToEngagement()
+        }
     }
 }
 

--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.Environment.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.Environment.swift
@@ -52,7 +52,7 @@ extension SecureConversations.Coordinator {
         var alertManager: AlertManager
         var queuesMonitor: QueuesMonitor
         var createEntryWidget: EntryWidgetBuilder
-        var shouldShowLeaveSecureConversationDialog: () -> Bool
+        var shouldShowLeaveSecureConversationDialog: (SecureConversations.ShouldShowLeaveCurrentConversationSource) -> Bool
         /// The value returning by the command corresponds to decision made by visitor
         /// whether to leave current conversation:
         /// - `true` - visitor decided to leave the conversation;
@@ -75,7 +75,7 @@ extension SecureConversations.Coordinator.Environment {
         screenShareHandler: ScreenShareHandler,
         isWindowVisible: ObservableValue<Bool>,
         interactor: Interactor,
-        shouldShowLeaveSecureConversationDialog: @escaping () -> Bool,
+        shouldShowLeaveSecureConversationDialog: @escaping (SecureConversations.ShouldShowLeaveCurrentConversationSource) -> Bool,
         leaveCurrentSecureConversation: Command<Bool>,
         switchToEngagement: Command<EngagementKind>
     ) -> Self {

--- a/GliaWidgets/SecureConversations/SecureConversations.ShouldShowLeaveCurrentConversationSource.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.ShouldShowLeaveCurrentConversationSource.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension SecureConversations {
+    enum ShouldShowLeaveCurrentConversationSource {
+        /// Used when `shouldShowLeaveSecureConversationDialog` is called once Chat Transcript screen is opened
+        case transcriptOpened
+        /// Used when `shouldShowLeaveSecureConversationDialog` is called once a visitor selects media type from
+        /// `Need Live Support?` banner.
+        case entryWidgetTopBanner
+    }
+}

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
@@ -44,7 +44,7 @@ extension ChatCoordinator {
         var alertManager: AlertManager
         var queuesMonitor: QueuesMonitor
         var createEntryWidget: EntryWidgetBuilder
-        var shouldShowLeaveSecureConversationDialog: () -> Bool
+        var shouldShowLeaveSecureConversationDialog: (SecureConversations.ShouldShowLeaveCurrentConversationSource) -> Bool
         /// The value returning by the command corresponds to decision made by visitor
         /// whether to leave current conversation:
         /// - `true` - visitor decided to leave the conversation;
@@ -60,7 +60,7 @@ extension ChatCoordinator.Environment {
     static func create(
         with environment: EngagementCoordinator.Environment,
         interactor: Interactor,
-        shouldShowLeaveSecureConversationDialog: @escaping () -> Bool,
+        shouldShowLeaveSecureConversationDialog: @escaping (SecureConversations.ShouldShowLeaveCurrentConversationSource) -> Bool,
         leaveCurrentSecureConversation: Command<Bool>,
         switchToEngagement: Command<EngagementKind>
     ) -> Self {

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
@@ -47,7 +47,7 @@ extension EngagementCoordinator.Environment {
         flipCameraButtonStyle: .nop,
         alertManager: .mock(),
         queuesMonitor: .mock(),
-        pendingSecureConversationStatus: { $0(.success(false)) },
+        hasPendingInteraction: { false },
         createEntryWidget: { _ in .mock() },
         dismissManager: .init { _, _, _ in },
         combineScheduler: .mock

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
@@ -46,7 +46,7 @@ extension EngagementCoordinator {
         var flipCameraButtonStyle: FlipCameraButtonStyle
         var alertManager: AlertManager
         var queuesMonitor: QueuesMonitor
-        var pendingSecureConversationStatus: CoreSdkClient.PendingSecureConversationStatus
+        var hasPendingInteraction: () -> Bool
         var createEntryWidget: EntryWidgetBuilder
         var dismissManager: GliaPresenter.DismissManager
         var combineScheduler: CombineBased.CombineScheduler
@@ -62,7 +62,8 @@ extension EngagementCoordinator.Environment {
         viewFactory: ViewFactory,
         alertManager: AlertManager,
         queuesMonitor: QueuesMonitor,
-        createEntryWidget: @escaping EntryWidgetBuilder
+        createEntryWidget: @escaping EntryWidgetBuilder,
+        hasPendingInteraction: @escaping () -> Bool
     ) -> Self {
         .init(
             fetchFile: environment.coreSdk.fetchFile,
@@ -109,7 +110,7 @@ extension EngagementCoordinator.Environment {
             flipCameraButtonStyle: viewFactory.theme.call.flipCameraButtonStyle,
             alertManager: alertManager,
             queuesMonitor: queuesMonitor,
-            pendingSecureConversationStatus: environment.coreSdk.pendingSecureConversationStatus,
+            hasPendingInteraction: hasPendingInteraction,
             createEntryWidget: createEntryWidget,
             dismissManager: environment.dismissManager,
             combineScheduler: environment.combineScheduler

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
@@ -328,7 +328,7 @@ extension EngagementCoordinator {
             environment: .create(
                 with: environment,
                 interactor: interactor,
-                shouldShowLeaveSecureConversationDialog: { false },
+                shouldShowLeaveSecureConversationDialog: { _ in false },
                 leaveCurrentSecureConversation: .nop,
                 switchToEngagement: .nop
             ),
@@ -529,9 +529,15 @@ extension EngagementCoordinator {
                 screenShareHandler: screenShareHandler,
                 isWindowVisible: isWindowVisible,
                 interactor: interactor,
-                shouldShowLeaveSecureConversationDialog: { [weak self] in
-                    guard let self, case .indirect = engagementLaunching else { return false }
-                    return true
+                shouldShowLeaveSecureConversationDialog: { [weak self] source in
+                    guard let self else { return false }
+                    switch source {
+                    case .transcriptOpened:
+                        guard case .indirect = engagementLaunching else { return false }
+                        return true
+                    case .entryWidgetTopBanner:
+                        return environment.hasPendingInteraction()
+                    }
                 },
                 leaveCurrentSecureConversation: leaveCurrentSecureConversation,
                 switchToEngagement: .init { [weak self] kind in

--- a/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
+++ b/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
@@ -104,8 +104,9 @@ extension EngagementCoordinator.Environment {
         flipCameraButtonStyle: .nop,
         alertManager: .failing(viewFactory: .mock()),
         queuesMonitor: .failing,
-        pendingSecureConversationStatus: { _ in
-            fail("\(Self.self).pendingSecureConversationStatus")
+        hasPendingInteraction: {
+            fail("\(Self.self).hasPendingInteraction")
+            return false
         },
         createEntryWidget: { _ in
             fail("\(Self.self).createEntryWidget")

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModel.Environment.Failing.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModel.Environment.Failing.swift
@@ -77,7 +77,10 @@ extension SecureConversations.TranscriptModel.Environment {
             fail("\(Self.self).maximumUploads")
             return 2
         },
-        shouldShowLeaveSecureConversationDialog: { false },
+        shouldShowLeaveSecureConversationDialog: { _ in
+            fail("\(Self.self).shouldShowLeaveSecureConversationDialog")
+            return false
+        },
         leaveCurrentSecureConversation: .init { _ in
             fail("\(Self.self).leaveCurrentSecureConversation")
         },

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModel.MigrateTests.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModel.MigrateTests.swift
@@ -23,6 +23,7 @@ final class TranscriptModelMigrateTests: XCTestCase {
         modelEnv.startSocketObservation = { calls.append(.startSocketObservation) }
 
         modelEnv.createEntryWidget = { _ in .mock() }
+        modelEnv.shouldShowLeaveSecureConversationDialog = { _ in false }
 
         let availabilityEnv = SecureConversations.Availability.Environment(
             listQueues: modelEnv.listQueues,

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+GVA.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+GVA.swift
@@ -146,6 +146,7 @@ extension SecureConversationsTranscriptModelTests {
         modelEnv.fetchSiteConfigurations = { _ in }
         modelEnv.getSecureUnreadMessageCount = { $0(.success(0)) }
         modelEnv.startSocketObservation = {}
+        modelEnv.shouldShowLeaveSecureConversationDialog = { _ in false }
         let scheduler = CoreSdkClient.ReactiveSwift.TestScheduler()
         modelEnv.messagesWithUnreadCountLoaderScheduler = scheduler
 

--- a/GliaWidgetsTests/SecureConversations/Coordinator/SecureConversations.Coordinator.Environment.Mock.swift
+++ b/GliaWidgetsTests/SecureConversations/Coordinator/SecureConversations.Coordinator.Environment.Mock.swift
@@ -56,7 +56,7 @@ extension SecureConversations.Coordinator.Environment {
         alertManager: .mock(),
         queuesMonitor: .mock(),
         createEntryWidget: { _ in .mock() },
-        shouldShowLeaveSecureConversationDialog: { false },
+        shouldShowLeaveSecureConversationDialog: { _ in false },
         leaveCurrentSecureConversation: .nop,
         switchToEngagement: .nop,
         markUnreadMessagesDelay: { .mock },

--- a/GliaWidgetsTests/Sources/Coordinators/Chat/ChatCoordinator.Environment.Mock.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/Chat/ChatCoordinator.Environment.Mock.swift
@@ -45,7 +45,7 @@ extension ChatCoordinator.Environment {
         alertManager: .mock(),
         queuesMonitor: .mock(), 
         createEntryWidget: { _ in .mock() },
-        shouldShowLeaveSecureConversationDialog: { false },
+        shouldShowLeaveSecureConversationDialog: { _ in false },
         leaveCurrentSecureConversation: .nop,
         switchToEngagement: .nop,
         markUnreadMessagesDelay: { .mock },

--- a/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinatorSecureConversationsTests.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinatorSecureConversationsTests.swift
@@ -75,12 +75,12 @@ extension EngagementCoordinatorTests {
 
         XCTAssertEqual(coordinator.engagementLaunching.currentKind, .messaging(.chatTranscript))
         XCTAssertEqual(coordinator.engagementLaunching.initialKind, .videoCall)
-        XCTAssertTrue(subCoordinator.coordinatorEnvironment.shouldShowLeaveSecureConversationDialog())
+        XCTAssertTrue(subCoordinator.coordinatorEnvironment.shouldShowLeaveSecureConversationDialog(.transcriptOpened))
 
         subCoordinator.coordinatorEnvironment.leaveCurrentSecureConversation(true)
 
         XCTAssertEqual(coordinator.engagementLaunching.currentKind, .videoCall)
-        XCTAssertFalse(subCoordinator.coordinatorEnvironment.shouldShowLeaveSecureConversationDialog())
+        XCTAssertFalse(subCoordinator.coordinatorEnvironment.shouldShowLeaveSecureConversationDialog(.transcriptOpened))
     }
 
     // MARK: - Leave Conversation
@@ -95,11 +95,11 @@ extension EngagementCoordinatorTests {
 
         XCTAssertEqual(coordinator.engagementLaunching.currentKind, .messaging(.chatTranscript))
         XCTAssertEqual(coordinator.engagementLaunching.initialKind, .videoCall)
-        XCTAssertTrue(subCoordinator.coordinatorEnvironment.shouldShowLeaveSecureConversationDialog())
+        XCTAssertTrue(subCoordinator.coordinatorEnvironment.shouldShowLeaveSecureConversationDialog(.transcriptOpened))
 
         subCoordinator.coordinatorEnvironment.leaveCurrentSecureConversation(false)
 
         XCTAssertEqual(coordinator.engagementLaunching.currentKind, .messaging(.chatTranscript))
-        XCTAssertFalse(subCoordinator.coordinatorEnvironment.shouldShowLeaveSecureConversationDialog())
+        XCTAssertFalse(subCoordinator.coordinatorEnvironment.shouldShowLeaveSecureConversationDialog(.transcriptOpened))
     }
 }


### PR DESCRIPTION
MOB-4069

**What was solved?**
This PR adds the logic that skips showing of Leave Current Conversation dialog in case when visitor selects Live media type from top banner and hasPendingInteraction is false

ℹ️ Please feel free to make suggestions regarding names for introduced enum and its cases 

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.