### PR TITLE
Fix top banner thread issue

### DIFF
--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
@@ -42,6 +42,8 @@ public final class EntryWidget: NSObject {
         observeSecureUnreadMessageCount()
 
         Publishers.CombineLatest(environment.queuesMonitor.$state, $unreadSecureMessageCount)
+            // injected combine scheduler will be added here in MOB-4077
+            .receive(on: DispatchQueue.main)
             .sink(receiveValue: { [weak self] in
                 guard let self else { return }
                 handleQueuesMonitorUpdates(state: $0, unreadSecureMessagesCount: $1)
@@ -55,6 +57,8 @@ public final class EntryWidget: NSObject {
                 }
                 return interactor.$currentEngagement.eraseToAnyPublisher()
             }
+            // injected combine scheduler will be added here in MOB-4077
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] engagement in
                 guard let self else { return }
                 ongoingEngagement = engagement
@@ -72,6 +76,8 @@ public final class EntryWidget: NSObject {
                 }
                 return interactor.$state.eraseToAnyPublisher()
             }
+            // injected combine scheduler will be added here in MOB-4077
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] state in
                 guard let self else { return }
                 interactorState = state
@@ -82,14 +88,18 @@ public final class EntryWidget: NSObject {
             }
             .store(in: &cancellables)
         environment.hasPendingInteractionPublisher.assign(to: &$hasPendingInteraction)
-        $hasPendingInteraction.sink { [weak self] _ in
-            guard let self else { return }
-            handleQueuesMonitorUpdates(
-                state: environment.queuesMonitor.state,
-                unreadSecureMessagesCount: unreadSecureMessageCount
-            )
-        }
-        .store(in: &cancellables)
+
+        $hasPendingInteraction
+            // injected combine scheduler will be added here in MOB-4077
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                handleQueuesMonitorUpdates(
+                    state: environment.queuesMonitor.state,
+                    unreadSecureMessagesCount: unreadSecureMessageCount
+                )
+            }
+            .store(in: &cancellables)
     }
 
     deinit {

--- a/GliaWidgets/Sources/View/Chat/SecureMessaging/TopBanner/SecureMessagingTopBannerView.swift
+++ b/GliaWidgets/Sources/View/Chat/SecureMessaging/TopBanner/SecureMessagingTopBannerView.swift
@@ -89,6 +89,8 @@ final class SecureMessagingTopBannerView: UIView {
         isExpanded.assign(to: &self.$isExpanded)
 
         $isExpanded
+            // injected combine scheduler will be added here in MOB-4077
+            .receive(on: DispatchQueue.main)
             .sink { isExpanded in
                 let angle = isExpanded ? .pi : 0
                 UIView.animate(withDuration: Self.rotationDuration) {

--- a/GliaWidgetsTests/Sources/EntryWidget/EntryWidgetTests.swift
+++ b/GliaWidgetsTests/Sources/EntryWidget/EntryWidgetTests.swift
@@ -37,7 +37,7 @@ class EntryWidgetTests: XCTestCase {
         )
 
         entryWidget.show(in: .init())
-
+        addDelay()
         if case let .mediaTypes(mediaTypes) = entryWidget.viewState {
             XCTAssertFalse(mediaTypes.contains(.init(type: .secureMessaging)))
         } else {
@@ -70,7 +70,7 @@ class EntryWidgetTests: XCTestCase {
         )
 
         entryWidget.show(in: .init())
-
+        addDelay()
         if case let .mediaTypes(mediaTypes) = entryWidget.viewState {
             XCTAssertTrue(mediaTypes.contains(.init(type: .secureMessaging)))
         } else {
@@ -100,7 +100,7 @@ class EntryWidgetTests: XCTestCase {
         environment.observeSecureUnreadMessageCount = observeMessageCount
 
         queuesMonitor.fetchAndMonitorQueues()
-
+        addDelay()
         let entryWidget = EntryWidget(
             queueIds: [mockQueueId],
             configuration: .default,
@@ -108,7 +108,7 @@ class EntryWidgetTests: XCTestCase {
         )
         
         entryWidget.show(in: .init())
-
+        addDelay()
         if case let .mediaTypes(mediaTypes) = entryWidget.viewState {
             XCTAssertTrue(mediaTypes.contains(.init(type: .secureMessaging, badgeCount: 5)))
         } else {
@@ -186,6 +186,7 @@ class EntryWidgetTests: XCTestCase {
             configuration: .default,
             environment: environment
         )
+        addDelay()
 
         XCTAssertEqual(
             entryWidget.viewState,
@@ -222,6 +223,7 @@ class EntryWidgetTests: XCTestCase {
             configuration: .default,
             environment: environment
         )
+        addDelay()
 
         XCTAssertEqual(
             entryWidget.viewState,
@@ -255,6 +257,7 @@ class EntryWidgetTests: XCTestCase {
             configuration: configuration,
             environment: environment
         )
+        addDelay()
 
         XCTAssertEqual(
             entryWidget.viewState,
@@ -289,6 +292,7 @@ class EntryWidgetTests: XCTestCase {
             configuration: configuration,
             environment: environment
         )
+        addDelay()
 
         XCTAssertEqual(
             entryWidget.viewState,
@@ -322,7 +326,7 @@ class EntryWidgetTests: XCTestCase {
         )
 
         entryWidget.show(in: .init())
-
+        addDelay()
         XCTAssertEqual(entryWidget.viewState, .ongoingEngagement(.chat))
     }
 
@@ -352,7 +356,7 @@ class EntryWidgetTests: XCTestCase {
         )
 
         entryWidget.show(in: .init())
-
+        addDelay()
         XCTAssertEqual(entryWidget.viewState, .ongoingEngagement(.audio))
     }
 
@@ -382,7 +386,7 @@ class EntryWidgetTests: XCTestCase {
         )
 
         entryWidget.show(in: .init())
-
+        addDelay()
         XCTAssertEqual(entryWidget.viewState, .ongoingEngagement(.video))
     }
 
@@ -412,7 +416,7 @@ class EntryWidgetTests: XCTestCase {
         )
 
         entryWidget.show(in: .init())
-
+        addDelay()
         XCTAssertEqual(entryWidget.viewState, .ongoingEngagement(.callVisualizer))
     }
 
@@ -429,7 +433,7 @@ class EntryWidgetTests: XCTestCase {
         )
 
         entryWidget.show(in: .init())
-
+        addDelay()
         XCTAssertEqual(entryWidget.viewState, .ongoingEngagement(.chat))
     }
 
@@ -446,7 +450,7 @@ class EntryWidgetTests: XCTestCase {
         )
 
         entryWidget.show(in: .init())
-
+        addDelay()
         XCTAssertEqual(entryWidget.viewState, .ongoingEngagement(.audio))
     }
 
@@ -463,7 +467,7 @@ class EntryWidgetTests: XCTestCase {
         )
 
         entryWidget.show(in: .init())
-
+        addDelay()
         XCTAssertEqual(entryWidget.viewState, .ongoingEngagement(.video))
     }
     
@@ -480,7 +484,7 @@ class EntryWidgetTests: XCTestCase {
         )
 
         entryWidget.show(in: .init())
-
+        addDelay()
         XCTAssertEqual(entryWidget.viewState, .ongoingEngagement(.chat))
     }
 
@@ -497,7 +501,7 @@ class EntryWidgetTests: XCTestCase {
         )
 
         entryWidget.show(in: .init())
-
+        addDelay()
         XCTAssertEqual(entryWidget.viewState, .ongoingEngagement(.audio))
     }
 
@@ -514,7 +518,7 @@ class EntryWidgetTests: XCTestCase {
         )
 
         entryWidget.show(in: .init())
-
+        addDelay()
         XCTAssertEqual(entryWidget.viewState, .ongoingEngagement(.video))
     }
 
@@ -554,7 +558,7 @@ class EntryWidgetTests: XCTestCase {
         )
 
         entryWidget.embed(in: .init())
-
+        addDelay()
         XCTAssertEqual(entryWidget.viewState, .mediaTypes([.init(type: .audio), .init(type: .chat), .init(type: .secureMessaging)]))
     }
 
@@ -626,6 +630,7 @@ class EntryWidgetTests: XCTestCase {
         )
 
         entryWidget.show(in: .init())
+        addDelay()
         XCTAssertTrue(logs.contains(expectedLogMessage))
     }
 
@@ -654,14 +659,21 @@ class EntryWidgetTests: XCTestCase {
         let oldInteractor = Interactor.mock()
         oldInteractor.setCurrentEngagement(.mock())
         interactorSubject.send(oldInteractor)
-
+        addDelay()
         XCTAssertEqual(entryWidget.viewState, .ongoingEngagement(.chat))
 
         let newInteractor = Interactor.mock()
         newInteractor.setCurrentEngagement(.mock(media: .init(audio: .twoWay, video: nil)))
         interactorSubject.send(newInteractor)
-
+        addDelay()
         XCTAssertEqual(entryWidget.viewState, .ongoingEngagement(.audio))
     }
+}
 
+extension EntryWidgetTests {
+    func addDelay(withDelay: Double = 0.1) {
+        let expectation = self.expectation(description: "Wait for view state update")
+        expectation.isInverted = true
+        wait(for: [expectation], timeout: withDelay)
+    }
 }

--- a/GliaWidgetsTests/Sources/QueuesMonitor/QueuesMonitorTests.swift
+++ b/GliaWidgetsTests/Sources/QueuesMonitor/QueuesMonitorTests.swift
@@ -211,7 +211,7 @@ class QueuesMonitorTests: XCTestCase {
 
         monitor.fetchAndMonitorQueues(queuesIds: [mockQueueId])
         monitor.fetchAndMonitorQueues(queuesIds: [mockQueueId])
-
+        addDelay()
         XCTAssertEqual(receivedQueues, [expectedUpdatedQueue])
         XCTAssertEqual(receivedUpdatedQueue?.state.status, .open)
         XCTAssertEqual(
@@ -483,5 +483,13 @@ class QueuesMonitorTests: XCTestCase {
         XCTAssertEqual(receivedQueues?.count, 2)
         XCTAssertTrue(receivedQueues?.contains(where: { $0.id == knownQueueId }) == true)
         XCTAssertTrue(receivedQueues?.contains(where: { $0.id == unknownQueueId }) == true)
+    }
+}
+
+extension QueuesMonitorTests {
+    func addDelay(withDelay: Double = 0.1) {
+        let expectation = self.expectation(description: "Wait for view state update")
+        expectation.isInverted = true
+        wait(for: [expectation], timeout: withDelay)
     }
 }

--- a/SnapshotTests/ChatViewControllerDynamicTypeFontTests.swift
+++ b/SnapshotTests/ChatViewControllerDynamicTypeFontTests.swift
@@ -61,7 +61,9 @@ final class ChatViewControllerDynamicTypeFontTests: SnapshotTestCase {
         viewController.view.setNeedsLayout()
         viewController.view.layoutIfNeeded()
         
-        viewController.assertSnapshot(as: .extra3LargeFont, in: .portrait)
-        viewController.assertSnapshot(as: .extra3LargeFont, in: .landscape)
+        DispatchQueue.main.async {
+            viewController.assertSnapshot(as: .extra3LargeFont, in: .portrait)
+            viewController.assertSnapshot(as: .extra3LargeFont, in: .landscape)
+        }
     }
 }

--- a/SnapshotTests/ChatViewControllerLayoutTests.swift
+++ b/SnapshotTests/ChatViewControllerLayoutTests.swift
@@ -101,9 +101,10 @@ final class ChatViewControllerLayoutTests: SnapshotTestCase {
         viewController.view.frame = UIScreen.main.bounds
         viewController.view.setNeedsLayout()
         viewController.view.layoutIfNeeded()
-        
-        viewController.assertSnapshot(as: .image, in: .portrait)
-        viewController.assertSnapshot(as: .image, in: .landscape)
+        DispatchQueue.main.async {
+            viewController.assertSnapshot(as: .image, in: .portrait)
+            viewController.assertSnapshot(as: .image, in: .landscape)
+        }
     }
 
     func test_secureMessagingBottomAndCollapsedTopBannerWithUnifiedUI() {
@@ -139,8 +140,10 @@ final class ChatViewControllerLayoutTests: SnapshotTestCase {
         viewController.view.frame = UIScreen.main.bounds
         viewController.view.setNeedsLayout()
         viewController.view.layoutIfNeeded()
-        
-        viewController.assertSnapshot(as: .image, in: .portrait)
-        viewController.assertSnapshot(as: .image, in: .landscape)
+
+        DispatchQueue.main.async {
+            viewController.assertSnapshot(as: .image, in: .portrait)
+            viewController.assertSnapshot(as: .image, in: .landscape)
+        }
     }
 }

--- a/SnapshotTests/ChatViewControllerVoiceOverTests.swift
+++ b/SnapshotTests/ChatViewControllerVoiceOverTests.swift
@@ -81,7 +81,9 @@ final class ChatViewControllerVoiceOverTests: SnapshotTestCase {
         viewController.view.frame = UIScreen.main.bounds
         viewController.view.setNeedsLayout()
         viewController.view.layoutIfNeeded()
-        
-        viewController.assertSnapshot(as: .accessibilityImage)
+
+        DispatchQueue.main.async {
+            viewController.assertSnapshot(as: .accessibilityImage)
+        }
     }
 }


### PR DESCRIPTION
**What was solved?**
When starting an engagement, then some values were updated from the background thread, which is prohibited. With this PR, UI related changes will happen from the main thread.

MOB-4074
**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
