### PR TITLE
Remove 'loading' state from QueuesMonitor to prevent EW getting stuck

### DIFF
--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
@@ -42,7 +42,10 @@ public final class EntryWidget: NSObject {
         observeSecureUnreadMessageCount()
 
         Publishers.CombineLatest(environment.queuesMonitor.$state, $unreadSecureMessageCount)
-            .sink(receiveValue: handleQueuesMonitorUpdates(state:unreadSecureMessagesCount:))
+            .sink(receiveValue: { [weak self] in
+                guard let self else { return }
+                handleQueuesMonitorUpdates(state: $0, unreadSecureMessagesCount: $1)
+            })
             .store(in: &cancellables)
 
         environment.interactorPublisher
@@ -398,7 +401,7 @@ private extension EntryWidget {
         unreadSecureMessagesCount: Int?
     ) -> EntryWidget.ViewState {
         switch queuesMonitorState {
-        case .idle, .loading:
+        case .idle:
             return .loading
         case .updated(let queues):
             let availableEngagementTypes = resolveAvailableEngagementTypes(from: queues)

--- a/GliaWidgets/Sources/Interactor/Interactor.swift
+++ b/GliaWidgets/Sources/Interactor/Interactor.swift
@@ -425,7 +425,7 @@ extension Interactor: CoreSdkClient.Interactable {
     }
 
     func fail(error: CoreSdkClient.SalemoveError) {
-        // Fail is called from CoreSDK when acces token expiration happens
+        // Fail is called from CoreSDK when access token expiration happens
         // and it leads to fetchQueues failure that stops queues observing
         // Also when token expires CoreSDK makes force deauthentication which
         // allows to refetch the queues without errors

--- a/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.Live.swift
+++ b/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.Live.swift
@@ -5,7 +5,6 @@ import Combine
 final class QueuesMonitor {
     enum State {
         case idle
-        case loading
         case updated([Queue])
         case failed(Error)
     }
@@ -48,7 +47,7 @@ final class QueuesMonitor {
             }
 
             let observedQueues = evaluateQueues(queuesIds: queuesIds, fetchedQueues: queues)
-
+            state = .updated(observedQueues)
             self._observedQueues.setValue(observedQueues)
             completion(.success(observedQueues))
         }
@@ -65,10 +64,6 @@ final class QueuesMonitor {
         queuesIds: [String] = [],
         fetchedQueuesCompletion: ((Result<[Queue], GliaCoreError>) -> Void)? = nil
     ) {
-        if case .loading = state { return }
-
-        state = .loading
-
         stopMonitoring()
 
         fetchQueues(queuesIds: queuesIds) { [weak self] result in


### PR DESCRIPTION
Remove 'loading' state from QueuesMonitor to prevent EntryWidgets getting stuck in 'loading' state when SDK is re-configured. Previously this 'QueuesMonitor.State.loading' was introduced to address multiple subscription creation, however this led to the issue with EntryWidgets. This multiple subscription issue should be addressed in subsequent ticket(s), once SC 2.0 is released. Also these changes address EntryWidgets memory leak issue caused by Combine subscription.

MOB-4068

**What was solved?**

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
