### PR TITLE
Check if queue is unstaffed or full on EW to filter out media types but SC

### DIFF
--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
@@ -216,6 +216,20 @@ private extension EntryWidget {
             availableMediaTypes.remove(.secureMessaging)
         }
 
+        let queuesStatuses = Set(queues.map { $0.state.status })
+        let areQueuesUnavailable = queuesStatuses.contains(.unstaffed) || queuesStatuses.contains(.full)
+
+        if !queuesStatuses.contains(.open) && areQueuesUnavailable {
+            // Entry Widget should not show unavailability if SecureConversation available even if queues is unstaffed or full
+            if availableMediaTypes.contains(.secureMessaging) {
+                availableMediaTypes.removeAll()
+                availableMediaTypes.insert(.secureMessaging)
+                // Entry Widget should show unavailability if queues is unstaffed or full and SecureConversation unavailable
+            } else {
+                availableMediaTypes.removeAll()
+            }
+        }
+
         return Array(availableMediaTypes).sorted(by: { $0.rawValue < $1.rawValue })
     }
 


### PR DESCRIPTION
**What was solved?**
This PR checks if queue is unstaffed or full on Entry Widget to filter out media types but Secure Conversation

**Release notes:**

 - [X] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [X] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

