### PR TITLE
Rename fetchVisitorInfo to getVisitorInfo in WidgetSDK

### DIFF
--- a/GliaWidgets/Public/Glia/Glia.Deprecated.swift
+++ b/GliaWidgets/Public/Glia/Glia.Deprecated.swift
@@ -1,3 +1,9 @@
 import GliaCoreSDK
 
-extension Glia {}
+extension Glia {
+    /// Deprecated, use ``Glia.getVisitorInfo(completion:`` instead.
+    @available(*, deprecated, message: "Deprecated, use ``Glia.getVisitorInfo(completion:`` instead. ")
+    public func fetchVisitorInfo(completion: @escaping (Result<GliaCore.VisitorInfo, Error>) -> Void) {
+        getVisitorInfo(completion: completion)
+    }
+}

--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -388,12 +388,12 @@ public class Glia {
     ///   `configure(with:uiConfig:assetsBuilder:completion:)` must be called prior to
     ///   this method, because `GliaError.sdkIsNotConfigured` will occur otherwise.
     ///
-    public func fetchVisitorInfo(completion: @escaping (Result<GliaCore.VisitorInfo, Error>) -> Void) {
+    public func getVisitorInfo(completion: @escaping (Result<GliaCore.VisitorInfo, Error>) -> Void) {
         guard configuration != nil else {
             completion(.failure(GliaError.sdkIsNotConfigured))
             return
         }
-        environment.coreSdk.fetchVisitorInfo(completion)
+        environment.coreSdk.getVisitorInfo(completion)
     }
 
     /// Update current Visitor's information.

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -8,9 +8,9 @@ struct CoreSdkClient {
     var clearSession: () -> Void
     var localeProvider: LocaleProvider
 
-    typealias FetchVisitorInfo = (_ completion: @escaping (Result<Self.Salemove.VisitorInfo, Error>) -> Void) -> Void
+    typealias GetVisitorInfo = (_ completion: @escaping (Result<Self.Salemove.VisitorInfo, Error>) -> Void) -> Void
 
-    var fetchVisitorInfo: FetchVisitorInfo
+    var getVisitorInfo: GetVisitorInfo
 
     typealias UpdateVisitorInfo = (
         _ info: Self.VisitorInfoUpdate,

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
@@ -7,7 +7,7 @@ extension CoreSdkClient {
             createAppDelegate: Self.AppDelegate.live,
             clearSession: GliaCore.sharedInstance.clearSession,
             localeProvider: .init(getRemoteString: GliaCore.sharedInstance.localeProvider.getRemoteString(_:)),
-            fetchVisitorInfo: GliaCore.sharedInstance.fetchVisitorInfo(_:),
+            getVisitorInfo: GliaCore.sharedInstance.fetchVisitorInfo(_:),
             updateVisitorInfo: GliaCore.sharedInstance.updateVisitorInfo(_:completion:),
             configureWithConfiguration: GliaCore.sharedInstance.configure(with:completion:),
             configureWithInteractor: GliaCore.sharedInstance.configure(interactor:),

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -8,7 +8,7 @@ extension CoreSdkClient {
         createAppDelegate: { .mock },
         clearSession: {},
         localeProvider: .mock,
-        fetchVisitorInfo: { _ in },
+        getVisitorInfo: { _ in },
         updateVisitorInfo: { _, _ in },
         configureWithConfiguration: { _, _ in },
         configureWithInteractor: { _ in },

--- a/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
@@ -6,7 +6,7 @@ extension CoreSdkClient {
         createAppDelegate: { .failing },
         clearSession: { fail("\(Self.self).clearSession") },
         localeProvider: .failing,
-        fetchVisitorInfo: { _ in fail("\(Self.self).fetchVisitorInfo") },
+        getVisitorInfo: { _ in fail("\(Self.self).getVisitorInfo") },
         updateVisitorInfo: { _, _ in fail("\(Self.self).updateVisitorInfo") },
         configureWithConfiguration: { _, _ in fail("\(Self.self).configureWithConfiguration") },
         configureWithInteractor: { _ in fail("\(Self.self).configureWithInteractor") },

--- a/TestingApp/ViewController/ViewController.swift
+++ b/TestingApp/ViewController/ViewController.swift
@@ -19,8 +19,8 @@ class ViewController: UIViewController {
 
     let visitorInfoModel = VisitorInfoModel(
         environment: .init(
-            fetchVisitorInfo: GliaCore.sharedInstance.fetchVisitorInfo,
-            updateVisitorInfo: GliaCore.sharedInstance.updateVisitorInfo,
+            getVisitorInfo: Glia.sharedInstance.getVisitorInfo,
+            updateVisitorInfo: Glia.sharedInstance.updateVisitorInfo,
             uuid: UUID.init
         )
     )

--- a/TestingApp/VisitorInfo/VisitorInfoModel.swift
+++ b/TestingApp/VisitorInfo/VisitorInfoModel.swift
@@ -88,7 +88,7 @@ final class VisitorInfoModel {
 
     func loadVisitorInfo() {
         self.fetchInfoRequestState = .inFlight
-        environment.fetchVisitorInfo { [weak self] result in
+        environment.getVisitorInfo { [weak self] result in
             guard let self else { return }
             // Attributes needs to be ordered in some way,
             // that is why we need to keep their IDs in order.
@@ -442,7 +442,7 @@ final class VisitorInfoModel {
 
 extension VisitorInfoModel {
     struct Environment {
-        let fetchVisitorInfo: (@escaping (Result<GliaCore.VisitorInfo, Error>) -> Void) -> Void
+        let getVisitorInfo: (@escaping (Result<GliaCore.VisitorInfo, Error>) -> Void) -> Void
         let updateVisitorInfo: (VisitorInfoUpdate, @escaping (Result<Bool, Error>) -> Void) -> Void
         let uuid: () -> UUID
     }


### PR DESCRIPTION
**What was solved?**
This PR refacotrs testing app to use existing WidgetSDK interface for Visitor info

MOB-4136
**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [X] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
