### PR TITLE
Rename listQueues to getQueues

### DIFF
--- a/GliaWidgets/Public/Glia/Glia.Deprecated.swift
+++ b/GliaWidgets/Public/Glia/Glia.Deprecated.swift
@@ -1,9 +1,15 @@
 import GliaCoreSDK
 
 extension Glia {
-    /// Deprecated, use ``Glia.getVisitorInfo(completion:`` instead.
-    @available(*, deprecated, message: "Deprecated, use ``Glia.getVisitorInfo(completion:`` instead. ")
+    /// Deprecated, use ``Glia.getVisitorInfo(completion:)`` instead.
+    @available(*, deprecated, message: "Deprecated, use ``Glia.getVisitorInfo(completion:)`` instead. ")
     public func fetchVisitorInfo(completion: @escaping (Result<GliaCore.VisitorInfo, Error>) -> Void) {
         getVisitorInfo(completion: completion)
+    }
+
+    /// Deprecated, use ``Glia.getQueues(completion:)`` instead.
+    @available(*, deprecated, message: "Deprecated, use ``Glia.getQueues(completion:)`` instead. ")
+    public func listQueues(_ completion: @escaping (Result<[Queue], Error>) -> Void) {
+        getQueues(completion)
     }
 }

--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -177,7 +177,7 @@ public class Glia {
             )
         )
         queuesMonitor = .init(environment: .init(
-            listQueues: environment.coreSdk.listQueues,
+            getQueues: environment.coreSdk.getQueues,
             subscribeForQueuesUpdates: environment.coreSdk.subscribeForQueuesUpdates,
             unsubscribeFromUpdates: environment.coreSdk.unsubscribeFromUpdates,
             logger: loggerPhase.logger
@@ -464,13 +464,13 @@ public class Glia {
     /// - Parameters:
     ///   - completion: A callback that will return the Result struct with `Queue` list or `GliaCoreError`.
     ///
-    public func listQueues(_ completion: @escaping (Result<[Queue], Error>) -> Void) {
+    public func getQueues(_ completion: @escaping (Result<[Queue], Error>) -> Void) {
         guard configuration != nil else {
             completion(.failure(GliaError.sdkIsNotConfigured))
             return
         }
 
-        environment.coreSdk.listQueues { queues, error in
+        environment.coreSdk.getQueues { queues, error in
             if let error {
                 completion(.failure(error))
                 return

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.Environment.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.Environment.swift
@@ -16,7 +16,7 @@ extension SecureConversations.TranscriptModel {
         var uiApplication: UIKitBased.UIApplication
         var sendSecureMessagePayload: CoreSdkClient.SendSecureMessagePayload
         var queueIds: [String]
-        var listQueues: CoreSdkClient.ListQueues
+        var getQueues: CoreSdkClient.ListQueues
         var createFileUploadListModel: SecureConversations.FileUploadListViewModel.Create
         var uuid: () -> UUID
         var secureUploadFile: CoreSdkClient.SecureConversationsUploadFile
@@ -66,7 +66,7 @@ extension SecureConversations.TranscriptModel.Environment {
             uiApplication: environment.uiApplication,
             sendSecureMessagePayload: environment.sendSecureMessagePayload,
             queueIds: environment.queueIds,
-            listQueues: environment.listQueues,
+            getQueues: environment.listQueues,
             createFileUploadListModel: environment.createFileUploadListModel,
             uuid: environment.uuid,
             secureUploadFile: environment.secureUploadFile,
@@ -111,7 +111,7 @@ extension SecureConversations.TranscriptModel.Environment {
         uiApplication: UIKitBased.UIApplication = .mock,
         sendSecureMessagePayload: @escaping CoreSdkClient.SendSecureMessagePayload = { _, _, _ in .mock },
         queueIds: [String] = [],
-        listQueues: @escaping CoreSdkClient.ListQueues = { _ in },
+        getQueues: @escaping CoreSdkClient.ListQueues = { _ in },
         createFileUploadListModel: @escaping SecureConversations.FileUploadListViewModel.Create = { _ in .mock() },
         uuid: @escaping () -> UUID = { .mock },
         secureUploadFile: @escaping CoreSdkClient.SecureConversationsUploadFile = { _, _, _ in .mock },
@@ -151,7 +151,7 @@ extension SecureConversations.TranscriptModel.Environment {
             uiApplication: uiApplication,
             sendSecureMessagePayload: sendSecureMessagePayload,
             queueIds: queueIds,
-            listQueues: listQueues,
+            getQueues: getQueues,
             createFileUploadListModel: createFileUploadListModel,
             uuid: uuid,
             secureUploadFile: secureUploadFile,

--- a/GliaWidgets/SecureConversations/SecureConversations.Availability.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Availability.swift
@@ -70,7 +70,7 @@ extension SecureConversations {
 
 extension SecureConversations.Availability {
     struct Environment {
-        var listQueues: CoreSdkClient.ListQueues
+        var getQueues: CoreSdkClient.ListQueues
         var isAuthenticated: () -> Bool
         var log: CoreSdkClient.Logger
         var queuesMonitor: QueuesMonitor
@@ -119,7 +119,7 @@ extension SecureConversations.Availability.Status {
 extension SecureConversations.Availability.Environment {
     static func create(with environment: ChatCoordinator.Environment) -> Self {
         .init(
-            listQueues: environment.listQueues,
+            getQueues: environment.listQueues,
             isAuthenticated: environment.isAuthenticated,
             log: environment.log,
             queuesMonitor: environment.queuesMonitor,
@@ -129,7 +129,7 @@ extension SecureConversations.Availability.Environment {
 
     static func create(with environment: SecureConversations.Coordinator.Environment) -> Self {
         .init(
-            listQueues: environment.listQueues,
+            getQueues: environment.listQueues,
             isAuthenticated: environment.isAuthenticated,
             log: environment.log,
             queuesMonitor: environment.queuesMonitor,
@@ -156,7 +156,7 @@ extension SecureConversations.Availability.Environment {
         getCurrentEngagement: @escaping CoreSdkClient.GetCurrentEngagement = { .mock() }
     ) -> Self {
         .init(
-            listQueues: listQueues,
+            getQueues: listQueues,
             isAuthenticated: isAuthenticated,
             log: log,
             queuesMonitor: queuesMonitor,

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
@@ -86,7 +86,7 @@ extension EngagementCoordinator.Environment {
             uiScreen: environment.uiScreen,
             notificationCenter: environment.notificationCenter,
             fetchChatHistory: environment.coreSdk.fetchChatHistory,
-            listQueues: environment.coreSdk.listQueues,
+            listQueues: environment.coreSdk.getQueues,
             sendSecureMessagePayload: environment.coreSdk.sendSecureMessagePayload,
             createFileUploader: environment.createFileUploader,
             createFileUploadListModel: environment.createFileUploadListModel,

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -35,7 +35,7 @@ struct CoreSdkClient {
         _ completion: @escaping Self.QueueRequestBlock
     ) -> Void
 
-    var listQueues: ListQueues
+    var getQueues: ListQueues
 
     typealias QueueForEngagement = (
         _ options: GliaCoreSDK.QueueForEngagementOptions,

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
@@ -12,7 +12,7 @@ extension CoreSdkClient {
             updateVisitorInfo: GliaCore.sharedInstance.updateVisitorInfo(_:completion:),
             configureWithConfiguration: GliaCore.sharedInstance.configure(with:completion:),
             configureWithInteractor: GliaCore.sharedInstance.configure(interactor:),
-            listQueues: GliaCore.sharedInstance.listQueues(completion:),
+            getQueues: GliaCore.sharedInstance.listQueues(completion:),
             queueForEngagement: { options, replaceExisting, completion in
                 let options = QueueForEngagementOptions(
                     queueIds: options.queueIds,

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -13,7 +13,7 @@ extension CoreSdkClient {
         updateVisitorInfo: { _, _ in },
         configureWithConfiguration: { _, _ in },
         configureWithInteractor: { _ in },
-        listQueues: { _ in },
+        getQueues: { _ in },
         queueForEngagement: { _, _, _ in },
         requestMediaUpgradeWithOffer: { _, _ in },
         sendMessagePreview: { _, _ in },

--- a/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.Environment.Mock.swift
+++ b/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.Environment.Mock.swift
@@ -2,7 +2,7 @@ import Foundation
 #if DEBUG
 extension QueuesMonitor.Environment {
     static let mock: Self = .init(
-        listQueues: { _ in },
+        getQueues: { _ in },
         subscribeForQueuesUpdates: { _, _ in UUID().uuidString },
         unsubscribeFromUpdates: { _, _ in },
         logger: .mock

--- a/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.Environment.swift
+++ b/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.Environment.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension QueuesMonitor {
     struct Environment {
-        var listQueues: CoreSdkClient.ListQueues
+        var getQueues: CoreSdkClient.ListQueues
         var subscribeForQueuesUpdates: CoreSdkClient.SubscribeForQueuesUpdates
         var unsubscribeFromUpdates: CoreSdkClient.UnsubscribeFromUpdates
         var logger: CoreSdkClient.Logger

--- a/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.Live.swift
+++ b/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.Live.swift
@@ -35,7 +35,7 @@ final class QueuesMonitor {
     ///   if no queues were found among site's queues returns default queues.
     ///
     func fetchQueues(queuesIds: [String], completion: @escaping (Result<[Queue], GliaCoreError>) -> Void) {
-        environment.listQueues { [weak self] queues, error in
+        environment.getQueues { [weak self] queues, error in
             guard let self else {
                 return
             }

--- a/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.Mock.swift
+++ b/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.Mock.swift
@@ -1,13 +1,13 @@
 #if DEBUG
 extension QueuesMonitor {
     static func mock(
-        listQueues: CoreSdkClient.ListQueues? = nil,
+        getQueues: CoreSdkClient.ListQueues? = nil,
         subscribeForQueuesUpdates: CoreSdkClient.SubscribeForQueuesUpdates? = nil,
         unsubscribeFromUpdates: CoreSdkClient.UnsubscribeFromUpdates? = nil
     ) -> Self {
         Self(
             environment: .init(
-                listQueues: listQueues ?? QueuesMonitor.Environment.mock.listQueues,
+                getQueues: getQueues ?? QueuesMonitor.Environment.mock.getQueues,
                 subscribeForQueuesUpdates: subscribeForQueuesUpdates ?? QueuesMonitor.Environment.mock.subscribeForQueuesUpdates,
                 unsubscribeFromUpdates: unsubscribeFromUpdates ?? QueuesMonitor.Environment.mock.unsubscribeFromUpdates,
                 logger: .mock

--- a/GliaWidgetsTests/QueuesMonitor.Failing.swift
+++ b/GliaWidgetsTests/QueuesMonitor.Failing.swift
@@ -3,7 +3,7 @@
 extension QueuesMonitor {
     static let failing = QueuesMonitor(
         environment: .init(
-            listQueues: CoreSdkClient.failing.listQueues,
+            getQueues: CoreSdkClient.failing.getQueues,
             subscribeForQueuesUpdates: CoreSdkClient.failing.subscribeForQueuesUpdates,
             unsubscribeFromUpdates: CoreSdkClient.failing.unsubscribeFromUpdates,
             logger: .failing

--- a/GliaWidgetsTests/SecureConversations/Availability.Environment.Failing.swift
+++ b/GliaWidgetsTests/SecureConversations/Availability.Environment.Failing.swift
@@ -2,7 +2,7 @@
 
 extension SecureConversations.Availability.Environment {
     static let failing = Self(
-        listQueues: { _ in
+        getQueues: { _ in
             fail("\(Self.self).listQueues")
         },
         isAuthenticated: {

--- a/GliaWidgetsTests/SecureConversations/AvailabilityTests.swift
+++ b/GliaWidgetsTests/SecureConversations/AvailabilityTests.swift
@@ -7,11 +7,11 @@ final class AvailabilityTests: XCTestCase {
     func testListQueuesErrorPassedToResult() throws {
         var env = Availability.Environment.failing
         let error = CoreSdkClient.SalemoveError.mock()
-        env.listQueues = { callback in
+        env.getQueues = { callback in
             callback(nil, error)
         }
         env.isAuthenticated = { true }
-        env.queuesMonitor = .mock(listQueues: env.listQueues)
+        env.queuesMonitor = .mock(getQueues: env.getQueues)
         let queueIds = [UUID.mock.uuidString]
         let availability = Availability(environment: env)
         var receivedResult: Result<Availability.Status, CoreSdkClient.SalemoveError>?
@@ -23,7 +23,7 @@ final class AvailabilityTests: XCTestCase {
 
     func testEmptyQueueStatus() throws {
         var env = Availability.Environment.failing
-        env.listQueues = { callback in
+        env.getQueues = { callback in
             callback([], nil)
         }
         var logger = CoreSdkClient.Logger.failing
@@ -31,7 +31,7 @@ final class AvailabilityTests: XCTestCase {
         logger.warningClosure = { _, _, _, _ in }
         env.log = logger
         env.isAuthenticated = { true }
-        env.queuesMonitor = .mock(listQueues: env.listQueues)
+        env.queuesMonitor = .mock(getQueues: env.getQueues)
         env.getCurrentEngagement = { .mock() }
         let queueIds = [UUID.mock.uuidString]
         let availability = Availability(environment: env)
@@ -44,7 +44,7 @@ final class AvailabilityTests: XCTestCase {
 
     func testUnauthenticatedQueueStatus() throws {
         var env = Availability.Environment.failing
-        env.listQueues = { callback in
+        env.getQueues = { callback in
             callback([], nil)
         }
         var logger = CoreSdkClient.Logger.failing
@@ -52,7 +52,7 @@ final class AvailabilityTests: XCTestCase {
         logger.warningClosure = { _, _, _, _ in }
         env.log = logger
         env.isAuthenticated = { false }
-        env.queuesMonitor = .mock(listQueues: env.listQueues)
+        env.queuesMonitor = .mock(getQueues: env.getQueues)
         let queueIds = [UUID.mock.uuidString]
         let availability = Availability(environment: env)
         var receivedResult: Result<Availability.Status, CoreSdkClient.SalemoveError>?
@@ -65,7 +65,7 @@ final class AvailabilityTests: XCTestCase {
     func testAvailableQueueStatus() throws {
         var env = Availability.Environment.failing
         let queueId = UUID.mock.uuidString
-        env.listQueues = { callback in
+        env.getQueues = { callback in
             callback([.mock(id: queueId, status: .open, media: [.messaging])], nil)
         }
         var logger = CoreSdkClient.Logger.failing
@@ -73,7 +73,7 @@ final class AvailabilityTests: XCTestCase {
         logger.infoClosure = { _, _, _, _ in }
         env.log = logger
         env.isAuthenticated = { true }
-        env.queuesMonitor = .mock(listQueues: env.listQueues)
+        env.queuesMonitor = .mock(getQueues: env.getQueues)
         let availability = Availability(environment: env)
         var receivedResult: Result<Availability.Status, CoreSdkClient.SalemoveError>?
         availability.checkSecureConversationsAvailability(for: [queueId]) { result in
@@ -92,7 +92,7 @@ final class AvailabilityTests: XCTestCase {
         var env = Availability.Environment.failing
         let generateUUID = UUID.incrementing
         let queueIds = [generateUUID().uuidString]
-        env.listQueues = { callback in
+        env.getQueues = { callback in
             callback([.mock(id: generateUUID().uuidString, status: .open, media: [.messaging])], nil)
         }
         var logger = CoreSdkClient.Logger.failing
@@ -100,7 +100,7 @@ final class AvailabilityTests: XCTestCase {
         logger.warningClosure = { _, _, _, _ in }
         env.log = logger
         env.isAuthenticated = { true }
-        env.queuesMonitor = .mock(listQueues: env.listQueues)
+        env.queuesMonitor = .mock(getQueues: env.getQueues)
         env.getCurrentEngagement = { .mock() }
         let availability = Availability(environment: env)
         var receivedResult: Result<Availability.Status, CoreSdkClient.SalemoveError>?
@@ -114,7 +114,7 @@ final class AvailabilityTests: XCTestCase {
         var env = Availability.Environment.failing
         let generateUUID = UUID.incrementing
         let queueId = generateUUID().uuidString
-        env.listQueues = { callback in
+        env.getQueues = { callback in
             callback([.mock(id: queueId, status: .closed, media: [.messaging])], nil)
         }
         var logger = CoreSdkClient.Logger.failing
@@ -122,7 +122,7 @@ final class AvailabilityTests: XCTestCase {
         logger.warningClosure = { _, _, _, _ in }
         env.log = logger
         env.isAuthenticated = { true }
-        env.queuesMonitor = .mock(listQueues: env.listQueues)
+        env.queuesMonitor = .mock(getQueues: env.getQueues)
         env.getCurrentEngagement = { .mock() }
         let availability = Availability(environment: env)
         var receivedResult: Result<Availability.Status, CoreSdkClient.SalemoveError>?
@@ -136,7 +136,7 @@ final class AvailabilityTests: XCTestCase {
         var env = Availability.Environment.failing
         let generateUUID = UUID.incrementing
         let queueId = generateUUID().uuidString
-        env.listQueues = { callback in
+        env.getQueues = { callback in
             callback([.mock(id: queueId, status: .closed, media: [.text])], nil)
         }
         env.getCurrentEngagement = { .mock() }
@@ -145,7 +145,7 @@ final class AvailabilityTests: XCTestCase {
         logger.warningClosure = { _, _, _, _ in }
         env.log = logger
         env.isAuthenticated = { true }
-        env.queuesMonitor = .mock(listQueues: env.listQueues)
+        env.queuesMonitor = .mock(getQueues: env.getQueues)
         let availability = Availability(environment: env)
         var receivedResult: Result<Availability.Status, CoreSdkClient.SalemoveError>?
         availability.checkSecureConversationsAvailability(for: [queueId]) { result in
@@ -157,7 +157,7 @@ final class AvailabilityTests: XCTestCase {
     func testAvailableStatusIfNoQueueIsPassed() throws {
         var env = Availability.Environment.failing
         let queueId = UUID.mock.uuidString
-        env.listQueues = { callback in
+        env.getQueues = { callback in
             callback([.mock(id: queueId, status: .open, isDefault: true, media: [.messaging])], nil)
         }
         var logger = CoreSdkClient.Logger.failing
@@ -166,7 +166,7 @@ final class AvailabilityTests: XCTestCase {
         logger.warningClosure = { _, _, _, _ in }
         env.log = logger
         env.isAuthenticated = { true }
-        env.queuesMonitor = .mock(listQueues: env.listQueues)
+        env.queuesMonitor = .mock(getQueues: env.getQueues)
         let availability = Availability(environment: env)
         var receivedResult: Result<Availability.Status, CoreSdkClient.SalemoveError>?
         availability.checkSecureConversationsAvailability(for: []) { result in
@@ -184,7 +184,7 @@ final class AvailabilityTests: XCTestCase {
     func testEmptyQueueStatusStatusIfThereIsNoDefaultQueuesWithProperConditions() throws {
         var env = Availability.Environment.failing
         let queueId = UUID.mock.uuidString
-        env.listQueues = { callback in
+        env.getQueues = { callback in
             callback([.mock(id: queueId, status: .closed, isDefault: true, media: [.text])], nil)
         }
         var logger = CoreSdkClient.Logger.failing
@@ -192,7 +192,7 @@ final class AvailabilityTests: XCTestCase {
         logger.warningClosure = { _, _, _, _ in }
         env.log = logger
         env.isAuthenticated = { true }
-        env.queuesMonitor = .mock(listQueues: env.listQueues)
+        env.queuesMonitor = .mock(getQueues: env.getQueues)
         env.getCurrentEngagement = { .mock() }
         let availability = Availability(environment: env)
         var receivedResult: Result<Availability.Status, CoreSdkClient.SalemoveError>?
@@ -207,7 +207,7 @@ final class AvailabilityTests: XCTestCase {
         env.getCurrentEngagement = {
             .mock(status: .transferring, capabilities: .init(text: true))
         }
-        env.listQueues = { callback in
+        env.getQueues = { callback in
             callback([], nil)
         }
         var logger = CoreSdkClient.Logger.failing
@@ -216,7 +216,7 @@ final class AvailabilityTests: XCTestCase {
         logger.warningClosure = { _, _, _, _ in }
         env.log = logger
         env.isAuthenticated = { true }
-        env.queuesMonitor = .mock(listQueues: env.listQueues)
+        env.queuesMonitor = .mock(getQueues: env.getQueues)
         let availability = Availability(environment: env)
         var receivedResult: Result<Availability.Status, CoreSdkClient.SalemoveError>?
         availability.checkSecureConversationsAvailability(for: []) { result in

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModel.Environment.Failing.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModel.Environment.Failing.swift
@@ -34,7 +34,7 @@ extension SecureConversations.TranscriptModel.Environment {
             return .mock
         },
         queueIds: [],
-        listQueues: { _ in
+        getQueues: { _ in
             fail("\(Self.self).listQueues")
         },
         createFileUploadListModel: { _ in

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModel.MigrateTests.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModel.MigrateTests.swift
@@ -15,7 +15,7 @@ final class TranscriptModelMigrateTests: XCTestCase {
         fileUploadListModel.environment.uploader.limitReached.value = false
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in fileUploadListModel }
-        modelEnv.listQueues = { _ in }
+        modelEnv.getQueues = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in
             calls.append(.fetchSiteConfigurations)
         }
@@ -26,10 +26,10 @@ final class TranscriptModelMigrateTests: XCTestCase {
         modelEnv.shouldShowLeaveSecureConversationDialog = { _ in false }
 
         let availabilityEnv = SecureConversations.Availability.Environment(
-            listQueues: modelEnv.listQueues,
+            getQueues: modelEnv.getQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            queuesMonitor: .mock(getQueues: modelEnv.getQueues),
             getCurrentEngagement: { .mock() }
         )
 

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+GVA.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+GVA.swift
@@ -121,7 +121,7 @@ extension SecureConversationsTranscriptModelTests {
         var modelEnv = TranscriptModel.Environment.failing
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in .mock() }
-        modelEnv.listQueues = { callback in callback([], nil) }
+        modelEnv.getQueues = { callback in callback([], nil) }
         modelEnv.uiApplication.canOpenURL = { _ in true }
         modelEnv.maximumUploads = { 2 }
         modelEnv.createEntryWidget = { _ in .mock() }
@@ -151,7 +151,7 @@ extension SecureConversationsTranscriptModelTests {
         modelEnv.messagesWithUnreadCountLoaderScheduler = scheduler
 
         let availabilityEnv = SecureConversations.Availability.Environment(
-            listQueues: modelEnv.listQueues,
+            getQueues: modelEnv.getQueues,
             isAuthenticated: { true },
             log: logger,
             queuesMonitor: .mock(),
@@ -194,12 +194,12 @@ private extension SecureConversationsTranscriptModelTests {
         modelEnv.log = logger
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in .mock() }
-        modelEnv.listQueues = { callback in callback([], nil) }
+        modelEnv.getQueues = { callback in callback([], nil) }
         modelEnv.uiApplication.canOpenURL = { _ in true }
         modelEnv.maximumUploads = { 2 }
         modelEnv.createEntryWidget = { _ in .mock() }
         let availabilityEnv = SecureConversations.Availability.Environment(
-            listQueues: modelEnv.listQueues,
+            getQueues: modelEnv.getQueues,
             isAuthenticated: { true },
             log: logger,
             queuesMonitor: .mock(),

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+MessageRetry.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+MessageRetry.swift
@@ -131,13 +131,13 @@ private extension SecureConversationsTranscriptModelTests {
         modelEnv.log = logger
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in .mock() }
-        modelEnv.listQueues = { callback in callback([], nil) }
+        modelEnv.getQueues = { callback in callback([], nil) }
         modelEnv.uiApplication.canOpenURL = { _ in true }
         modelEnv.maximumUploads = { 2 }
         modelEnv.sendSecureMessagePayload = { _, _, _ in .mock }
         modelEnv.createEntryWidget = { _ in .mock() }
         let availabilityEnv = SecureConversations.Availability.Environment(
-            listQueues: modelEnv.listQueues,
+            getQueues: modelEnv.getQueues,
             isAuthenticated: { true },
             log: logger,
             queuesMonitor: .mock(),

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+ResponseCard.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+ResponseCard.swift
@@ -40,12 +40,12 @@ private extension SecureConversationsTranscriptModelTests {
         modelEnv.log = logger
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in .mock() }
-        modelEnv.listQueues = { callback in callback([], nil) }
+        modelEnv.getQueues = { callback in callback([], nil) }
         modelEnv.uiApplication.canOpenURL = { _ in true }
         modelEnv.maximumUploads = { 2 }
         modelEnv.createEntryWidget = { _ in .mock() }
         let availabilityEnv = SecureConversations.Availability.Environment(
-            listQueues: modelEnv.listQueues,
+            getQueues: modelEnv.getQueues,
             isAuthenticated: { true },
             log: logger,
             queuesMonitor: .mock(),

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+URLs.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+URLs.swift
@@ -104,11 +104,11 @@ private extension SecureConversationsTranscriptModelTests {
         modelEnv.log = logger
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in .mock() }
-        modelEnv.listQueues = { callback in callback([], nil) }
+        modelEnv.getQueues = { callback in callback([], nil) }
         modelEnv.maximumUploads = { 2 }
         modelEnv.createEntryWidget = { _ in .mock() }
         let availabilityEnv = SecureConversations.Availability.Environment(
-            listQueues: modelEnv.listQueues,
+            getQueues: modelEnv.getQueues,
             isAuthenticated: { true },
             log: logger,
             queuesMonitor: .mock(),

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests.swift
@@ -16,14 +16,14 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.log = logger
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in .mock() }
-        modelEnv.listQueues = { callback in callback([], nil) }
+        modelEnv.getQueues = { callback in callback([], nil) }
         modelEnv.maximumUploads = { 2 }
         modelEnv.createEntryWidget = { _ in .mock() }
         let availabilityEnv = SecureConversations.Availability.Environment(
-            listQueues: modelEnv.listQueues,
+            getQueues: modelEnv.getQueues,
             isAuthenticated: { true },
             log: logger,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            queuesMonitor: .mock(getQueues: modelEnv.getQueues),
             getCurrentEngagement: { .mock() }
         )
         let viewModel = TranscriptModel(
@@ -48,14 +48,14 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.log = logger
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in .mock() }
-        modelEnv.listQueues = { callback in callback(nil, .mock()) }
+        modelEnv.getQueues = { callback in callback(nil, .mock()) }
         modelEnv.maximumUploads = { 2 }
         modelEnv.createEntryWidget = { _ in .mock() }
         let availabilityEnv = SecureConversations.Availability.Environment(
-            listQueues: modelEnv.listQueues,
+            getQueues: modelEnv.getQueues,
             isAuthenticated: { false },
             log: logger,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            queuesMonitor: .mock(getQueues: modelEnv.getQueues),
             getCurrentEngagement: { .mock() }
         )
         let viewModel = TranscriptModel(
@@ -76,7 +76,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         var modelEnv = TranscriptModel.Environment.failing
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in .mock() }
-        modelEnv.listQueues = { _ in }
+        modelEnv.getQueues = { _ in }
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.getSecureUnreadMessageCount = { _ in }
         modelEnv.startSocketObservation = {}
@@ -88,10 +88,10 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         }
 
         let availabilityEnv = SecureConversations.Availability.Environment(
-            listQueues: modelEnv.listQueues,
+            getQueues: modelEnv.getQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            queuesMonitor: .mock(getQueues: modelEnv.getQueues),
             getCurrentEngagement: { .mock() }
         )
 
@@ -115,7 +115,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         var modelEnv = TranscriptModel.Environment.failing
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in .mock() }
-        modelEnv.listQueues = { _ in }
+        modelEnv.getQueues = { _ in }
         modelEnv.maximumUploads = { 2 }
         modelEnv.createEntryWidget = { _ in .mock() }
         modelEnv.createEntryWidget = { _ in .mock() }
@@ -137,10 +137,10 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         }
         modelEnv.startSocketObservation = {}
         let availabilityEnv = SecureConversations.Availability.Environment(
-            listQueues: modelEnv.listQueues,
+            getQueues: modelEnv.getQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            queuesMonitor: .mock(getQueues: modelEnv.getQueues),
             getCurrentEngagement: { .mock() }
         )
         let viewModel = TranscriptModel(
@@ -164,7 +164,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         var modelEnv = TranscriptModel.Environment.failing
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in .mock() }
-        modelEnv.listQueues = { _ in }
+        modelEnv.getQueues = { _ in }
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
         modelEnv.getSecureUnreadMessageCount = { _ in }
@@ -172,10 +172,10 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.maximumUploads = { 2 }
         modelEnv.createEntryWidget = { _ in .mock() }
         let availabilityEnv = SecureConversations.Availability.Environment(
-            listQueues: modelEnv.listQueues,
+            getQueues: modelEnv.getQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            queuesMonitor: .mock(getQueues: modelEnv.getQueues),
             getCurrentEngagement: { .mock() }
         )
         let viewModel = TranscriptModel(
@@ -214,17 +214,17 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
 
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in fileUploadListModel }
-        modelEnv.listQueues = { _ in }
+        modelEnv.getQueues = { _ in }
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
         modelEnv.getSecureUnreadMessageCount = { _ in }
         modelEnv.maximumUploads = { 2 }
         modelEnv.createEntryWidget = { _ in .mock() }
         let availabilityEnv = SecureConversations.Availability.Environment(
-            listQueues: modelEnv.listQueues,
+            getQueues: modelEnv.getQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            queuesMonitor: .mock(getQueues: modelEnv.getQueues),
             getCurrentEngagement: { .mock() }
         )
 
@@ -258,17 +258,17 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
 
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in fileUploadListModel }
-        modelEnv.listQueues = { _ in }
+        modelEnv.getQueues = { _ in }
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
         modelEnv.getSecureUnreadMessageCount = { _ in }
         modelEnv.maximumUploads = { 2 }
         modelEnv.createEntryWidget = { _ in .mock() }
         let availabilityEnv = SecureConversations.Availability.Environment(
-            listQueues: modelEnv.listQueues,
+            getQueues: modelEnv.getQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            queuesMonitor: .mock(getQueues: modelEnv.getQueues),
             getCurrentEngagement: { .mock() }
         )
 
@@ -298,17 +298,17 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
 
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in fileUploadListModel }
-        modelEnv.listQueues = { _ in }
+        modelEnv.getQueues = { _ in }
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
         modelEnv.getSecureUnreadMessageCount = { _ in }
         modelEnv.maximumUploads = { 2 }
         modelEnv.createEntryWidget = { _ in .mock() }
         let availabilityEnv = SecureConversations.Availability.Environment(
-            listQueues: modelEnv.listQueues,
+            getQueues: modelEnv.getQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            queuesMonitor: .mock(getQueues: modelEnv.getQueues),
             getCurrentEngagement: { .mock() }
         )
 
@@ -335,7 +335,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         let nonEmptyText = "No empty message."
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in fileUploadListModel }
-        modelEnv.listQueues = { _ in }
+        modelEnv.getQueues = { _ in }
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
         modelEnv.getSecureUnreadMessageCount = { _ in }
@@ -351,10 +351,10 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             return .mock
         }
         let availabilityEnv = SecureConversations.Availability.Environment(
-            listQueues: modelEnv.listQueues,
+            getQueues: modelEnv.getQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            queuesMonitor: .mock(getQueues: modelEnv.getQueues),
             getCurrentEngagement: { .mock() }
         )
 
@@ -380,7 +380,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         fileUploadListModel.environment.uploader.limitReached.value = false
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in fileUploadListModel }
-        modelEnv.listQueues = { _ in }
+        modelEnv.getQueues = { _ in }
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
         modelEnv.startSocketObservation = {}
@@ -393,10 +393,10 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         }
 
         let availabilityEnv = SecureConversations.Availability.Environment(
-            listQueues: modelEnv.listQueues,
+            getQueues: modelEnv.getQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            queuesMonitor: .mock(getQueues: modelEnv.getQueues),
             getCurrentEngagement: { .mock() }
         )
 
@@ -421,7 +421,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         fileUploadListModel.environment.uploader.limitReached.value = false
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in fileUploadListModel }
-        modelEnv.listQueues = { _ in }
+        modelEnv.getQueues = { _ in }
         modelEnv.maximumUploads = { 2 }
         modelEnv.fetchChatHistory = { callback in
             callback(.success([.mock(sender: .operator)]))
@@ -444,10 +444,10 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.shouldShowLeaveSecureConversationDialog = { _ in false }
 
         let availabilityEnv = SecureConversations.Availability.Environment(
-            listQueues: modelEnv.listQueues,
+            getQueues: modelEnv.getQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            queuesMonitor: .mock(getQueues: modelEnv.getQueues),
             getCurrentEngagement: { .mock() }
         )
 
@@ -481,7 +481,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         fileUploadListModel.environment.uploader.limitReached.value = false
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in fileUploadListModel }
-        modelEnv.listQueues = { _ in }
+        modelEnv.getQueues = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.maximumUploads = { 2 }
@@ -496,10 +496,10 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.messagesWithUnreadCountLoaderScheduler = scheduler
 
         let availabilityEnv = SecureConversations.Availability.Environment(
-            listQueues: modelEnv.listQueues,
+            getQueues: modelEnv.getQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            queuesMonitor: .mock(getQueues: modelEnv.getQueues),
             getCurrentEngagement: { .mock() }
         )
 
@@ -549,7 +549,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         fileUploadListModel.environment.uploader.limitReached.value = false
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in fileUploadListModel }
-        modelEnv.listQueues = { _ in }
+        modelEnv.getQueues = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.maximumUploads = { 2 }
@@ -564,10 +564,10 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.messagesWithUnreadCountLoaderScheduler = scheduler
 
         let availabilityEnv = SecureConversations.Availability.Environment(
-            listQueues: modelEnv.listQueues,
+            getQueues: modelEnv.getQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            queuesMonitor: .mock(getQueues: modelEnv.getQueues),
             getCurrentEngagement: { .mock() }
         )
 
@@ -627,11 +627,11 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnvironment.log = logger
         var availabilityEnv = SecureConversations.Availability.Environment.failing
         availabilityEnv.log = logger
-        availabilityEnv.listQueues = { callback in
+        availabilityEnv.getQueues = { callback in
             callback([], nil)
         }
         availabilityEnv.isAuthenticated = { true }
-        availabilityEnv.queuesMonitor = .mock(listQueues: availabilityEnv.listQueues)
+        availabilityEnv.queuesMonitor = .mock(getQueues: availabilityEnv.getQueues)
         availabilityEnv.getCurrentEngagement = { .mock() }
         let model = TranscriptModel(
             isCustomCardSupported: false,
@@ -660,11 +660,11 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnvironment.createEntryWidget = { _ in .mock() }
         var availabilityEnv = SecureConversations.Availability.Environment.failing
         availabilityEnv.log = logger
-        availabilityEnv.listQueues = { callback in
+        availabilityEnv.getQueues = { callback in
             callback([.mock()], nil)
         }
         availabilityEnv.isAuthenticated = { false }
-        availabilityEnv.queuesMonitor = .mock(listQueues: availabilityEnv.listQueues)
+        availabilityEnv.queuesMonitor = .mock(getQueues: availabilityEnv.getQueues)
         let model = TranscriptModel(
             isCustomCardSupported: false,
             environment: modelEnvironment,
@@ -676,7 +676,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         XCTAssertFalse(model.isSecureConversationsAvailable)
     }
 
-    func testIsSecureConversationsAvailableIsFalseDueToListQueuesError() {
+    func testIsSecureConversationsAvailableIsFalseDueTogetQueuesError() {
         var modelEnvironment = TranscriptModel.Environment.failing
         var logger = CoreSdkClient.Logger.failing
         logger.prefixedClosure = { _ in logger }
@@ -690,11 +690,11 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         }
         modelEnvironment.createEntryWidget = { _ in .mock() }
         var availabilityEnv = SecureConversations.Availability.Environment.failing
-        availabilityEnv.listQueues = { callback in
+        availabilityEnv.getQueues = { callback in
             callback(nil, .mock())
         }
         availabilityEnv.isAuthenticated = { false }
-        availabilityEnv.queuesMonitor = .mock(listQueues: availabilityEnv.listQueues)
+        availabilityEnv.queuesMonitor = .mock(getQueues: availabilityEnv.getQueues)
         let model = TranscriptModel(
             isCustomCardSupported: false,
             environment: modelEnvironment,
@@ -722,11 +722,11 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnvironment.createEntryWidget = { _ in .mock() }
         var availabilityEnv = SecureConversations.Availability.Environment.failing
         availabilityEnv.log = logger
-        availabilityEnv.listQueues = { callback in
+        availabilityEnv.getQueues = { callback in
             callback([.mock()], nil)
         }
         availabilityEnv.isAuthenticated = { true }
-        availabilityEnv.queuesMonitor = .mock(listQueues: availabilityEnv.listQueues)
+        availabilityEnv.queuesMonitor = .mock(getQueues: availabilityEnv.getQueues)
         availabilityEnv.getCurrentEngagement = { .mock() }
         let model = TranscriptModel(
             isCustomCardSupported: false,
@@ -755,11 +755,11 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnvironment.createEntryWidget = { _ in .mock() }
         var availabilityEnv = SecureConversations.Availability.Environment.failing
         availabilityEnv.log = logger
-        availabilityEnv.listQueues = { callback in
+        availabilityEnv.getQueues = { callback in
             callback([.mock()], nil)
         }
         availabilityEnv.isAuthenticated = { true }
-        availabilityEnv.queuesMonitor = .mock(listQueues: availabilityEnv.listQueues)
+        availabilityEnv.queuesMonitor = .mock(getQueues: availabilityEnv.getQueues)
         availabilityEnv.getCurrentEngagement = { .mock() }
         let model = TranscriptModel(
             isCustomCardSupported: false,
@@ -791,7 +791,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.gcd.mainQueue.asyncAfterDeadline = { _, function in function() }
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in fileUploadListModel }
-        modelEnv.listQueues = { _ in }
+        modelEnv.getQueues = { _ in }
         modelEnv.loadChatMessagesFromHistory = { true }
         modelEnv.fetchChatHistory = { $0(.success([.mock(), .mock(), .mock()])) }
         modelEnv.getSecureUnreadMessageCount = { $0(.success(5)) }
@@ -817,10 +817,10 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
 
 
         let availabilityEnv = SecureConversations.Availability.Environment(
-            listQueues: modelEnv.listQueues,
+            getQueues: modelEnv.getQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            queuesMonitor: .mock(getQueues: modelEnv.getQueues),
             getCurrentEngagement: { .mock() }
         )
 
@@ -848,7 +848,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.gcd.mainQueue.asyncAfterDeadline = { _, function in function() }
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in fileUploadListModel }
-        modelEnv.listQueues = { _ in }
+        modelEnv.getQueues = { _ in }
         modelEnv.loadChatMessagesFromHistory = { true }
         modelEnv.fetchChatHistory = { $0(.success([.mock(), .mock(), .mock()])) }
         modelEnv.getSecureUnreadMessageCount = { $0(.success(5)) }
@@ -869,10 +869,10 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.markUnreadMessagesDelay = { .zero }
 
         let availabilityEnv = SecureConversations.Availability.Environment(
-            listQueues: modelEnv.listQueues,
+            getQueues: modelEnv.getQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            queuesMonitor: .mock(getQueues: modelEnv.getQueues),
             getCurrentEngagement: { .mock() }
         )
 
@@ -900,7 +900,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.gcd.mainQueue.asyncAfterDeadline = { _, function in function() }
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in fileUploadListModel }
-        modelEnv.listQueues = { _ in }
+        modelEnv.getQueues = { _ in }
         modelEnv.loadChatMessagesFromHistory = { true }
         modelEnv.fetchChatHistory = { $0(.success([.mock(), .mock(), .mock()])) }
         modelEnv.getSecureUnreadMessageCount = { $0(.success(5)) }
@@ -926,10 +926,10 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         }
 
         let availabilityEnv = SecureConversations.Availability.Environment(
-            listQueues: modelEnv.listQueues,
+            getQueues: modelEnv.getQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            queuesMonitor: .mock(getQueues: modelEnv.getQueues),
             getCurrentEngagement: { .mock() }
         )
 
@@ -966,7 +966,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.uiApplication.applicationState = { .active }
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in fileUploadListModel }
-        modelEnv.listQueues = { _ in }
+        modelEnv.getQueues = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
         modelEnv.getSecureUnreadMessageCount = { $0(.success(0)) }
         modelEnv.maximumUploads = { 2 }
@@ -993,10 +993,10 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         }
 
         let availabilityEnv = SecureConversations.Availability.Environment(
-            listQueues: modelEnv.listQueues,
+            getQueues: modelEnv.getQueues,
             isAuthenticated: { true },
             log: .failing,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            queuesMonitor: .mock(getQueues: modelEnv.getQueues),
             getCurrentEngagement: { .mock() }
         )
 
@@ -1035,7 +1035,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.log = logger
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in .mock() }
-        modelEnv.listQueues = { callback in callback([], nil) }
+        modelEnv.getQueues = { callback in callback([], nil) }
         modelEnv.maximumUploads = { 2 }
         modelEnv.createEntryWidget = { config in .mock(configuration: config) }
 
@@ -1057,10 +1057,10 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             calls.append(.switchToEngagement(kind))
         }
         let availabilityEnv = SecureConversations.Availability.Environment(
-            listQueues: modelEnv.listQueues,
+            getQueues: modelEnv.getQueues,
             isAuthenticated: { true },
             log: logger,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            queuesMonitor: .mock(getQueues: modelEnv.getQueues),
             getCurrentEngagement: { .mock() }
         )
         let viewModel = TranscriptModel(
@@ -1092,7 +1092,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.log = logger
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in .mock() }
-        modelEnv.listQueues = { callback in callback([], nil) }
+        modelEnv.getQueues = { callback in callback([], nil) }
         modelEnv.maximumUploads = { 2 }
         modelEnv.createEntryWidget = { config in .mock(configuration: config) }
 
@@ -1114,10 +1114,10 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             calls.append(.switchToEngagement(kind))
         }
         let availabilityEnv = SecureConversations.Availability.Environment(
-            listQueues: modelEnv.listQueues,
+            getQueues: modelEnv.getQueues,
             isAuthenticated: { true },
             log: logger,
-            queuesMonitor: .mock(listQueues: modelEnv.listQueues),
+            queuesMonitor: .mock(getQueues: modelEnv.getQueues),
             getCurrentEngagement: { .mock() }
         )
         let viewModel = TranscriptModel(

--- a/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.Mock.swift
+++ b/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.Mock.swift
@@ -50,7 +50,7 @@ extension SecureConversations.WelcomeViewModel.Environment {
 extension SecureConversations.Availability {
     static let mock: SecureConversations.Availability = .init(
         environment: .init(
-            listQueues: { _ in },
+            getQueues: { _ in },
             isAuthenticated: { true },
             log: .mock,
             queuesMonitor: .mock(),

--- a/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModelSpec.swift
+++ b/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModelSpec.swift
@@ -609,7 +609,7 @@ extension SecureConversationsWelcomeViewModelTests {
     func testAvailabilityAvailable() {
         let uuid = UUID.mock.uuidString
         var availability = SecureConversations.Availability.mock
-        availability.environment.listQueues = { completion in
+        availability.environment.getQueues = { completion in
             let queue = CoreSdkClient.Queue.mock(
                 id: uuid,
                 name: "",
@@ -631,7 +631,7 @@ extension SecureConversationsWelcomeViewModelTests {
 
         let uuid = UUID.mock.uuidString
         var availability = SecureConversations.Availability.mock
-        availability.environment.listQueues = { completion in
+        availability.environment.getQueues = { completion in
             let queue = CoreSdkClient.Queue.mock(
                 id: uuid,
                 name: "",
@@ -643,7 +643,7 @@ extension SecureConversationsWelcomeViewModelTests {
         }
 
         availability.environment.isAuthenticated = { true }
-        availability.environment.queuesMonitor = .mock(listQueues: availability.environment.listQueues)
+        availability.environment.queuesMonitor = .mock(getQueues: availability.environment.getQueues)
 
         let delegate: (WelcomeViewModel.DelegateEvent) -> Void = { event in
             switch event {
@@ -675,7 +675,7 @@ extension SecureConversationsWelcomeViewModelTests {
 
         let uuid = UUID.mock.uuidString
         var availability = SecureConversations.Availability.mock
-        availability.environment.listQueues = { completion in
+        availability.environment.getQueues = { completion in
             let queue = CoreSdkClient.Queue.mock(
                 id: uuid,
                 name: "",
@@ -687,7 +687,7 @@ extension SecureConversationsWelcomeViewModelTests {
         }
 
         availability.environment.isAuthenticated = { false }
-        availability.environment.queuesMonitor = .mock(listQueues: availability.environment.listQueues)
+        availability.environment.queuesMonitor = .mock(getQueues: availability.environment.getQueues)
 
         let delegate: (WelcomeViewModel.DelegateEvent) -> Void = { event in
             switch event {

--- a/GliaWidgetsTests/Sources/ChatView/ChatViewTest.swift
+++ b/GliaWidgetsTests/Sources/ChatView/ChatViewTest.swift
@@ -131,7 +131,7 @@ final class ChatViewTest: XCTestCase {
         let queueId = "queueId"
         let mockQueue = CoreSdkClient.Queue.mock(id: queueId, media: [.text, .audio, .messaging])
         let queuesMonitor = QueuesMonitor.mock(
-            listQueues: {
+            getQueues: {
                 $0([mockQueue], nil)
             },
             subscribeForQueuesUpdates: { _, completion in

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -510,7 +510,7 @@ class ChatViewModelTests: XCTestCase {
 
         let transcriptFileUploadListModel = FileUploadListViewModel(environment: transcriptFileUploadListModelEnv)
         transcriptModelEnv.createFileUploadListModel = { _ in transcriptFileUploadListModel }
-        transcriptModelEnv.listQueues = { callback in callback([], nil) }
+        transcriptModelEnv.getQueues = { callback in callback([], nil) }
         transcriptModelEnv.maximumUploads = { 2 }
         var logger = CoreSdkClient.Logger.failing
         logger.prefixedClosure = { _ in logger }
@@ -519,7 +519,7 @@ class ChatViewModelTests: XCTestCase {
         transcriptModelEnv.log = logger
 
         let availabilityEnv = SecureConversations.Availability.Environment(
-            listQueues: transcriptModelEnv.listQueues,
+            getQueues: transcriptModelEnv.getQueues,
             isAuthenticated: { true },
             log: logger,
             queuesMonitor: .mock(),

--- a/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
@@ -11,7 +11,7 @@ extension CoreSdkClient {
         updateVisitorInfo: { _, _ in fail("\(Self.self).updateVisitorInfo") },
         configureWithConfiguration: { _, _ in fail("\(Self.self).configureWithConfiguration") },
         configureWithInteractor: { _ in fail("\(Self.self).configureWithInteractor") },
-        listQueues: { _ in fail("\(Self.self).listQueues") },
+        getQueues: { _ in fail("\(Self.self).listQueues") },
         queueForEngagement: { _, _, _ in fail("\(Self.self).queueForEngagement") },
         requestMediaUpgradeWithOffer: { _, _ in fail("\(Self.self).requestMediaUpgradeWithOffer") },
         sendMessagePreview: { _, _ in fail("\(Self.self).sendMessagePreview") },

--- a/GliaWidgetsTests/Sources/EntryWidget/EntryWidgetTests.swift
+++ b/GliaWidgetsTests/Sources/EntryWidget/EntryWidgetTests.swift
@@ -15,7 +15,7 @@ class EntryWidgetTests: XCTestCase {
         let mockQueue = Queue.mock(id: mockQueueId, media: [.messaging, .audio])
 
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
-        queueMonitorEnvironment.listQueues = { completion in
+        queueMonitorEnvironment.getQueues = { completion in
             completion([mockQueue], nil)
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
@@ -49,7 +49,7 @@ class EntryWidgetTests: XCTestCase {
         let mockQueue = Queue.mock(id: mockQueueId, media: [.messaging, .audio])
 
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
-        queueMonitorEnvironment.listQueues = { completion in
+        queueMonitorEnvironment.getQueues = { completion in
             completion([mockQueue], nil)
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
@@ -80,7 +80,7 @@ class EntryWidgetTests: XCTestCase {
         let mockQueueId = "mockQueueId"
         let mockQueue = Queue.mock(id: mockQueueId, media: [.messaging, .audio])
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
-        queueMonitorEnvironment.listQueues = { completion in
+        queueMonitorEnvironment.getQueues = { completion in
             completion([mockQueue], nil)
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
@@ -161,7 +161,7 @@ class EntryWidgetTests: XCTestCase {
 
         var environment = EntryWidget.Environment.mock()
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
-        queueMonitorEnvironment.listQueues = { completion in
+        queueMonitorEnvironment.getQueues = { completion in
             completion([mockQueue], nil)
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
@@ -193,7 +193,7 @@ class EntryWidgetTests: XCTestCase {
         let mockQueueId = "mockQueueId"
         let mockQueue = Queue.mock(id: mockQueueId, media: [.messaging, .audio, .video, .text])
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
-        queueMonitorEnvironment.listQueues = { completion in
+        queueMonitorEnvironment.getQueues = { completion in
             completion([mockQueue], nil)
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
@@ -229,7 +229,7 @@ class EntryWidgetTests: XCTestCase {
         let mockQueueId = "mockQueueId"
         let mockQueue = Queue.mock(id: mockQueueId, media: [.messaging, .audio, .video, .text])
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
-        queueMonitorEnvironment.listQueues = { completion in
+        queueMonitorEnvironment.getQueues = { completion in
             completion([mockQueue], nil)
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
@@ -262,7 +262,7 @@ class EntryWidgetTests: XCTestCase {
         let mockQueueId = "mockQueueId"
         let mockQueue = Queue.mock(id: mockQueueId, media: [.audio, .video, .text])
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
-        queueMonitorEnvironment.listQueues = { completion in
+        queueMonitorEnvironment.getQueues = { completion in
             completion([mockQueue], nil)
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
@@ -297,7 +297,7 @@ class EntryWidgetTests: XCTestCase {
         let mockQueue = Queue.mock(id: mockQueueId, media: [.messaging, .audio])
 
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
-        queueMonitorEnvironment.listQueues = { completion in
+        queueMonitorEnvironment.getQueues = { completion in
             completion([mockQueue], nil)
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
@@ -326,7 +326,7 @@ class EntryWidgetTests: XCTestCase {
         let mockQueue = Queue.mock(id: mockQueueId, media: [.messaging, .audio])
 
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
-        queueMonitorEnvironment.listQueues = { completion in
+        queueMonitorEnvironment.getQueues = { completion in
             completion([mockQueue], nil)
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
@@ -355,7 +355,7 @@ class EntryWidgetTests: XCTestCase {
         let mockQueue = Queue.mock(id: mockQueueId, media: [.messaging, .audio])
 
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
-        queueMonitorEnvironment.listQueues = { completion in
+        queueMonitorEnvironment.getQueues = { completion in
             completion([mockQueue], nil)
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
@@ -384,7 +384,7 @@ class EntryWidgetTests: XCTestCase {
         let mockQueue = Queue.mock(id: mockQueueId, media: [.messaging, .audio])
 
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
-        queueMonitorEnvironment.listQueues = { completion in
+        queueMonitorEnvironment.getQueues = { completion in
             completion([mockQueue], nil)
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
@@ -520,7 +520,7 @@ class EntryWidgetTests: XCTestCase {
         let mockQueue = Queue.mock(id: mockQueueId, media: [.text, .audio])
 
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
-        queueMonitorEnvironment.listQueues = { completion in
+        queueMonitorEnvironment.getQueues = { completion in
             completion([mockQueue], nil)
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
@@ -552,7 +552,7 @@ class EntryWidgetTests: XCTestCase {
         let mockQueue = Queue.mock(id: mockQueueId, media: [.messaging, .audio])
 
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
-        queueMonitorEnvironment.listQueues = { completion in
+        queueMonitorEnvironment.getQueues = { completion in
             completion([mockQueue], nil)
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
@@ -585,7 +585,7 @@ class EntryWidgetTests: XCTestCase {
         let mockQueue = Queue.mock(id: mockQueueId, media: [.messaging, .audio])
 
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
-        queueMonitorEnvironment.listQueues = { completion in
+        queueMonitorEnvironment.getQueues = { completion in
             completion([mockQueue], nil)
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
@@ -621,7 +621,7 @@ class EntryWidgetTests: XCTestCase {
         let mockQueueId = "mockQueueId"
         let mockQueue = Queue.mock(id: mockQueueId, media: [.messaging, .audio])
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
-        queueMonitorEnvironment.listQueues = { completion in
+        queueMonitorEnvironment.getQueues = { completion in
             completion([mockQueue], nil)
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
@@ -652,7 +652,7 @@ class EntryWidgetTests: XCTestCase {
         let mockQueue = Queue.mock(id: mockQueueId, status: .unstaffed, media: [.messaging, .audio, .video])
 
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
-        queueMonitorEnvironment.listQueues = { completion in
+        queueMonitorEnvironment.getQueues = { completion in
             completion([mockQueue], nil)
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
@@ -686,7 +686,7 @@ class EntryWidgetTests: XCTestCase {
         let mockQueue = Queue.mock(id: mockQueueId, status: .full, media: [.audio, .video])
 
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
-        queueMonitorEnvironment.listQueues = { completion in
+        queueMonitorEnvironment.getQueues = { completion in
             completion([mockQueue], nil)
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
@@ -718,7 +718,7 @@ class EntryWidgetTests: XCTestCase {
         let openMockQueue = Queue.mock(id: mockQueueId, status: .full, media: [.audio, .video])
 
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
-        queueMonitorEnvironment.listQueues = { completion in
+        queueMonitorEnvironment.getQueues = { completion in
             completion([mockQueue], nil)
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+RestoreEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+RestoreEngagement.swift
@@ -49,7 +49,7 @@ extension GliaTests {
             calls.append(.snackBarPresent)
         }
 
-        sdkEnv.coreSdk.listQueues = { callback in callback([], nil) }
+        sdkEnv.coreSdk.getQueues = { callback in callback([], nil) }
         sdkEnv.coreSdk.subscribeForQueuesUpdates = { _, _ in
             return UUID.mock.uuidString
         }

--- a/GliaWidgetsTests/Sources/InteractorTests.swift
+++ b/GliaWidgetsTests/Sources/InteractorTests.swift
@@ -681,14 +681,14 @@ class InteractorTests: XCTestCase {
     
     func test_interactorFailShouldRefetchAndRestartQueuesMonitor() {
         enum Call {
-            case listQueues
+            case getQueues
             case subscribeForUpdates
         }
         var calls: [Call] = []
         let interactor = Interactor.failing
         let queuesMonitor = QueuesMonitor.mock()
-        queuesMonitor.environment.listQueues = { completion in
-            calls.append(.listQueues)
+        queuesMonitor.environment.getQueues = { completion in
+            calls.append(.getQueues)
             completion([.mock()], nil)
         }
         
@@ -702,7 +702,7 @@ class InteractorTests: XCTestCase {
 
         interactor.fail(error: .mock())
     
-        XCTAssertEqual(calls, [.listQueues, .subscribeForUpdates])
+        XCTAssertEqual(calls, [.getQueues, .subscribeForUpdates])
     }
 }
 

--- a/GliaWidgetsTests/Sources/QueuesMonitor/QueuesMonitorTests.swift
+++ b/GliaWidgetsTests/Sources/QueuesMonitor/QueuesMonitorTests.swift
@@ -6,7 +6,7 @@ import GliaCoreSDK
 
 class QueuesMonitorTests: XCTestCase {
     private enum Call {
-        case listQueues
+        case getQueues
         case subscribeForQueuesUpdates
         case unsubscribeFromUpdates
     }
@@ -37,8 +37,8 @@ class QueuesMonitorTests: XCTestCase {
         monitor.environment.logger.infoClosure = { logMessage, _, _, _ in
             receivedLogMessage = logMessage as? String ?? ""
         }
-        monitor.environment.listQueues = { completion in
-            envCalls.append(.listQueues)
+        monitor.environment.getQueues = { completion in
+            envCalls.append(.getQueues)
             completion(mockQueues, nil)
         }
         monitor.environment.subscribeForQueuesUpdates = { _, completion in
@@ -59,7 +59,7 @@ class QueuesMonitorTests: XCTestCase {
         monitor.fetchAndMonitorQueues(queuesIds: [mockQueueId])
 
         XCTAssertEqual(receivedQueues, expectedObservedQueues)
-        XCTAssertEqual(envCalls, [.listQueues, .subscribeForQueuesUpdates])
+        XCTAssertEqual(envCalls, [.getQueues, .subscribeForQueuesUpdates])
         XCTAssertEqual(receivedLogMessage, expectedLogMessage)
     }
 
@@ -77,8 +77,8 @@ class QueuesMonitorTests: XCTestCase {
         monitor.environment.logger.infoClosure = { logMessage, _, _, _ in
             receivedLogMessage.append(logMessage as? String ?? "")
         }
-        monitor.environment.listQueues = { completion in
-            envCalls.append(.listQueues)
+        monitor.environment.getQueues = { completion in
+            envCalls.append(.getQueues)
             completion(mockQueues, nil)
         }
         monitor.environment.subscribeForQueuesUpdates = { _, completion in
@@ -99,11 +99,11 @@ class QueuesMonitorTests: XCTestCase {
         monitor.fetchAndMonitorQueues(queuesIds: ["1"])
 
         XCTAssertEqual(receivedQueues, expectedObservedQueues)
-        XCTAssertEqual(envCalls, [.listQueues, .subscribeForQueuesUpdates])
+        XCTAssertEqual(envCalls, [.getQueues, .subscribeForQueuesUpdates])
         XCTAssertEqual(expectedLogMessages, receivedLogMessage)
     }
 
-    func test_fetchAndMonitorQueuesListQueuesReturnsError() {
+    func test_fetchAndMonitorQueuesgetQueuesReturnsError() {
         var envCalls: [Call] = []
         let expectedErrorLog = "Setting up queues. Failed to get site queues: mock"
         var receivedErrorLog = ""
@@ -111,8 +111,8 @@ class QueuesMonitorTests: XCTestCase {
         monitor.environment.logger.errorClosure = { logMessage, _, _, _ in
             receivedErrorLog = logMessage as? String ?? ""
         }
-        monitor.environment.listQueues = { completion in
-            envCalls.append(.listQueues)
+        monitor.environment.getQueues = { completion in
+            envCalls.append(.getQueues)
             completion(nil, expectedError)
         }
         monitor.environment.subscribeForQueuesUpdates = { _, completion in
@@ -132,7 +132,7 @@ class QueuesMonitorTests: XCTestCase {
         monitor.fetchAndMonitorQueues(queuesIds: ["1"])
 
         XCTAssertEqual(receivedError, expectedError)
-        XCTAssertEqual(envCalls, [.listQueues])
+        XCTAssertEqual(envCalls, [.getQueues])
         XCTAssertEqual(expectedErrorLog, receivedErrorLog)
     }
 
@@ -144,8 +144,8 @@ class QueuesMonitorTests: XCTestCase {
         let expectedUpdatedQueue = Queue.mock(id: mockQueueId, status: .open)
         let mockQueues = [expectedObservedQueue, Queue.mock(id: UUID().uuidString)]
 
-        monitor.environment.listQueues = { completion in
-            envCalls.append(.listQueues)
+        monitor.environment.getQueues = { completion in
+            envCalls.append(.getQueues)
             completion(mockQueues, nil)
         }
         monitor.environment.subscribeForQueuesUpdates = { _, completion in
@@ -172,7 +172,7 @@ class QueuesMonitorTests: XCTestCase {
 
         XCTAssertEqual(receivedQueues, [expectedUpdatedQueue])
         XCTAssertEqual(receivedUpdatedQueue?.state.status, .open)
-        XCTAssertEqual(envCalls, [.listQueues, .subscribeForQueuesUpdates])
+        XCTAssertEqual(envCalls, [.getQueues, .subscribeForQueuesUpdates])
     }
 
     func test_fetchAndMonitorQueuesWithQueuesStopsPreviousMonitoring() {
@@ -183,8 +183,8 @@ class QueuesMonitorTests: XCTestCase {
         let expectedUpdatedQueue = Queue.mock(id: mockQueueId, status: .open)
         let mockQueues = [expectedObservedQueue, Queue.mock(id: UUID().uuidString)]
 
-        monitor.environment.listQueues = { completion in
-            envCalls.append(.listQueues)
+        monitor.environment.getQueues = { completion in
+            envCalls.append(.getQueues)
             completion(mockQueues, nil)
         }
         monitor.environment.subscribeForQueuesUpdates = { _, completion in
@@ -217,7 +217,7 @@ class QueuesMonitorTests: XCTestCase {
         XCTAssertEqual(receivedUpdatedQueue?.state.status, .open)
         XCTAssertEqual(
             envCalls,
-            [.listQueues, .subscribeForQueuesUpdates, .unsubscribeFromUpdates, .listQueues, .subscribeForQueuesUpdates]
+            [.getQueues, .subscribeForQueuesUpdates, .unsubscribeFromUpdates, .getQueues, .subscribeForQueuesUpdates]
         )
     }
     
@@ -229,8 +229,8 @@ class QueuesMonitorTests: XCTestCase {
         let expectedUpdatedQueue = Queue.mock(id: mockQueueId, status: .open)
         let mockQueues = [expectedObservedQueue, Queue.mock(id: UUID().uuidString)]
 
-        monitor.environment.listQueues = { completion in
-            envCalls.append(.listQueues)
+        monitor.environment.getQueues = { completion in
+            envCalls.append(.getQueues)
             completion(mockQueues, nil)
         }
         monitor.environment.subscribeForQueuesUpdates = { _, completion in
@@ -265,7 +265,7 @@ class QueuesMonitorTests: XCTestCase {
         XCTAssertEqual(receivedUpdatedQueue?.state.status, .open)
         XCTAssertEqual(
             envCalls,
-            [.listQueues, .subscribeForQueuesUpdates, .unsubscribeFromUpdates, .listQueues, .subscribeForQueuesUpdates]
+            [.getQueues, .subscribeForQueuesUpdates, .unsubscribeFromUpdates, .getQueues, .subscribeForQueuesUpdates]
         )
     }
 
@@ -275,8 +275,8 @@ class QueuesMonitorTests: XCTestCase {
         let expectedError = CoreSdkClient.SalemoveError.mock()
         let mockQueues = [Queue.mock()]
 
-        monitor.environment.listQueues = { completion in
-            envCalls.append(.listQueues)
+        monitor.environment.getQueues = { completion in
+            envCalls.append(.getQueues)
             completion(mockQueues, nil)
         }
         monitor.environment.subscribeForQueuesUpdates = { _, completion in
@@ -299,7 +299,7 @@ class QueuesMonitorTests: XCTestCase {
         monitor.fetchAndMonitorQueues(queuesIds: [UUID().uuidString])
 
         XCTAssertEqual(receivedError, expectedError)
-        XCTAssertEqual(envCalls, [.listQueues, .subscribeForQueuesUpdates])
+        XCTAssertEqual(envCalls, [.getQueues, .subscribeForQueuesUpdates])
     }
 
     // MARK: Stop monitoring
@@ -308,8 +308,8 @@ class QueuesMonitorTests: XCTestCase {
 
         let expectedError = CoreSdkClient.SalemoveError.mock()
 
-        monitor.environment.listQueues = { completion in
-            envCalls.append(.listQueues)
+        monitor.environment.getQueues = { completion in
+            envCalls.append(.getQueues)
             completion([], nil)
         }
         monitor.environment.subscribeForQueuesUpdates = { _, completion in
@@ -337,14 +337,14 @@ class QueuesMonitorTests: XCTestCase {
         monitor.stopMonitoring()
 
         XCTAssertEqual(receivedError, expectedError)
-        XCTAssertEqual(envCalls, [.listQueues, .subscribeForQueuesUpdates, .unsubscribeFromUpdates])
+        XCTAssertEqual(envCalls, [.getQueues, .subscribeForQueuesUpdates, .unsubscribeFromUpdates])
     }
 
     func test_stopMonitoringSuccess() {
         var envCalls: [Call] = []
 
-        monitor.environment.listQueues = { completion in
-            envCalls.append(.listQueues)
+        monitor.environment.getQueues = { completion in
+            envCalls.append(.getQueues)
             completion([], nil)
         }
         monitor.environment.subscribeForQueuesUpdates = { _, completion in
@@ -361,7 +361,7 @@ class QueuesMonitorTests: XCTestCase {
 
         monitor.stopMonitoring()
 
-        XCTAssertEqual(envCalls, [.listQueues, .subscribeForQueuesUpdates, .unsubscribeFromUpdates])
+        XCTAssertEqual(envCalls, [.getQueues, .subscribeForQueuesUpdates, .unsubscribeFromUpdates])
     }
 
     func test_receiveOlderQueue_doesNotReplaceExistingQueue() {
@@ -376,8 +376,8 @@ class QueuesMonitorTests: XCTestCase {
             lastUpdated: Date(timeIntervalSinceNow: -1000)
         )
 
-        monitor.environment.listQueues = { completion in
-            envCalls.append(.listQueues)
+        monitor.environment.getQueues = { completion in
+            envCalls.append(.getQueues)
             completion([existingQueue], nil)
         }
         monitor.environment.subscribeForQueuesUpdates = { _, completion in
@@ -398,7 +398,7 @@ class QueuesMonitorTests: XCTestCase {
 
         monitor.fetchAndMonitorQueues(queuesIds: [mockQueueId])
 
-        XCTAssertEqual(envCalls, [.listQueues, .subscribeForQueuesUpdates])
+        XCTAssertEqual(envCalls, [.getQueues, .subscribeForQueuesUpdates])
         XCTAssertEqual(receivedQueues?.count, 1)
         XCTAssertEqual(receivedQueues?.first?.lastUpdated, existingQueue.lastUpdated)
     }
@@ -417,8 +417,8 @@ class QueuesMonitorTests: XCTestCase {
             lastUpdated: Date() // now
         )
 
-        monitor.environment.listQueues = { completion in
-            envCalls.append(.listQueues)
+        monitor.environment.getQueues = { completion in
+            envCalls.append(.getQueues)
             completion([oldQueue], nil)
         }
         monitor.environment.subscribeForQueuesUpdates = { _, completion in
@@ -440,7 +440,7 @@ class QueuesMonitorTests: XCTestCase {
 
         monitor.fetchAndMonitorQueues(queuesIds: [mockQueueId])
 
-        XCTAssertEqual(envCalls, [.listQueues, .subscribeForQueuesUpdates])
+        XCTAssertEqual(envCalls, [.getQueues, .subscribeForQueuesUpdates])
         XCTAssertEqual(receivedQueues?.count, 1)
         XCTAssertEqual(receivedQueues?.first?.lastUpdated, newerQueue.lastUpdated)
     }
@@ -458,8 +458,8 @@ class QueuesMonitorTests: XCTestCase {
             lastUpdated: Date()
         )
 
-        monitor.environment.listQueues = { completion in
-            envCalls.append(.listQueues)
+        monitor.environment.getQueues = { completion in
+            envCalls.append(.getQueues)
             completion([knownQueue], nil)
         }
         monitor.environment.subscribeForQueuesUpdates = { _, completion in
@@ -481,7 +481,7 @@ class QueuesMonitorTests: XCTestCase {
 
         monitor.fetchAndMonitorQueues(queuesIds: [knownQueueId])
 
-        XCTAssertEqual(envCalls, [.listQueues, .subscribeForQueuesUpdates])
+        XCTAssertEqual(envCalls, [.getQueues, .subscribeForQueuesUpdates])
         XCTAssertEqual(receivedQueues?.count, 2)
         XCTAssertTrue(receivedQueues?.contains(where: { $0.id == knownQueueId }) == true)
         XCTAssertTrue(receivedQueues?.contains(where: { $0.id == unknownQueueId }) == true)

--- a/TestingApp/Settings/SettingsViewController.swift
+++ b/TestingApp/Settings/SettingsViewController.swift
@@ -120,7 +120,7 @@ private extension SettingsViewController {
             extraButton: .init(title: "List queues", tap: { [weak self] in
                 let alert = UIAlertController(title: "List queues", message: "Please choose queue", preferredStyle: .alert)
 
-                Glia.sharedInstance.listQueues { [weak self] result in
+                Glia.sharedInstance.getQueues { [weak self] result in
                     switch result {
                     case .success(let queues):
                         queues.sorted(by: { $0.name < $1.name }).forEach { queue in


### PR DESCRIPTION
**What was solved?**
This PR renames listQueues to getQueues, to align iOS with Android. The actions of those methods will remain unchanged.

MOB-4200

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [X] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
