### PR TITLE
Collect all Secure Conversation related coresdkclient interfaces together

### DIFF
--- a/GliaWidgets/Public/Glia/Glia+EntryWidget.swift
+++ b/GliaWidgets/Public/Glia/Glia+EntryWidget.swift
@@ -18,7 +18,7 @@ extension Glia {
             queueIds: queueIds,
             configuration: configuration,
             environment: .init(
-                observeSecureUnreadMessageCount: environment.coreSdk.subscribeForUnreadSCMessageCount,
+                observeSecureUnreadMessageCount: environment.coreSdk.secureConversations.subscribeForUnreadMessageCount,
                 unsubscribeFromUpdates: environment.coreSdk.unsubscribeFromUpdates,
                 queuesMonitor: queuesMonitor,
                 engagementLauncher: try getEngagementLauncher(queueIds: queueIds),

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.Environment.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.Environment.swift
@@ -2,8 +2,8 @@ import Foundation
 
 extension SecureConversations.TranscriptModel {
     struct Environment {
+        var secureConversations: CoreSdkClient.SecureConversations
         var fetchFile: CoreSdkClient.FetchFile
-        var downloadSecureFile: CoreSdkClient.DownloadSecureFile
         var fileManager: FoundationBased.FileManager
         var data: FoundationBased.Data
         var date: () -> Date
@@ -14,17 +14,13 @@ extension SecureConversations.TranscriptModel {
         var loadChatMessagesFromHistory: () -> Bool
         var fetchChatHistory: CoreSdkClient.FetchChatHistory
         var uiApplication: UIKitBased.UIApplication
-        var sendSecureMessagePayload: CoreSdkClient.SendSecureMessagePayload
         var queueIds: [String]
         var getQueues: CoreSdkClient.ListQueues
         var createFileUploadListModel: SecureConversations.FileUploadListViewModel.Create
         var uuid: () -> UUID
-        var secureUploadFile: CoreSdkClient.SecureConversationsUploadFile
         var fileUploadListStyle: FileUploadListStyle
         var fetchSiteConfigurations: CoreSdkClient.FetchSiteConfigurations
-        var getSecureUnreadMessageCount: CoreSdkClient.GetSecureUnreadMessageCount
         var messagesWithUnreadCountLoaderScheduler: CoreSdkClient.ReactiveSwift.DateScheduler
-        var secureMarkMessagesAsRead: CoreSdkClient.SecureMarkMessagesAsRead
         var interactor: Interactor
         var startSocketObservation: CoreSdkClient.StartSocketObservation
         var stopSocketObservation: CoreSdkClient.StopSocketObservation
@@ -52,8 +48,8 @@ extension SecureConversations.TranscriptModel.Environment {
         viewFactory: ViewFactory
     ) -> Self {
         .init(
+            secureConversations: environment.secureConversations,
             fetchFile: environment.fetchFile,
-            downloadSecureFile: environment.downloadSecureFile,
             fileManager: environment.fileManager,
             data: environment.data,
             date: environment.date,
@@ -64,18 +60,14 @@ extension SecureConversations.TranscriptModel.Environment {
             loadChatMessagesFromHistory: environment.fromHistory,
             fetchChatHistory: environment.fetchChatHistory,
             uiApplication: environment.uiApplication,
-            sendSecureMessagePayload: environment.sendSecureMessagePayload,
             queueIds: environment.queueIds,
             getQueues: environment.listQueues,
             createFileUploadListModel: environment.createFileUploadListModel,
             uuid: environment.uuid,
-            secureUploadFile: environment.secureUploadFile,
             // TODO: MOB-3763
             fileUploadListStyle: viewFactory.theme.chatStyle.messageEntry.enabled.uploadList,
             fetchSiteConfigurations: environment.fetchSiteConfigurations,
-            getSecureUnreadMessageCount: environment.getSecureUnreadMessageCount,
             messagesWithUnreadCountLoaderScheduler: environment.messagesWithUnreadCountLoaderScheduler,
-            secureMarkMessagesAsRead: environment.secureMarkMessagesAsRead,
             interactor: environment.interactor,
             startSocketObservation: environment.startSocketObservation,
             stopSocketObservation: environment.stopSocketObservation,
@@ -97,8 +89,8 @@ extension SecureConversations.TranscriptModel.Environment {
 #if DEBUG
 extension SecureConversations.TranscriptModel.Environment {
     static func mock(
+        secureConversations: CoreSdkClient.SecureConversations = .mock,
         fetchFile: @escaping CoreSdkClient.FetchFile = { _, _, _ in },
-        downloadSecureFile: @escaping CoreSdkClient.DownloadSecureFile = { _, _, _ in .mock },
         fileManager: FoundationBased.FileManager = .mock,
         data: FoundationBased.Data = .mock,
         date: @escaping () -> Date = { .mock },
@@ -109,17 +101,13 @@ extension SecureConversations.TranscriptModel.Environment {
         loadChatMessagesFromHistory: @escaping () -> Bool = { false },
         fetchChatHistory: @escaping CoreSdkClient.FetchChatHistory = { _ in },
         uiApplication: UIKitBased.UIApplication = .mock,
-        sendSecureMessagePayload: @escaping CoreSdkClient.SendSecureMessagePayload = { _, _, _ in .mock },
         queueIds: [String] = [],
         getQueues: @escaping CoreSdkClient.ListQueues = { _ in },
         createFileUploadListModel: @escaping SecureConversations.FileUploadListViewModel.Create = { _ in .mock() },
         uuid: @escaping () -> UUID = { .mock },
-        secureUploadFile: @escaping CoreSdkClient.SecureConversationsUploadFile = { _, _, _ in .mock },
         fileUploadListStyle: FileUploadListStyle = .mock,
         fetchSiteConfigurations: @escaping CoreSdkClient.FetchSiteConfigurations = { _ in },
-        getSecureUnreadMessageCount: @escaping CoreSdkClient.GetSecureUnreadMessageCount = { _ in },
         messagesWithUnreadCountLoaderScheduler: CoreSdkClient.ReactiveSwift.DateScheduler = CoreSdkClient.ReactiveSwift.TestScheduler(),
-        secureMarkMessagesAsRead: @escaping CoreSdkClient.SecureMarkMessagesAsRead = { _ in .mock },
         interactor: Interactor = .mock(),
         startSocketObservation: @escaping CoreSdkClient.StartSocketObservation = {},
         stopSocketObservation: @escaping CoreSdkClient.StopSocketObservation = {},
@@ -137,8 +125,8 @@ extension SecureConversations.TranscriptModel.Environment {
         combineScheduler: AnyCombineScheduler = .mock
     ) -> Self {
         Self(
+            secureConversations: secureConversations,
             fetchFile: fetchFile,
-            downloadSecureFile: downloadSecureFile,
             fileManager: fileManager,
             data: data,
             date: date,
@@ -149,17 +137,13 @@ extension SecureConversations.TranscriptModel.Environment {
             loadChatMessagesFromHistory: loadChatMessagesFromHistory,
             fetchChatHistory: fetchChatHistory,
             uiApplication: uiApplication,
-            sendSecureMessagePayload: sendSecureMessagePayload,
             queueIds: queueIds,
             getQueues: getQueues,
             createFileUploadListModel: createFileUploadListModel,
             uuid: uuid,
-            secureUploadFile: secureUploadFile,
             fileUploadListStyle: fileUploadListStyle,
             fetchSiteConfigurations: fetchSiteConfigurations,
-            getSecureUnreadMessageCount: getSecureUnreadMessageCount,
             messagesWithUnreadCountLoaderScheduler: messagesWithUnreadCountLoaderScheduler,
-            secureMarkMessagesAsRead: secureMarkMessagesAsRead,
             interactor: interactor,
             startSocketObservation: startSocketObservation,
             stopSocketObservation: stopSocketObservation,

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.GVA.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.GVA.swift
@@ -105,7 +105,7 @@ private extension SecureConversations.TranscriptModel {
             animated: true
         )
 
-        _ = environment.sendSecureMessagePayload(
+        _ = environment.secureConversations.sendMessagePayload(
             outgoingMessage.payload,
             environment.queueIds
         ) { [weak self] result in

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
@@ -294,7 +294,7 @@ extension SecureConversations.TranscriptModel {
             animated: true
         )
 
-        _ = environment.sendSecureMessagePayload(
+        _ = environment.secureConversations.sendMessagePayload(
             outgoingMessage.payload,
             environment.queueIds
         ) { [weak self] result in
@@ -352,7 +352,7 @@ extension SecureConversations.TranscriptModel {
         appendItem(item, to: pendingSection, animated: true)
         action?(.scrollToBottom(animated: true))
 
-        _ = environment.sendSecureMessagePayload(
+        _ = environment.secureConversations.sendMessagePayload(
             outgoingMessage.payload,
             environment.queueIds
         ) { [weak self] result in
@@ -781,7 +781,7 @@ extension SecureConversations.TranscriptModel: ApplicationVisibilityTracker {
     }
 
     fileprivate func performMarkMessagesAsReadRequest() {
-        _ = environment.secureMarkMessagesAsRead { [weak self] result in
+        _ = environment.secureConversations.markMessagesAsRead { [weak self] result in
             guard let self else { return }
 
             switch result {
@@ -879,7 +879,7 @@ extension SecureConversations.TranscriptModel {
             .uploader
             .uploads
             .map { [environment] upload in
-                upload.environment.uploadFile = .toSecureMessaging(environment.secureUploadFile)
+                upload.environment.uploadFile = .toSecureMessaging(environment.secureConversations.uploadFile)
                 return upload
             }
         event(.messageTextChanged(chatModel.messageText))

--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.Environment.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.Environment.swift
@@ -2,11 +2,10 @@ import Foundation
 
 extension SecureConversations.Coordinator {
     struct Environment {
+        var secureConversations: CoreSdkClient.SecureConversations
         var queueIds: [String]
         var listQueues: CoreSdkClient.ListQueues
-        var sendSecureMessagePayload: CoreSdkClient.SendSecureMessagePayload
         var createFileUploader: FileUploader.Create
-        var uploadSecureFile: CoreSdkClient.SecureConversationsUploadFile
         var fileManager: FoundationBased.FileManager
         var data: FoundationBased.Data
         var date: () -> Date
@@ -33,10 +32,7 @@ extension SecureConversations.Coordinator {
         var getNonTransferredSecureConversationEngagement: CoreSdkClient.GetCurrentEngagement
         var submitSurveyAnswer: CoreSdkClient.SubmitSurveyAnswer
         var interactor: Interactor
-        var getSecureUnreadMessageCount: CoreSdkClient.GetSecureUnreadMessageCount
         var messagesWithUnreadCountLoaderScheduler: CoreSdkClient.ReactiveSwift.DateScheduler
-        var secureMarkMessagesAsRead: CoreSdkClient.SecureMarkMessagesAsRead
-        var downloadSecureFile: CoreSdkClient.DownloadSecureFile
         var isAuthenticated: () -> Bool
         var startSocketObservation: CoreSdkClient.StartSocketObservation
         var stopSocketObservation: CoreSdkClient.StopSocketObservation
@@ -80,11 +76,10 @@ extension SecureConversations.Coordinator.Environment {
         switchToEngagement: Command<EngagementKind>
     ) -> Self {
         .init(
+            secureConversations: environment.secureConversations,
             queueIds: queueIds,
             listQueues: environment.listQueues,
-            sendSecureMessagePayload: environment.sendSecureMessagePayload,
             createFileUploader: environment.createFileUploader,
-            uploadSecureFile: environment.uploadSecureFile,
             fileManager: environment.fileManager,
             data: environment.data,
             date: environment.date,
@@ -111,10 +106,7 @@ extension SecureConversations.Coordinator.Environment {
             getNonTransferredSecureConversationEngagement: environment.getNonTransferredSecureConversationEngagement,
             submitSurveyAnswer: environment.submitSurveyAnswer,
             interactor: interactor,
-            getSecureUnreadMessageCount: environment.getSecureUnreadMessageCount,
             messagesWithUnreadCountLoaderScheduler: environment.messagesWithUnreadCountLoaderScheduler,
-            secureMarkMessagesAsRead: environment.secureMarkMessagesAsRead,
-            downloadSecureFile: environment.downloadSecureFile,
             isAuthenticated: environment.isAuthenticated,
             startSocketObservation: environment.startSocketObservation,
             stopSocketObservation: environment.stopSocketObservation,

--- a/GliaWidgets/SecureConversations/SecureConversations.MessagesWithUnreadCountLoader.Environment.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.MessagesWithUnreadCountLoader.Environment.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension SecureConversations.MessagesWithUnreadCountLoader {
     struct Environment {
-        var getSecureUnreadMessageCount: CoreSdkClient.GetSecureUnreadMessageCount
+        var getSecureUnreadMessageCount: CoreSdkClient.SecureConversations.GetUnreadMessageCount
         var fetchChatHistory: CoreSdkClient.FetchChatHistory
         var scheduler: CoreSdkClient.ReactiveSwift.DateScheduler
     }
@@ -11,7 +11,7 @@ extension SecureConversations.MessagesWithUnreadCountLoader {
 extension SecureConversations.MessagesWithUnreadCountLoader.Environment {
     static func create(with environment: SecureConversations.TranscriptModel.Environment) -> Self {
         .init(
-            getSecureUnreadMessageCount: environment.getSecureUnreadMessageCount,
+            getSecureUnreadMessageCount: environment.secureConversations.getUnreadMessageCount,
             fetchChatHistory: environment.fetchChatHistory,
             scheduler: environment.messagesWithUnreadCountLoaderScheduler
         )

--- a/GliaWidgets/SecureConversations/SecureConversations.PendingInteraction.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.PendingInteraction.swift
@@ -91,10 +91,10 @@ extension SecureConversations {
 
 extension SecureConversations.PendingInteraction {
     struct Environment {
-        var observePendingSecureConversationsStatus: CoreSdkClient.ObservePendingSecureConversationStatus
-        var observeSecureConversationsUnreadMessageCount: CoreSdkClient.SubscribeForUnreadSCMessageCount
-        var unsubscribeFromUnreadCount: CoreSdkClient.UnsubscribeFromUnreadCount
-        var unsubscribeFromPendingStatus: CoreSdkClient.UnsubscribeFromPendingSCStatus
+        var observePendingSecureConversationsStatus: CoreSdkClient.SecureConversations.ObservePendingStatus
+        var observeSecureConversationsUnreadMessageCount: CoreSdkClient.SecureConversations.SubscribeForUnreadMessageCount
+        var unsubscribeFromUnreadCount: CoreSdkClient.SecureConversations.UnsubscribeFromUnreadCount
+        var unsubscribeFromPendingStatus: CoreSdkClient.SecureConversations.UnsubscribeFromPendingStatus
         var interactorPublisher: AnyPublisher<Interactor?, Never>
     }
 }
@@ -114,10 +114,10 @@ extension SecureConversations.PendingInteraction.Environment {
         client: CoreSdkClient,
         interactorPublisher: AnyPublisher<Interactor?, Never>
     ) {
-        self.observePendingSecureConversationsStatus = client.observePendingSecureConversationStatus
-        self.observeSecureConversationsUnreadMessageCount = client.subscribeForUnreadSCMessageCount
-        self.unsubscribeFromPendingStatus = client.unsubscribeFromPendingSecureConversationStatus
-        self.unsubscribeFromUnreadCount = client.unsubscribeFromUnreadCount
+        self.observePendingSecureConversationsStatus = client.secureConversations.observePendingStatus
+        self.observeSecureConversationsUnreadMessageCount = client.secureConversations.subscribeForUnreadMessageCount
+        self.unsubscribeFromPendingStatus = client.secureConversations.unsubscribeFromPendingStatus
+        self.unsubscribeFromUnreadCount = client.secureConversations.unsubscribeFromPendingStatus
         self.interactorPublisher = interactorPublisher
     }
 }

--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.Environment.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.Environment.swift
@@ -2,10 +2,10 @@ import Foundation
 
 extension SecureConversations.WelcomeViewModel {
     struct Environment {
+        var secureConversations: CoreSdkClient.SecureConversations
         var welcomeStyle: SecureConversations.WelcomeStyle
         var queueIds: [String]
         var listQueues: CoreSdkClient.ListQueues
-        var sendSecureMessagePayload: CoreSdkClient.SendSecureMessagePayload
         var fileUploader: FileUploader
         var uiApplication: UIKitBased.UIApplication
         var createFileUploadListModel: SecureConversations.FileUploadListViewModel.Create
@@ -13,7 +13,6 @@ extension SecureConversations.WelcomeViewModel {
         var startSocketObservation: CoreSdkClient.StartSocketObservation
         var stopSocketObservation: CoreSdkClient.StopSocketObservation
         var getCurrentEngagement: CoreSdkClient.GetCurrentEngagement
-        var uploadSecureFile: CoreSdkClient.SecureConversationsUploadFile
         var uploadFileToEngagement: CoreSdkClient.UploadFileToEngagement
         var createSendMessagePayload: CoreSdkClient.CreateSendMessagePayload
         var log: CoreSdkClient.Logger
@@ -26,10 +25,10 @@ extension SecureConversations.WelcomeViewModel.Environment {
         viewFactory: ViewFactory
     ) -> Self {
         .init(
+            secureConversations: environment.secureConversations,
             welcomeStyle: viewFactory.theme.secureConversationsWelcome,
             queueIds: environment.queueIds,
             listQueues: environment.listQueues,
-            sendSecureMessagePayload: environment.sendSecureMessagePayload,
             fileUploader: environment.createFileUploader(
                 environment.maximumUploads(),
                 .create(with: environment)
@@ -40,7 +39,6 @@ extension SecureConversations.WelcomeViewModel.Environment {
             startSocketObservation: environment.startSocketObservation,
             stopSocketObservation: environment.stopSocketObservation,
             getCurrentEngagement: environment.getCurrentEngagement,
-            uploadSecureFile: environment.uploadSecureFile,
             uploadFileToEngagement: environment.uploadFileToEngagement,
             createSendMessagePayload: environment.createSendMessagePayload,
             log: environment.log

--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.swift
@@ -111,7 +111,7 @@ private extension SecureConversations.WelcomeViewModel {
             fileUploadListModel.attachment
         )
 
-        _ = environment.sendSecureMessagePayload(
+        _ = environment.secureConversations.sendMessagePayload(
             payload,
             queueIds
         ) { [weak self] result in
@@ -447,7 +447,7 @@ extension SecureConversations.WelcomeViewModel {
         fileUploadListModel.environment.uploader.environment.uploadFile =
         isEngagementOngoing ?
             .toEngagement(environment.uploadFileToEngagement) :
-            .toSecureMessaging(environment.uploadSecureFile)
+            .toSecureMessaging(environment.secureConversations.uploadFile)
     }
 
     private func removeUpload(_ upload: FileUpload) {

--- a/GliaWidgets/Sources/Coordinators/Call/CallCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/Call/CallCoordinator.Environment.swift
@@ -2,8 +2,8 @@ import Foundation
 
 extension CallCoordinator {
     struct Environment {
+        var secureConversations: CoreSdkClient.SecureConversations
         var fetchFile: CoreSdkClient.FetchFile
-        var downloadSecureFile: CoreSdkClient.DownloadSecureFile
         var uploadFileToEngagement: CoreSdkClient.UploadFileToEngagement
         var fileManager: FoundationBased.FileManager
         var data: FoundationBased.Data
@@ -31,7 +31,6 @@ extension CallCoordinator {
         var flipCameraButtonStyle: FlipCameraButtonStyle
         var alertManager: AlertManager
         var isAuthenticated: () -> Bool
-        var secureMarkMessagesAsRead: CoreSdkClient.SecureMarkMessagesAsRead
         var markUnreadMessagesDelay: () -> DispatchQueue.SchedulerTimeType.Stride
         var combineScheduler: AnyCombineScheduler
         var createEntryWidget: EntryWidgetBuilder
@@ -41,8 +40,8 @@ extension CallCoordinator {
 extension CallCoordinator.Environment {
     static func create(with environment: EngagementCoordinator.Environment) -> Self {
         .init(
+            secureConversations: environment.secureConversations,
             fetchFile: environment.fetchFile,
-            downloadSecureFile: environment.downloadSecureFile,
             uploadFileToEngagement: environment.uploadFileToEngagement,
             fileManager: environment.fileManager,
             data: environment.data,
@@ -70,7 +69,6 @@ extension CallCoordinator.Environment {
             flipCameraButtonStyle: environment.flipCameraButtonStyle,
             alertManager: environment.alertManager,
             isAuthenticated: environment.isAuthenticated,
-            secureMarkMessagesAsRead: environment.secureMarkMessagesAsRead,
             markUnreadMessagesDelay: environment.markUnreadMessagesDelay,
             combineScheduler: environment.combineScheduler,
             createEntryWidget: environment.createEntryWidget

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
@@ -2,6 +2,7 @@ import Foundation
 
 extension ChatCoordinator {
     struct Environment {
+        var secureConversations: CoreSdkClient.SecureConversations
         var fetchFile: CoreSdkClient.FetchFile
         var uploadFileToEngagement: CoreSdkClient.UploadFileToEngagement
         var fileManager: FoundationBased.FileManager
@@ -20,14 +21,9 @@ extension ChatCoordinator {
         var uiApplication: UIKitBased.UIApplication
         var fetchChatHistory: CoreSdkClient.FetchChatHistory
         var createFileUploadListModel: SecureConversations.FileUploadListViewModel.Create
-        var sendSecureMessagePayload: CoreSdkClient.SendSecureMessagePayload
         var queueIds: [String]
         var listQueues: CoreSdkClient.ListQueues
-        var secureUploadFile: CoreSdkClient.SecureConversationsUploadFile
-        var getSecureUnreadMessageCount: CoreSdkClient.GetSecureUnreadMessageCount
         var messagesWithUnreadCountLoaderScheduler: CoreSdkClient.ReactiveSwift.DateScheduler
-        var secureMarkMessagesAsRead: CoreSdkClient.SecureMarkMessagesAsRead
-        var downloadSecureFile: CoreSdkClient.DownloadSecureFile
         var isAuthenticated: () -> Bool
         var interactor: Interactor
         var startSocketObservation: CoreSdkClient.StartSocketObservation
@@ -65,6 +61,7 @@ extension ChatCoordinator.Environment {
         switchToEngagement: Command<EngagementKind>
     ) -> Self {
         .init(
+            secureConversations: environment.secureConversations,
             fetchFile: environment.fetchFile,
             uploadFileToEngagement: environment.uploadFileToEngagement,
             fileManager: environment.fileManager,
@@ -83,14 +80,9 @@ extension ChatCoordinator.Environment {
             uiApplication: environment.uiApplication,
             fetchChatHistory: environment.fetchChatHistory,
             createFileUploadListModel: environment.createFileUploadListModel,
-            sendSecureMessagePayload: environment.sendSecureMessagePayload,
             queueIds: interactor.queueIds ?? [],
             listQueues: environment.listQueues,
-            secureUploadFile: environment.uploadSecureFile,
-            getSecureUnreadMessageCount: environment.getSecureUnreadMessageCount,
             messagesWithUnreadCountLoaderScheduler: environment.messagesWithUnreadCountLoaderScheduler,
-            secureMarkMessagesAsRead: environment.secureMarkMessagesAsRead,
-            downloadSecureFile: environment.downloadSecureFile,
             isAuthenticated: environment.isAuthenticated,
             interactor: interactor,
             startSocketObservation: environment.startSocketObservation,
@@ -117,6 +109,7 @@ extension ChatCoordinator.Environment {
 
     static func create(with environment: SecureConversations.Coordinator.Environment) -> Self {
         .init(
+            secureConversations: environment.secureConversations,
             fetchFile: environment.fetchFile,
             uploadFileToEngagement: environment.uploadFileToEngagement,
             fileManager: environment.fileManager,
@@ -135,14 +128,9 @@ extension ChatCoordinator.Environment {
             uiApplication: environment.uiApplication,
             fetchChatHistory: environment.fetchChatHistory,
             createFileUploadListModel: environment.createFileUploadListModel,
-            sendSecureMessagePayload: environment.sendSecureMessagePayload,
             queueIds: environment.queueIds,
             listQueues: environment.listQueues,
-            secureUploadFile: environment.uploadSecureFile,
-            getSecureUnreadMessageCount: environment.getSecureUnreadMessageCount,
             messagesWithUnreadCountLoaderScheduler: environment.messagesWithUnreadCountLoaderScheduler,
-            secureMarkMessagesAsRead: environment.secureMarkMessagesAsRead,
-            downloadSecureFile: environment.downloadSecureFile,
             isAuthenticated: environment.isAuthenticated,
             interactor: environment.interactor,
             startSocketObservation: environment.startSocketObservation,

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.Mock.swift
@@ -1,6 +1,7 @@
 #if DEBUG
 extension EngagementCoordinator.Environment {
     static let mock = Self(
+        secureConversations: .mock,
         fetchFile: { _, _, _ in },
         uploadFileToEngagement: { _, _, _ in },
         audioSession: .mock,
@@ -22,15 +23,10 @@ extension EngagementCoordinator.Environment {
         notificationCenter: .mock,
         fetchChatHistory: { _ in },
         listQueues: { _ in },
-        sendSecureMessagePayload: { _, _, _ in .mock },
         createFileUploader: FileUploader.mock,
         createFileUploadListModel: SecureConversations.FileUploadListViewModel.mock(environment:),
-        uploadSecureFile: { _, _, _ in .mock },
-        getSecureUnreadMessageCount: { _ in },
         messagesWithUnreadCountLoaderScheduler: CoreSdkClient.reactiveSwiftDateSchedulerMock,
-        secureMarkMessagesAsRead: { _ in .mock },
         markUnreadMessagesDelay: { .mock },
-        downloadSecureFile: { _, _, _ in .mock },
         isAuthenticated: { false },
         startSocketObservation: {},
         stopSocketObservation: {},

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
@@ -2,6 +2,7 @@ import Foundation
 
 extension EngagementCoordinator {
     struct Environment {
+        var secureConversations: CoreSdkClient.SecureConversations
         var fetchFile: CoreSdkClient.FetchFile
         var uploadFileToEngagement: CoreSdkClient.UploadFileToEngagement
         var audioSession: Glia.Environment.AudioSession
@@ -23,15 +24,10 @@ extension EngagementCoordinator {
         var notificationCenter: FoundationBased.NotificationCenter
         var fetchChatHistory: CoreSdkClient.FetchChatHistory
         var listQueues: CoreSdkClient.ListQueues
-        var sendSecureMessagePayload: CoreSdkClient.SendSecureMessagePayload
         var createFileUploader: FileUploader.Create
         var createFileUploadListModel: SecureConversations.FileUploadListViewModel.Create
-        var uploadSecureFile: CoreSdkClient.SecureConversationsUploadFile
-        var getSecureUnreadMessageCount: CoreSdkClient.GetSecureUnreadMessageCount
         var messagesWithUnreadCountLoaderScheduler: CoreSdkClient.ReactiveSwift.DateScheduler
-        var secureMarkMessagesAsRead: CoreSdkClient.SecureMarkMessagesAsRead
         var markUnreadMessagesDelay: () -> DispatchQueue.SchedulerTimeType.Stride
-        var downloadSecureFile: CoreSdkClient.DownloadSecureFile
         var isAuthenticated: () -> Bool
         var startSocketObservation: CoreSdkClient.StartSocketObservation
         var stopSocketObservation: CoreSdkClient.StopSocketObservation
@@ -66,6 +62,7 @@ extension EngagementCoordinator.Environment {
         hasPendingInteraction: @escaping () -> Bool
     ) -> Self {
         .init(
+            secureConversations: environment.coreSdk.secureConversations,
             fetchFile: environment.coreSdk.fetchFile,
             uploadFileToEngagement: environment.coreSdk.uploadFileToEngagement,
             audioSession: environment.audioSession,
@@ -87,15 +84,10 @@ extension EngagementCoordinator.Environment {
             notificationCenter: environment.notificationCenter,
             fetchChatHistory: environment.coreSdk.fetchChatHistory,
             listQueues: environment.coreSdk.getQueues,
-            sendSecureMessagePayload: environment.coreSdk.sendSecureMessagePayload,
             createFileUploader: environment.createFileUploader,
             createFileUploadListModel: environment.createFileUploadListModel,
-            uploadSecureFile: environment.coreSdk.uploadSecureFile,
-            getSecureUnreadMessageCount: environment.coreSdk.getSecureUnreadMessageCount,
             messagesWithUnreadCountLoaderScheduler: environment.messagesWithUnreadCountLoaderScheduler,
-            secureMarkMessagesAsRead: environment.coreSdk.secureMarkMessagesAsRead,
             markUnreadMessagesDelay: markUnreadMessagesDelay,
-            downloadSecureFile: environment.coreSdk.downloadSecureFile,
             isAuthenticated: environment.isAuthenticated,
             startSocketObservation: environment.coreSdk.startSocketObservation,
             stopSocketObservation: environment.coreSdk.stopSocketObservation,

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -5,6 +5,7 @@ import GliaCoreDependency
 struct CoreSdkClient {
     var pushNotifications: PushNotifications
     var liveObservation: LiveObservation
+    var secureConversations: SecureConversations
     var createAppDelegate: () -> AppDelegate
     var clearSession: () -> Void
     var localeProvider: LocaleProvider
@@ -129,38 +130,6 @@ struct CoreSdkClient {
 
     var requestVisitorCode: RequestVisitorCode
 
-    typealias SendSecureMessagePayload = (
-        _ secureMessagePayload: SendMessagePayload,
-        _ queueIds: [String],
-        _ completion: @escaping (Result<Self.Message, Error>) -> Void
-    ) -> Self.Cancellable
-
-    var sendSecureMessagePayload: SendSecureMessagePayload
-
-    typealias SecureConversationsUploadFile = (
-        _ file: EngagementFile,
-        _ progress: EngagementFileProgressBlock?,
-        _ completion: @escaping (Result<EngagementFileInformation, Swift.Error>) -> Void
-    ) -> Self.Cancellable
-
-    var uploadSecureFile: SecureConversationsUploadFile
-
-    typealias GetSecureUnreadMessageCount = (_ callback: @escaping (Result<Int, Error>) -> Void) -> Void
-
-    var getSecureUnreadMessageCount: GetSecureUnreadMessageCount
-
-    typealias SecureMarkMessagesAsRead = (_ callback: @escaping (Result<Void, Error>) -> Void) -> Cancellable
-
-    var secureMarkMessagesAsRead: SecureMarkMessagesAsRead
-
-    typealias DownloadSecureFile = (
-        _ file: EngagementFile,
-        _ progress: @escaping EngagementFileProgressBlock,
-        _ completion: @escaping (Result<EngagementFileData, Error>) -> Void
-    ) -> Cancellable
-
-    var downloadSecureFile: DownloadSecureFile
-
     typealias StartSocketObservation = () -> Void
 
     var startSocketObservation: StartSocketObservation
@@ -194,32 +163,61 @@ struct CoreSdkClient {
     ) -> Void
 
     var unsubscribeFromUpdates: UnsubscribeFromUpdates
+}
 
-    typealias SubscribeForUnreadSCMessageCount = (
+extension CoreSdkClient {
+    struct SecureConversations {
+        var sendMessagePayload: SendPayload
+        var uploadFile: UploadFile
+        var getUnreadMessageCount: GetUnreadMessageCount
+        var markMessagesAsRead: MarkMessagesAsRead
+        var downloadFile: DownloadFile
+        var subscribeForUnreadMessageCount: SubscribeForUnreadMessageCount
+        var unsubscribeFromUnreadMessageCount: UnsubscribeFromUnreadCount
+        var pendingStatus: PendingStatus
+        var observePendingStatus: ObservePendingStatus
+        var unsubscribeFromPendingStatus: UnsubscribeFromPendingStatus
+    }
+}
+
+extension CoreSdkClient.SecureConversations {
+    typealias Cancellable = GliaCore.Cancellable
+
+    typealias Message = GliaCoreSDK.Message
+
+    typealias SendPayload = (
+        _ secureMessagePayload: SendMessagePayload,
+        _ queueIds: [String],
+        _ completion: @escaping (Result<Message, Error>) -> Void
+    ) -> Cancellable
+
+    typealias UploadFile = (
+        _ file: EngagementFile,
+        _ progress: EngagementFileProgressBlock?,
+        _ completion: @escaping (Result<EngagementFileInformation, Swift.Error>) -> Void
+    ) -> Cancellable
+
+    typealias GetUnreadMessageCount = (_ callback: @escaping (Result<Int, Error>) -> Void) -> Void
+
+    typealias MarkMessagesAsRead = (_ callback: @escaping (Result<Void, Error>) -> Void) -> Cancellable
+
+    typealias DownloadFile = (
+        _ file: EngagementFile,
+        _ progress: @escaping EngagementFileProgressBlock,
+        _ completion: @escaping (Result<EngagementFileData, Error>) -> Void
+    ) -> Cancellable
+
+    typealias SubscribeForUnreadMessageCount = (
         _ completion: @escaping (Result<Int?, Error>) -> Void
     ) -> String?
 
-    var subscribeForUnreadSCMessageCount: SubscribeForUnreadSCMessageCount
-
-    typealias PendingSecureConversationStatus = (_ callback: @escaping (Result<Bool, Error>) -> Void) -> Void
-
-    var pendingSecureConversationStatus: PendingSecureConversationStatus
-
-    typealias ObservePendingSecureConversationStatus = (_ callback: @escaping (Result<Bool, Error>) -> Void) -> String?
-
-    var observePendingSecureConversationStatus: ObservePendingSecureConversationStatus
-
-    typealias UnsubscribeFromPendingSCStatus = (String) -> Void
-
-    var unsubscribeFromPendingSecureConversationStatus: UnsubscribeFromPendingSCStatus
-
     typealias UnsubscribeFromUnreadCount = (String) -> Void
 
-    var unsubscribeFromUnreadCount: UnsubscribeFromUnreadCount
+    typealias PendingStatus = (_ callback: @escaping (Result<Bool, Error>) -> Void) -> Void
 
-    var liveObservationPause: () -> Void
+    typealias ObservePendingStatus = (_ callback: @escaping (Result<Bool, Error>) -> Void) -> String?
 
-    var liveObservationResume: () -> Void
+    typealias UnsubscribeFromPendingStatus = (String) -> Void
 }
 
 extension CoreSdkClient {

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
@@ -5,6 +5,7 @@ extension CoreSdkClient {
         .init(
             pushNotifications: .live,
             liveObservation: .live,
+            secureConversations: .live,
             createAppDelegate: Self.AppDelegate.live,
             clearSession: GliaCore.sharedInstance.clearSession,
             localeProvider: .init(getRemoteString: GliaCore.sharedInstance.localeProvider.getRemoteString(_:)),
@@ -50,11 +51,6 @@ extension CoreSdkClient {
                 }
             },
             requestVisitorCode: GliaCore.sharedInstance.callVisualizer.requestVisitorCode(completion:),
-            sendSecureMessagePayload: GliaCore.sharedInstance.secureConversations.send(secureMessagePayload:queueIds:completion:),
-            uploadSecureFile: GliaCore.sharedInstance.secureConversations.uploadFile(_:progress:completion:),
-            getSecureUnreadMessageCount: GliaCore.sharedInstance.secureConversations.getUnreadMessageCount(completion:),
-            secureMarkMessagesAsRead: GliaCore.sharedInstance.secureConversations.markMessagesAsRead(completion:),
-            downloadSecureFile: GliaCore.sharedInstance.secureConversations.downloadFile(_:progress:completion:),
             startSocketObservation: GliaCore.sharedInstance.startSocketObservation,
             stopSocketObservation: GliaCore.sharedInstance.stopSocketObservation,
             createSendMessagePayload: CoreSdkClient.SendMessagePayload.init(content:attachment:),
@@ -65,18 +61,24 @@ extension CoreSdkClient {
                 )
             },
             subscribeForQueuesUpdates: GliaCore.sharedInstance.subscribeForQueuesUpdates(forQueues:completion:),
-            unsubscribeFromUpdates: GliaCore.sharedInstance.unsubscribeFromUpdates(queueCallbackId:onError:),
-            subscribeForUnreadSCMessageCount: GliaCore.sharedInstance.secureConversations.subscribeToUnreadMessageCount(completion:),
-            pendingSecureConversationStatus: GliaCore.sharedInstance.secureConversations.pendingSecureConversationStatus,
-            observePendingSecureConversationStatus: GliaCore.sharedInstance.secureConversations.subscribeToPendingSecureConversationStatus,
-            unsubscribeFromPendingSecureConversationStatus: {
-                GliaCore.sharedInstance.secureConversations.unsubscribeFromPendingSecureConversationStatus($0)
-            },
-            unsubscribeFromUnreadCount: GliaCore.sharedInstance.secureConversations.unsubscribeFromUnreadMessageCount,
-            liveObservationPause: GliaCore.sharedInstance.liveObservation.pause,
-            liveObservationResume: GliaCore.sharedInstance.liveObservation.resume
+            unsubscribeFromUpdates: GliaCore.sharedInstance.unsubscribeFromUpdates(queueCallbackId:onError:)
         )
     }()
+}
+
+extension CoreSdkClient.SecureConversations {
+    static let live = Self(
+        sendMessagePayload: GliaCore.sharedInstance.secureConversations.send(secureMessagePayload:queueIds:completion:),
+        uploadFile: GliaCore.sharedInstance.secureConversations.uploadFile(_:progress:completion:),
+        getUnreadMessageCount: GliaCore.sharedInstance.secureConversations.getUnreadMessageCount(completion:),
+        markMessagesAsRead: GliaCore.sharedInstance.secureConversations.markMessagesAsRead(completion:),
+        downloadFile: GliaCore.sharedInstance.secureConversations.downloadFile(_:progress:completion:),
+        subscribeForUnreadMessageCount: GliaCore.sharedInstance.secureConversations.subscribeToUnreadMessageCount(completion:),
+        unsubscribeFromUnreadMessageCount: GliaCore.sharedInstance.secureConversations.unsubscribeFromUnreadMessageCount,
+        pendingStatus: GliaCore.sharedInstance.secureConversations.pendingSecureConversationStatus,
+        observePendingStatus: GliaCore.sharedInstance.secureConversations.subscribeToPendingSecureConversationStatus,
+        unsubscribeFromPendingStatus: { GliaCore.sharedInstance.secureConversations.unsubscribeFromPendingSecureConversationStatus($0) }
+    )
 }
 
 extension CoreSdkClient.LiveObservation {

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -6,6 +6,7 @@ extension CoreSdkClient {
     static let mock = Self(
         pushNotifications: .mock,
         liveObservation: .mock,
+        secureConversations: .mock,
         createAppDelegate: { .mock },
         clearSession: {},
         localeProvider: .mock,
@@ -29,25 +30,28 @@ extension CoreSdkClient {
         authentication: { _ in .mock },
         fetchChatHistory: { _ in },
         requestVisitorCode: { _ in .mock },
-        sendSecureMessagePayload: { _, _, _ in .mock },
-        uploadSecureFile: { _, _, _ in .mock },
-        getSecureUnreadMessageCount: { _ in },
-        secureMarkMessagesAsRead: { _ in .mock },
-        downloadSecureFile: { _, _, _ in .mock },
         startSocketObservation: {},
         stopSocketObservation: {},
         createSendMessagePayload: { _, _ in .mock() },
         createLogger: { _ in Logger.mock },
         getCameraDeviceManageable: { .mock },
         subscribeForQueuesUpdates: { _, _ in UUID.mock.uuidString },
-        unsubscribeFromUpdates: { _, _ in },
-        subscribeForUnreadSCMessageCount: { _ in UUID.mock.uuidString },
-        pendingSecureConversationStatus: { $0(.success(false)) },
-        observePendingSecureConversationStatus: { _ in nil },
-        unsubscribeFromPendingSecureConversationStatus: { _ in },
-        unsubscribeFromUnreadCount: { _ in },
-        liveObservationPause: {},
-        liveObservationResume: {}
+        unsubscribeFromUpdates: { _, _ in }
+    )
+}
+
+extension CoreSdkClient.SecureConversations {
+    static let mock = Self(
+        sendMessagePayload: { _, _, _ in .mock },
+        uploadFile: { _, _, _ in .mock },
+        getUnreadMessageCount: { _ in },
+        markMessagesAsRead: { _ in .mock },
+        downloadFile: { _, _, _ in .mock },
+        subscribeForUnreadMessageCount: { _ in UUID.mock.uuidString },
+        unsubscribeFromUnreadMessageCount: { _ in },
+        pendingStatus: { $0(.success(false)) },
+        observePendingStatus: { _ in nil },
+        unsubscribeFromPendingStatus: { _ in }
     )
 }
 

--- a/GliaWidgets/Sources/Download/FileDownload.Environment.Interface.swift
+++ b/GliaWidgets/Sources/Download/FileDownload.Environment.Interface.swift
@@ -3,7 +3,7 @@ import Foundation
 extension FileDownload {
     struct Environment {
         var fetchFile: CoreSdkClient.FetchFile
-        var downloadSecureFile: CoreSdkClient.DownloadSecureFile
+        var downloadSecureFile: CoreSdkClient.SecureConversations.DownloadFile
         var fileManager: FoundationBased.FileManager
         var gcd: GCD
         var uiScreen: UIKitBased.UIScreen
@@ -14,7 +14,7 @@ extension FileDownload {
 extension FileDownload.Environment {
     enum FetchFile {
         case fromEngagement(CoreSdkClient.FetchFile)
-        case fromSecureMessaging(CoreSdkClient.DownloadSecureFile)
+        case fromSecureMessaging(CoreSdkClient.SecureConversations.DownloadFile)
     }
 }
 extension FileDownload.Environment.FetchFile {
@@ -58,7 +58,7 @@ extension FileDownload.Environment.FetchFile {
 
     struct Environment {
         var fetchFile: CoreSdkClient.FetchFile
-        var downloadSecureFile: CoreSdkClient.DownloadSecureFile
+        var downloadSecureFile: CoreSdkClient.SecureConversations.DownloadFile
     }
 }
 

--- a/GliaWidgets/Sources/Download/FileDownloader.Environment.swift
+++ b/GliaWidgets/Sources/Download/FileDownloader.Environment.swift
@@ -3,7 +3,7 @@ import Foundation
 extension FileDownloader {
     struct Environment {
         var fetchFile: CoreSdkClient.FetchFile
-        var downloadSecureFile: CoreSdkClient.DownloadSecureFile
+        var downloadSecureFile: CoreSdkClient.SecureConversations.DownloadFile
         var fileManager: FoundationBased.FileManager
         var data: FoundationBased.Data
         var date: () -> Date
@@ -18,7 +18,7 @@ extension FileDownloader.Environment {
     static func create(with environment: SecureConversations.TranscriptModel.Environment) -> Self {
         .init(
             fetchFile: environment.fetchFile,
-            downloadSecureFile: environment.downloadSecureFile,
+            downloadSecureFile: environment.secureConversations.downloadFile,
             fileManager: environment.fileManager,
             data: environment.data,
             date: environment.date,
@@ -32,7 +32,7 @@ extension FileDownloader.Environment {
     static func create(with environment: ChatViewModel.Environment) -> Self {
         .init(
             fetchFile: environment.fetchFile,
-            downloadSecureFile: environment.downloadSecureFile,
+            downloadSecureFile: environment.secureConversations.downloadFile,
             fileManager: environment.fileManager,
             data: environment.data,
             date: environment.date,

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.Environment.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.Environment.swift
@@ -3,7 +3,7 @@ import Combine
 
 extension EntryWidget {
     struct Environment {
-        var observeSecureUnreadMessageCount: CoreSdkClient.SubscribeForUnreadSCMessageCount
+        var observeSecureUnreadMessageCount: CoreSdkClient.SecureConversations.SubscribeForUnreadMessageCount
         var unsubscribeFromUpdates: CoreSdkClient.UnsubscribeFromUpdates
         var queuesMonitor: QueuesMonitor
         var engagementLauncher: EngagementLauncher

--- a/GliaWidgets/Sources/Upload/FileUpload.Environment.Interface.swift
+++ b/GliaWidgets/Sources/Upload/FileUpload.Environment.Interface.swift
@@ -10,7 +10,7 @@ extension FileUpload {
 extension FileUpload.Environment {
     enum UploadFile {
         case toEngagement(CoreSdkClient.UploadFileToEngagement)
-        case toSecureMessaging(CoreSdkClient.SecureConversationsUploadFile)
+        case toSecureMessaging(CoreSdkClient.SecureConversations.UploadFile)
     }
 
     static func create(with environment: FileUploader.Environment) -> Self {

--- a/GliaWidgets/Sources/Upload/FileUploader.Environment.Interface.swift
+++ b/GliaWidgets/Sources/Upload/FileUploader.Environment.Interface.swift
@@ -20,7 +20,7 @@ extension FileUploader.Environment {
 extension FileUploader.Environment {
     static func create(with environment: SecureConversations.Coordinator.Environment) -> Self {
         .init(
-            uploadFile: .toSecureMessaging(environment.uploadSecureFile),
+            uploadFile: .toSecureMessaging(environment.secureConversations.uploadFile),
             fileManager: environment.fileManager,
             data: environment.data,
             date: environment.date,
@@ -33,7 +33,7 @@ extension FileUploader.Environment {
 
     static func create(with environment: SecureConversations.TranscriptModel.Environment) -> Self {
         .init(
-            uploadFile: .toSecureMessaging(environment.secureUploadFile),
+            uploadFile: .toSecureMessaging(environment.secureConversations.uploadFile),
             fileManager: environment.fileManager,
             data: environment.data,
             date: environment.date,

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Environment.Interface.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Environment.Interface.swift
@@ -2,8 +2,8 @@ import Foundation
 
 extension EngagementViewModel {
     struct Environment {
+        var secureConversations: CoreSdkClient.SecureConversations
         var fetchFile: CoreSdkClient.FetchFile
-        var downloadSecureFile: CoreSdkClient.DownloadSecureFile
         var uploadFileToEngagement: CoreSdkClient.UploadFileToEngagement
         var fileManager: FoundationBased.FileManager
         var data: FoundationBased.Data
@@ -30,7 +30,6 @@ extension EngagementViewModel {
         var alertManager: AlertManager
         var isAuthenticated: () -> Bool
         var notificationCenter: FoundationBased.NotificationCenter
-        var secureMarkMessagesAsRead: CoreSdkClient.SecureMarkMessagesAsRead
         var markUnreadMessagesDelay: () -> DispatchQueue.SchedulerTimeType.Stride
         var combineScheduler: AnyCombineScheduler
         var createEntryWidget: EntryWidgetBuilder
@@ -46,8 +45,8 @@ extension EngagementViewModel.Environment {
         viewFactory: ViewFactory
     ) -> EngagementViewModel.Environment {
         .init(
+            secureConversations: environment.secureConversations,
             fetchFile: environment.fetchFile,
-            downloadSecureFile: environment.downloadSecureFile,
             uploadFileToEngagement: environment.uploadFileToEngagement,
             fileManager: environment.fileManager,
             data: environment.data,
@@ -74,7 +73,6 @@ extension EngagementViewModel.Environment {
             alertManager: environment.alertManager,
             isAuthenticated: environment.isAuthenticated,
             notificationCenter: environment.notificationCenter,
-            secureMarkMessagesAsRead: environment.secureMarkMessagesAsRead,
             markUnreadMessagesDelay: environment.markUnreadMessagesDelay,
             combineScheduler: environment.combineScheduler,
             createEntryWidget: environment.createEntryWidget,
@@ -89,8 +87,8 @@ extension EngagementViewModel.Environment {
         viewFactory: ViewFactory
     ) -> EngagementViewModel.Environment {
         .init(
+            secureConversations: environment.secureConversations,
             fetchFile: environment.fetchFile,
-            downloadSecureFile: environment.downloadSecureFile,
             uploadFileToEngagement: environment.uploadFileToEngagement,
             fileManager: environment.fileManager,
             data: environment.data,
@@ -117,7 +115,6 @@ extension EngagementViewModel.Environment {
             alertManager: environment.alertManager,
             isAuthenticated: environment.isAuthenticated,
             notificationCenter: environment.notificationCenter,
-            secureMarkMessagesAsRead: environment.secureMarkMessagesAsRead,
             markUnreadMessagesDelay: environment.markUnreadMessagesDelay,
             combineScheduler: environment.combineScheduler,
             createEntryWidget: environment.createEntryWidget,

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Environment.Mock.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.Environment.Mock.swift
@@ -4,8 +4,8 @@ import Foundation
 
 extension ChatViewModel.Environment {
     static let mock = Self(
+        secureConversations: .mock,
         fetchFile: { _, _, _ in },
-        downloadSecureFile: { _, _, _ in .mock },
         uploadFileToEngagement: { _, _, _ in },
         fileManager: .mock,
         data: .mock,
@@ -38,7 +38,6 @@ extension ChatViewModel.Environment {
         alertManager: .mock(),
         isAuthenticated: { false },
         notificationCenter: .mock,
-        secureMarkMessagesAsRead: { _ in .mock },
         markUnreadMessagesDelay: { .mock },
         combineScheduler: .mock,
         createEntryWidget: { _ in .mock() },

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -1062,7 +1062,7 @@ extension ChatViewModel: ApplicationVisibilityTracker {
             delayScheduler: environment.combineScheduler.global
         )
             .sink { [weak self] _ in
-                _ = self?.environment.secureMarkMessagesAsRead { _ in }
+                _ = self?.environment.secureConversations.markMessagesAsRead { _ in }
             }
             .store(in: &markMessagesAsReadCancellables)
     }

--- a/GliaWidgetsTests/CallVisualizer/CallVisualizerTests+LO.swift
+++ b/GliaWidgetsTests/CallVisualizer/CallVisualizerTests+LO.swift
@@ -30,10 +30,7 @@ extension CallVisualizerTests {
         gliaEnv.snackBar.present = { _, _, _, _, _, _, _ in
             calls.append(.presentSnackBar)
         }
-        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        gliaEnv.coreSdk.secureConversations.observePendingStatus = { _ in nil }
         let sdk = Glia(environment: gliaEnv)
         try sdk.configure(with: .mock(), theme: .mock(), completion: { _ in })
 
@@ -70,10 +67,7 @@ extension CallVisualizerTests {
         gliaEnv.snackBar.present = { _, _, _, _, _, _, _ in
             calls.append(.presentSnackBar)
         }
-        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        gliaEnv.coreSdk.secureConversations.observePendingStatus = { _ in nil }
         let sdk = Glia(environment: gliaEnv)
         try sdk.configure(with: .mock(), theme: .mock(), completion: { _ in })
 
@@ -110,10 +104,7 @@ extension CallVisualizerTests {
         gliaEnv.snackBar.present = { _, _, _, _, _, _, _ in
             calls.append(.presentSnackBar)
         }
-        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        gliaEnv.coreSdk.secureConversations.observePendingStatus = { _ in nil }
         let sdk = Glia(environment: gliaEnv)
         try sdk.configure(with: .mock(), theme: .mock(), completion: { _ in })
 
@@ -144,10 +135,7 @@ extension CallVisualizerTests {
         gliaEnv.callVisualizerPresenter = .init(presenter: { nil })
         gliaEnv.gcd.mainQueue.asyncIfNeeded = { $0() }
         gliaEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
-        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        gliaEnv.coreSdk.secureConversations.observePendingStatus = { _ in nil }
         let sdk = Glia(environment: gliaEnv)
         sdk.environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             sdk.environment.coreSdk.getCurrentEngagement = {
@@ -181,10 +169,7 @@ extension CallVisualizerTests {
         gliaEnv.callVisualizerPresenter = .init(presenter: { nil })
         gliaEnv.gcd.mainQueue.asyncIfNeeded = { $0() }
         gliaEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
-        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        gliaEnv.coreSdk.secureConversations.observePendingStatus = { _ in nil }
         let sdk = Glia(environment: gliaEnv)
         sdk.environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             sdk.environment.coreSdk.getCurrentEngagement = {
@@ -218,10 +203,7 @@ extension CallVisualizerTests {
         gliaEnv.callVisualizerPresenter = .init(presenter: { nil })
         gliaEnv.gcd.mainQueue.asyncIfNeeded = { $0() }
         gliaEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
-        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        gliaEnv.coreSdk.secureConversations.observePendingStatus = { _ in nil }
         let sdk = Glia(environment: gliaEnv)
         sdk.environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             sdk.environment.coreSdk.getCurrentEngagement = {

--- a/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
+++ b/GliaWidgetsTests/Coordinator/RootCoordinator.Environment.Failing.swift
@@ -2,6 +2,7 @@
 
 extension EngagementCoordinator.Environment {
     static let failing = Self(
+        secureConversations: .failing,
         fetchFile: { _, _, _ in
             fail("\(Self.self).fetchFile")
         },
@@ -46,10 +47,6 @@ extension EngagementCoordinator.Environment {
         notificationCenter: .failing,
         fetchChatHistory: { _ in fail("\(Self.self).fetchChatHistory") },
         listQueues: { _ in fail("\(Self.self).listQueues") },
-        sendSecureMessagePayload: { _, _, _ in
-            fail("\(Self.self).sendSecureMessagePayload")
-            return .mock
-        },
         createFileUploader: { _, _ in
             .failing
         },
@@ -57,24 +54,9 @@ extension EngagementCoordinator.Environment {
             fail("\(Self.self).createFileUploadListModel")
             return .mock()
         },
-        uploadSecureFile: { _, _, _ in
-            fail("\(Self.self).uploadSecureFile")
-            return .mock
-        },
-        getSecureUnreadMessageCount: { _ in
-            fail("\(Self.self).getSecureUnreadMessageCount")
-        },
         messagesWithUnreadCountLoaderScheduler: CoreSdkClient.reactiveSwiftDateSchedulerMock,
-        secureMarkMessagesAsRead: { _ in
-            fail("\(Self.self).secureMarkMessagesAsRead")
-            return .mock
-        },
         markUnreadMessagesDelay: {
             fail("\(Self.self).markUnreadMessagesDelay")
-            return .mock
-        },
-        downloadSecureFile: { _, _, _ in
-            fail("\(Self.self).downloadSecureFile")
             return .mock
         },
         isAuthenticated: {

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModel.Environment.Failing.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModel.Environment.Failing.swift
@@ -2,12 +2,9 @@
 
 extension SecureConversations.TranscriptModel.Environment {
     static let failing = SecureConversations.TranscriptModel.Environment(
+        secureConversations: .failing,
         fetchFile: { _, _, _ in
             fail("\(Self.self).fetchFile")
-        },
-        downloadSecureFile: { _, _, _ in
-            fail("\(Self.self).downloadSecureFile")
-            return .mock
         },
         fileManager: .failing,
         data: .failing,
@@ -29,10 +26,6 @@ extension SecureConversations.TranscriptModel.Environment {
             fail("\(Self.self).fetchChatHistory")
         },
         uiApplication: .failing,
-        sendSecureMessagePayload: { _, _, _ in
-            fail("\(Self.self).sendSecureMessagePayload")
-            return .mock
-        },
         queueIds: [],
         getQueues: { _ in
             fail("\(Self.self).listQueues")
@@ -45,22 +38,11 @@ extension SecureConversations.TranscriptModel.Environment {
             fail("\(Self.self).uuid")
             return .mock
         },
-        secureUploadFile: { _, _, _ in
-            fail("\(Self.self).secureUploadFile")
-            return .mock
-        },
         fileUploadListStyle: .mock,
         fetchSiteConfigurations: { _ in
             fail("\(Self.self).fetchSiteConfigurations")
         },
-        getSecureUnreadMessageCount: { _ in
-            fail("\(Self.self).getSecureUnreadMessageCount")
-        },
         messagesWithUnreadCountLoaderScheduler: CoreSdkClient.ReactiveSwift.TestScheduler(startDate: .mock),
-        secureMarkMessagesAsRead: { _ in
-            fail("\(Self.self).secureMarkMessagesAsRead")
-            return .mock
-        },
         interactor: .mock(),
         startSocketObservation: {
             fail("\(Self.self).startSocketObservation")

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+GVA.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+GVA.swift
@@ -57,7 +57,7 @@ extension SecureConversationsTranscriptModelTests {
         viewModel.environment.uiApplication.open = { url in
             calls.append(.openUrl(url.absoluteString))
         }
-        viewModel.environment.sendSecureMessagePayload = { payload, _, _ in
+        viewModel.environment.secureConversations.sendMessagePayload = { payload, _, _ in
             calls.append(.sendOption(payload.content, payload.attachment?.selectedOption))
             return .mock
         }
@@ -84,7 +84,7 @@ extension SecureConversationsTranscriptModelTests {
         viewModel.environment.uiApplication.open = { url in
             calls.append(.openUrl(url.absoluteString))
         }
-        viewModel.environment.sendSecureMessagePayload = { payload, _, _ in
+        viewModel.environment.secureConversations.sendMessagePayload = { payload, _, _ in
             calls.append(.sendOption(payload.content, payload.attachment?.selectedOption))
             return .mock
         }
@@ -144,7 +144,7 @@ extension SecureConversationsTranscriptModelTests {
         modelEnv.fetchChatHistory = { $0(.success([message])) }
         modelEnv.loadChatMessagesFromHistory = { true }
         modelEnv.fetchSiteConfigurations = { _ in }
-        modelEnv.getSecureUnreadMessageCount = { $0(.success(0)) }
+        modelEnv.secureConversations.getUnreadMessageCount = { $0(.success(0)) }
         modelEnv.startSocketObservation = {}
         modelEnv.shouldShowLeaveSecureConversationDialog = { _ in false }
         let scheduler = CoreSdkClient.ReactiveSwift.TestScheduler()

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+MessageRetry.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+MessageRetry.swift
@@ -77,7 +77,7 @@ extension SecureConversationsTranscriptModelTests {
             }
         }
 
-        viewModel.environment.sendSecureMessagePayload = { _, _, completion in
+        viewModel.environment.secureConversations.sendMessagePayload = { _, _, completion in
             completion(.failure(GliaError.internalError))
             return .mock
         }
@@ -134,7 +134,7 @@ private extension SecureConversationsTranscriptModelTests {
         modelEnv.getQueues = { callback in callback([], nil) }
         modelEnv.uiApplication.canOpenURL = { _ in true }
         modelEnv.maximumUploads = { 2 }
-        modelEnv.sendSecureMessagePayload = { _, _, _ in .mock }
+        modelEnv.secureConversations.sendMessagePayload = { _, _, _ in .mock }
         modelEnv.createEntryWidget = { _ in .mock() }
         let availabilityEnv = SecureConversations.Availability.Environment(
             getQueues: modelEnv.getQueues,

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests.swift
@@ -78,7 +78,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.createFileUploadListModel = { _ in .mock() }
         modelEnv.getQueues = { _ in }
         modelEnv.fetchChatHistory = { _ in }
-        modelEnv.getSecureUnreadMessageCount = { _ in }
+        modelEnv.secureConversations.getUnreadMessageCount = { _ in }
         modelEnv.startSocketObservation = {}
         modelEnv.maximumUploads = { 2 }
         modelEnv.createEntryWidget = { _ in .mock() }
@@ -133,7 +133,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             calls.append(.loadSiteConfiguration)
         }
 
-        modelEnv.getSecureUnreadMessageCount = { _ in calls.append(.getSecureUnreadMessageCount)
+        modelEnv.secureConversations.getUnreadMessageCount = { _ in calls.append(.getSecureUnreadMessageCount)
         }
         modelEnv.startSocketObservation = {}
         let availabilityEnv = SecureConversations.Availability.Environment(
@@ -167,7 +167,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.getQueues = { _ in }
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
-        modelEnv.getSecureUnreadMessageCount = { _ in }
+        modelEnv.secureConversations.getUnreadMessageCount = { _ in }
         modelEnv.startSocketObservation = {}
         modelEnv.maximumUploads = { 2 }
         modelEnv.createEntryWidget = { _ in .mock() }
@@ -217,7 +217,6 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.getQueues = { _ in }
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
-        modelEnv.getSecureUnreadMessageCount = { _ in }
         modelEnv.maximumUploads = { 2 }
         modelEnv.createEntryWidget = { _ in .mock() }
         let availabilityEnv = SecureConversations.Availability.Environment(
@@ -261,7 +260,6 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.getQueues = { _ in }
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
-        modelEnv.getSecureUnreadMessageCount = { _ in }
         modelEnv.maximumUploads = { 2 }
         modelEnv.createEntryWidget = { _ in .mock() }
         let availabilityEnv = SecureConversations.Availability.Environment(
@@ -301,7 +299,6 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.getQueues = { _ in }
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
-        modelEnv.getSecureUnreadMessageCount = { _ in }
         modelEnv.maximumUploads = { 2 }
         modelEnv.createEntryWidget = { _ in .mock() }
         let availabilityEnv = SecureConversations.Availability.Environment(
@@ -338,7 +335,6 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.getQueues = { _ in }
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
-        modelEnv.getSecureUnreadMessageCount = { _ in }
         modelEnv.createSendMessagePayload = {
             .mock(messageIdSuffix: "mock", content: $0, attachment: $1)
         }
@@ -346,7 +342,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.createEntryWidget = { _ in .mock() }
         enum Call: Equatable { case sendSecureMessagePayload }
         var calls: [Call] = []
-        modelEnv.sendSecureMessagePayload = { _, _, _ in
+        modelEnv.secureConversations.sendMessagePayload = { _, _, _ in
             calls.append(.sendSecureMessagePayload)
             return .mock
         }
@@ -388,7 +384,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.createEntryWidget = { _ in .mock() }
         enum Call: Equatable { case getSecureUnreadMessageCount }
         var calls: [Call] = []
-        modelEnv.getSecureUnreadMessageCount = { _ in
+        modelEnv.secureConversations.getUnreadMessageCount = { _ in
             calls.append(.getSecureUnreadMessageCount)
         }
 
@@ -427,7 +423,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             callback(.success([.mock(sender: .operator)]))
         }
         modelEnv.fetchSiteConfigurations = { _ in }
-        modelEnv.getSecureUnreadMessageCount = { callback in
+        modelEnv.secureConversations.getUnreadMessageCount = { callback in
             callback(.success(1))
         }
         modelEnv.startSocketObservation = {}
@@ -485,7 +481,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.fetchSiteConfigurations = { _ in }
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.maximumUploads = { 2 }
-        modelEnv.getSecureUnreadMessageCount = { callback in
+        modelEnv.secureConversations.getUnreadMessageCount = { callback in
             callback(.success(0))
         }
         modelEnv.startSocketObservation = {}
@@ -553,7 +549,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.fetchSiteConfigurations = { _ in }
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.maximumUploads = { 2 }
-        modelEnv.getSecureUnreadMessageCount = { callback in
+        modelEnv.secureConversations.getUnreadMessageCount = { callback in
             callback(.success(0))
         }
         modelEnv.startSocketObservation = {}
@@ -794,7 +790,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.getQueues = { _ in }
         modelEnv.loadChatMessagesFromHistory = { true }
         modelEnv.fetchChatHistory = { $0(.success([.mock(), .mock(), .mock()])) }
-        modelEnv.getSecureUnreadMessageCount = { $0(.success(5)) }
+        modelEnv.secureConversations.getUnreadMessageCount = { $0(.success(5)) }
         modelEnv.fetchSiteConfigurations = { _ in }
         modelEnv.startSocketObservation = {}
         modelEnv.maximumUploads = { 2 }
@@ -804,7 +800,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.uiApplication.applicationState = { .active }
         enum Call: Equatable { case secureMarkMessagesAsRead }
         var calls: [Call] = []
-        modelEnv.secureMarkMessagesAsRead = { completion in
+        modelEnv.secureConversations.markMessagesAsRead = { completion in
             calls.append(.secureMarkMessagesAsRead)
             completion(.success(()))
             return .mock
@@ -851,7 +847,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.getQueues = { _ in }
         modelEnv.loadChatMessagesFromHistory = { true }
         modelEnv.fetchChatHistory = { $0(.success([.mock(), .mock(), .mock()])) }
-        modelEnv.getSecureUnreadMessageCount = { $0(.success(5)) }
+        modelEnv.secureConversations.getUnreadMessageCount = { $0(.success(5)) }
         modelEnv.fetchSiteConfigurations = { _ in }
         modelEnv.startSocketObservation = {}
         modelEnv.maximumUploads = { 2 }
@@ -860,7 +856,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.messagesWithUnreadCountLoaderScheduler = scheduler
         enum Call: Equatable { case secureMarkMessagesAsRead }
         var calls: [Call] = []
-        modelEnv.secureMarkMessagesAsRead = { completion in
+        modelEnv.secureConversations.markMessagesAsRead = { completion in
             calls.append(.secureMarkMessagesAsRead)
             completion(.success(()))
             return .mock
@@ -903,7 +899,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.getQueues = { _ in }
         modelEnv.loadChatMessagesFromHistory = { true }
         modelEnv.fetchChatHistory = { $0(.success([.mock(), .mock(), .mock()])) }
-        modelEnv.getSecureUnreadMessageCount = { $0(.success(5)) }
+        modelEnv.secureConversations.getUnreadMessageCount = { $0(.success(5)) }
         modelEnv.fetchSiteConfigurations = { _ in }
         modelEnv.startSocketObservation = {}
         modelEnv.maximumUploads = { 2 }
@@ -913,7 +909,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.messagesWithUnreadCountLoaderScheduler = scheduler
         enum Call: Equatable { case secureMarkMessagesAsRead }
         var calls: [Call] = []
-        modelEnv.secureMarkMessagesAsRead = { completion in
+        modelEnv.secureConversations.markMessagesAsRead = { completion in
             calls.append(.secureMarkMessagesAsRead)
             completion(.success(()))
             return .mock
@@ -968,14 +964,14 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.createFileUploadListModel = { _ in fileUploadListModel }
         modelEnv.getQueues = { _ in }
         modelEnv.fetchSiteConfigurations = { _ in }
-        modelEnv.getSecureUnreadMessageCount = { $0(.success(0)) }
+        modelEnv.secureConversations.getUnreadMessageCount = { $0(.success(0)) }
         modelEnv.maximumUploads = { 2 }
         modelEnv.startSocketObservation = {}
         modelEnv.gcd.mainQueue.asyncAfterDeadline = { _, callback in callback() }
         modelEnv.loadChatMessagesFromHistory = { true }
         modelEnv.createEntryWidget = { _ in .mock() }
         modelEnv.uiApplication.applicationState = { .active }
-        modelEnv.secureMarkMessagesAsRead = { completion in
+        modelEnv.secureConversations.markMessagesAsRead = { completion in
             calls.append(.secureMarkMessagesAsRead)
             completion(.success(()))
             return .mock

--- a/GliaWidgetsTests/SecureConversations/Coordinator/SecureConversations.Coordinator.Environment.Mock.swift
+++ b/GliaWidgetsTests/SecureConversations/Coordinator/SecureConversations.Coordinator.Environment.Mock.swift
@@ -3,11 +3,10 @@ import Foundation
 
 extension SecureConversations.Coordinator.Environment {
     static let mock = Self(
+        secureConversations: .mock,
         queueIds: [],
         listQueues: { completion in },
-        sendSecureMessagePayload: { secureMessagePayload, queueIds, completion in .mock },
         createFileUploader: { maximumUploads, environment in .mock() },
-        uploadSecureFile: { file, progress, completion in .mock },
         fileManager: .mock,
         data: .mock,
         date: { .mock },
@@ -34,10 +33,7 @@ extension SecureConversations.Coordinator.Environment {
         getNonTransferredSecureConversationEngagement: { .mock() },
         submitSurveyAnswer: { answers, surveyId, engagementId, completion in },
         interactor: .mock(),
-        getSecureUnreadMessageCount: { callback in },
         messagesWithUnreadCountLoaderScheduler: CoreSdkClient.reactiveSwiftDateSchedulerMock,
-        secureMarkMessagesAsRead: { callback in .mock },
-        downloadSecureFile: { file, progress, completion in .mock },
         isAuthenticated: { true },
         startSocketObservation: { },
         stopSocketObservation: { },

--- a/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.Mock.swift
+++ b/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.Mock.swift
@@ -11,10 +11,10 @@ extension SecureConversations.WelcomeViewModel {
 
 extension SecureConversations.WelcomeViewModel.Environment {
     static func mock(
+        secureConversations: CoreSdkClient.SecureConversations = .mock,
         welcomeStyle: SecureConversations.WelcomeStyle = Theme().secureConversationsWelcomeStyle,
         queueIds: [String] = [],
         listQueues: @escaping CoreSdkClient.ListQueues = { _ in },
-        sendSecureMessagePayload: @escaping CoreSdkClient.SendSecureMessagePayload = { _, _, _ in return .mock },
         fileUploader: FileUploader = .mock(),
         uiApplication: UIKitBased.UIApplication = .mock,
         createFileUploadListModel: @escaping SecureConversations.FileUploadListViewModel.Create = { _ in .mock() },
@@ -22,16 +22,15 @@ extension SecureConversations.WelcomeViewModel.Environment {
         startSocketObservation: @escaping CoreSdkClient.StartSocketObservation = {},
         stopSocketObservation: @escaping CoreSdkClient.StopSocketObservation = {},
         getCurrentEngagement: @escaping CoreSdkClient.GetCurrentEngagement = { .mock() },
-        uploadSecureFile: @escaping CoreSdkClient.SecureConversationsUploadFile = { _, _, _ in .mock },
         uploadFileToEngagement: @escaping CoreSdkClient.UploadFileToEngagement = { _, _, _ in },
         createSendMessagePayload: @escaping CoreSdkClient.CreateSendMessagePayload = { _, _ in .mock() },
         log: CoreSdkClient.Logger = .mock
     ) -> SecureConversations.WelcomeViewModel.Environment {
         .init(
+            secureConversations: secureConversations,
             welcomeStyle: welcomeStyle,
             queueIds: queueIds,
             listQueues: listQueues,
-            sendSecureMessagePayload: sendSecureMessagePayload,
             fileUploader: fileUploader,
             uiApplication: uiApplication,
             createFileUploadListModel: createFileUploadListModel,
@@ -39,7 +38,6 @@ extension SecureConversations.WelcomeViewModel.Environment {
             startSocketObservation: startSocketObservation,
             stopSocketObservation: stopSocketObservation,
             getCurrentEngagement: getCurrentEngagement,
-            uploadSecureFile: uploadSecureFile,
             uploadFileToEngagement: uploadFileToEngagement,
             createSendMessagePayload: createSendMessagePayload,
             log: log

--- a/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModelSpec.swift
+++ b/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModelSpec.swift
@@ -133,7 +133,7 @@ extension SecureConversationsWelcomeViewModelTests {
 extension SecureConversationsWelcomeViewModelTests {
     func testSuccessfulMessageSend() {
         var isCalled = false
-        viewModel.environment.sendSecureMessagePayload = { _, _, completion in
+        viewModel.environment.secureConversations.sendMessagePayload = { _, _, completion in
             let mockedMessage = CoreSdkClient.Message(
                 id: UUID.mock.uuidString,
                 content: "Content",
@@ -163,7 +163,7 @@ extension SecureConversationsWelcomeViewModelTests {
     func testFailedMessageSend() {
         var isCalled = false
         var alertInputType: AlertInputType?
-        viewModel.environment.sendSecureMessagePayload = { _, _, completion in
+        viewModel.environment.secureConversations.sendMessagePayload = { _, _, completion in
             completion(.failure(CoreSdkClient.GliaCoreError(reason: "")))
 
             return .mock

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -30,8 +30,8 @@ class ChatViewModelTests: XCTestCase {
             chatType: .nonAuthenticated,
             replaceExistingEnqueueing: false,
             environment: .init(
+                secureConversations: .failing,
                 fetchFile: { _, _, _ in },
-                downloadSecureFile: { _, _, _ in .mock },
                 uploadFileToEngagement: { _, _, _ in },
                 fileManager: fileManager,
                 data: .failing,
@@ -72,7 +72,6 @@ class ChatViewModelTests: XCTestCase {
                 alertManager: .mock(),
                 isAuthenticated: { false },
                 notificationCenter: .mock,
-                secureMarkMessagesAsRead: { _ in .mock },
                 markUnreadMessagesDelay: { .mock },
                 combineScheduler: .mock,
                 createEntryWidget: { _ in .mock() },
@@ -1297,7 +1296,7 @@ class ChatViewModelTests: XCTestCase {
         viewModelEnv.notificationCenter.publisherForNotification = { _ in
             Empty<Notification, Never>().eraseToAnyPublisher()
         }
-        viewModelEnv.secureMarkMessagesAsRead = { completion in
+        viewModelEnv.secureConversations.markMessagesAsRead = { completion in
             calls.append(.secureMarkMessagesAsRead)
             completion(.success(()))
             return .mock
@@ -1331,7 +1330,7 @@ class ChatViewModelTests: XCTestCase {
         viewModelEnv.notificationCenter.publisherForNotification = { _ in
             Empty<Notification, Never>().eraseToAnyPublisher()
         }
-        viewModelEnv.secureMarkMessagesAsRead = { completion in
+        viewModelEnv.secureConversations.markMessagesAsRead = { completion in
             calls.append(.secureMarkMessagesAsRead)
             completion(.success(()))
             return .mock
@@ -1365,7 +1364,7 @@ class ChatViewModelTests: XCTestCase {
         viewModelEnv.notificationCenter.publisherForNotification = { _ in
             Empty<Notification, Never>().eraseToAnyPublisher()
         }
-        viewModelEnv.secureMarkMessagesAsRead = { completion in
+        viewModelEnv.secureConversations.markMessagesAsRead = { completion in
             calls.append(.secureMarkMessagesAsRead)
             completion(.success(()))
             return .mock
@@ -1394,7 +1393,7 @@ class ChatViewModelTests: XCTestCase {
         viewModelEnv.notificationCenter.publisherForNotification = { _ in
             Empty<Notification, Never>().eraseToAnyPublisher()
         }
-        viewModelEnv.secureMarkMessagesAsRead = { completion in
+        viewModelEnv.secureConversations.markMessagesAsRead = { completion in
             calls.append(.secureMarkMessagesAsRead)
             completion(.success(()))
             return .mock
@@ -1422,7 +1421,7 @@ class ChatViewModelTests: XCTestCase {
         viewModelEnv.notificationCenter.publisherForNotification = { _ in
             Empty<Notification, Never>().eraseToAnyPublisher()
         }
-        viewModelEnv.secureMarkMessagesAsRead = { completion in
+        viewModelEnv.secureConversations.markMessagesAsRead = { completion in
             calls.append(.secureMarkMessagesAsRead)
             completion(.success(()))
             return .mock
@@ -1449,7 +1448,7 @@ class ChatViewModelTests: XCTestCase {
         viewModelEnv.notificationCenter.publisherForNotification = { type in
             Empty<Notification, Never>().eraseToAnyPublisher()
         }
-        viewModelEnv.secureMarkMessagesAsRead = { completion in
+        viewModelEnv.secureConversations.markMessagesAsRead = { completion in
             calls.append(.secureMarkMessagesAsRead)
             completion(.success(()))
             return .mock
@@ -1481,7 +1480,7 @@ class ChatViewModelTests: XCTestCase {
             }
             return Empty<Notification, Never>().eraseToAnyPublisher()
         }
-        viewModelEnv.secureMarkMessagesAsRead = { completion in
+        viewModelEnv.secureConversations.markMessagesAsRead = { completion in
             calls.append(.secureMarkMessagesAsRead)
             completion(.success(()))
             return .mock
@@ -1513,7 +1512,7 @@ class ChatViewModelTests: XCTestCase {
             }
             return Empty<Notification, Never>().eraseToAnyPublisher()
         }
-        viewModelEnv.secureMarkMessagesAsRead = { completion in
+        viewModelEnv.secureConversations.markMessagesAsRead = { completion in
             calls.append(.secureMarkMessagesAsRead)
             completion(.success(()))
             return .mock
@@ -1542,7 +1541,7 @@ class ChatViewModelTests: XCTestCase {
         viewModelEnv.notificationCenter.publisherForNotification = { type in
             Empty<Notification, Never>().eraseToAnyPublisher()
         }
-        viewModelEnv.secureMarkMessagesAsRead = { completion in
+        viewModelEnv.secureConversations.markMessagesAsRead = { completion in
             calls.append(.secureMarkMessagesAsRead)
             completion(.success(()))
             return .mock

--- a/GliaWidgetsTests/Sources/Coordinators/Call/CallCoordinator.Environment.Mock.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/Call/CallCoordinator.Environment.Mock.swift
@@ -3,8 +3,8 @@ import Foundation
 
 extension CallCoordinator.Environment {
     static let mock = Self(
+        secureConversations: .mock,
         fetchFile: { engagementFile, progress, completion in },
-        downloadSecureFile: { file, progress, completion in .mock },
         uploadFileToEngagement: { file, progress, completion in },
         fileManager: .mock,
         data: .mock,
@@ -32,7 +32,6 @@ extension CallCoordinator.Environment {
         flipCameraButtonStyle: .nop,
         alertManager: .mock(),
         isAuthenticated: { false },
-        secureMarkMessagesAsRead: { _ in .mock },
         markUnreadMessagesDelay: { .mock },
         combineScheduler: .mock,
         createEntryWidget: { _ in .mock() }

--- a/GliaWidgetsTests/Sources/Coordinators/Chat/ChatCoordinator.Environment.Mock.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/Chat/ChatCoordinator.Environment.Mock.swift
@@ -3,6 +3,7 @@ import Foundation
 
 extension ChatCoordinator.Environment {
     static var mock = Self(
+        secureConversations: .mock,
         fetchFile: { engagementFile, progress, completion in },
         uploadFileToEngagement: { file, progress, completion in },
         fileManager: .mock,
@@ -21,14 +22,9 @@ extension ChatCoordinator.Environment {
         uiApplication: .mock,
         fetchChatHistory: { completion in },
         createFileUploadListModel: { environment in .mock() },
-        sendSecureMessagePayload: { secureMessagePayload, queueIds, completion in .mock },
         queueIds: [],
         listQueues: { completion in },
-        secureUploadFile: { file, progress, completion in .mock },
-        getSecureUnreadMessageCount: { callback in },
         messagesWithUnreadCountLoaderScheduler: CoreSdkClient.reactiveSwiftDateSchedulerMock,
-        secureMarkMessagesAsRead: { callback in .mock },
-        downloadSecureFile: { file, progress, completion in .mock },
         isAuthenticated: { false },
         interactor: .mock(),
         startSocketObservation: { },

--- a/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
@@ -4,6 +4,7 @@ extension CoreSdkClient {
     static let failing = Self(
         pushNotifications: .failing,
         liveObservation: .failing,
+        secureConversations: .failing,
         createAppDelegate: { .failing },
         clearSession: { fail("\(Self.self).clearSession") },
         localeProvider: .failing,
@@ -33,25 +34,6 @@ extension CoreSdkClient {
             fail("\(Self.self).requestVisitorCode")
             return .init()
         },
-        sendSecureMessagePayload: { _, _, _ in
-            fail("\(Self.self).sendSecureMessagePayload")
-            return .mock
-        },
-        uploadSecureFile: { _, _, _ in
-            fail("\(Self.self).uploadSecureFile")
-            return .mock
-        },
-        getSecureUnreadMessageCount: { _ in
-            fail("\(Self.self).getSecureUnreadMessageCount")
-        },
-        secureMarkMessagesAsRead: { _ in
-            fail("\(Self.self).secureMarkMessagesAsRead")
-            return .mock
-        },
-        downloadSecureFile: { _, _, _ in
-            fail("\(Self.self).downloadSecureFile")
-            return .mock
-        },
         startSocketObservation: {
             fail("\(Self.self).startSocketObservation")
         },
@@ -75,29 +57,47 @@ extension CoreSdkClient {
         },
         unsubscribeFromUpdates: { _, _ in
             fail("\(Self.self).unsubscribeFromUpdates")
+        }
+    )
+}
+
+extension CoreSdkClient.SecureConversations {
+    static let failing = Self(
+        sendMessagePayload: { _, _, _ in
+            fail("\(Self.self).sendMessagePayload")
+            return .mock
         },
-        subscribeForUnreadSCMessageCount: { _ in
-            fail("\(Self.self).subscribeForUnreadSCMessageCount")
+        uploadFile: { _, _, _ in
+            fail("\(Self.self).uploadFile")
+            return .mock
+        },
+        getUnreadMessageCount: { _ in
+            fail("\(Self.self).getUnreadMessageCount")
+        },
+        markMessagesAsRead: { _ in
+            fail("\(Self.self).markMessagesAsRead")
+            return .mock
+        },
+        downloadFile: { _, _, _ in
+            fail("\(Self.self).downloadFile")
+            return .mock
+        },
+        subscribeForUnreadMessageCount: { _ in
+            fail("\(Self.self).subscribeForUnreadMessageCount")
             return ""
         },
-        pendingSecureConversationStatus: { _ in
-            fail("\(Self.self).pendingSecureConversationStatus")
-        },
-        observePendingSecureConversationStatus: { _ in
-            fail("\(Self.self).observePendingSecureConversationStatus")
-            return nil
-        },
-        unsubscribeFromPendingSecureConversationStatus: { _ in
-            fail("\(Self.self).unsubscribeFromPendingSecureConversationStatus")
-        },
-        unsubscribeFromUnreadCount: { _ in
+        unsubscribeFromUnreadMessageCount: { _ in
             fail("\(Self.self).unsubscribeFromUnreadCount")
         },
-        liveObservationPause: {
-            fail("\(Self.self).liveObservationPause")
+        pendingStatus: { _ in
+            fail("\(Self.self).pendingStatus")
         },
-        liveObservationResume: {
-            fail("\(Self.self).liveObservationResume")
+        observePendingStatus: { _ in
+            fail("\(Self.self).observePendingStatus")
+            return nil
+        },
+        unsubscribeFromPendingStatus: { _ in
+            fail("\(Self.self).unsubscribeFromPendingStatus")
         }
     )
 }

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+EngagementLauncher.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+EngagementLauncher.swift
@@ -392,12 +392,7 @@ private extension GliaTests {
         }
         sdkEnv.isAuthenticated = { false }
         sdkEnv.coreSdk.getCurrentEngagement = { nil }
-        sdkEnv.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
-        sdkEnv.coreSdk.pendingSecureConversationStatus = { _ in }
-        sdkEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        sdkEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        sdkEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        sdkEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        sdkEnv.coreSdk.secureConversations.observePendingStatus = { _ in nil }
         let window = UIWindow(frame: .zero)
         window.rootViewController = UIViewController()
         window.makeKeyAndVisible()

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+RestoreEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+RestoreEngagement.swift
@@ -25,16 +25,11 @@ extension GliaTests {
         sdkEnv.gcd.mainQueue.async = { $0() }
         let siteMock = try CoreSdkClient.Site.mock()
         sdkEnv.coreSdk.fetchSiteConfigurations = { callback in callback(.success(siteMock)) }
-        sdkEnv.coreSdk.pendingSecureConversationStatus = { _ in }
-        sdkEnv.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
         sdkEnv.conditionalCompilation.isDebug = { true }
         sdkEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
-        sdkEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        sdkEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        sdkEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        sdkEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        sdkEnv.coreSdk.secureConversations.observePendingStatus = { _ in nil }
 
         let window = UIWindow(frame: .zero)
         window.rootViewController = .init()
@@ -106,17 +101,13 @@ extension GliaTests {
         sdkEnv.coreSdk.createLogger = { _ in logger }
         let siteMock = try CoreSdkClient.Site.mock()
         sdkEnv.coreSdk.fetchSiteConfigurations = { callback in callback(.success(siteMock)) }
-        sdkEnv.coreSdk.pendingSecureConversationStatus = { _ in }
-        sdkEnv.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
         sdkEnv.conditionalCompilation.isDebug = { true }
         sdkEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
         let uuidGen = UUID.incrementing
-        sdkEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in uuidGen().uuidString }
-        sdkEnv.coreSdk.observePendingSecureConversationStatus = { _ in uuidGen().uuidString }
-        sdkEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        sdkEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        sdkEnv.coreSdk.secureConversations.subscribeForUnreadMessageCount = { _ in uuidGen().uuidString }
+        sdkEnv.coreSdk.secureConversations.observePendingStatus = { _ in uuidGen().uuidString }
         sdkEnv.gcd.mainQueue.async = { $0() }
 
         let window = UIWindow(frame: .zero)
@@ -164,17 +155,13 @@ extension GliaTests {
         sdkEnv.coreSdk.createLogger = { _ in logger }
         let siteMock = try CoreSdkClient.Site.mock()
         sdkEnv.coreSdk.fetchSiteConfigurations = { callback in callback(.success(siteMock)) }
-        sdkEnv.coreSdk.pendingSecureConversationStatus = { _ in }
-        sdkEnv.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
         sdkEnv.conditionalCompilation.isDebug = { true }
         sdkEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
         let uuidGen = UUID.incrementing
-        sdkEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in uuidGen().uuidString }
-        sdkEnv.coreSdk.observePendingSecureConversationStatus = { _ in uuidGen().uuidString }
-        sdkEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        sdkEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        sdkEnv.coreSdk.secureConversations.subscribeForUnreadMessageCount = { _ in uuidGen().uuidString }
+        sdkEnv.coreSdk.secureConversations.observePendingStatus = { _ in uuidGen().uuidString }
         sdkEnv.gcd.mainQueue.async = { $0() }
 
         let window = UIWindow(frame: .zero)
@@ -224,21 +211,18 @@ extension GliaTests {
         sdkEnv.coreSdk.createLogger = { _ in logger }
         let siteMock = try CoreSdkClient.Site.mock()
         sdkEnv.coreSdk.fetchSiteConfigurations = { callback in callback(.success(siteMock)) }
-        sdkEnv.coreSdk.pendingSecureConversationStatus = { _ in }
-        sdkEnv.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
+        sdkEnv.coreSdk.secureConversations.pendingStatus = { _ in }
         sdkEnv.conditionalCompilation.isDebug = { true }
         sdkEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
         sdkEnv.snackBar.present = { _, _, _, _, _, _, _ in }
         let uuidGen = UUID.incrementing
-        sdkEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in uuidGen().uuidString }
-        sdkEnv.coreSdk.observePendingSecureConversationStatus = { callback in
+        sdkEnv.coreSdk.secureConversations.subscribeForUnreadMessageCount = { _ in uuidGen().uuidString }
+        sdkEnv.coreSdk.secureConversations.observePendingStatus = { callback in
             callback(.success(true))
             return uuidGen().uuidString
         }
-        sdkEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        sdkEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
         sdkEnv.gcd.mainQueue.async = { $0() }
 
         let window = UIWindow(frame: .zero)

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
@@ -23,12 +23,9 @@ extension GliaTests {
         logger.prefixedClosure = { _ in logger }
         logger.infoClosure = { _, _, _, _ in }
         sdkEnv.coreSdk.createLogger = { _ in logger }
-        sdkEnv.coreSdk.pendingSecureConversationStatus = { _ in }
-        sdkEnv.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
-        sdkEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        sdkEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        sdkEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        sdkEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        sdkEnv.coreSdk.secureConversations.pendingStatus = { _ in }
+        sdkEnv.coreSdk.secureConversations.getUnreadMessageCount = { $0(.success(0)) }
+        sdkEnv.coreSdk.secureConversations.observePendingStatus = { _ in nil }
         sdkEnv.conditionalCompilation.isDebug = { true }
         sdkEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
@@ -63,10 +60,7 @@ extension GliaTests {
         gliaEnv.conditionalCompilation.isDebug = { false }
         gliaEnv.coreSdk.createLogger = { _ in logger }
         gliaEnv.coreSdk.localeProvider.getRemoteString = { _ in nil }
-        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        gliaEnv.coreSdk.secureConversations.observePendingStatus = { _ in nil }
         let sdk = Glia(environment: gliaEnv)
         sdk.queuesMonitor = .mock()
         sdk.environment.conditionalCompilation.isDebug = { true }
@@ -103,7 +97,6 @@ extension GliaTests {
         logger.prefixedClosure = { _ in logger }
         logger.configureLocalLogLevelClosure = { _ in }
         logger.configureRemoteLogLevelClosure = { _ in }
-        environment.coreSdk.pendingSecureConversationStatus = { _ in }
         environment.coreSdk.createLogger = { _ in logger }
         environment.conditionalCompilation.isDebug = { false }
         environment.createRootCoordinator = { _, _, _, _, _, _, _ in
@@ -115,11 +108,8 @@ extension GliaTests {
         }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
         environment.coreSdk.getCurrentEngagement = { nil }
-        environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
-        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        environment.coreSdk.secureConversations.getUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.secureConversations.observePendingStatus = { _ in nil }
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
         try sdk.configure(
@@ -164,13 +154,9 @@ extension GliaTests {
             completion(.success(()))
         }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
-        environment.coreSdk.pendingSecureConversationStatus = { _ in }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
-        environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
-        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        environment.coreSdk.secureConversations.getUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.secureConversations.observePendingStatus = { _ in nil }
 
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
@@ -218,13 +204,10 @@ extension GliaTests {
             completion(.success(()))
         }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
-        environment.coreSdk.pendingSecureConversationStatus = { _ in }
+        environment.coreSdk.secureConversations.pendingStatus = { _ in }
         environment.coreSdk.getCurrentEngagement = { nil }
-        environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
-        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        environment.coreSdk.secureConversations.getUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.secureConversations.observePendingStatus = { _ in nil }
 
         var logger = CoreSdkClient.Logger.failing
         logger.configureLocalLogLevelClosure = { _ in }
@@ -288,12 +271,8 @@ extension GliaTests {
         }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
-        environment.coreSdk.pendingSecureConversationStatus = { _ in }
-        environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
-        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        environment.coreSdk.secureConversations.getUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.secureConversations.observePendingStatus = { _ in nil }
 
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
@@ -345,12 +324,8 @@ extension GliaTests {
         }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
-        environment.coreSdk.pendingSecureConversationStatus = { _ in }
-        environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
-        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        environment.coreSdk.secureConversations.getUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.secureConversations.observePendingStatus = { _ in nil }
 
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
@@ -398,18 +373,14 @@ extension GliaTests {
             )
         }
 
-        environment.coreSdk.pendingSecureConversationStatus = { _ in }
         environment.coreSdk.localeProvider.getRemoteString = { _ in "" }
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.getCurrentEngagement = { nil }
-        environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
-        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        environment.coreSdk.secureConversations.getUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.secureConversations.observePendingStatus = { _ in nil }
 
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
@@ -462,17 +433,13 @@ extension GliaTests {
         }
 
         environment.coreSdk.localeProvider.getRemoteString = { _ in "" }
-        environment.coreSdk.pendingSecureConversationStatus = { _ in }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
         environment.coreSdk.getCurrentEngagement = { nil }
-        environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
-        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        environment.coreSdk.secureConversations.getUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.secureConversations.observePendingStatus = { _ in nil }
 
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
@@ -509,23 +476,22 @@ extension GliaTests {
         }
 
         environment.coreSdk.localeProvider.getRemoteString = { _ in "" }
-        environment.coreSdk.pendingSecureConversationStatus = { $0(.success(true)) }
+        environment.coreSdk.secureConversations.pendingStatus = { $0(.success(true)) }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
         let uuIdGen = UUID.incrementing
         environment.coreSdk.getCurrentEngagement = { nil }
-        environment.coreSdk.subscribeForUnreadSCMessageCount = {
+        environment.coreSdk.secureConversations.subscribeForUnreadMessageCount = {
             $0(.success(0))
             return uuIdGen().uuidString
         }
-        environment.coreSdk.observePendingSecureConversationStatus = {
+        environment.coreSdk.secureConversations.observePendingStatus = {
             $0(.success(true))
             return uuIdGen().uuidString
         }
-        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        environment.coreSdk.secureConversations.unsubscribeFromPendingStatus = { _ in }
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
         try sdk.configure(
@@ -559,17 +525,14 @@ extension GliaTests {
         }
 
         environment.coreSdk.localeProvider.getRemoteString = { _ in "" }
-        environment.coreSdk.pendingSecureConversationStatus = { $0(.success(false)) }
+        environment.coreSdk.secureConversations.pendingStatus = { $0(.success(false)) }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
         environment.coreSdk.getCurrentEngagement = { nil }
-        environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
-        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        environment.coreSdk.secureConversations.getUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.secureConversations.observePendingStatus = { _ in nil }
 
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
@@ -604,23 +567,22 @@ extension GliaTests {
         }
 
         environment.coreSdk.localeProvider.getRemoteString = { _ in "" }
-        environment.coreSdk.pendingSecureConversationStatus = { $0(.success(true)) }
+        environment.coreSdk.secureConversations.pendingStatus = { $0(.success(true)) }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
         let uuIdGen = UUID.incrementing
         environment.coreSdk.getCurrentEngagement = { nil }
-        environment.coreSdk.subscribeForUnreadSCMessageCount = { callback in
+        environment.coreSdk.secureConversations.subscribeForUnreadMessageCount = { callback in
             callback(.success(0))
             return uuIdGen().uuidString
         }
-        environment.coreSdk.observePendingSecureConversationStatus = { callback in
+        environment.coreSdk.secureConversations.observePendingStatus = { callback in
             callback(.success(true))
             return uuIdGen().uuidString
         }
-        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        environment.coreSdk.secureConversations.unsubscribeFromPendingStatus = { _ in }
 
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
@@ -654,16 +616,14 @@ extension GliaTests {
         }
 
         environment.coreSdk.localeProvider.getRemoteString = { _ in "" }
-        environment.coreSdk.pendingSecureConversationStatus = { $0(.success(false)) }
+        environment.coreSdk.secureConversations.pendingStatus = { $0(.success(false)) }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
-        environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
-        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        environment.coreSdk.secureConversations.getUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.secureConversations.subscribeForUnreadMessageCount = { _ in nil }
+        environment.coreSdk.secureConversations.observePendingStatus = { _ in nil }
         environment.coreSdk.fetchSiteConfigurations = { _ in }
 
         let sdk = Glia(environment: environment)

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -14,10 +14,6 @@ final class GliaTests: XCTestCase {
         environment.coreSdk.createLogger = { _ in logger }
         environment.print = .mock
         environment.conditionalCompilation.isDebug = { false }
-        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
 
         let sdk = Glia(environment: environment)
         sdk.endEngagement { result in
@@ -43,10 +39,6 @@ final class GliaTests: XCTestCase {
         environment.coreSdk.createLogger = { _ in logger }
         environment.print = .mock
         environment.conditionalCompilation.isDebug = { false }
-        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
 
         let sdk = Glia(environment: environment)
         sdk.interactor = .mock()
@@ -68,10 +60,6 @@ final class GliaTests: XCTestCase {
         logger.configureRemoteLogLevelClosure = { _ in }
         environment.coreSdk.createLogger = { _ in logger }
         environment.conditionalCompilation.isDebug = { false }
-        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
 
         let sdk = Glia(environment: environment)
         XCTAssertNotNil(sdk.messageRenderer)
@@ -102,10 +90,7 @@ final class GliaTests: XCTestCase {
         gliaEnv.callVisualizerPresenter = .init(presenter: { nil })
         gliaEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
         gliaEnv.coreSdk.fetchSiteConfigurations = { _ in }
-        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        gliaEnv.coreSdk.secureConversations.observePendingStatus = { _ in nil }
         let sdk = Glia(environment: gliaEnv)
         sdk.onEvent = {
             calls.append(.onEvent($0))
@@ -143,10 +128,7 @@ final class GliaTests: XCTestCase {
             completion(.success(()))
         }
         gliaEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
-        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        gliaEnv.coreSdk.secureConversations.observePendingStatus = { _ in nil }
 
         let sdk = Glia(environment: gliaEnv)
         sdk.onEvent = {
@@ -184,10 +166,7 @@ final class GliaTests: XCTestCase {
             completion(.success(()))
         }
         gliaEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
-        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        gliaEnv.coreSdk.secureConversations.observePendingStatus = { _ in nil }
 
         let sdk = Glia(environment: gliaEnv)
         sdk.onEvent = {
@@ -234,10 +213,7 @@ final class GliaTests: XCTestCase {
             completion(.success(()))
         }
         gliaEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
-        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        gliaEnv.coreSdk.secureConversations.observePendingStatus = { _ in nil }
 
         let sdk = Glia(environment: gliaEnv)
         sdk.onEvent = {
@@ -282,10 +258,7 @@ final class GliaTests: XCTestCase {
             completion(.success(()))
         }
         gliaEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
-        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        gliaEnv.coreSdk.secureConversations.observePendingStatus = { _ in nil }
 
         let sdk = Glia(environment: gliaEnv)
         sdk.onEvent = {
@@ -313,10 +286,6 @@ final class GliaTests: XCTestCase {
         environment.coreSdk.createLogger = { _ in logger }
         environment.conditionalCompilation.isDebug = { false }
         environment.coreSdk.getCurrentEngagement = { .mock() }
-        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
         let sdk = Glia(environment: environment)
 
         XCTAssertThrowsError(try sdk.configure(
@@ -340,10 +309,7 @@ final class GliaTests: XCTestCase {
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
-        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        environment.coreSdk.secureConversations.observePendingStatus = { _ in nil }
         let sdk = Glia(environment: environment)
         try sdk.configure(
             with: .mock(),
@@ -373,10 +339,7 @@ final class GliaTests: XCTestCase {
         environment.coreSdk.getCurrentEngagement = { .mock() }
         environment.print = .mock
         environment.conditionalCompilation.isDebug = { false }
-        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        environment.coreSdk.secureConversations.observePendingStatus = { _ in nil }
         let sdk = Glia(environment: environment)
 
         var resultingError: Error?
@@ -400,10 +363,6 @@ final class GliaTests: XCTestCase {
         logger.configureRemoteLogLevelClosure = { _ in }
         environment.coreSdk.createLogger = { _ in logger }
         environment.conditionalCompilation.isDebug = { false }
-        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
         let sdk = Glia(environment: environment)
         let coordinator = EngagementCoordinator.mock()
         let delegate = GliaViewControllerDelegateMock()
@@ -430,10 +389,6 @@ final class GliaTests: XCTestCase {
         logger.configureRemoteLogLevelClosure = { _ in }
         environment.coreSdk.createLogger = { _ in logger }
         environment.conditionalCompilation.isDebug = { false }
-        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
         let sdk = Glia(environment: environment)
         let coordinator = EngagementCoordinator.mock()
         let delegate = GliaViewControllerDelegateMock()
@@ -460,10 +415,6 @@ final class GliaTests: XCTestCase {
         logger.configureRemoteLogLevelClosure = { _ in }
         environment.coreSdk.createLogger = { _ in logger }
         environment.conditionalCompilation.isDebug = { false }
-        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
 
         XCTAssertFalse(Glia(environment: environment).isConfigured)
     }
@@ -481,10 +432,7 @@ final class GliaTests: XCTestCase {
         }
         environment.conditionalCompilation.isDebug = { true }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
-        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        environment.coreSdk.secureConversations.observePendingStatus = { _ in nil }
         let sdk = Glia(environment: environment)
         try sdk.configure(
             with: .mock(),
@@ -507,10 +455,7 @@ final class GliaTests: XCTestCase {
         }
         environment.conditionalCompilation.isDebug = { true }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
-        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        environment.coreSdk.secureConversations.observePendingStatus = { _ in nil }
         environment.coreSdk.getCurrentEngagement = { .mock(status: .transferring, capabilities: .init(text: true)) }
         let sdk = Glia(environment: environment)
         try sdk.configure(
@@ -534,10 +479,7 @@ final class GliaTests: XCTestCase {
         }
         environment.conditionalCompilation.isDebug = { true }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
-        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        environment.coreSdk.secureConversations.observePendingStatus = { _ in nil }
         let sdk = Glia(environment: environment)
         try sdk.configure(
             with: .mock(),
@@ -565,10 +507,7 @@ final class GliaTests: XCTestCase {
                 throw CoreSdkClient.GliaCoreError.mock()
             }
         }
-        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        environment.coreSdk.secureConversations.observePendingStatus = { _ in nil }
         let sdk = Glia(environment: environment)
 
         try sdk.configure(
@@ -596,10 +535,6 @@ final class GliaTests: XCTestCase {
         environment.coreSDKConfigurator.configureWithConfiguration = { _, _ in
             throw CoreSdkClient.GliaCoreError.mock()
         }
-        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
         let sdk = Glia(environment: environment)
         try? sdk.configure(
             with: .mock(),
@@ -621,16 +556,12 @@ final class GliaTests: XCTestCase {
         }
         environment.conditionalCompilation.isDebug = { true }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
-        environment.coreSdk.pendingSecureConversationStatus = { _ in }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
-        environment.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.secureConversations.getUnreadMessageCount = { $0(.success(0)) }
         var engCoordEnvironment = EngagementCoordinator.Environment.engagementCoordEnvironmentWithKeyWindow
         engCoordEnvironment.fileManager = .mock
         environment.createRootCoordinator = { _, _, _, _, _, _, _ in EngagementCoordinator.mock(environment: engCoordEnvironment) }
-        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        environment.coreSdk.secureConversations.observePendingStatus = { _ in nil }
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
         enum Call {
@@ -676,10 +607,7 @@ final class GliaTests: XCTestCase {
             callback(.success(()))
         }
         gliaEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
-        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        gliaEnv.coreSdk.secureConversations.observePendingStatus = { _ in nil }
         let sdk = Glia(environment: gliaEnv)
         try sdk.configure(
             with: .mock(),
@@ -757,10 +685,7 @@ final class GliaTests: XCTestCase {
             completion(.success(()))
         }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
-        environment.coreSdk.subscribeForUnreadSCMessageCount = { _ in nil }
-        environment.coreSdk.observePendingSecureConversationStatus = { _ in nil }
-        environment.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        environment.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        environment.coreSdk.secureConversations.observePendingStatus = { _ in nil }
         let sdk = Glia(environment: environment)
         let configuration = Configuration.mock()
 
@@ -788,16 +713,14 @@ final class GliaTests: XCTestCase {
         logger.configureRemoteLogLevelClosure = { _ in }
         gliaEnv.coreSdk.createLogger = { _ in logger }
         gliaEnv.conditionalCompilation.isDebug = { true }
-        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { callback in
+        gliaEnv.coreSdk.secureConversations.subscribeForUnreadMessageCount = { callback in
             callback(.success(0))
             return uuidGen().uuidString
         }
-        gliaEnv.coreSdk.observePendingSecureConversationStatus = { callback in
+        gliaEnv.coreSdk.secureConversations.observePendingStatus = { callback in
             callback(.success(true))
             return uuidGen().uuidString
         }
-        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
         gliaEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
@@ -822,16 +745,14 @@ final class GliaTests: XCTestCase {
         logger.prefixedClosure = { _ in logger }
         gliaEnv.coreSdk.createLogger = { _ in logger }
         gliaEnv.conditionalCompilation.isDebug = { true }
-        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { callback in
+        gliaEnv.coreSdk.secureConversations.subscribeForUnreadMessageCount = { callback in
             callback(.success(3))
             return uuidGen().uuidString
         }
-        gliaEnv.coreSdk.observePendingSecureConversationStatus = { callback in
+        gliaEnv.coreSdk.secureConversations.observePendingStatus = { callback in
             callback(.success(false))
             return uuidGen().uuidString
         }
-        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
         gliaEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
@@ -857,13 +778,10 @@ final class GliaTests: XCTestCase {
         logger.infoClosure = { _, _, _, _ in }
         logger.prefixedClosure = { _ in logger }
         gliaEnv.coreSdk.createLogger = { _ in logger }
-        gliaEnv.coreSdk.pendingSecureConversationStatus = { $0(.success(false)) }
-        gliaEnv.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
+        gliaEnv.coreSdk.secureConversations.pendingStatus = { $0(.success(false)) }
         gliaEnv.conditionalCompilation.isDebug = { true }
-        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in uuidGen().uuidString }
-        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in uuidGen().uuidString }
-        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        gliaEnv.coreSdk.secureConversations.subscribeForUnreadMessageCount = { _ in uuidGen().uuidString }
+        gliaEnv.coreSdk.secureConversations.observePendingStatus = { _ in uuidGen().uuidString }
         gliaEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
@@ -889,13 +807,10 @@ final class GliaTests: XCTestCase {
         logger.infoClosure = { _, _, _, _ in }
         logger.prefixedClosure = { _ in logger }
         gliaEnv.coreSdk.createLogger = { _ in logger }
-        gliaEnv.coreSdk.pendingSecureConversationStatus = { $0(.success(false)) }
-        gliaEnv.coreSdk.getSecureUnreadMessageCount = { $0(.success(0)) }
+        gliaEnv.coreSdk.secureConversations.pendingStatus = { $0(.success(false)) }
         gliaEnv.conditionalCompilation.isDebug = { true }
-        gliaEnv.coreSdk.subscribeForUnreadSCMessageCount = { _ in uuidGen().uuidString }
-        gliaEnv.coreSdk.observePendingSecureConversationStatus = { _ in uuidGen().uuidString }
-        gliaEnv.coreSdk.unsubscribeFromPendingSecureConversationStatus = { _ in }
-        gliaEnv.coreSdk.unsubscribeFromUnreadCount = { _ in }
+        gliaEnv.coreSdk.secureConversations.subscribeForUnreadMessageCount = { _ in uuidGen().uuidString }
+        gliaEnv.coreSdk.secureConversations.observePendingStatus = { _ in uuidGen().uuidString }
         gliaEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
         let authentication = CoreSdkClient.Authentication(deauthenticateWithCallback: { callback in
             callback(.success(()))

--- a/GliaWidgetsTests/ViewModel/Chat/ChatViewModel.Environment.Failing.swift
+++ b/GliaWidgetsTests/ViewModel/Chat/ChatViewModel.Environment.Failing.swift
@@ -5,12 +5,9 @@ extension ChatViewModel.Environment {
         fetchChatHistory: CoreSdkClient.FetchChatHistory? = nil
     ) -> Self {
         .init(
+            secureConversations: .failing,
             fetchFile: { _, _, _ in
                 fail("\(Self.self).fetchFile")
-            },
-            downloadSecureFile: { _, _, _ in
-                fail("\(Self.self).downloadSecureFile")
-                return .mock
             },
             uploadFileToEngagement: { _, _, _ in
                 fail("\(Self.self).uploadFileToEngagement")
@@ -65,7 +62,6 @@ extension ChatViewModel.Environment {
                 return false
             },
             notificationCenter: .mock,
-            secureMarkMessagesAsRead: { _ in .mock },
             markUnreadMessagesDelay: { .mock },
             combineScheduler: .mock,
             createEntryWidget: { _ in


### PR DESCRIPTION
**What was solved?**
This purpose of this PR is to bring all secure conversations related coreSdk interfaces under one secure conversations wrapper. This makes the usage of those interfaces better and improves readability.

MOB-4243

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
