### PR TITLE
Create SecureConversations public WidgetSDK interfaces

### DIFF
--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -132,7 +132,8 @@ public class Glia {
     var queuesMonitor: QueuesMonitor
     public let pushNotifications: PushNotifications
     var alertManager: AlertManager
-    public var liveObservation: LiveObservation
+    public let liveObservation: LiveObservation
+    public let secureConversation: SecureConversations
     // We need to store `features` via `configure` method to use it
     // when engagement gets restored for Direct ID authentication flow.
     var features: Features?
@@ -192,6 +193,8 @@ public class Glia {
         liveObservation = .init(environment: .create(with: environment))
 
         pushNotifications = .init(environment: .create(with: environment))
+
+        secureConversation = .init(environment: .create(with: environment))
     }
 
     /// Setup SDK using specific engagement configuration without starting the engagement.

--- a/GliaWidgets/SecureConversations/SecureConversations.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.swift
@@ -1,4 +1,50 @@
 import Foundation
 
 /// Namespace for all secure conversations functionality
-public enum SecureConversations { }
+public struct SecureConversations {
+    let environment: Environment
+
+    /// Gets the count of unread messages sent through secure conversations.
+    ///
+    /// This count will increase if an operator sends a message and the visitor hasn't marked them as read yet.
+    ///
+    /// - Parameter completion: A callback that will return a `Result` with the number of unread
+    /// secure conversation messages on success, or `Swift.Error` on failure.
+    public func getUnreadMessageCount(_ callback: @escaping (Result<Int, Error>) -> Void) {
+        environment.coreSdk.secureConversations.getUnreadMessageCount(callback)
+    }
+
+    /// Observes the count of unread messages sent through secure conversations.
+    ///
+    /// This count will increase if an operator sends a message and the visitor hasn't marked
+    /// them as read yet
+    ///
+    /// - Parameter completion: A callback that will call a `Result` with the number of unread
+    /// secure conversation messages on success every time `unreadMessageCount` changes, or `Swift.Error` on failure.
+    ///
+    /// - returns:
+    /// A unique callback ID or `nil` if callback was not registered due to error.
+    /// This callback ID could be used to usubscribe from Secure Conversation unread messages count updates.
+    public func subscribeSecureUnreadMessageCount(_ completion: @escaping (Result<Int?, Error>) -> Void) -> String? {
+        return environment.coreSdk.secureConversations.subscribeForUnreadMessageCount(completion)
+    }
+
+    /// Remove subscription for 'subscribeToUnreadMessageCount' methods updates.
+    /// 
+    /// - Parameter subscriptionToken: Subscription token produced by `subscribeToUnreadMessageCount` method.
+    public func unsubscribeSecureUnreadMessageCount(_ subscriptionToken: String) {
+        return environment.coreSdk.secureConversations.unsubscribeFromUnreadMessageCount(subscriptionToken)
+    }
+}
+
+extension SecureConversations {
+    struct Environment {
+        let coreSdk: CoreSdkClient
+    }
+}
+
+extension SecureConversations.Environment {
+    static func create(with environment: Glia.Environment) -> Self {
+        .init(coreSdk: environment.coreSdk)
+    }
+}


### PR DESCRIPTION
**What was solved?**
To align platforms, and redirect integrators to use WidgetSDK interfaces only, 3 new SecureConversations interfaces were created that under the hood use the same CoreSDK interfaces.

MOB-4201
**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [X] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
