### PR TITLE
Create push notifications intermediate alert

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -168,6 +168,7 @@
 		210150742CC13E8900294BA4 /* QueuesMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210150732CC13E8900294BA4 /* QueuesMonitorTests.swift */; };
 		210150782CC14E8200294BA4 /* QueuesMonitor.Environment.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210150752CC140A600294BA4 /* QueuesMonitor.Environment.Mock.swift */; };
 		210150792CC14E8200294BA4 /* QueuesMonitor.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2100B47D2CB6A37A00AC7527 /* QueuesMonitor.Mock.swift */; };
+		2130F5F22D9D7E740068E46B /* AlertViewController+RequestPushNotificationsPermissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2130F5F12D9D7E740068E46B /* AlertViewController+RequestPushNotificationsPermissions.swift */; };
 		215A25902CA44D8A0013023E /* Glia+EngagementLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215A258F2CA44D8A0013023E /* Glia+EngagementLauncher.swift */; };
 		215A25932CA44D900013023E /* EngagementLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215A25912CA44D900013023E /* EngagementLauncher.swift */; };
 		215A25982CABC7DF0013023E /* EngagementLauncherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215A25972CABC7DF0013023E /* EngagementLauncherTests.swift */; };
@@ -1268,6 +1269,7 @@
 		2100B4862CB91E7B00AC7527 /* CancelBag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelBag.swift; sourceTree = "<group>"; };
 		210150732CC13E8900294BA4 /* QueuesMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueuesMonitorTests.swift; sourceTree = "<group>"; };
 		210150752CC140A600294BA4 /* QueuesMonitor.Environment.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueuesMonitor.Environment.Mock.swift; sourceTree = "<group>"; };
+		2130F5F12D9D7E740068E46B /* AlertViewController+RequestPushNotificationsPermissions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AlertViewController+RequestPushNotificationsPermissions.swift"; sourceTree = "<group>"; };
 		215A258F2CA44D8A0013023E /* Glia+EngagementLauncher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Glia+EngagementLauncher.swift"; sourceTree = "<group>"; };
 		215A25912CA44D900013023E /* EngagementLauncher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EngagementLauncher.swift; sourceTree = "<group>"; };
 		215A25972CABC7DF0013023E /* EngagementLauncherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngagementLauncherTests.swift; sourceTree = "<group>"; };
@@ -3176,6 +3178,7 @@
 				C47901B625ED2FB0007EE195 /* AlertViewController+ScreenShareOffer.swift */,
 				6E60DD5527146C9D001422EF /* AlertViewController+SingleAction.swift */,
 				C0B325E62AC5A8FA006BC430 /* AlertViewController+LiveObservationConfirmation.swift */,
+				2130F5F12D9D7E740068E46B /* AlertViewController+RequestPushNotificationsPermissions.swift */,
 			);
 			path = Alert;
 			sourceTree = "<group>";
@@ -6171,6 +6174,7 @@
 				C09046DA2B7E09D1003C437C /* UserImageStyle.RemoteConfig.swift in Sources */,
 				9A8130B527D7563000220BBD /* LocalFile.Environment.Interface.swift in Sources */,
 				9AB3401B27FB4720006E0FE2 /* OperatorTypingIndicatorStyle.Accessibility.swift in Sources */,
+				2130F5F22D9D7E740068E46B /* AlertViewController+RequestPushNotificationsPermissions.swift in Sources */,
 				1AA738B625790D9900E1120F /* ActionButton.swift in Sources */,
 				84D2293028C61FF300F64FE7 /* WKNavigationPolicyProvider.Mock.swift in Sources */,
 				1A0C144425B868FC00B00695 /* CallCoordinator.swift in Sources */,

--- a/GliaWidgets/Localization.swift
+++ b/GliaWidgets/Localization.swift
@@ -724,6 +724,12 @@ internal enum Localization {
       }
     }
   }
+  internal enum PushNotificationsAlert {
+    /// Please allow push notifications to receive new messages alerts.
+    internal static var message: String { Localization.tr("Localizable", "push_notifications_alert.message", fallback: "Please allow push notifications to receive new messages alerts.") }
+    /// Allow Push Notifications
+    internal static var title: String { Localization.tr("Localizable", "push_notifications_alert.title", fallback: "Allow Push Notifications") }
+  }
   internal enum ScreenSharing {
     internal enum VisitorScreen {
       internal enum Disclaimer {

--- a/GliaWidgets/Resources/en.lproj/Localizable.strings
+++ b/GliaWidgets/Resources/en.lproj/Localizable.strings
@@ -274,3 +274,6 @@
 "entry_widget.ongoing_engagement.button.accessibility.hint" = "Returns to ongoing engagement";
 "entry_widget.call_visualizer.description" = "You are already in contact with the support team";
 "entry_widget.call_visualizer.button.label" = "Call Visualizer";
+
+"push_notifications_alert.title" = "Allow Push Notifications";
+"push_notifications_alert.message" = "Please allow push notifications to receive new messages alerts.";

--- a/GliaWidgets/Sources/AlertManager/Alert/AlertViewController+RequestPushNotificationsPermissions.swift
+++ b/GliaWidgets/Sources/AlertManager/Alert/AlertViewController+RequestPushNotificationsPermissions.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+extension AlertViewController {
+    func makeRequestPNPermissionsAlertView(
+        with conf: ConfirmationAlertConfiguration,
+        accepted: @escaping () -> Void,
+        declined: @escaping () -> Void
+    ) -> AlertView {
+        let alertView = viewFactory.makeAlertView()
+        alertView.title = conf.title
+        alertView.message = conf.message
+        alertView.showsPoweredBy = conf.showsPoweredBy
+        alertView.showsCloseButton = false
+
+        let alertStyle = viewFactory.theme.alert
+        var declineButtonStyle = alertStyle.negativeAction
+        declineButtonStyle.title = conf.negativeTitle
+
+        var acceptButtonStyle = alertStyle.positiveAction
+        acceptButtonStyle.title = conf.positiveTitle
+
+        let declineButton = ActionButton(
+            props: .init(
+                style: declineButtonStyle,
+                tap: .init { [weak self] in self?.dismiss(animated: true, completion: declined) }
+            )
+        )
+
+        let acceptButton = ActionButton(
+            props: .init(
+                style: acceptButtonStyle,
+                tap: .init { [weak self] in self?.dismiss(animated: true, completion: accepted) }
+            )
+        )
+        alertView.addActionView(declineButton)
+        alertView.addActionView(acceptButton)
+
+        return alertView
+    }
+}

--- a/GliaWidgets/Sources/AlertManager/Alert/AlertViewController.swift
+++ b/GliaWidgets/Sources/AlertManager/Alert/AlertViewController.swift
@@ -95,6 +95,7 @@ class AlertViewController: UIViewController, Replaceable {
         )
     }
 
+    // swiftlint:disable:next function_body_length
     private func makeAlertView() -> AlertView? {
         switch type {
         case let .message(conf, accessibilityIdentifier, dismissed):
@@ -157,6 +158,12 @@ class AlertViewController: UIViewController, Replaceable {
                 with: conf,
                 accessibilityIdentifier: accessibilityIdentifier,
                 dismissed: dismissed
+            )
+        case let .requestPushNoticationsPermissions(conf, accepted, declined):
+            return makeRequestPNPermissionsAlertView(
+                with: conf,
+                accepted: accepted,
+                declined: declined
             )
         }
     }

--- a/GliaWidgets/Sources/AlertManager/AlertInputType.swift
+++ b/GliaWidgets/Sources/AlertManager/AlertInputType.swift
@@ -34,6 +34,7 @@ enum AlertInputType: Equatable {
         answer: CoreSdkClient.AnswerBlock
     )
     case leaveCurrentConversation(confirmed: () -> Void, declined: (() -> Void)? = nil)
+    case requestPushNoticationsPermissions(confirmed: () -> Void, declined: () -> Void)
 
     static func == (lhs: AlertInputType, rhs: AlertInputType) -> Bool {
         switch (lhs, rhs) {
@@ -67,6 +68,8 @@ enum AlertInputType: Equatable {
         case let (.error(lhsError, _), .error(rhsError, _)):
             return (lhsError as NSError?) == (rhsError as NSError?)
         case (.leaveCurrentConversation, .leaveCurrentConversation):
+            return true
+        case (.requestPushNoticationsPermissions, .requestPushNoticationsPermissions):
             return true
         default:
             return false

--- a/GliaWidgets/Sources/AlertManager/AlertType.swift
+++ b/GliaWidgets/Sources/AlertManager/AlertType.swift
@@ -52,6 +52,11 @@ enum AlertType {
         accessibilityIdentifier: String?,
         dismissed: (() -> Void)?
     )
+    case requestPushNoticationsPermissions(
+        conf: ConfirmationAlertConfiguration,
+        accepted: () -> Void,
+        declined: () -> Void
+    )
 
     /// Indicating presentation priority of an alert.
     /// Based on comparing values we can decide whether an alert can be replaced with another alert.
@@ -59,7 +64,7 @@ enum AlertType {
         switch self {
         case .singleAction, .singleMediaUpgrade, .screenShareOffer, .criticalError:
             return .highest
-        case .confirmation, .liveObservationConfirmation:
+        case .confirmation, .liveObservationConfirmation, .requestPushNoticationsPermissions:
             return .high
         case .message, .systemAlert, .view, .leaveConversation:
             return .regular

--- a/GliaWidgets/Sources/AlertManager/AlertTypeComposer.swift
+++ b/GliaWidgets/Sources/AlertManager/AlertTypeComposer.swift
@@ -86,6 +86,8 @@ extension AlertManager.AlertTypeComposer {
             )
         case let .leaveCurrentConversation(confirmed, declined):
             return leaveCurrentConversationAlertType(confirmed: confirmed, declined: declined)
+        case let .requestPushNoticationsPermissions(confirmed, declined):
+            return requestPNPermissionsAlertType(accepted: confirmed, declined: declined)
         }
     }
 
@@ -340,6 +342,17 @@ private extension AlertManager.AlertTypeComposer {
             conf: theme.alertConfiguration.leaveCurrentConversation,
             accessibilityIdentifier: "alert_confirmation_leaveCurrentConversation",
             confirmed: confirmed,
+            declined: declined
+        )
+    }
+
+    func requestPNPermissionsAlertType(
+        accepted: @escaping () -> Void,
+        declined: @escaping () -> Void
+    ) -> AlertType {
+        .requestPushNoticationsPermissions(
+            conf: theme.alertConfiguration.pushNotificationsPermissions,
+            accepted: accepted,
             declined: declined
         )
     }

--- a/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.Mock.swift
+++ b/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.Mock.swift
@@ -22,7 +22,8 @@ extension AlertConfiguration {
             unsupportedGvaBroadcastError: .mock(),
             liveObservationConfirmation: .mock(),
             expiredAccessTokenError: .mock(),
-            leaveCurrentConversation: .mock()
+            leaveCurrentConversation: .mock(),
+            pushNotificationsPermissions: .mock()
         )
     }
 }

--- a/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.swift
+++ b/GliaWidgets/Sources/Theme/Alert/AlertConfiguration.swift
@@ -63,6 +63,9 @@ public struct AlertConfiguration: Equatable {
     /// Configuration of the current conversation leaving confirmation alert.
     public var leaveCurrentConversation: ConfirmationAlertConfiguration
 
+    /// Configuration of the intermediate push notifications permissions alert
+    public var pushNotificationsPermissions: ConfirmationAlertConfiguration
+
     /// - Parameters:
     ///   - leaveQueue: Configuration of the queue leaving confirmation alert.
     ///   - endEngagement: Configuration of the engagement ending confirmation alert.
@@ -107,7 +110,8 @@ public struct AlertConfiguration: Equatable {
         unsupportedGvaBroadcastError: MessageAlertConfiguration,
         liveObservationConfirmation: ConfirmationAlertConfiguration,
         expiredAccessTokenError: MessageAlertConfiguration,
-        leaveCurrentConversation: ConfirmationAlertConfiguration
+        leaveCurrentConversation: ConfirmationAlertConfiguration,
+        pushNotificationsPermissions: ConfirmationAlertConfiguration
     ) {
         self.leaveQueue = leaveQueue
         self.endEngagement = endEngagement
@@ -130,5 +134,6 @@ public struct AlertConfiguration: Equatable {
         self.liveObservationConfirmation = liveObservationConfirmation
         self.expiredAccessTokenError = expiredAccessTokenError
         self.leaveCurrentConversation = leaveCurrentConversation
+        self.pushNotificationsPermissions = pushNotificationsPermissions
     }
 }

--- a/GliaWidgets/Sources/Theme/Theme+AlertConfiguration.swift
+++ b/GliaWidgets/Sources/Theme/Theme+AlertConfiguration.swift
@@ -158,6 +158,16 @@ extension Theme {
             showsPoweredBy: showsPoweredBy
         )
 
+        let pushNotificationsPermissions = ConfirmationAlertConfiguration(
+            // TODO: MOB-4254 Add actual localization strings taken from tech writers
+            title: Localization.PushNotificationsAlert.title,
+            message: Localization.PushNotificationsAlert.message,
+            negativeTitle: Localization.General.cancel,
+            positiveTitle: Localization.General.allow,
+            switchButtonBackgroundColors: false,
+            showsPoweredBy: showsPoweredBy
+        )
+
         return AlertConfiguration(
             leaveQueue: leaveQueue,
             endEngagement: endEngagement,
@@ -179,7 +189,8 @@ extension Theme {
             unsupportedGvaBroadcastError: unsupportedGvaBroadcastError,
             liveObservationConfirmation: liveObservationConfirmation,
             expiredAccessTokenError: expiredAccessTokenError,
-            leaveCurrentConversation: leaveCurrentConversation
+            leaveCurrentConversation: leaveCurrentConversation,
+            pushNotificationsPermissions: pushNotificationsPermissions
         )
     }
 }


### PR DESCRIPTION
**What was solved?**
This PR creates push notifications intermediate alert

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

