### PR TITLE
Add localeProvider interface

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -723,6 +723,7 @@
 		C00DE0AB2CD3847B005956B4 /* EntryWidgetViewLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00DE0AA2CD3847B005956B4 /* EntryWidgetViewLayoutTests.swift */; };
 		C00DE0AD2CD3BD53005956B4 /* EntryWidgetViewVoiceOverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00DE0AC2CD3BD53005956B4 /* EntryWidgetViewVoiceOverTests.swift */; };
 		C00DE0AF2CD3BF35005956B4 /* EntryWidgetViewDynamicTypeFontTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00DE0AE2CD3BF35005956B4 /* EntryWidgetViewDynamicTypeFontTests.swift */; };
+		C010DAC62DAD0D0900DA54DA /* Glia.LocaleProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C010DAC52DAD0D0200DA54DA /* Glia.LocaleProvider.swift */; };
 		C0175A0F2A55A624001FACDE /* ChatMessagaEntryViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0175A0E2A55A624001FACDE /* ChatMessagaEntryViewTests.swift */; };
 		C0175A112A55AA3E001FACDE /* ChatMessageEntryView.+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0175A102A55AA3E001FACDE /* ChatMessageEntryView.+Mock.swift */; };
 		C0175A132A56E29E001FACDE /* ChatMessageCardType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0175A122A56E29E001FACDE /* ChatMessageCardType.swift */; };
@@ -1821,6 +1822,7 @@
 		C00DE0AA2CD3847B005956B4 /* EntryWidgetViewLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryWidgetViewLayoutTests.swift; sourceTree = "<group>"; };
 		C00DE0AC2CD3BD53005956B4 /* EntryWidgetViewVoiceOverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryWidgetViewVoiceOverTests.swift; sourceTree = "<group>"; };
 		C00DE0AE2CD3BF35005956B4 /* EntryWidgetViewDynamicTypeFontTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryWidgetViewDynamicTypeFontTests.swift; sourceTree = "<group>"; };
+		C010DAC52DAD0D0200DA54DA /* Glia.LocaleProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Glia.LocaleProvider.swift; sourceTree = "<group>"; };
 		C0175A0E2A55A624001FACDE /* ChatMessagaEntryViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessagaEntryViewTests.swift; sourceTree = "<group>"; };
 		C0175A102A55AA3E001FACDE /* ChatMessageEntryView.+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatMessageEntryView.+Mock.swift"; sourceTree = "<group>"; };
 		C0175A122A56E29E001FACDE /* ChatMessageCardType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageCardType.swift; sourceTree = "<group>"; };
@@ -3892,6 +3894,7 @@
 			children = (
 				AFBBF5772851C391004993B3 /* Glia.Deprecated.swift */,
 				7594098E298D3929008B173A /* Glia.OpaqueAuthentication.swift */,
+				C010DAC52DAD0D0200DA54DA /* Glia.LocaleProvider.swift */,
 				1A60AF7D25656F0400E53F53 /* Glia.swift */,
 				C0D6CA622C19C59100D4709B /* Glia.OpaqueAuthentication.Environment.swift */,
 				755D187E29A6B1B90009F5E8 /* Glia+EngagementSetup.swift */,
@@ -6393,6 +6396,7 @@
 				AF3D520D2983B3DD00AD8E69 /* FileUploader.Environment.Interface.swift in Sources */,
 				1ABD6C5925B5758000D56EFA /* BubbleStyle.swift in Sources */,
 				C0D2F08B29A4E95700803B47 /* ConnectView.Mock.swift in Sources */,
+				C010DAC62DAD0D0900DA54DA /* Glia.LocaleProvider.swift in Sources */,
 				8491AF272A8E3F6A00CC3E72 /* CGColor+Extensions.swift in Sources */,
 				C0175A252A66A431001FACDE /* GvaPersistentButtonOptionView.swift in Sources */,
 				AF10ED9129BF85C700E85309 /* UnreadMessageDividerStyle.swift in Sources */,

--- a/GliaWidgets/Public/Glia/Glia.LocaleProvider.swift
+++ b/GliaWidgets/Public/Glia/Glia.LocaleProvider.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension Glia {
+    /// Locale provider is used for retrieving remote strings for associated key
+    public final class LocaleProvider {
+        let locale: (String) -> String?
+
+        init(locale: @escaping (String) -> String?) {
+            self.locale = locale
+        }
+    }
+}
+
+extension Glia.LocaleProvider {
+    /// Retrieves remote string value if exists
+    /// - Parameter key: String value which remote string is associated with.
+    /// - Returns: `String` value if exists, otherwise returns `nil`
+    public func getRemoteString(_ key: String) -> String? {
+        locale(key)
+    }
+}

--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -134,6 +134,7 @@ public class Glia {
     var alertManager: AlertManager
     public let liveObservation: LiveObservation
     public let secureConversation: SecureConversations
+    public let localeProvider: LocaleProvider
     // We need to store `features` via `configure` method to use it
     // when engagement gets restored for Direct ID authentication flow.
     var features: Features?
@@ -195,6 +196,8 @@ public class Glia {
         pushNotifications = .init(environment: .create(with: environment))
 
         secureConversation = .init(environment: .create(with: environment))
+
+        localeProvider = .init(locale: environment.coreSdk.localeProvider.getRemoteString)
     }
 
     /// Setup SDK using specific engagement configuration without starting the engagement.


### PR DESCRIPTION
**What was solved?**
This PR adds localeProvider interface, so that integrators could get remote strings as a fallback mechanism when necessary.

MOB-4287

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [X] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
