### PR TITLE
Remove coresdk import where possible

### DIFF
--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.CustomCard.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.CustomCard.swift
@@ -1,5 +1,4 @@
 import Foundation
-import GliaCoreSDK
 
 // MARK: Custom cards
 extension SecureConversations.TranscriptModel {

--- a/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
+++ b/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Combine
 import UIKit
-import GliaCoreSDK
 
 /// Call Visualizer is a feature for operators to transfer their visitors from conventional communication methods,
 /// such as a phone call, to Glia solution. The visitor needs to provide to the operator a visitor code,

--- a/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeViewModel.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VisitorCode/VisitorCodeViewModel.swift
@@ -1,5 +1,4 @@
 import UIKit
-import GliaCoreSDK
 
 extension CallVisualizer {
     class VisitorCodeViewModel {

--- a/GliaWidgets/Sources/EngagementLauncher/EngagementLauncher.swift
+++ b/GliaWidgets/Sources/EngagementLauncher/EngagementLauncher.swift
@@ -1,5 +1,4 @@
 import Foundation
-import GliaCoreSDK
 
  /// `EngagementLauncher`class allows launching different types of engagements, such as chat,
  /// audio calls, video calls, and secure messaging.

--- a/GliaWidgets/Sources/MessageRenderer/ChatMessageRenderer.Interface.swift
+++ b/GliaWidgets/Sources/MessageRenderer/ChatMessageRenderer.Interface.swift
@@ -1,5 +1,4 @@
 import UIKit
-import GliaCoreSDK
 
 /// Message renderer for AI custom cards.
 public struct MessageRenderer {

--- a/GliaWidgets/Sources/ViewController/Survey/Components/BooleanQuestionView/Survey.BooleanQuestionView.swift
+++ b/GliaWidgets/Sources/ViewController/Survey/Components/BooleanQuestionView/Survey.BooleanQuestionView.swift
@@ -1,4 +1,3 @@
-import GliaCoreSDK
 import UIKit
 
 extension Survey {

--- a/GliaWidgets/Sources/ViewController/Survey/Components/ScaleQuestionView/Survey.ScaleQuestionView.swift
+++ b/GliaWidgets/Sources/ViewController/Survey/Components/ScaleQuestionView/Survey.ScaleQuestionView.swift
@@ -1,4 +1,3 @@
-import GliaCoreSDK
 import UIKit
 
 extension Survey {

--- a/GliaWidgets/Sources/ViewController/Survey/Components/SingleChoiceQuestionView/Survey.SingleChoiceQuestionView.swift
+++ b/GliaWidgets/Sources/ViewController/Survey/Components/SingleChoiceQuestionView/Survey.SingleChoiceQuestionView.swift
@@ -1,4 +1,3 @@
-import GliaCoreSDK
 import UIKit
 
 extension Survey {

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+ChoiceCards.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+ChoiceCards.swift
@@ -1,5 +1,4 @@
 import Foundation
-import GliaCoreSDK
 
 extension ChatViewModel {
     func sendChoiceCardResponse(_ option: ChatChoiceCardOption, to messageId: String) {

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+CustomCard.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+CustomCard.swift
@@ -1,6 +1,4 @@
 import Foundation
-import GliaCoreSDK
-
 // MARK: Custom cards
 
 extension ChatViewModel {

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+GVA.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+GVA.swift
@@ -1,5 +1,4 @@
 import Foundation
-import GliaCoreSDK
 
 private extension String {
     static let gvaOptionUrlTargetModal = "modal"

--- a/GliaWidgets/Sources/ViewModel/Chat/Data/OutgoingMessage.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/Data/OutgoingMessage.swift
@@ -1,5 +1,4 @@
 import Foundation
-import GliaCoreSDK
 
 class OutgoingMessage: Equatable {
     let files: [LocalFile]

--- a/GliaWidgetsTests/CallVisualizer/VisitorCodeTests.swift
+++ b/GliaWidgetsTests/CallVisualizer/VisitorCodeTests.swift
@@ -1,6 +1,5 @@
 @testable import GliaWidgets
 import XCTest
-import GliaCoreSDK
 
 class VisitorCodeTests: XCTestCase {
     func test_vc_deinit() {

--- a/GliaWidgetsTests/ChatMessage/ChatMessageTests.swift
+++ b/GliaWidgetsTests/ChatMessage/ChatMessageTests.swift
@@ -1,4 +1,3 @@
-import GliaCoreSDK
 import XCTest
 
 @testable import GliaWidgets

--- a/GliaWidgetsTests/Sources/ChatViewControllerTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewControllerTests.swift
@@ -1,5 +1,4 @@
 @testable import GliaWidgets
-import GliaCoreSDK
 import XCTest
 
 class ChatViewControllerTests: XCTestCase {

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+MessageRetry.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+MessageRetry.swift
@@ -1,6 +1,5 @@
 @testable import GliaWidgets
 import XCTest
-import GliaCoreSDK
 
 extension ChatViewModelTests {
     func testSendMessageRetrySuccess() {

--- a/GliaWidgetsTests/Sources/EntryWidget/EntryWidgetViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/EntryWidget/EntryWidgetViewModelTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import Combine
-import GliaCoreSDK
 
 @testable import GliaWidgets
 

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+RestoreEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+RestoreEngagement.swift
@@ -1,5 +1,4 @@
 @testable import GliaWidgets
-import GliaCoreSDK
 import XCTest
 
 extension GliaTests {

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
@@ -1,4 +1,3 @@
-import GliaCoreSDK
 import XCTest
 
 @testable import GliaWidgets

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -1,4 +1,3 @@
-import GliaCoreSDK
 import XCTest
 
 @testable import GliaWidgets

--- a/TestingApp/VisitorInfo/VisitorInfoViewController.swift
+++ b/TestingApp/VisitorInfo/VisitorInfoViewController.swift
@@ -1,6 +1,5 @@
 import UIKit
 import GliaWidgets
-import GliaCoreSDK
 
 extension ViewController {
     @IBAction func showUpdateVisitorInfo() {


### PR DESCRIPTION
**What was solved?**
CoreSDK was imported needlessly in many places, and could be removed

MOB-4288
**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
