### PR TITLE
Add all core push notification interfaces to widgetsdk

### DIFF
--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -235,9 +235,23 @@ extension CoreSdkClient {
             _ application: UIApplication,
             _ deviceToken: Data
         ) -> Void
-
+        var applicationDidFailToRegisterForRemoteNotificationsWithError: (
+            _ application: UIApplication,
+            _ error: any Error
+        ) -> Void
         var setPushHandler: (PushHandler?) -> Void
         var pushHandler: () -> PushHandler?
+        var subscribeTo: ([GliaCoreSDK.PushNotificationsType]) -> Void
+        var userNotificationCenterWillPresent: (
+            _ center: UNUserNotificationCenter,
+            _ willPresentNotification: UNNotification,
+            _ completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+        ) -> Void
+        var userNotificationCenterDidReceiveResponse: (
+            _ center: UNUserNotificationCenter,
+            _ didReceiveResponse: UNNotificationResponse,
+            _ completionHandler: @escaping () -> Void
+        ) -> Void
     }
 }
 

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
@@ -91,10 +91,35 @@ extension CoreSdkClient.LiveObservation {
 
 extension CoreSdkClient.PushNotifications {
     static let live = Self(
-        applicationDidRegisterForRemoteNotificationsWithDeviceToken:
-            GliaCore.sharedInstance.pushNotifications.application(_:didRegisterForRemoteNotificationsWithDeviceToken:),
+        applicationDidRegisterForRemoteNotificationsWithDeviceToken: { application, token in
+            GliaCore.sharedInstance.pushNotifications.application(
+                application,
+                didRegisterForRemoteNotificationsWithDeviceToken: token
+            )
+        },
+        applicationDidFailToRegisterForRemoteNotificationsWithError: { application, error in
+            GliaCore.sharedInstance.pushNotifications.application(
+                application,
+                didFailToRegisterForRemoteNotificationsWithError: error
+            )
+        },
         setPushHandler: { GliaCore.sharedInstance.pushNotifications.handler = $0 },
-        pushHandler: { GliaCore.sharedInstance.pushNotifications.handler }
+        pushHandler: { GliaCore.sharedInstance.pushNotifications.handler },
+        subscribeTo: GliaCore.sharedInstance.pushNotifications.subscribeTo(_:),
+        userNotificationCenterWillPresent: { center, willPresent, completionHandler in
+            GliaCore.sharedInstance.pushNotifications.userNotificationCenter(
+                center,
+                willPresent: willPresent,
+                withCompletionHandler: completionHandler
+            )
+        },
+        userNotificationCenterDidReceiveResponse: { center, didReceive, completionHandler in
+            GliaCore.sharedInstance.pushNotifications.userNotificationCenter(
+                center,
+                didReceive: didReceive,
+                withCompletionHandler: completionHandler
+            )
+        }
     )
 }
 

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -66,8 +66,12 @@ extension CoreSdkClient.LiveObservation {
 extension CoreSdkClient.PushNotifications {
     static let mock = Self(
         applicationDidRegisterForRemoteNotificationsWithDeviceToken: { _, _ in },
+        applicationDidFailToRegisterForRemoteNotificationsWithError: { _, _ in },
         setPushHandler: { _ in },
-        pushHandler: { nil }
+        pushHandler: { nil },
+        subscribeTo: { _ in },
+        userNotificationCenterWillPresent: { _, _, _ in },
+        userNotificationCenterDidReceiveResponse: { _, _, _ in }
     )
 }
 

--- a/GliaWidgets/Sources/PushNotifications/PushNotifications.swift
+++ b/GliaWidgets/Sources/PushNotifications/PushNotifications.swift
@@ -1,10 +1,19 @@
 import Foundation
 import GliaCoreSDK
 
+public typealias PushNotificationsType = GliaCoreSDK.PushNotificationsType
+
 public struct PushNotifications {
     let environment: Environment
 
-    /// Application did register for remote notifications with device token
+    /// Notifies the push notifications system that the application has successfully registered for remote notifications.
+    ///
+    /// This method is usually called from the `UIApplicationDelegate`'s registration success callback.
+    ///
+    /// - Parameters:
+    ///   - application: The application instance that registered for notifications.
+    ///   - deviceToken: The device token received from APNs.
+    ///
     public func applicationDidRegisterForRemoteNotificationsWithDeviceToken(
         application: UIApplication,
         deviceToken: Data
@@ -15,16 +24,86 @@ public struct PushNotifications {
         )
     }
 
-    /// Set the current handler that the SDK is forwarding the
-    /// UNNotificationResponse.actionIdentifier to.
+    /// Notifies the push notifications system that the application failed to register for remote notifications.
+    ///
+    /// This method is typically called from the `UIApplicationDelegate`'s failure callback.
+    ///
+    /// - Parameters:
+    ///   - application: The application instance that attempted registration.
+    ///   - error: The error encountered during the registration process.
+    ///
+    public func applicationDidFailToRegisterForRemoteNotificationsWithError(
+        application: UIApplication,
+        error: any Error
+    ) {
+        environment.coreSdk.pushNotifications.applicationDidFailToRegisterForRemoteNotificationsWithError(
+            application,
+            error
+        )
+    }
+
+    /// Sets the current push action handler that the SDK uses to forward notification actions.
+    ///
+    /// This handler is executed in response to user interactions with notifications (via
+    /// `UNNotificationResponse.actionIdentifier`).
+    ///
+    /// - Parameter handler: An optional `PushActionBlock` closure used as a callback for push actions.
+    ///
     public func setPushHandler(_ handler: GliaCoreSDK.PushActionBlock?) {
         environment.coreSdk.pushNotifications.setPushHandler(handler)
     }
 
-    /// The current handler that the SDK is forwarding the
-    /// UNNotificationResponse.actionIdentifier to.
-    public func pushHandler() -> GliaCoreSDK.PushActionBlock? {
-        environment.coreSdk.pushNotifications.pushHandler()
+    /// Forwards the notification delivery event to the underlying SDK when a notification is about to be presented.
+    ///
+    /// This method should be called from `UNUserNotificationCenterDelegate`'s
+    /// `userNotificationCenter(_:willPresent:withCompletionHandler:)` method.
+    ///
+    /// - Parameters:
+    ///   - center: The `UNUserNotificationCenter` instance handling the notification.
+    ///   - willPresentNotificationCenter: The `UNNotification` to be presented.
+    ///   - completionHandler: A closure that takes the presentation options for the notification.
+    ///
+    public func userNotificationCenterWillPresent(
+        center: UNUserNotificationCenter,
+        willPresent: UNNotification,
+        completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        environment.coreSdk.pushNotifications.userNotificationCenterWillPresent(
+            center,
+            willPresent,
+            completionHandler
+        )
+    }
+
+    /// Forwards the user's response for a delivered notification to the underlying SDK.
+    ///
+    /// This method should be invoked from `UNUserNotificationCenterDelegate`'s
+    /// `userNotificationCenter(_:didReceive:withCompletionHandler:)` method.
+    ///
+    /// - Parameters:
+    ///   - center: The `UNUserNotificationCenter` instance that handled the response.
+    ///   - didReceiveResponseCenter: The `UNNotificationResponse` received from the user.
+    ///   - completionHandler: A closure executed once the response has been handled.
+    ///
+    public func userNotificationCenterDidReceiveResponse(
+        center: UNUserNotificationCenter,
+        didReceive: UNNotificationResponse,
+        completionHandler: @escaping () -> Void
+    ) {
+        environment.coreSdk.pushNotifications.userNotificationCenterDidReceiveResponse(
+            center,
+            didReceive,
+            completionHandler
+        )
+    }
+
+    /// Subscribe to specific push notifications type.
+    ///
+    /// - Parameters:
+    ///   - types: array of PushnotificationType
+    ///
+    public func subscribeTo(_ types: [PushNotificationsType]) {
+        environment.coreSdk.pushNotifications.subscribeTo(types)
     }
 }
 

--- a/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
@@ -120,12 +120,24 @@ extension CoreSdkClient.PushNotifications {
         applicationDidRegisterForRemoteNotificationsWithDeviceToken: { _, _ in
             fail("\(Self.self).applicationDidRegisterForRemoteNotificationsWithDeviceToken")
         },
+        applicationDidFailToRegisterForRemoteNotificationsWithError: { _, _ in
+            fail("\(Self.self).applicationDidFailToRegisterForRemoteNotificationsWithError")
+        },
         setPushHandler: { _ in
             fail("\(Self.self).setPushHandler")
         },
         pushHandler: {
             fail("\(Self.self).pushHandler")
             return nil
+        },
+        subscribeTo: { _ in
+            fail("\(Self.self).subscribeTo")
+        },
+        userNotificationCenterWillPresent: { _, _, _ in
+            fail("\(Self.self).userNotificationCenterWillPresent")
+        },
+        userNotificationCenterDidReceiveResponse: { _, _, _ in
+            fail("\(Self.self).userNotificationCenterDidReceiveResponse")
         }
     )
 }


### PR DESCRIPTION
**What was solved?**
Additional PushNotification interfaces are needed in WidgetSDK, so that integrators will not have any need to use CoreSDK directly

MOB-4294

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [X] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
