### PR TITLE
Integrate Intermediate dialog into authentication flow

### DIFF
--- a/GliaWidgets/Sources/AlertManager/Alert/AlertViewController.swift
+++ b/GliaWidgets/Sources/AlertManager/Alert/AlertViewController.swift
@@ -159,7 +159,7 @@ class AlertViewController: UIViewController, Replaceable {
                 accessibilityIdentifier: accessibilityIdentifier,
                 dismissed: dismissed
             )
-        case let .requestPushNoticationsPermissions(conf, accepted, declined):
+        case let .requestPushNotificationsPermissions(conf, accepted, declined):
             return makeRequestPNPermissionsAlertView(
                 with: conf,
                 accepted: accepted,

--- a/GliaWidgets/Sources/AlertManager/AlertInputType.swift
+++ b/GliaWidgets/Sources/AlertManager/AlertInputType.swift
@@ -34,7 +34,7 @@ enum AlertInputType: Equatable {
         answer: CoreSdkClient.AnswerBlock
     )
     case leaveCurrentConversation(confirmed: () -> Void, declined: (() -> Void)? = nil)
-    case requestPushNoticationsPermissions(confirmed: () -> Void, declined: () -> Void)
+    case requestPushNotificationsPermissions(confirmed: () -> Void, declined: () -> Void)
 
     static func == (lhs: AlertInputType, rhs: AlertInputType) -> Bool {
         switch (lhs, rhs) {
@@ -69,7 +69,7 @@ enum AlertInputType: Equatable {
             return (lhsError as NSError?) == (rhsError as NSError?)
         case (.leaveCurrentConversation, .leaveCurrentConversation):
             return true
-        case (.requestPushNoticationsPermissions, .requestPushNoticationsPermissions):
+        case (.requestPushNotificationsPermissions, .requestPushNotificationsPermissions):
             return true
         default:
             return false

--- a/GliaWidgets/Sources/AlertManager/AlertType.swift
+++ b/GliaWidgets/Sources/AlertManager/AlertType.swift
@@ -52,7 +52,7 @@ enum AlertType {
         accessibilityIdentifier: String?,
         dismissed: (() -> Void)?
     )
-    case requestPushNoticationsPermissions(
+    case requestPushNotificationsPermissions(
         conf: ConfirmationAlertConfiguration,
         accepted: () -> Void,
         declined: () -> Void
@@ -64,7 +64,7 @@ enum AlertType {
         switch self {
         case .singleAction, .singleMediaUpgrade, .screenShareOffer, .criticalError:
             return .highest
-        case .confirmation, .liveObservationConfirmation, .requestPushNoticationsPermissions:
+        case .confirmation, .liveObservationConfirmation, .requestPushNotificationsPermissions:
             return .high
         case .message, .systemAlert, .view, .leaveConversation:
             return .regular

--- a/GliaWidgets/Sources/AlertManager/AlertTypeComposer.swift
+++ b/GliaWidgets/Sources/AlertManager/AlertTypeComposer.swift
@@ -86,7 +86,7 @@ extension AlertManager.AlertTypeComposer {
             )
         case let .leaveCurrentConversation(confirmed, declined):
             return leaveCurrentConversationAlertType(confirmed: confirmed, declined: declined)
-        case let .requestPushNoticationsPermissions(confirmed, declined):
+        case let .requestPushNotificationsPermissions(confirmed, declined):
             return requestPNPermissionsAlertType(accepted: confirmed, declined: declined)
         }
     }
@@ -350,7 +350,8 @@ private extension AlertManager.AlertTypeComposer {
         accepted: @escaping () -> Void,
         declined: @escaping () -> Void
     ) -> AlertType {
-        .requestPushNoticationsPermissions(
+        environment.log.prefixed(Self.self).info("Show Push Notifications Intermediate Dialog")
+        return .requestPushNotificationsPermissions(
             conf: theme.alertConfiguration.pushNotificationsPermissions,
             accepted: accepted,
             declined: declined

--- a/TestingApp/ViewController/ViewController+Authentication.swift
+++ b/TestingApp/ViewController/ViewController+Authentication.swift
@@ -3,6 +3,7 @@ import GliaWidgets
 
 extension ViewController {
     @IBAction private func toggleAuthentication() {
+        setupPushNotificationConfig()
         let authenticate = {
             self.catchingError {
                 let authentication = try Glia.sharedInstance.authentication(with: self.authenticationBehavior)

--- a/TestingApp/ViewController/ViewController+Configure.swift
+++ b/TestingApp/ViewController/ViewController+Configure.swift
@@ -3,8 +3,9 @@ import GliaWidgets
 
 extension ViewController {
     @IBAction private func configureSDKTapped() {
+        setupPushNotificationConfig()
         showRemoteConfigAlert { [weak self] fileName in
-            self?.configureSDK(uiConfigName: fileName) { [weak self] result in
+            self?.configureSDK(uiConfigName: fileName) { result in
                 guard case let .failure(error) = result else { return }
                 self?.showErrorAlert(using: error)
             }
@@ -29,12 +30,7 @@ extension ViewController {
             }
         }
 
-        #if DEBUG
-        let pushNotifications = Configuration.PushNotifications.sandbox
-        #else
-        let pushNotifications = Configuration.PushNotifications.disabled
-        #endif
-        configuration.pushNotifications = pushNotifications
+        setupPushNotificationConfig()
 
         if autoConfigureSdkToggle.isOn {
             configureSDK(uiConfigName: nil) { [weak self] result in
@@ -49,6 +45,18 @@ extension ViewController {
         } else {
             completion()
         }
+    }
+
+    func setupPushNotificationConfig() {
+        #if DEBUG
+        let pushNotifications = Configuration.PushNotifications.sandbox
+        #else
+        let pushNotifications = Configuration.PushNotifications.disabled
+        #endif
+        configuration.pushNotifications = pushNotifications
+
+        let pushNotificationsTypes: [PushNotificationsType] = [.start, .message, .end]
+        Glia.sharedInstance.pushNotifications.subscribeTo(pushNotificationsTypes)
     }
 
     func configureSDK(

--- a/TestingApp/ViewController/ViewController.swift
+++ b/TestingApp/ViewController/ViewController.swift
@@ -162,8 +162,6 @@ extension ViewController {
 
 // MARK: - Private
 private extension ViewController {
-
-
     func setupPushHandler() {
         Glia.sharedInstance.pushNotifications.setPushHandler { [weak self] push in
             switch (push.type, push.timing) {


### PR DESCRIPTION
MOB-4236

**What was solved?**
Push Notifications Intermediate dialog was integrated into authentication flow

**Release notes:**

 - [x] Feature
 - [ ] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
![photo_2025-04-18 14 09 40](https://github.com/user-attachments/assets/cfd06eba-8213-4291-9194-971c1726ee18)