### PR TITLE
Remove two push notifications interfaces

### DIFF
--- a/GliaWidgets/Sources/PushNotifications/PushNotifications.swift
+++ b/GliaWidgets/Sources/PushNotifications/PushNotifications.swift
@@ -53,50 +53,6 @@ public struct PushNotifications {
         environment.coreSdk.pushNotifications.setPushHandler(handler)
     }
 
-    /// Forwards the notification delivery event to the underlying SDK when a notification is about to be presented.
-    ///
-    /// This method should be called from `UNUserNotificationCenterDelegate`'s
-    /// `userNotificationCenter(_:willPresent:withCompletionHandler:)` method.
-    ///
-    /// - Parameters:
-    ///   - center: The `UNUserNotificationCenter` instance handling the notification.
-    ///   - willPresentNotificationCenter: The `UNNotification` to be presented.
-    ///   - completionHandler: A closure that takes the presentation options for the notification.
-    ///
-    public func userNotificationCenterWillPresent(
-        center: UNUserNotificationCenter,
-        willPresent: UNNotification,
-        completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
-    ) {
-        environment.coreSdk.pushNotifications.userNotificationCenterWillPresent(
-            center,
-            willPresent,
-            completionHandler
-        )
-    }
-
-    /// Forwards the user's response for a delivered notification to the underlying SDK.
-    ///
-    /// This method should be invoked from `UNUserNotificationCenterDelegate`'s
-    /// `userNotificationCenter(_:didReceive:withCompletionHandler:)` method.
-    ///
-    /// - Parameters:
-    ///   - center: The `UNUserNotificationCenter` instance that handled the response.
-    ///   - didReceiveResponseCenter: The `UNNotificationResponse` received from the user.
-    ///   - completionHandler: A closure executed once the response has been handled.
-    ///
-    public func userNotificationCenterDidReceiveResponse(
-        center: UNUserNotificationCenter,
-        didReceive: UNNotificationResponse,
-        completionHandler: @escaping () -> Void
-    ) {
-        environment.coreSdk.pushNotifications.userNotificationCenterDidReceiveResponse(
-            center,
-            didReceive,
-            completionHandler
-        )
-    }
-
     /// Subscribe to specific push notifications type.
     ///
     /// - Parameters:


### PR DESCRIPTION
**What was solved?**
Those interfaces were introduced but later turned out not to be needed. No deprecation is necessary, as those interfaces have not been released yet.
**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
