### PR TITLE
Add localization strings for intermediate PN strings

### DIFF
--- a/GliaWidgets/Localization.swift
+++ b/GliaWidgets/Localization.swift
@@ -725,10 +725,16 @@ internal enum Localization {
     }
   }
   internal enum PushNotificationsAlert {
-    /// Please allow push notifications to receive new messages alerts.
-    internal static var message: String { Localization.tr("Localizable", "push_notifications_alert.message", fallback: "Please allow push notifications to receive new messages alerts.") }
-    /// Allow Push Notifications
-    internal static var title: String { Localization.tr("Localizable", "push_notifications_alert.title", fallback: "Allow Push Notifications") }
+    /// Allow push notifications so we can message you (and return your messages) in the app.
+    internal static var message: String { Localization.tr("Localizable", "push_notifications_alert.message", fallback: "Allow push notifications so we can message you (and return your messages) in the app.") }
+    /// Stay In Touch
+    internal static var title: String { Localization.tr("Localizable", "push_notifications_alert.title", fallback: "Stay In Touch") }
+    internal enum Button {
+      /// Not right now
+      internal static var negative: String { Localization.tr("Localizable", "push_notifications_alert.button.negative", fallback: "Not right now") }
+      /// Allow
+      internal static var positive: String { Localization.tr("Localizable", "push_notifications_alert.button.positive", fallback: "Allow") }
+    }
   }
   internal enum ScreenSharing {
     internal enum VisitorScreen {

--- a/GliaWidgets/Resources/en.lproj/Localizable.strings
+++ b/GliaWidgets/Resources/en.lproj/Localizable.strings
@@ -275,5 +275,8 @@
 "entry_widget.call_visualizer.description" = "You are already in contact with the support team";
 "entry_widget.call_visualizer.button.label" = "Call Visualizer";
 
-"push_notifications_alert.title" = "Allow Push Notifications";
-"push_notifications_alert.message" = "Please allow push notifications to receive new messages alerts.";
+"push_notifications_alert.title" = "Stay In Touch";
+"push_notifications_alert.message" = "Allow push notifications so we can message you (and return your messages) in the app.";
+"push_notifications_alert.button.positive" = "Allow";
+"push_notifications_alert.button.negative" = "Not right now";
+

--- a/GliaWidgets/Sources/Theme/Theme+AlertConfiguration.swift
+++ b/GliaWidgets/Sources/Theme/Theme+AlertConfiguration.swift
@@ -159,11 +159,10 @@ extension Theme {
         )
 
         let pushNotificationsPermissions = ConfirmationAlertConfiguration(
-            // TODO: MOB-4254 Add actual localization strings taken from tech writers
             title: Localization.PushNotificationsAlert.title,
             message: Localization.PushNotificationsAlert.message,
-            negativeTitle: Localization.General.cancel,
-            positiveTitle: Localization.General.allow,
+            negativeTitle: Localization.PushNotificationsAlert.Button.negative,
+            positiveTitle: Localization.PushNotificationsAlert.Button.positive,
             switchButtonBackgroundColors: false,
             showsPoweredBy: showsPoweredBy
         )


### PR DESCRIPTION
**What was solved?**
Add localization strings for intermediate PN strings.
@1toomas This alert is showed before asking a system alert for Secure Conversation messages Push Notifications during visitor authentication. I deleted the strings that I used as placeholders.

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.
