### PR TITLE
Show chat transcript upon receiving SC message push

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -193,6 +193,7 @@
 		2188DEE52CEE2C6000FA3BEF /* SendingMessageUnavailableBannerViewStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2188DEE22CEE2C6000FA3BEF /* SendingMessageUnavailableBannerViewStyle.swift */; };
 		2188DEE72CEE2E2100FA3BEF /* SecureMessagingTopBannerViewStyle.Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2188DEE62CEE2E2100FA3BEF /* SecureMessagingTopBannerViewStyle.Accessibility.swift */; };
 		2188DEE92CEE2E3400FA3BEF /* SecureMessagingTopBannerViewStyle.RemoteConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2188DEE82CEE2E3400FA3BEF /* SecureMessagingTopBannerViewStyle.RemoteConfig.swift */; };
+		218CE31E2DBBB2AA0046A302 /* GliaTests+PushNotifcationsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 218CE31D2DBBB2AA0046A302 /* GliaTests+PushNotifcationsAction.swift */; };
 		2198B7AC2CAEB14D002C442B /* QueuesMonitor.Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2198B7AB2CAEB14D002C442B /* QueuesMonitor.Live.swift */; };
 		2198B7AE2CB035A6002C442B /* QueuesMonitor.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2198B7AD2CB035A6002C442B /* QueuesMonitor.Environment.swift */; };
 		21BADEBB2D2D7F94000AD9CF /* MockConfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 21BADEBA2D2D7F94000AD9CF /* MockConfiguration.json */; };
@@ -1295,6 +1296,7 @@
 		2188DEE22CEE2C6000FA3BEF /* SendingMessageUnavailableBannerViewStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendingMessageUnavailableBannerViewStyle.swift; sourceTree = "<group>"; };
 		2188DEE62CEE2E2100FA3BEF /* SecureMessagingTopBannerViewStyle.Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureMessagingTopBannerViewStyle.Accessibility.swift; sourceTree = "<group>"; };
 		2188DEE82CEE2E3400FA3BEF /* SecureMessagingTopBannerViewStyle.RemoteConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureMessagingTopBannerViewStyle.RemoteConfig.swift; sourceTree = "<group>"; };
+		218CE31D2DBBB2AA0046A302 /* GliaTests+PushNotifcationsAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GliaTests+PushNotifcationsAction.swift"; sourceTree = "<group>"; };
 		2198B7AB2CAEB14D002C442B /* QueuesMonitor.Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueuesMonitor.Live.swift; sourceTree = "<group>"; };
 		2198B7AD2CB035A6002C442B /* QueuesMonitor.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueuesMonitor.Environment.swift; sourceTree = "<group>"; };
 		21BADEBA2D2D7F94000AD9CF /* MockConfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MockConfiguration.json; sourceTree = "<group>"; };
@@ -4399,6 +4401,7 @@
 			children = (
 				8491AF612AA20F8F00CC3E72 /* Mocks */,
 				7512A5A627C3926500319DF1 /* GliaTests.swift */,
+				218CE31D2DBBB2AA0046A302 /* GliaTests+PushNotifcationsAction.swift */,
 				846A5C4429F6BEFA0049B29F /* GliaTests+StartEngagement.swift */,
 				AFFA99812C57D658004A2825 /* GliaTests+RestoreEngagement.swift */,
 				215A25992CAC19780013023E /* GliaTests+EngagementLauncher.swift */,
@@ -6877,6 +6880,7 @@
 				846A5C4529F6BEFA0049B29F /* GliaTests+StartEngagement.swift in Sources */,
 				7512A57A27BF9FCD00319DF1 /* ChatViewModelTests.swift in Sources */,
 				84602A792AEAB7CA0031E606 /* Survey.Mock.swift in Sources */,
+				218CE31E2DBBB2AA0046A302 /* GliaTests+PushNotifcationsAction.swift in Sources */,
 				210150742CC13E8900294BA4 /* QueuesMonitorTests.swift in Sources */,
 				31CCE3E42BCE8F3A00F92535 /* CallVisualizerCoordinatorTests.swift in Sources */,
 			);

--- a/GliaWidgets/Public/Glia/Glia+RestoreEngagement.swift
+++ b/GliaWidgets/Public/Glia/Glia+RestoreEngagement.swift
@@ -33,6 +33,7 @@ extension Glia {
         features: Features,
         maximize: Bool
     ) {
+        engagementRestorationState = .restoring
         // In this case, where engagement is restored, LO acknowledgement dialog
         // should not appear again, however snack bar message has to be shown via
         // `showSnackBarIfNeeded` function.
@@ -90,5 +91,6 @@ extension Glia {
         }
 
         showSnackBarIfNeeded()
+        engagementRestorationState = .restored
     }
 }

--- a/GliaWidgets/Public/Glia/Glia.OpaqueAuthentication.swift
+++ b/GliaWidgets/Public/Glia/Glia.OpaqueAuthentication.swift
@@ -114,7 +114,7 @@ extension Glia {
                     case .failure:
                         break
                     }
-
+                    self?.engagementRestorationState = .none
                     callback(result.mapError(Glia.Authentication.Error.init))
                 }
             },
@@ -188,6 +188,7 @@ extension Glia {
         sceneProvider: SceneProvider?,
         features: Features?
     ) {
+        engagementRestorationState = .restoring
         closeRootCoordinator()
         // Restart engagement happens implicitly, however, to create RootCoordinator
         // queueId, engagementKind, etc. are needed.
@@ -195,7 +196,10 @@ extension Glia {
         // should be restarted with the same options.
         guard let interactor = interactor,
               let viewFactory = viewFactory,
-              let features = features else { return }
+              let features = features else {
+            engagementRestorationState = .restored
+            return
+        }
 
         // Waits for while for establishing socket connection, connection to channels, and
         // receive necessary information about engagement.
@@ -220,6 +224,7 @@ extension Glia {
             } else {
                 self?.closeRootCoordinator()
             }
+            self?.engagementRestorationState = .restored
         }
     }
 

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -231,6 +231,18 @@ extension CoreSdkClient {
 
 extension CoreSdkClient {
     struct PushNotifications {
+        struct Actions {
+            var setSecureMessageAction: (@escaping () -> Void) -> Void
+            var secureMessageAction: () -> (() -> Void)?
+
+            init(
+                setSecureMessageAction: @escaping (@escaping () -> Void) -> Void,
+                secureMessageAction: @escaping () -> (() -> Void)?
+            ) {
+                self.setSecureMessageAction = setSecureMessageAction
+                self.secureMessageAction = secureMessageAction
+            }
+        }
         var applicationDidRegisterForRemoteNotificationsWithDeviceToken: (
             _ application: UIApplication,
             _ deviceToken: Data
@@ -242,6 +254,7 @@ extension CoreSdkClient {
         var setPushHandler: (PushHandler?) -> Void
         var pushHandler: () -> PushHandler?
         var subscribeTo: ([GliaCoreSDK.PushNotificationsType]) -> Void
+        var actions: Actions
     }
 }
 

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
@@ -105,7 +105,11 @@ extension CoreSdkClient.PushNotifications {
         },
         setPushHandler: { GliaCore.sharedInstance.pushNotifications.handler = $0 },
         pushHandler: { GliaCore.sharedInstance.pushNotifications.handler },
-        subscribeTo: GliaCore.sharedInstance.pushNotifications.subscribeTo(_:)
+        subscribeTo: GliaCore.sharedInstance.pushNotifications.subscribeTo(_:),
+        actions: .init(
+            setSecureMessageAction: { GliaCore.sharedInstance.pushNotificationsActionProcessor.secureMessagePushNotificationAction = $0 },
+            secureMessageAction: { GliaCore.sharedInstance.pushNotificationsActionProcessor.secureMessagePushNotificationAction }
+        )
     )
 }
 

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -63,13 +63,21 @@ extension CoreSdkClient.LiveObservation {
     )
 }
 
+extension CoreSdkClient.PushNotifications.Actions {
+    static let mock = Self(
+        setSecureMessageAction: { _ in },
+        secureMessageAction: { nil }
+    )
+}
+
 extension CoreSdkClient.PushNotifications {
     static let mock = Self(
         applicationDidRegisterForRemoteNotificationsWithDeviceToken: { _, _ in },
         applicationDidFailToRegisterForRemoteNotificationsWithError: { _, _ in },
         setPushHandler: { _ in },
         pushHandler: { nil },
-        subscribeTo: { _ in }
+        subscribeTo: { _ in },
+        actions: .mock
     )
 }
 

--- a/GliaWidgets/Sources/EngagementLauncher/EngagementLauncher.swift
+++ b/GliaWidgets/Sources/EngagementLauncher/EngagementLauncher.swift
@@ -47,3 +47,9 @@ public final class EngagementLauncher {
         try startEngagement(.messaging(.welcome), sceneProvider)
     }
 }
+
+extension EngagementLauncher {
+    func startSecureMessaging(initialScreen: SecureConversations.InitialScreen, sceneProvider: SceneProvider? = nil) throws {
+        try startEngagement(.messaging(initialScreen), sceneProvider)
+    }
+}

--- a/GliaWidgets/Sources/Presenter/GliaPresenter.swift
+++ b/GliaWidgets/Sources/Presenter/GliaPresenter.swift
@@ -65,7 +65,14 @@ final class GliaPresenter {
                 """
             )
         }
-
+        if viewController === presentingController {
+            environment.log.warning(
+                """
+                Attempt to present the same instance of \(presentingController.self).
+                """
+            )
+            return
+        }
         presentingController.present(
             viewController,
             animated: animated,

--- a/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
@@ -132,7 +132,11 @@ extension CoreSdkClient.PushNotifications {
         },
         subscribeTo: { _ in
             fail("\(Self.self).subscribeTo")
-        }
+        },
+        actions: .init(
+            setSecureMessageAction: { _ in },
+            secureMessageAction: { return nil }
+        )
     )
 }
 

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+PushNotifcationsAction.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+PushNotifcationsAction.swift
@@ -1,0 +1,91 @@
+@testable import GliaWidgets
+@_spi(GliaWidgets) import GliaCoreSDK
+import XCTest
+
+extension GliaTests {
+    func test_startSecureMessageWhenSecureMessagePushReceivedBeforeConfigure() throws {
+        let sdk = makeConfigurableSDK()
+
+        sdk.environment.coreSdk.pushNotifications.actions.secureMessageAction()?()
+
+        try sdk.configure(
+            with: .mock(),
+            theme: .mock()
+        ) { _ in }
+
+        sdk.engagementRestorationState = .restored
+
+        XCTAssertEqual(sdk.engagement, .messaging(.chatTranscript))
+    }
+
+    func test_startSecureMessageWhenSecureMessagePushReceivedAfterConfigure() throws {
+        let sdk = makeConfigurableSDK()
+
+        try sdk.configure(
+            with: .mock(),
+            theme: .mock()
+        ) { _ in }
+
+        sdk.engagementRestorationState = .restored
+
+        sdk.environment.coreSdk.pushNotifications.actions.secureMessageAction()?()
+
+        XCTAssertEqual(sdk.engagement, .messaging(.chatTranscript))
+    }
+
+    func test_startSecureMessageWhenSecureMessagePushReceivedForUnauthenticatedUser() throws {
+        let sdk = makeConfigurableSDK(isAuthenticated: false)
+
+        try sdk.configure(
+            with: .mock(),
+            theme: .mock()
+        ) { _ in }
+
+        sdk.engagementRestorationState = .restored
+
+        sdk.environment.coreSdk.pushNotifications.actions.secureMessageAction()?()
+
+        XCTAssertEqual(sdk.engagement, .none)
+    }
+}
+
+private extension GliaTests {
+    func makeConfigurableSDK(isAuthenticated: Bool = true) -> Glia {
+        var sdkEnv = Glia.Environment.mock
+        sdkEnv.coreSDKConfigurator.configureWithInteractor = { _ in }
+        sdkEnv.coreSdk.localeProvider = .mock
+        
+        var mockSCMessagePushAction: (() -> Void)?
+        sdkEnv.coreSdk.pushNotifications.actions = .init(
+            setSecureMessageAction: { mockSCMessagePushAction = $0 },
+            secureMessageAction: { mockSCMessagePushAction }
+        )
+        sdkEnv.createRootCoordinator = { _, _, _, engagementLaunching, _, _, _ in
+                .mock(
+                    engagementLaunching: engagementLaunching,
+                    environment: .engagementCoordEnvironmentWithKeyWindow
+                )
+        }
+        sdkEnv.print.printClosure = { _, _, _ in }
+        var logger = CoreSdkClient.Logger.failing
+        logger.configureLocalLogLevelClosure = { _ in }
+        logger.configureRemoteLogLevelClosure = { _ in }
+        logger.prefixedClosure = { _ in logger }
+        logger.infoClosure = { _, _, _, _ in }
+        sdkEnv.coreSdk.createLogger = { _ in logger }
+        sdkEnv.conditionalCompilation.isDebug = { true }
+        sdkEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
+            completion(.success(()))
+        }
+        sdkEnv.isAuthenticated = { isAuthenticated }
+        sdkEnv.coreSdk.getCurrentEngagement = { nil }
+        sdkEnv.coreSdk.secureConversations.observePendingStatus = { _ in nil }
+        let window = UIWindow(frame: .zero)
+        window.rootViewController = UIViewController()
+        window.makeKeyAndVisible()
+        sdkEnv.uiApplication.windows = { [window] }
+        let sdk = Glia(environment: sdkEnv)
+        sdk.queuesMonitor = .mock()
+        return sdk
+    }
+}

--- a/TestingApp/AppDelegate.swift
+++ b/TestingApp/AppDelegate.swift
@@ -12,7 +12,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return .init(window: window, handlers: deepLinksHandlers)
     }()
 
-
     func applicationDidFinishLaunching(_ application: UIApplication) {
         handleProcessInfo()
         handleSetAnimationsEnabled()


### PR DESCRIPTION
**What was solved?**
Show chat transcript upon receiving SC message push

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [X] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.
