### PR TITLE
Configuration.isWhiteLabelApp property not working

### DIFF
--- a/GliaWidgets/Public/Configuration/Configuration.swift
+++ b/GliaWidgets/Public/Configuration/Configuration.swift
@@ -19,6 +19,7 @@ public struct Configuration {
     public var pushNotifications: PushNotifications
 
     /// Controls the visibility of the "Powered by" text and image.
+    @available(*, deprecated, message: "Replaced by RemoteConfiguration.isWhiteLabelApp")
     public let isWhiteLabelApp: Bool
 
     /// Company name. Appears during connection with operator.

--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -248,9 +248,14 @@ public class Glia {
             throw GliaError.configuringDuringEngagementIsNotAllowed
         }
 
+        if configuration.isWhiteLabelApp {
+            theme.showsPoweredBy = false
+        }
+
         if let uiConfig {
             theme.apply(configuration: uiConfig, assetsBuilder: assetsBuilder)
         }
+
         self.theme = theme
         self.assetsBuilder = assetsBuilder
         // We need to store features to be used for restored engagement

--- a/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration.swift
+++ b/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration.swift
@@ -13,6 +13,7 @@ public struct RemoteConfiguration: Codable {
     let snackBar: SnackBar?
     let webBrowserScreen: WebView?
     let entryWidget: EntryWidget?
+    let isWhiteLabelApp: Bool?
 }
 
 extension RemoteConfiguration {

--- a/GliaWidgets/Sources/Theme/Theme.RemoteConfig.swift
+++ b/GliaWidgets/Sources/Theme/Theme.RemoteConfig.swift
@@ -57,5 +57,8 @@ extension Theme {
             configuration: configuration.entryWidget,
             assetsBuilder: assetsBuilder
         )
+        if configuration.isWhiteLabelApp ?? false {
+            showsPoweredBy = false
+        }
     }
 }

--- a/GliaWidgets/Sources/Theme/Theme.swift
+++ b/GliaWidgets/Sources/Theme/Theme.swift
@@ -59,6 +59,7 @@ public class Theme {
     public lazy var secureConversationsConfirmation: SecureConversations.ConfirmationStyle = defaultSecureConversationsConfirmationStyle
 
     /// Controls the visibility of the "Powered by" text and image.
+    @available(*, deprecated, message: "Replaced by RemoteConfiguration.isWhiteLabelApp")
     public var showsPoweredBy: Bool
 
     /// Snack bar View style.

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -656,7 +656,8 @@ final class GliaTests: XCTestCase {
             secureMessagingConfirmationScreen: nil,
             snackBar: nil,
             webBrowserScreen: nil,
-            entryWidget: nil
+            entryWidget: nil,
+            isWhiteLabelApp: nil
         )
 
         let theme = Theme(colorStyle: .custom(themeColor))

--- a/TestingApp/Extensions/Configuration.Extensions.swift
+++ b/TestingApp/Extensions/Configuration.Extensions.swift
@@ -64,6 +64,7 @@ extension Configuration: Codable {
              site,
              visitorContext,
              pushNotifications,
+             isWhiteLabelApp,
              manualLocaleOverride
     }
 
@@ -75,6 +76,7 @@ extension Configuration: Codable {
             site: container.decode(String.self, forKey: .site),
             visitorContext: container.decodeIfPresent(VisitorContext.self, forKey: .visitorContext),
             pushNotifications: container.decodeIfPresent(PushNotifications.self, forKey: .pushNotifications) ?? .disabled,
+            isWhiteLabelApp: container.decodeIfPresent(Bool.self, forKey: .isWhiteLabelApp) ?? false,
             manualLocaleOverride: container.decodeIfPresent(String.self, forKey: .manualLocaleOverride) ?? nil
         )
     }
@@ -86,6 +88,7 @@ extension Configuration: Codable {
         try container.encode(site, forKey: .site)
         try container.encode(visitorContext, forKey: .visitorContext)
         try container.encode(pushNotifications, forKey: .pushNotifications)
+        try container.encode(isWhiteLabelApp, forKey: .isWhiteLabelApp)
         try container.encode(manualLocaleOverride, forKey: .manualLocaleOverride)
     }
 }

--- a/TestingApp/Settings/SettingsViewController.swift
+++ b/TestingApp/Settings/SettingsViewController.swift
@@ -15,6 +15,7 @@ final class SettingsViewController: UIViewController {
     private var queueIDCell: SettingsTextCell!
     private var environmentCell: EnvironmentSettingsTextCell!
     private var visitorContextAssedIdCell: SettingsTextCell!
+    private var isWhiteLabelAppCell: SettingsSwitchCell!
     private var manualLocaleOverrideCell: SettingsTextCell!
     private var bubbleFeatureCell: SettingsSwitchCell!
     private var primaryColorCell: SettingsColorCell!
@@ -158,7 +159,12 @@ private extension SettingsViewController {
             text: props.config.manualLocaleOverride ?? ""
         )
         manualLocaleOverrideCell.textField.accessibilityIdentifier = "settings_manual_locale_override_textfield"
-
+    
+        isWhiteLabelAppCell = SettingsSwitchCell(
+            title: "Is white label App",
+            isOn: props.config.isWhiteLabelApp
+        )
+        
         bubbleFeatureCell = SettingsSwitchCell(
             title: "Present \"Bubble\" overlay in engagement time",
             isOn: props.features ~= .bubbleView
@@ -281,7 +287,8 @@ private extension SettingsViewController {
             siteApiKeySecretCell,
             queueIDCell,
             visitorContextAssedIdCell,
-            manualLocaleOverrideCell
+            manualLocaleOverrideCell,
+            isWhiteLabelAppCell
         ]
         configurationSection = Section(
             title: "Glia configuration",
@@ -293,8 +300,10 @@ private extension SettingsViewController {
     private func updateConfiguration() {
         let uuid = UUID(uuidString: visitorContextAssedIdCell.textField.text ?? "")
 
-        let manualLocaleOverrideText =  manualLocaleOverrideCell.textField.text ?? ""
+        let manualLocaleOverrideText = manualLocaleOverrideCell.textField.text ?? ""
         let manualLocaleOverride = manualLocaleOverrideText.isEmpty ? nil : manualLocaleOverrideText
+        
+        let isWhiteLabelApp = isWhiteLabelAppCell.switcher.isOn
 
         props.changeConfig(
             Configuration(
@@ -302,6 +311,7 @@ private extension SettingsViewController {
                 environment: environmentCell.environment,
                 site: siteCell.textField.text ?? "",
                 visitorContext: uuid.map { Configuration.VisitorContext(assetId: $0) },
+                isWhiteLabelApp: isWhiteLabelApp,
                 manualLocaleOverride: manualLocaleOverride
             )
         )


### PR DESCRIPTION
**What was solved?**

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.
 
 **NOTE**: Modifying this value after the SDK has been configured will have no effect, as the views are retained in memory with the previous configuration. I don't believe there's a valid use case for this workflow, so I haven't made any changes to address it.
