### PR TITLE
Disable production push environment for Testing app

### DIFF
--- a/TestingApp/ViewController/ViewController+Configure.swift
+++ b/TestingApp/ViewController/ViewController+Configure.swift
@@ -51,7 +51,7 @@ extension ViewController {
         #if DEBUG
         let pushNotifications = Configuration.PushNotifications.sandbox
         #else
-        let pushNotifications = Configuration.PushNotifications.production
+        let pushNotifications = Configuration.PushNotifications.disabled
         #endif
         configuration.pushNotifications = pushNotifications
 


### PR DESCRIPTION
## What was solved?
This PR reverts https://github.com/salemove/ios-sdk-widgets/pull/1276 as it breaks acceptance tests. This changes will be merged back after adopting acceptance tests.

### Release notes

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

### Additional info

 - [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to [**Logging from iOS SDKs** → **Things to consider for newly added logs**](https://glia.atlassian.net/wiki/spaces/ENG/pages/3589734507/Logging+from+iOS+SDKs#Things-to-consider-for-newly-added-logs) in Confluence for more information.
