### PR TITLE
IsWhiteLabel not working

### DIFF
--- a/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration.swift
+++ b/GliaWidgets/Sources/RemoteConfiguration/RemoteConfiguration.swift
@@ -13,7 +13,7 @@ public struct RemoteConfiguration: Codable {
     let snackBar: SnackBar?
     let webBrowserScreen: WebView?
     let entryWidget: EntryWidget?
-    let isWhiteLabelApp: Bool?
+    let isWhiteLabel: Bool?
 }
 
 extension RemoteConfiguration {

--- a/GliaWidgets/Sources/Theme/Theme.RemoteConfig.swift
+++ b/GliaWidgets/Sources/Theme/Theme.RemoteConfig.swift
@@ -57,7 +57,7 @@ extension Theme {
             configuration: configuration.entryWidget,
             assetsBuilder: assetsBuilder
         )
-        if configuration.isWhiteLabelApp ?? false {
+        if configuration.isWhiteLabel ?? false {
             showsPoweredBy = false
         }
     }

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -657,7 +657,7 @@ final class GliaTests: XCTestCase {
             snackBar: nil,
             webBrowserScreen: nil,
             entryWidget: nil,
-            isWhiteLabelApp: nil
+            isWhiteLabel: nil
         )
 
         let theme = Theme(colorStyle: .custom(themeColor))


### PR DESCRIPTION
**What was solved?**

Renamed the RemoteConfig.isWhiteLabelApp property to  whiteLabel as discussed [here](https://github.com/salemove/mobile-sdk-unified/pull/42).

**Release notes:**

 - [] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
