### PR TITLE
Create Queue object in WidgetSDK

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -211,9 +211,9 @@
 		3100EEFD293F757E00D57F71 /* SecureConversations.WelcomeStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3100EEFC293F757E00D57F71 /* SecureConversations.WelcomeStyle.swift */; };
 		3100EEFF293F7E0900D57F71 /* Theme+SecureConversationsWelcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3100EEFE293F7E0900D57F71 /* Theme+SecureConversationsWelcome.swift */; };
 		3115D45C29A4FD3F00D99561 /* SecureConversations.Availability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3115D45B29A4FD3F00D99561 /* SecureConversations.Availability.swift */; };
-		3115EFBA2BC960B500B24D5A /* (null) in Sources */ = {isa = PBXBuildFile; };
-		3117EBA22B9B041100F520D8 /* (null) in Sources */ = {isa = PBXBuildFile; };
-		3117EBA42B9B426200F520D8 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		3115EFBA2BC960B500B24D5A /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		3117EBA22B9B041100F520D8 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		3117EBA42B9B426200F520D8 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		311C03352B5588C0002E4FF8 /* SecureConversations.CoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311C03342B5588C0002E4FF8 /* SecureConversations.CoordinatorTests.swift */; };
 		311CAFCD29F8FAE20067B59F /* SecureConversations.TranscriptModel.CustomCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311CAFCC29F8FAE20067B59F /* SecureConversations.TranscriptModel.CustomCard.swift */; };
 		313EBD552943116E008E9597 /* SecureConversations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 313EBD542943116E008E9597 /* SecureConversations.swift */; };
@@ -716,6 +716,10 @@
 		AFF9542A2ADD8DB600C277E0 /* CoreSDKConfigurator.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF954292ADD8DB600C277E0 /* CoreSDKConfigurator.Mock.swift */; };
 		AFF9542C2ADDA10600C277E0 /* CoreSDKConfigurator.Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF9542B2ADDA10600C277E0 /* CoreSDKConfigurator.Failing.swift */; };
 		AFFA99822C57D658004A2825 /* GliaTests+RestoreEngagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFFA99812C57D658004A2825 /* GliaTests+RestoreEngagement.swift */; };
+		C0029A592DC8DD7300603586 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0029A582DC8DD6D00603586 /* Queue.swift */; };
+		C0029A5B2DC8E28F00603586 /* QueueState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0029A5A2DC8E28B00603586 /* QueueState.swift */; };
+		C0029A5D2DC8E2F500603586 /* QueueStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0029A5C2DC8E2F000603586 /* QueueStatus.swift */; };
+		C0029A5F2DC8E31E00603586 /* MediaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0029A5E2DC8E31700603586 /* MediaType.swift */; };
 		C004A98D2D772AD100750E3C /* SecureMessagingTopBannerView.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C004A98C2D772ABC00750E3C /* SecureMessagingTopBannerView.Environment.swift */; };
 		C00DE0AB2CD3847B005956B4 /* EntryWidgetViewLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00DE0AA2CD3847B005956B4 /* EntryWidgetViewLayoutTests.swift */; };
 		C00DE0AD2CD3BD53005956B4 /* EntryWidgetViewVoiceOverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00DE0AC2CD3BD53005956B4 /* EntryWidgetViewVoiceOverTests.swift */; };
@@ -1812,6 +1816,10 @@
 		AFF9542B2ADDA10600C277E0 /* CoreSDKConfigurator.Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSDKConfigurator.Failing.swift; sourceTree = "<group>"; };
 		AFFA99812C57D658004A2825 /* GliaTests+RestoreEngagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GliaTests+RestoreEngagement.swift"; sourceTree = "<group>"; };
 		B97A8A0B9AD30D0AB8666042 /* Pods_GliaWidgetsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GliaWidgetsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C0029A582DC8DD6D00603586 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
+		C0029A5A2DC8E28B00603586 /* QueueState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueState.swift; sourceTree = "<group>"; };
+		C0029A5C2DC8E2F000603586 /* QueueStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueStatus.swift; sourceTree = "<group>"; };
+		C0029A5E2DC8E31700603586 /* MediaType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaType.swift; sourceTree = "<group>"; };
 		C004A98C2D772ABC00750E3C /* SecureMessagingTopBannerView.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureMessagingTopBannerView.Environment.swift; sourceTree = "<group>"; };
 		C00DE0AA2CD3847B005956B4 /* EntryWidgetViewLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryWidgetViewLayoutTests.swift; sourceTree = "<group>"; };
 		C00DE0AC2CD3BD53005956B4 /* EntryWidgetViewVoiceOverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryWidgetViewVoiceOverTests.swift; sourceTree = "<group>"; };
@@ -3448,10 +3456,14 @@
 		2198B7AA2CAEB13E002C442B /* QueuesMonitor */ = {
 			isa = PBXGroup;
 			children = (
+				C0029A5E2DC8E31700603586 /* MediaType.swift */,
+				C0029A582DC8DD6D00603586 /* Queue.swift */,
+				2198B7AD2CB035A6002C442B /* QueuesMonitor.Environment.swift */,
+				210150752CC140A600294BA4 /* QueuesMonitor.Environment.Mock.swift */,
 				2198B7AB2CAEB14D002C442B /* QueuesMonitor.Live.swift */,
 				2100B47D2CB6A37A00AC7527 /* QueuesMonitor.Mock.swift */,
-				210150752CC140A600294BA4 /* QueuesMonitor.Environment.Mock.swift */,
-				2198B7AD2CB035A6002C442B /* QueuesMonitor.Environment.swift */,
+				C0029A5A2DC8E28B00603586 /* QueueState.swift */,
+				C0029A5C2DC8E2F000603586 /* QueueStatus.swift */,
 			);
 			path = QueuesMonitor;
 			sourceTree = "<group>";
@@ -5942,6 +5954,7 @@
 				C09046E42B7E0DB5003C437C /* HeaderButtonStyle.RemoteConfig.swift in Sources */,
 				C090471B2B7E1A94003C437C /* GvaGalleryCardStyle.RemoteConfig.swift in Sources */,
 				1AE15E38257A578B00A642C0 /* MessageAlertConfiguration.swift in Sources */,
+				C0029A5D2DC8E2F500603586 /* QueueStatus.swift in Sources */,
 				C0D6CA472C19B35B00D4709B /* BubbleWindow.Environment.swift in Sources */,
 				C0175A132A56E29E001FACDE /* ChatMessageCardType.swift in Sources */,
 				AF7753122B19EC3200E523A2 /* Logger.Live.swift in Sources */,
@@ -5953,6 +5966,7 @@
 				8491AF0A2A78FED700CC3E72 /* GvaGalleryListViewStyle.swift in Sources */,
 				845E2F9D283FCB1400C04D56 /* Theme.Survey.Checkbox.Accessibility.swift in Sources */,
 				C0D6CA0D2C1848E700D4709B /* GliaViewController.Environment.swift in Sources */,
+				C0029A592DC8DD7300603586 /* Queue.swift in Sources */,
 				C090477A2B7E27AC003C437C /* AlertStyle.RemoteConfig.swift in Sources */,
 				752A833C2AF59EDB005E468D /* SnackBar+View.swift in Sources */,
 				C0D2F0542993CCD100803B47 /* VideoCallView.CallButtonBar.swift in Sources */,
@@ -6515,6 +6529,7 @@
 				C090470D2B7E16F1003C437C /* Theme.Layer.RemoteConfig.swift in Sources */,
 				1A60AFCA2566943F00E53F53 /* EngagementCoordinator.swift in Sources */,
 				1ABD6C9225B6F2D200D56EFA /* String+TemplateString.swift in Sources */,
+				C0029A5B2DC8E28F00603586 /* QueueState.swift in Sources */,
 				C09046EE2B7E0F70003C437C /* Theme.OperatorChatMessageStyle.Accessibility.swift in Sources */,
 				2100B4802CB6B5A400AC7527 /* LockIsolated.swift in Sources */,
 				84265E61298D7B2900D65842 /* ScreenSharingCoordinator.swift in Sources */,
@@ -6695,6 +6710,7 @@
 				AF552ED72BECDCDF00FD5653 /* UIButton+Extensions.swift in Sources */,
 				9A3E1D9B27B73246005634EB /* FoundationBased.Mock.swift in Sources */,
 				C0D6CA572C19BDCD00D4709B /* QuickLookViewModel.Environment.swift in Sources */,
+				C0029A5F2DC8E31E00603586 /* MediaType.swift in Sources */,
 				75FF151427F3A2D600FE7BE2 /* Theme.Survey.swift in Sources */,
 				C0D6CA272C18743E00D4709B /* CallDurationCounter.Environment.swift in Sources */,
 				84681AA32A66D90000DD7406 /* AdjustedTouchAreaButton.swift in Sources */,
@@ -6769,7 +6785,7 @@
 				8492F9192CAD329800242691 /* TranscriptModelTests+MessageRetry.swift in Sources */,
 				8491AF602AA1EBB600CC3E72 /* TranscriptModelTests+URLs.swift in Sources */,
 				9A8130C427D9099F00220BBD /* FileDownload.Environment.Failing.swift in Sources */,
-				3117EBA22B9B041100F520D8 /* (null) in Sources */,
+				3117EBA22B9B041100F520D8 /* BuildFile in Sources */,
 				31CCE3E52BCE8F3A00F92535 /* CallVisualizer.Coordinator.Environment.Mock.swift in Sources */,
 				31CCE3E72BCE8F3A00F92535 /* VisitorCodeCoordinatorTests.swift in Sources */,
 				AF29811029E06E830005BD55 /* Availability.Environment.Failing.swift in Sources */,
@@ -6795,7 +6811,7 @@
 				EB9ADB552828E66B00FAE8A4 /* CallTests.swift in Sources */,
 				AF9DB22E2890571A00A0C442 /* RootCoordinator.Environment.Failing.swift in Sources */,
 				AF9DB23128905A1D00A0C442 /* ViewFactory.Environment.Failing.swift in Sources */,
-				3117EBA42B9B426200F520D8 /* (null) in Sources */,
+				3117EBA42B9B426200F520D8 /* BuildFile in Sources */,
 				848570512BEE3CCC00CEBCC5 /* ChatStyle.Mock.swift in Sources */,
 				9A3E1DA027BA7B9F005634EB /* FileSystemStorageTests.swift in Sources */,
 				EB9ADB5A2829089F00FAE8A4 /* ChatItem+Equatable.swift in Sources */,
@@ -6826,7 +6842,7 @@
 				2100B4842CB8143400AC7527 /* QueuesMonitor.Failing.swift in Sources */,
 				3146C9432AB1851C0047D8CC /* LocalizationTests.swift in Sources */,
 				8492F9172CAD2F2000242691 /* TranscriptModelTests+ResponseCard.swift in Sources */,
-				3115EFBA2BC960B500B24D5A /* (null) in Sources */,
+				3115EFBA2BC960B500B24D5A /* BuildFile in Sources */,
 				31CCE3E62BCE8F3A00F92535 /* ScreenSharingCoordinatorTests.swift in Sources */,
 				846A5C3929D18D400049B29F /* ScreenShareHandlerTests.swift in Sources */,
 				216D310B2CF790980019CA9E /* EntryWidget.Mock.swift in Sources */,

--- a/GliaWidgets/Public/Glia/Glia.Deprecated.swift
+++ b/GliaWidgets/Public/Glia/Glia.Deprecated.swift
@@ -1,3 +1,4 @@
+import Foundation
 import GliaCoreSDK
 
 extension Glia {

--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -504,18 +504,13 @@ public class Glia {
             return
         }
 
-        environment.coreSdk.getQueues { queues, error in
-            if let error {
-                completion(.failure(error))
-                return
-            }
-
-            if let queues {
+        environment.coreSdk.getQueues { result in
+            switch result {
+            case let .success(queues):
                 completion(.success(queues))
-                return
+            case let .failure(error):
+                completion(.failure(error))
             }
-
-            completion(.failure(GliaError.internalError))
         }
     }
 

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.Environment.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.Environment.swift
@@ -16,7 +16,7 @@ extension SecureConversations.TranscriptModel {
         var fetchChatHistory: CoreSdkClient.FetchChatHistory
         var uiApplication: UIKitBased.UIApplication
         var queueIds: [String]
-        var getQueues: CoreSdkClient.ListQueues
+        var getQueues: CoreSdkClient.GetQueues
         var createFileUploadListModel: SecureConversations.FileUploadListViewModel.Create
         var uuid: () -> UUID
         var fileUploadListStyle: FileUploadListStyle
@@ -103,7 +103,7 @@ extension SecureConversations.TranscriptModel.Environment {
         fetchChatHistory: @escaping CoreSdkClient.FetchChatHistory = { _ in },
         uiApplication: UIKitBased.UIApplication = .mock,
         queueIds: [String] = [],
-        getQueues: @escaping CoreSdkClient.ListQueues = { _ in },
+        getQueues: @escaping CoreSdkClient.GetQueues = { _ in },
         createFileUploadListModel: @escaping SecureConversations.FileUploadListViewModel.Create = { _ in .mock() },
         uuid: @escaping () -> UUID = { .mock },
         fileUploadListStyle: FileUploadListStyle = .mock,

--- a/GliaWidgets/SecureConversations/SecureConversations.Availability.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Availability.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension SecureConversations {
     struct Availability {
-        typealias CompletionResult = (Result<Status, CoreSdkClient.SalemoveError>) -> Void
+        typealias CompletionResult = (Result<Status, Error>) -> Void
 
         var environment: Environment
 
@@ -28,8 +28,8 @@ extension SecureConversations {
         }
 
         private func checkQueues(
-            fetchedQueues: [CoreSdkClient.Queue],
-            completion: (Result<Status, CoreSdkClient.SalemoveError>) -> Void
+            fetchedQueues: [Queue],
+            completion: (Result<Status, Error>) -> Void
         ) {
             guard environment.isAuthenticated() else {
                 environment.log.warning("Secure Messaging is unavailable because the visitor is not authenticated.")
@@ -59,10 +59,10 @@ extension SecureConversations {
             completion(.success(.available(.queues(queueIds: queueIds))))
         }
 
-        private var defaultPredicate: (CoreSdkClient.Queue) -> Bool {
+        private var defaultPredicate: (Queue) -> Bool {
             {
                 $0.state.status != .closed &&
-                $0.state.media.contains(CoreSdkClient.MediaType.messaging)
+                $0.state.media.contains(MediaType.messaging)
             }
         }
     }
@@ -70,7 +70,7 @@ extension SecureConversations {
 
 extension SecureConversations.Availability {
     struct Environment {
-        var getQueues: CoreSdkClient.ListQueues
+        var getQueues: CoreSdkClient.GetQueues
         var isAuthenticated: () -> Bool
         var log: CoreSdkClient.Logger
         var queuesMonitor: QueuesMonitor
@@ -149,7 +149,7 @@ extension SecureConversations.Availability {
 
 extension SecureConversations.Availability.Environment {
     static func mock(
-        listQueues: @escaping CoreSdkClient.ListQueues = { _ in },
+        listQueues: @escaping CoreSdkClient.GetQueues = { _ in },
         isAuthenticated: @escaping () -> Bool = { false },
         log: CoreSdkClient.Logger = .mock,
         queuesMonitor: QueuesMonitor = .mock(),

--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.Environment.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.Environment.swift
@@ -4,7 +4,7 @@ extension SecureConversations.Coordinator {
     struct Environment {
         var secureConversations: CoreSdkClient.SecureConversations
         var queueIds: [String]
-        var listQueues: CoreSdkClient.ListQueues
+        var listQueues: CoreSdkClient.GetQueues
         var createFileUploader: FileUploader.Create
         var fileManager: FoundationBased.FileManager
         var data: FoundationBased.Data

--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.Environment.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.Environment.swift
@@ -5,7 +5,7 @@ extension SecureConversations.WelcomeViewModel {
         var secureConversations: CoreSdkClient.SecureConversations
         var welcomeStyle: SecureConversations.WelcomeStyle
         var queueIds: [String]
-        var listQueues: CoreSdkClient.ListQueues
+        var listQueues: CoreSdkClient.GetQueues
         var fileUploader: FileUploader
         var uiApplication: UIKitBased.UIApplication
         var createFileUploadListModel: SecureConversations.FileUploadListViewModel.Create

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.Environment.swift
@@ -22,7 +22,7 @@ extension ChatCoordinator {
         var fetchChatHistory: CoreSdkClient.FetchChatHistory
         var createFileUploadListModel: SecureConversations.FileUploadListViewModel.Create
         var queueIds: [String]
-        var listQueues: CoreSdkClient.ListQueues
+        var listQueues: CoreSdkClient.GetQueues
         var messagesWithUnreadCountLoaderScheduler: CoreSdkClient.ReactiveSwift.DateScheduler
         var isAuthenticated: () -> Bool
         var interactor: Interactor

--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.Environment.swift
@@ -23,7 +23,7 @@ extension EngagementCoordinator {
         var uiScreen: UIKitBased.UIScreen
         var notificationCenter: FoundationBased.NotificationCenter
         var fetchChatHistory: CoreSdkClient.FetchChatHistory
-        var listQueues: CoreSdkClient.ListQueues
+        var listQueues: CoreSdkClient.GetQueues
         var createFileUploader: FileUploader.Create
         var createFileUploadListModel: SecureConversations.FileUploadListViewModel.Create
         var messagesWithUnreadCountLoaderScheduler: CoreSdkClient.ReactiveSwift.DateScheduler

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -32,11 +32,11 @@ struct CoreSdkClient {
 
     var configureWithInteractor: ConfigureWithInteractor
 
-    typealias ListQueues = (
-        _ completion: @escaping Self.QueueRequestBlock
+    typealias GetQueues = (
+        _ completion: @escaping (Result<[Queue], Error>) -> Void
     ) -> Void
 
-    var getQueues: ListQueues
+    var getQueues: GetQueues
 
     typealias QueueForEngagement = (
         _ options: GliaCoreSDK.QueueForEngagementOptions,
@@ -152,7 +152,7 @@ struct CoreSdkClient {
 
     typealias SubscribeForQueuesUpdates = (
         _ queueIds: [String],
-        _ completion: @escaping (Result<GliaCoreSDK.Queue, GliaCoreSDK.GliaCoreError>) -> Void
+        _ completion: @escaping (Result<Queue, Error>) -> Void
     ) -> String?
 
     var subscribeForQueuesUpdates: SubscribeForQueuesUpdates
@@ -319,7 +319,6 @@ extension CoreSdkClient {
     typealias OperatorBlock = GliaCoreSDK.OperatorBlock
     typealias OperatorTypingStatus = GliaCoreSDK.OperatorTypingStatus
     typealias OperatorTypingStatusUpdate = GliaCoreSDK.OperatorTypingStatusUpdate
-    typealias Queue = GliaCoreSDK.Queue
     typealias QueueError = GliaCoreSDK.QueueError
     typealias QueueState = GliaCoreSDK.QueueState
     typealias QueueStatus = GliaCoreSDK.QueueStatus

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -492,7 +492,7 @@ extension CoreSdkClient.Site {
     }
 }
 
-extension CoreSdkClient.Queue {
+extension Queue {
     static func mock(
         id: String = "",
         name: String = "",
@@ -500,13 +500,12 @@ extension CoreSdkClient.Queue {
         isDefault: Bool = false,
         media: [MediaType] = [],
         lastUpdated: Date = Date()
-    ) -> CoreSdkClient.Queue {
-        CoreSdkClient.Queue(
+    ) -> Queue {
+        Queue(
             id: id,
             name: name,
-            status: status,
+            state: .init(status: status, media: media),
             isDefault: isDefault,
-            media: media,
             lastUpdated: lastUpdated
         )
     }

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.MediaTypeItem.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.MediaTypeItem.swift
@@ -1,4 +1,3 @@
-import GliaCoreSDK
 import SwiftUI
 
 extension EntryWidget {

--- a/GliaWidgets/Sources/QueuesMonitor/MediaType.swift
+++ b/GliaWidgets/Sources/QueuesMonitor/MediaType.swift
@@ -1,0 +1,41 @@
+import Foundation
+import GliaCoreSDK
+
+public enum MediaType: String, Decodable {
+    /// Audio stream
+    case audio
+
+    /// Video stream
+    case video
+
+    /// Text messages
+    case text
+
+    /// Asynchronous messages
+    case messaging
+
+    /// Phone call
+    case phone
+
+    /// Current SDK version unsupported media type
+    case unknown
+
+    public init(mediaType: GliaCoreSDK.MediaType) {
+        switch mediaType {
+        case .audio:
+            self = .audio
+        case .video:
+            self = .video
+        case .text:
+            self = .text
+        case .messaging:
+            self = .messaging
+        case .phone:
+            self = .phone
+        case .unknown:
+            self = .unknown
+        @unknown default:
+            self = .unknown
+        }
+    }
+}

--- a/GliaWidgets/Sources/QueuesMonitor/Queue.swift
+++ b/GliaWidgets/Sources/QueuesMonitor/Queue.swift
@@ -1,0 +1,50 @@
+import Foundation
+import GliaCoreSDK
+
+public struct Queue: Equatable {
+    /// Queue identifier
+    public let id: String
+    /// Queue name
+    public let name: String
+    /// Queue state
+    public let state: QueueState
+    /// Indicates that queue is the default. `true` if Queue is default
+    public let isDefault: Bool
+    /// Queue dispatch time
+    public let lastUpdated: Date
+
+    /// Initializes Queue.
+    ///
+    /// - Parameters:
+    ///   - id: Queue identifier.
+    ///   - name: Queue name.
+    ///   - status: Queue status.
+    ///   - isDefault: Indicates that queue is the default.
+    ///   - media: An array of media types for which queuing is enabled.
+    ///   - lastUpdated: Queue dispatch time
+    public init(
+        id: String,
+        name: String,
+        state: QueueState,
+        isDefault: Bool,
+        lastUpdated: Date
+    ) {
+        self.id = id
+        self.name = name
+        self.isDefault = isDefault
+        self.state = state
+        self.lastUpdated = lastUpdated
+    }
+}
+
+extension GliaCoreSDK.Queue {
+    func asWidgetSDKQueue() -> Queue {
+        .init(
+            id: self.id,
+            name: self.name,
+            state: state.asWidgetSDKQueueState(),
+            isDefault: isDefault,
+            lastUpdated: lastUpdated
+        )
+    }
+}

--- a/GliaWidgets/Sources/QueuesMonitor/QueueState.swift
+++ b/GliaWidgets/Sources/QueuesMonitor/QueueState.swift
@@ -1,0 +1,18 @@
+import Foundation
+import GliaCoreSDK
+
+public struct QueueState: Decodable, Equatable {
+    /// Queue status
+    public let status: QueueStatus
+    /// An array of media types for which queuing is enabled
+    public let media: [MediaType]
+}
+
+extension GliaCoreSDK.QueueState {
+    func asWidgetSDKQueueState() -> QueueState {
+        .init(
+            status: .init(coreStatus: status),
+            media: media.map { MediaType(mediaType: $0) }
+        )
+    }
+}

--- a/GliaWidgets/Sources/QueuesMonitor/QueueStatus.swift
+++ b/GliaWidgets/Sources/QueuesMonitor/QueueStatus.swift
@@ -1,0 +1,32 @@
+import Foundation
+import GliaCoreSDK
+
+public enum QueueStatus: Decodable, Equatable, Hashable {
+    /// Visitor can enqueue
+    case open
+    /// Visitor cannot enqueue because the Queue is closed
+    case closed
+    /// Visitor cannot enqueue because the Queue reached its max capacity
+    case full
+    /// Visitor cannot enqueue because the Queue is unstaffed
+    case unstaffed
+    /// Visitor should not enqueue because the Queue state is not supported
+    case unknown(String)
+
+    public init(coreStatus: GliaCoreSDK.QueueStatus) {
+        switch coreStatus {
+        case .open:
+          self = .open
+        case .closed:
+          self = .closed
+        case .full:
+          self = .full
+        case .unstaffed:
+          self = .unstaffed
+        case .unknown(let raw):
+          self = .unknown(raw)
+        @unknown default:
+            self = .unknown(coreStatus.rawValue)
+        }
+      }
+}

--- a/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.Environment.swift
+++ b/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.Environment.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension QueuesMonitor {
     struct Environment {
-        var getQueues: CoreSdkClient.ListQueues
+        var getQueues: CoreSdkClient.GetQueues
         var subscribeForQueuesUpdates: CoreSdkClient.SubscribeForQueuesUpdates
         var unsubscribeFromUpdates: CoreSdkClient.UnsubscribeFromUpdates
         var logger: CoreSdkClient.Logger

--- a/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.Mock.swift
+++ b/GliaWidgets/Sources/QueuesMonitor/QueuesMonitor.Mock.swift
@@ -1,7 +1,7 @@
 #if DEBUG
 extension QueuesMonitor {
     static func mock(
-        getQueues: CoreSdkClient.ListQueues? = nil,
+        getQueues: CoreSdkClient.GetQueues? = nil,
         subscribeForQueuesUpdates: CoreSdkClient.SubscribeForQueuesUpdates? = nil,
         unsubscribeFromUpdates: CoreSdkClient.UnsubscribeFromUpdates? = nil
     ) -> Self {

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+GVA.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+GVA.swift
@@ -121,7 +121,7 @@ extension SecureConversationsTranscriptModelTests {
         var modelEnv = TranscriptModel.Environment.failing
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in .mock() }
-        modelEnv.getQueues = { callback in callback([], nil) }
+        modelEnv.getQueues = { callback in callback(.success([])) }
         modelEnv.uiApplication.canOpenURL = { _ in true }
         modelEnv.maximumUploads = { 2 }
         modelEnv.createEntryWidget = { _ in .mock() }
@@ -194,7 +194,7 @@ private extension SecureConversationsTranscriptModelTests {
         modelEnv.log = logger
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in .mock() }
-        modelEnv.getQueues = { callback in callback([], nil) }
+        modelEnv.getQueues = { callback in callback(.success([])) }
         modelEnv.uiApplication.canOpenURL = { _ in true }
         modelEnv.maximumUploads = { 2 }
         modelEnv.createEntryWidget = { _ in .mock() }

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+MessageRetry.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+MessageRetry.swift
@@ -131,7 +131,7 @@ private extension SecureConversationsTranscriptModelTests {
         modelEnv.log = logger
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in .mock() }
-        modelEnv.getQueues = { callback in callback([], nil) }
+        modelEnv.getQueues = { callback in callback(.success([])) }
         modelEnv.uiApplication.canOpenURL = { _ in true }
         modelEnv.maximumUploads = { 2 }
         modelEnv.secureConversations.sendMessagePayload = { _, _, _ in .mock }

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+ResponseCard.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+ResponseCard.swift
@@ -40,7 +40,7 @@ private extension SecureConversationsTranscriptModelTests {
         modelEnv.log = logger
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in .mock() }
-        modelEnv.getQueues = { callback in callback([], nil) }
+        modelEnv.getQueues = { callback in callback(.success([])) }
         modelEnv.uiApplication.canOpenURL = { _ in true }
         modelEnv.maximumUploads = { 2 }
         modelEnv.createEntryWidget = { _ in .mock() }

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+URLs.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+URLs.swift
@@ -104,7 +104,7 @@ private extension SecureConversationsTranscriptModelTests {
         modelEnv.log = logger
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in .mock() }
-        modelEnv.getQueues = { callback in callback([], nil) }
+        modelEnv.getQueues = { callback in callback(.success([])) }
         modelEnv.maximumUploads = { 2 }
         modelEnv.createEntryWidget = { _ in .mock() }
         let availabilityEnv = SecureConversations.Availability.Environment(

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests.swift
@@ -16,7 +16,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.log = logger
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in .mock() }
-        modelEnv.getQueues = { callback in callback([], nil) }
+        modelEnv.getQueues = { callback in callback(.success([])) }
         modelEnv.maximumUploads = { 2 }
         modelEnv.createEntryWidget = { _ in .mock() }
         let availabilityEnv = SecureConversations.Availability.Environment(
@@ -48,7 +48,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.log = logger
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in .mock() }
-        modelEnv.getQueues = { callback in callback(nil, .mock()) }
+        let mockError = NSError(domain: "", code: 1)
+        modelEnv.getQueues = { callback in callback(.failure(mockError)) }
         modelEnv.maximumUploads = { 2 }
         modelEnv.createEntryWidget = { _ in .mock() }
         let availabilityEnv = SecureConversations.Availability.Environment(
@@ -624,7 +625,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         var availabilityEnv = SecureConversations.Availability.Environment.failing
         availabilityEnv.log = logger
         availabilityEnv.getQueues = { callback in
-            callback([], nil)
+            callback(.success([]))
         }
         availabilityEnv.isAuthenticated = { true }
         availabilityEnv.queuesMonitor = .mock(getQueues: availabilityEnv.getQueues)
@@ -657,7 +658,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         var availabilityEnv = SecureConversations.Availability.Environment.failing
         availabilityEnv.log = logger
         availabilityEnv.getQueues = { callback in
-            callback([.mock()], nil)
+            callback(.success([.mock()]))
         }
         availabilityEnv.isAuthenticated = { false }
         availabilityEnv.queuesMonitor = .mock(getQueues: availabilityEnv.getQueues)
@@ -686,8 +687,9 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         }
         modelEnvironment.createEntryWidget = { _ in .mock() }
         var availabilityEnv = SecureConversations.Availability.Environment.failing
+        let mockError = NSError(domain: "", code: 1)
         availabilityEnv.getQueues = { callback in
-            callback(nil, .mock())
+            callback(.failure(mockError))
         }
         availabilityEnv.isAuthenticated = { false }
         availabilityEnv.queuesMonitor = .mock(getQueues: availabilityEnv.getQueues)
@@ -719,7 +721,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         var availabilityEnv = SecureConversations.Availability.Environment.failing
         availabilityEnv.log = logger
         availabilityEnv.getQueues = { callback in
-            callback([.mock()], nil)
+            callback(.success([.mock()]))
         }
         availabilityEnv.isAuthenticated = { true }
         availabilityEnv.queuesMonitor = .mock(getQueues: availabilityEnv.getQueues)
@@ -752,7 +754,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         var availabilityEnv = SecureConversations.Availability.Environment.failing
         availabilityEnv.log = logger
         availabilityEnv.getQueues = { callback in
-            callback([.mock()], nil)
+            callback(.success([.mock()]))
         }
         availabilityEnv.isAuthenticated = { true }
         availabilityEnv.queuesMonitor = .mock(getQueues: availabilityEnv.getQueues)
@@ -1031,7 +1033,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.log = logger
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in .mock() }
-        modelEnv.getQueues = { callback in callback([], nil) }
+        modelEnv.getQueues = { callback in callback(.success([])) }
         modelEnv.maximumUploads = { 2 }
         modelEnv.createEntryWidget = { config in .mock(configuration: config) }
 
@@ -1088,7 +1090,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.log = logger
         modelEnv.fileManager = .mock
         modelEnv.createFileUploadListModel = { _ in .mock() }
-        modelEnv.getQueues = { callback in callback([], nil) }
+        modelEnv.getQueues = { callback in callback(.success([])) }
         modelEnv.maximumUploads = { 2 }
         modelEnv.createEntryWidget = { config in .mock(configuration: config) }
 

--- a/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.Mock.swift
+++ b/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.Mock.swift
@@ -14,7 +14,7 @@ extension SecureConversations.WelcomeViewModel.Environment {
         secureConversations: CoreSdkClient.SecureConversations = .mock,
         welcomeStyle: SecureConversations.WelcomeStyle = Theme().secureConversationsWelcomeStyle,
         queueIds: [String] = [],
-        listQueues: @escaping CoreSdkClient.ListQueues = { _ in },
+        listQueues: @escaping CoreSdkClient.GetQueues = { _ in },
         fileUploader: FileUploader = .mock(),
         uiApplication: UIKitBased.UIApplication = .mock,
         createFileUploadListModel: @escaping SecureConversations.FileUploadListViewModel.Create = { _ in .mock() },

--- a/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModelSpec.swift
+++ b/GliaWidgetsTests/SecureConversations/Welcome/SecureConversations.WelcomeViewModelSpec.swift
@@ -610,14 +610,14 @@ extension SecureConversationsWelcomeViewModelTests {
         let uuid = UUID.mock.uuidString
         var availability = SecureConversations.Availability.mock
         availability.environment.getQueues = { completion in
-            let queue = CoreSdkClient.Queue.mock(
+            let queue = Queue.mock(
                 id: uuid,
                 name: "",
                 status: .open,
                 isDefault: true,
                 media: [.messaging]
             )
-            completion([queue], nil)
+            completion(.success([queue]))
         }
         availability.environment.isAuthenticated = { true }
 
@@ -632,14 +632,14 @@ extension SecureConversationsWelcomeViewModelTests {
         let uuid = UUID.mock.uuidString
         var availability = SecureConversations.Availability.mock
         availability.environment.getQueues = { completion in
-            let queue = CoreSdkClient.Queue.mock(
+            let queue = Queue.mock(
                 id: uuid,
                 name: "",
                 status: .open,
                 isDefault: true,
                 media: [.text]
             )
-            completion([queue], nil)
+            completion(.success([queue]))
         }
 
         availability.environment.isAuthenticated = { true }
@@ -676,14 +676,14 @@ extension SecureConversationsWelcomeViewModelTests {
         let uuid = UUID.mock.uuidString
         var availability = SecureConversations.Availability.mock
         availability.environment.getQueues = { completion in
-            let queue = CoreSdkClient.Queue.mock(
+            let queue = Queue.mock(
                 id: uuid,
                 name: "",
                 status: .open,
                 isDefault: true,
                 media: [.messaging]
             )
-            completion([queue], nil)
+            completion(.success([queue]))
         }
 
         availability.environment.isAuthenticated = { false }

--- a/GliaWidgetsTests/Sources/ChatView/ChatViewTest.swift
+++ b/GliaWidgetsTests/Sources/ChatView/ChatViewTest.swift
@@ -130,10 +130,10 @@ final class ChatViewTest: XCTestCase {
 
         var entryWidgetEnv = EntryWidget.Environment.mock()
         let queueId = "queueId"
-        let mockQueue = CoreSdkClient.Queue.mock(id: queueId, media: [.text, .audio, .messaging])
+        let mockQueue = Queue.mock(id: queueId, media: [.text, .audio, .messaging])
         let queuesMonitor = QueuesMonitor.mock(
             getQueues: {
-                $0([mockQueue], nil)
+                $0(.success([mockQueue]))
             },
             subscribeForQueuesUpdates: { _, completion in
                 completion(.success(mockQueue))

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -509,7 +509,7 @@ class ChatViewModelTests: XCTestCase {
 
         let transcriptFileUploadListModel = FileUploadListViewModel(environment: transcriptFileUploadListModelEnv)
         transcriptModelEnv.createFileUploadListModel = { _ in transcriptFileUploadListModel }
-        transcriptModelEnv.getQueues = { callback in callback([], nil) }
+        transcriptModelEnv.getQueues = { callback in callback(.success([])) }
         transcriptModelEnv.maximumUploads = { 2 }
         var logger = CoreSdkClient.Logger.failing
         logger.prefixedClosure = { _ in logger }

--- a/GliaWidgetsTests/Sources/EntryWidget/EntryWidgetTests.swift
+++ b/GliaWidgetsTests/Sources/EntryWidget/EntryWidgetTests.swift
@@ -16,7 +16,7 @@ class EntryWidgetTests: XCTestCase {
 
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
         queueMonitorEnvironment.getQueues = { completion in
-            completion([mockQueue], nil)
+            completion(.success([mockQueue]))
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
             completion(.success(mockQueue))
@@ -50,7 +50,7 @@ class EntryWidgetTests: XCTestCase {
 
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
         queueMonitorEnvironment.getQueues = { completion in
-            completion([mockQueue], nil)
+            completion(.success([mockQueue]))
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
             completion(.success(mockQueue))
@@ -81,7 +81,7 @@ class EntryWidgetTests: XCTestCase {
         let mockQueue = Queue.mock(id: mockQueueId, media: [.messaging, .audio])
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
         queueMonitorEnvironment.getQueues = { completion in
-            completion([mockQueue], nil)
+            completion(.success([mockQueue]))
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
             completion(.success(mockQueue))
@@ -162,7 +162,7 @@ class EntryWidgetTests: XCTestCase {
         var environment = EntryWidget.Environment.mock()
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
         queueMonitorEnvironment.getQueues = { completion in
-            completion([mockQueue], nil)
+            completion(.success([mockQueue]))
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
             completion(.success(mockQueue))
@@ -194,7 +194,7 @@ class EntryWidgetTests: XCTestCase {
         let mockQueue = Queue.mock(id: mockQueueId, media: [.messaging, .audio, .video, .text])
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
         queueMonitorEnvironment.getQueues = { completion in
-            completion([mockQueue], nil)
+            completion(.success([mockQueue]))
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
             completion(.success(mockQueue))
@@ -230,7 +230,7 @@ class EntryWidgetTests: XCTestCase {
         let mockQueue = Queue.mock(id: mockQueueId, media: [.messaging, .audio, .video, .text])
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
         queueMonitorEnvironment.getQueues = { completion in
-            completion([mockQueue], nil)
+            completion(.success([mockQueue]))
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
             completion(.success(mockQueue))
@@ -263,7 +263,7 @@ class EntryWidgetTests: XCTestCase {
         let mockQueue = Queue.mock(id: mockQueueId, media: [.audio, .video, .text])
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
         queueMonitorEnvironment.getQueues = { completion in
-            completion([mockQueue], nil)
+            completion(.success([mockQueue]))
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
             completion(.success(mockQueue))
@@ -298,7 +298,7 @@ class EntryWidgetTests: XCTestCase {
 
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
         queueMonitorEnvironment.getQueues = { completion in
-            completion([mockQueue], nil)
+            completion(.success([mockQueue]))
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
             completion(.success(mockQueue))
@@ -327,7 +327,7 @@ class EntryWidgetTests: XCTestCase {
 
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
         queueMonitorEnvironment.getQueues = { completion in
-            completion([mockQueue], nil)
+            completion(.success([mockQueue]))
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
             completion(.success(mockQueue))
@@ -356,7 +356,7 @@ class EntryWidgetTests: XCTestCase {
 
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
         queueMonitorEnvironment.getQueues = { completion in
-            completion([mockQueue], nil)
+            completion(.success([mockQueue]))
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
             completion(.success(mockQueue))
@@ -385,7 +385,7 @@ class EntryWidgetTests: XCTestCase {
 
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
         queueMonitorEnvironment.getQueues = { completion in
-            completion([mockQueue], nil)
+            completion(.success([mockQueue]))
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
             completion(.success(mockQueue))
@@ -521,7 +521,7 @@ class EntryWidgetTests: XCTestCase {
 
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
         queueMonitorEnvironment.getQueues = { completion in
-            completion([mockQueue], nil)
+            completion(.success([mockQueue]))
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
             completion(.success(mockQueue))
@@ -553,7 +553,7 @@ class EntryWidgetTests: XCTestCase {
 
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
         queueMonitorEnvironment.getQueues = { completion in
-            completion([mockQueue], nil)
+            completion(.success([mockQueue]))
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
             completion(.success(mockQueue))
@@ -586,7 +586,7 @@ class EntryWidgetTests: XCTestCase {
 
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
         queueMonitorEnvironment.getQueues = { completion in
-            completion([mockQueue], nil)
+            completion(.success([mockQueue]))
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
             completion(.success(mockQueue))
@@ -622,7 +622,7 @@ class EntryWidgetTests: XCTestCase {
         let mockQueue = Queue.mock(id: mockQueueId, media: [.messaging, .audio])
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
         queueMonitorEnvironment.getQueues = { completion in
-            completion([mockQueue], nil)
+            completion(.success([mockQueue]))
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
             completion(.success(mockQueue))
@@ -653,7 +653,7 @@ class EntryWidgetTests: XCTestCase {
 
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
         queueMonitorEnvironment.getQueues = { completion in
-            completion([mockQueue], nil)
+            completion(.success([mockQueue]))
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
             completion(.success(mockQueue))
@@ -687,7 +687,7 @@ class EntryWidgetTests: XCTestCase {
 
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
         queueMonitorEnvironment.getQueues = { completion in
-            completion([mockQueue], nil)
+            completion(.success([mockQueue]))
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
             completion(.success(mockQueue))
@@ -719,7 +719,7 @@ class EntryWidgetTests: XCTestCase {
 
         var queueMonitorEnvironment: QueuesMonitor.Environment = .mock
         queueMonitorEnvironment.getQueues = { completion in
-            completion([mockQueue], nil)
+            completion(.success([mockQueue]))
         }
         queueMonitorEnvironment.subscribeForQueuesUpdates = { _, completion in
             completion(.success(mockQueue))

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+RestoreEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+RestoreEngagement.swift
@@ -43,7 +43,7 @@ extension GliaTests {
             calls.append(.snackBarPresent)
         }
 
-        sdkEnv.coreSdk.getQueues = { callback in callback([], nil) }
+        sdkEnv.coreSdk.getQueues = { callback in callback(.success([])) }
         sdkEnv.coreSdk.subscribeForQueuesUpdates = { _, _ in
             return UUID.mock.uuidString
         }

--- a/GliaWidgetsTests/Sources/InteractorTests.swift
+++ b/GliaWidgetsTests/Sources/InteractorTests.swift
@@ -689,7 +689,7 @@ class InteractorTests: XCTestCase {
         let queuesMonitor = QueuesMonitor.mock()
         queuesMonitor.environment.getQueues = { completion in
             calls.append(.getQueues)
-            completion([.mock()], nil)
+            completion(.success([.mock()]))
         }
         
         queuesMonitor.environment.subscribeForQueuesUpdates = { _, completion in

--- a/GliaWidgetsTests/Sources/QueuesMonitor/QueuesMonitorTests.swift
+++ b/GliaWidgetsTests/Sources/QueuesMonitor/QueuesMonitorTests.swift
@@ -39,7 +39,7 @@ class QueuesMonitorTests: XCTestCase {
         }
         monitor.environment.getQueues = { completion in
             envCalls.append(.getQueues)
-            completion(mockQueues, nil)
+            completion(.success(mockQueues))
         }
         monitor.environment.subscribeForQueuesUpdates = { _, completion in
             envCalls.append(.subscribeForQueuesUpdates)
@@ -47,7 +47,7 @@ class QueuesMonitorTests: XCTestCase {
             return UUID().uuidString
         }
 
-        var receivedQueues: [Queue]?
+        var receivedQueues: [GliaWidgets.Queue]?
         monitor.$state
             .sink { state in
                 if case let .updated(queues) = state {
@@ -79,7 +79,7 @@ class QueuesMonitorTests: XCTestCase {
         }
         monitor.environment.getQueues = { completion in
             envCalls.append(.getQueues)
-            completion(mockQueues, nil)
+            completion(.success(mockQueues))
         }
         monitor.environment.subscribeForQueuesUpdates = { _, completion in
             envCalls.append(.subscribeForQueuesUpdates)
@@ -87,7 +87,7 @@ class QueuesMonitorTests: XCTestCase {
             return UUID().uuidString
         }
 
-        var receivedQueues: [Queue]?
+        var receivedQueues: [GliaWidgets.Queue]?
         monitor.$state
             .sink { state in
                 if case let .updated(queues) = state {
@@ -113,7 +113,7 @@ class QueuesMonitorTests: XCTestCase {
         }
         monitor.environment.getQueues = { completion in
             envCalls.append(.getQueues)
-            completion(nil, expectedError)
+            completion(.failure(expectedError))
         }
         monitor.environment.subscribeForQueuesUpdates = { _, completion in
             envCalls.append(.subscribeForQueuesUpdates)
@@ -150,7 +150,7 @@ class QueuesMonitorTests: XCTestCase {
 
         monitor.environment.getQueues = { completion in
             envCalls.append(.getQueues)
-            completion(mockQueues, nil)
+            completion(.success(mockQueues))
         }
         monitor.environment.subscribeForQueuesUpdates = { [expectedUpdatedQueue] _, completion in
             envCalls.append(.subscribeForQueuesUpdates)
@@ -159,8 +159,8 @@ class QueuesMonitorTests: XCTestCase {
             return UUID().uuidString
         }
 
-        var receivedQueues: [Queue]?
-        var receivedUpdatedQueue: Queue?
+        var receivedQueues: [GliaWidgets.Queue]?
+        var receivedUpdatedQueue: GliaWidgets.Queue?
         monitor.$state
             .receive(on: CoreSdkClient.AnyCombineScheduler.mock.mainScheduler)
             // Drop initial .idle and .updated with listed queues state update
@@ -194,7 +194,7 @@ class QueuesMonitorTests: XCTestCase {
 
         monitor.environment.getQueues = { completion in
             envCalls.append(.getQueues)
-            completion(mockQueues, nil)
+            completion(.success(mockQueues))
         }
         monitor.environment.subscribeForQueuesUpdates = { _, completion in
             envCalls.append(.subscribeForQueuesUpdates)
@@ -206,8 +206,8 @@ class QueuesMonitorTests: XCTestCase {
             envCalls.append(.unsubscribeFromUpdates)
         }
 
-        var receivedQueues: [Queue]?
-        var receivedUpdatedQueue: Queue?
+        var receivedQueues: [GliaWidgets.Queue]?
+        var receivedUpdatedQueue: GliaWidgets.Queue?
         monitor.$state
             .receive(on: CoreSdkClient.AnyCombineScheduler.mock.mainScheduler)
             // Drop initial .idle and .updated with listed queues state update
@@ -244,7 +244,7 @@ class QueuesMonitorTests: XCTestCase {
 
         monitor.environment.getQueues = { completion in
             envCalls.append(.getQueues)
-            completion(mockQueues, nil)
+            completion(.success(mockQueues))
         }
         monitor.environment.subscribeForQueuesUpdates = { _, completion in
             envCalls.append(.subscribeForQueuesUpdates)
@@ -257,8 +257,8 @@ class QueuesMonitorTests: XCTestCase {
             error(CoreSdkClient.SalemoveError.mock())
         }
 
-        var receivedQueues: [Queue]?
-        var receivedUpdatedQueue: Queue?
+        var receivedQueues: [GliaWidgets.Queue]?
+        var receivedUpdatedQueue: GliaWidgets.Queue?
         monitor.$state
             .receive(on: CoreSdkClient.AnyCombineScheduler.mock.mainScheduler)
             // Drop initial .idle and .updated with listed queues state update
@@ -290,7 +290,7 @@ class QueuesMonitorTests: XCTestCase {
 
         monitor.environment.getQueues = { completion in
             envCalls.append(.getQueues)
-            completion(mockQueues, nil)
+            completion(.success(mockQueues))
         }
         monitor.environment.subscribeForQueuesUpdates = { _, completion in
             envCalls.append(.subscribeForQueuesUpdates)
@@ -323,7 +323,7 @@ class QueuesMonitorTests: XCTestCase {
 
         monitor.environment.getQueues = { completion in
             envCalls.append(.getQueues)
-            completion([], nil)
+            completion(.success([]))
         }
         monitor.environment.subscribeForQueuesUpdates = { _, completion in
             envCalls.append(.subscribeForQueuesUpdates)
@@ -358,7 +358,7 @@ class QueuesMonitorTests: XCTestCase {
 
         monitor.environment.getQueues = { completion in
             envCalls.append(.getQueues)
-            completion([], nil)
+            completion(.success([]))
         }
         monitor.environment.subscribeForQueuesUpdates = { _, completion in
             envCalls.append(.subscribeForQueuesUpdates)
@@ -391,14 +391,14 @@ class QueuesMonitorTests: XCTestCase {
 
         monitor.environment.getQueues = { completion in
             envCalls.append(.getQueues)
-            completion([existingQueue], nil)
+            completion(.success([existingQueue]))
         }
         monitor.environment.subscribeForQueuesUpdates = { _, completion in
             envCalls.append(.subscribeForQueuesUpdates)
             completion(.success(olderQueue))
             return UUID().uuidString
         }
-        var receivedQueues: [Queue]?
+        var receivedQueues: [GliaWidgets.Queue]?
         monitor.$state
             // Drop initial .idle and then .updated after fetching
             .dropFirst(2)
@@ -432,7 +432,7 @@ class QueuesMonitorTests: XCTestCase {
 
         monitor.environment.getQueues = { completion in
             envCalls.append(.getQueues)
-            completion([oldQueue], nil)
+            completion(.success([oldQueue]))
         }
         monitor.environment.subscribeForQueuesUpdates = { _, completion in
             envCalls.append(.subscribeForQueuesUpdates)
@@ -440,7 +440,7 @@ class QueuesMonitorTests: XCTestCase {
             return UUID().uuidString
         }
 
-        var receivedQueues: [Queue]?
+        var receivedQueues: [GliaWidgets.Queue]?
         monitor.$state
             // Drop initial .idle and then .updated after fetching
             .dropFirst(2)
@@ -473,7 +473,7 @@ class QueuesMonitorTests: XCTestCase {
 
         monitor.environment.getQueues = { completion in
             envCalls.append(.getQueues)
-            completion([knownQueue], nil)
+            completion(.success([knownQueue]))
         }
         monitor.environment.subscribeForQueuesUpdates = { _, completion in
             envCalls.append(.subscribeForQueuesUpdates)
@@ -481,7 +481,7 @@ class QueuesMonitorTests: XCTestCase {
             return UUID().uuidString
         }
 
-        var receivedQueues: [Queue]?
+        var receivedQueues: [GliaWidgets.Queue]?
         monitor.$state
             // Drop initial .idle and then .updated after fetching
             .dropFirst(2)


### PR DESCRIPTION
**What was solved?**
To avoid a situation where the integrator needs to import CoreSDK, a widgetSDK Queue object was created

MOB-4330
**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
