### PR TITLE
Add VisitorInfo object to WidgetSDK

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -211,9 +211,9 @@
 		3100EEFD293F757E00D57F71 /* SecureConversations.WelcomeStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3100EEFC293F757E00D57F71 /* SecureConversations.WelcomeStyle.swift */; };
 		3100EEFF293F7E0900D57F71 /* Theme+SecureConversationsWelcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3100EEFE293F7E0900D57F71 /* Theme+SecureConversationsWelcome.swift */; };
 		3115D45C29A4FD3F00D99561 /* SecureConversations.Availability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3115D45B29A4FD3F00D99561 /* SecureConversations.Availability.swift */; };
-		3115EFBA2BC960B500B24D5A /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		3117EBA22B9B041100F520D8 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		3117EBA42B9B426200F520D8 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		3115EFBA2BC960B500B24D5A /* (null) in Sources */ = {isa = PBXBuildFile; };
+		3117EBA22B9B041100F520D8 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		3117EBA42B9B426200F520D8 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		311C03352B5588C0002E4FF8 /* SecureConversations.CoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311C03342B5588C0002E4FF8 /* SecureConversations.CoordinatorTests.swift */; };
 		311CAFCD29F8FAE20067B59F /* SecureConversations.TranscriptModel.CustomCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311CAFCC29F8FAE20067B59F /* SecureConversations.TranscriptModel.CustomCard.swift */; };
 		313EBD552943116E008E9597 /* SecureConversations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 313EBD542943116E008E9597 /* SecureConversations.swift */; };
@@ -915,6 +915,7 @@
 		C0B325E72AC5A8FA006BC430 /* AlertViewController+LiveObservationConfirmation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B325E62AC5A8FA006BC430 /* AlertViewController+LiveObservationConfirmation.swift */; };
 		C0C5BB772CAD4278001B2025 /* MediaTypeItemStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C5BB762CAD4259001B2025 /* MediaTypeItemStyle.swift */; };
 		C0C5BB792CAD42FD001B2025 /* MediaTypeItemStyle.RemoteConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C5BB782CAD42FD001B2025 /* MediaTypeItemStyle.RemoteConfig.swift */; };
+		C0CC6CCC2DCB547D003F7997 /* VisitorInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0CC6CCB2DCB5479003F7997 /* VisitorInfo.swift */; };
 		C0D2F02C2991219100803B47 /* VideoCallCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F02B2991219100803B47 /* VideoCallCoordinator.swift */; };
 		C0D2F02E2991221900803B47 /* VideoCallCoordinator.DelegateEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F02D2991221900803B47 /* VideoCallCoordinator.DelegateEvent.swift */; };
 		C0D2F0302991229F00803B47 /* VideoCallCoordinator.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F02F2991229F00803B47 /* VideoCallCoordinator.Environment.swift */; };
@@ -2015,6 +2016,7 @@
 		C0B325E62AC5A8FA006BC430 /* AlertViewController+LiveObservationConfirmation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AlertViewController+LiveObservationConfirmation.swift"; sourceTree = "<group>"; };
 		C0C5BB762CAD4259001B2025 /* MediaTypeItemStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTypeItemStyle.swift; sourceTree = "<group>"; };
 		C0C5BB782CAD42FD001B2025 /* MediaTypeItemStyle.RemoteConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTypeItemStyle.RemoteConfig.swift; sourceTree = "<group>"; };
+		C0CC6CCB2DCB5479003F7997 /* VisitorInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitorInfo.swift; sourceTree = "<group>"; };
 		C0D2F02B2991219100803B47 /* VideoCallCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCallCoordinator.swift; sourceTree = "<group>"; };
 		C0D2F02D2991221900803B47 /* VideoCallCoordinator.DelegateEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCallCoordinator.DelegateEvent.swift; sourceTree = "<group>"; };
 		C0D2F02F2991229F00803B47 /* VideoCallCoordinator.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCallCoordinator.Environment.swift; sourceTree = "<group>"; };
@@ -2850,47 +2852,48 @@
 		1A60AFC12566857200E53F53 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				C0193DD82D957D0500801CF6 /* PushNotifications */,
-				2198B7AA2CAEB13E002C442B /* QueuesMonitor */,
-				215A25922CA44D900013023E /* EngagementLauncher */,
-				C0F3DE352C69F4A700DE6D7B /* EntryWidget */,
 				C0D6C9E72C09C70B00D4709B /* AlertManager */,
-				84C24CF62B8353840089A388 /* ProcessInfoHandling */,
-				84520BD92B0FA14700F97617 /* WebViewController */,
-				C02248A82AD53DDF00CC4930 /* LiveObservation */,
-				AF7753152B1DBF8900E523A2 /* GliaLogging */,
-				AF1C19782B14FC4900F8810F /* ConditionalCompilationClient */,
-				AF62910D2B0813B000D3D76B /* SwiftBased */,
-				84D5B95E2A14DEFD00807F92 /* QuickLookBased */,
-				C05E3EDC29C99DEE0013BC81 /* ProximityManager */,
 				C4794E6E270673FC00F989F7 /* Animation */,
 				75940965298D38B6008B173A /* BundleManaging */,
 				75940968298D38C2008B173A /* CallVisualizer */,
 				75940951298D3832008B173A /* Command */,
 				1A60AF6A25656C1E00E53F53 /* Component */,
+				AF1C19782B14FC4900F8810F /* ConditionalCompilationClient */,
 				1A60AFC62566865F00E53F53 /* Coordinator */,
 				1A60AF6825656C0200E53F53 /* Coordinators */,
 				75940940298D378A008B173A /* CoreSDKClient */,
 				847956342AD96AA8004EF60C /* CoreSDKConfigurator */,
 				1A1E309425F8CA3400850E68 /* Download */,
+				215A25922CA44D900013023E /* EngagementLauncher */,
+				C0F3DE352C69F4A700DE6D7B /* EntryWidget */,
 				1A60B025256806D500E53F53 /* Extensions */,
 				1A8366AE25FF409B005FE7EE /* File */,
 				7594090F29891BD5008B173A /* FontScaling */,
 				7594091029891BE8008B173A /* FoundationBased */,
 				7594091129891BFD008B173A /* GCD */,
 				75940947298D37E8008B173A /* GliaEnvironment */,
+				AF7753152B1DBF8900E523A2 /* GliaLogging */,
 				7594094E298D3810008B173A /* IdCollection */,
 				1AC7A74D258256FF00567FF8 /* Interactor */,
 				75940954298D386F008B173A /* Layout */,
+				C02248A82AD53DDF00CC4930 /* LiveObservation */,
 				7594095B298D3889008B173A /* MessageRenderer */,
 				9AE9E4B627E1E30500BFE239 /* MockHelpers.swift */,
 				1A0C9ADE25C9623800815406 /* Observable */,
 				1A60AFEF2566A4A700E53F53 /* Presenter */,
+				84C24CF62B8353840089A388 /* ProcessInfoHandling */,
+				C05E3EDC29C99DEE0013BC81 /* ProximityManager */,
+				C0193DD82D957D0500801CF6 /* PushNotifications */,
+				2198B7AA2CAEB13E002C442B /* QueuesMonitor */,
+				84D5B95E2A14DEFD00807F92 /* QuickLookBased */,
 				75940939298D376A008B173A /* RemoteConfiguration */,
 				C42463722673ABCD0082C135 /* Screensharing */,
 				1A5F815D258A43D900A605DA /* Section */,
+				AF78C08D2CD968F600167BA4 /* StatefulStyle.swift */,
 				1A1E309925F8E1E900850E68 /* Storage */,
+				AF62910D2B0813B000D3D76B /* SwiftBased */,
 				1A60AF7825656DE700E53F53 /* Theme */,
+				AF9C0C3B2BC4739800C25E47 /* Transformable.swift */,
 				7594091229891C23008B173A /* UIKitBased */,
 				84A318A02869ECFC00CA1DE5 /* Unavailable.swift */,
 				1A2DA72B25EF9B5B00032611 /* Upload */,
@@ -2900,9 +2903,9 @@
 				1A60AF6725656BF200E53F53 /* ViewController */,
 				1A60AFCC256694E300E53F53 /* ViewFactory */,
 				1A60AFC52566865600E53F53 /* ViewModel */,
+				C0CC6CCA2DCB5470003F7997 /* VisitorInfo */,
+				84520BD92B0FA14700F97617 /* WebViewController */,
 				84D2292C28C61DE000F64FE7 /* WKNavigationPolicyProvider */,
-				AF9C0C3B2BC4739800C25E47 /* Transformable.swift */,
-				AF78C08D2CD968F600167BA4 /* StatefulStyle.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -5152,6 +5155,14 @@
 			path = CallVisualizer;
 			sourceTree = "<group>";
 		};
+		C0CC6CCA2DCB5470003F7997 /* VisitorInfo */ = {
+			isa = PBXGroup;
+			children = (
+				C0CC6CCB2DCB5479003F7997 /* VisitorInfo.swift */,
+			);
+			path = VisitorInfo;
+			sourceTree = "<group>";
+		};
 		C0D2F0292991213B00803B47 /* VideoCall */ = {
 			isa = PBXGroup;
 			children = (
@@ -5751,9 +5762,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-GliaWidgetsTests/Pods-GliaWidgetsTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-GliaWidgetsTests/Pods-GliaWidgetsTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -5871,9 +5886,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-TestingApp/Pods-TestingApp-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-TestingApp/Pods-TestingApp-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -5906,9 +5925,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-SnapshotTests/Pods-SnapshotTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-SnapshotTests/Pods-SnapshotTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -5984,6 +6007,7 @@
 				8464297D2A459E7D00943BD6 /* UIViewController+Replaceble.swift in Sources */,
 				C0C5BB772CAD4278001B2025 /* MediaTypeItemStyle.swift in Sources */,
 				C09046EA2B7E0F06003C437C /* Theme.VIsitorChatMessageStyle.RemoteConfig.swift in Sources */,
+				C0CC6CCC2DCB547D003F7997 /* VisitorInfo.swift in Sources */,
 				C09046A82B7D08CD003C437C /* WelcomeStyle.SendButton.LoadingStyle.RemoteConfig.swift in Sources */,
 				1A2DA72625EF892600032611 /* FilePickerController.swift in Sources */,
 				1ABD6C9625B6F46700D56EFA /* AlertViewController+SingleMediaUpgrade.swift in Sources */,
@@ -6785,7 +6809,7 @@
 				8492F9192CAD329800242691 /* TranscriptModelTests+MessageRetry.swift in Sources */,
 				8491AF602AA1EBB600CC3E72 /* TranscriptModelTests+URLs.swift in Sources */,
 				9A8130C427D9099F00220BBD /* FileDownload.Environment.Failing.swift in Sources */,
-				3117EBA22B9B041100F520D8 /* BuildFile in Sources */,
+				3117EBA22B9B041100F520D8 /* (null) in Sources */,
 				31CCE3E52BCE8F3A00F92535 /* CallVisualizer.Coordinator.Environment.Mock.swift in Sources */,
 				31CCE3E72BCE8F3A00F92535 /* VisitorCodeCoordinatorTests.swift in Sources */,
 				AF29811029E06E830005BD55 /* Availability.Environment.Failing.swift in Sources */,
@@ -6811,7 +6835,7 @@
 				EB9ADB552828E66B00FAE8A4 /* CallTests.swift in Sources */,
 				AF9DB22E2890571A00A0C442 /* RootCoordinator.Environment.Failing.swift in Sources */,
 				AF9DB23128905A1D00A0C442 /* ViewFactory.Environment.Failing.swift in Sources */,
-				3117EBA42B9B426200F520D8 /* BuildFile in Sources */,
+				3117EBA42B9B426200F520D8 /* (null) in Sources */,
 				848570512BEE3CCC00CEBCC5 /* ChatStyle.Mock.swift in Sources */,
 				9A3E1DA027BA7B9F005634EB /* FileSystemStorageTests.swift in Sources */,
 				EB9ADB5A2829089F00FAE8A4 /* ChatItem+Equatable.swift in Sources */,
@@ -6842,7 +6866,7 @@
 				2100B4842CB8143400AC7527 /* QueuesMonitor.Failing.swift in Sources */,
 				3146C9432AB1851C0047D8CC /* LocalizationTests.swift in Sources */,
 				8492F9172CAD2F2000242691 /* TranscriptModelTests+ResponseCard.swift in Sources */,
-				3115EFBA2BC960B500B24D5A /* BuildFile in Sources */,
+				3115EFBA2BC960B500B24D5A /* (null) in Sources */,
 				31CCE3E62BCE8F3A00F92535 /* ScreenSharingCoordinatorTests.swift in Sources */,
 				846A5C3929D18D400049B29F /* ScreenShareHandlerTests.swift in Sources */,
 				216D310B2CF790980019CA9E /* EntryWidget.Mock.swift in Sources */,

--- a/GliaWidgets/Public/Glia/Glia.Deprecated.swift
+++ b/GliaWidgets/Public/Glia/Glia.Deprecated.swift
@@ -5,7 +5,7 @@ extension Glia {
     /// Deprecated, use ``Glia.getVisitorInfo(completion:)`` instead.
     @available(*, deprecated, message: "Deprecated, use ``Glia.getVisitorInfo(completion:)`` instead. ")
     public func fetchVisitorInfo(completion: @escaping (Result<GliaCore.VisitorInfo, Error>) -> Void) {
-        getVisitorInfo(completion: completion)
+        environment.coreSdk.getVisitorInfoDeprecated(completion)
     }
 
     /// Deprecated, use ``Glia.getQueues(completion:)`` instead.

--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -427,7 +427,7 @@ public class Glia {
     ///   `configure(with:uiConfig:assetsBuilder:completion:)` must be called prior to
     ///   this method, because `GliaError.sdkIsNotConfigured` will occur otherwise.
     ///
-    public func getVisitorInfo(completion: @escaping (Result<GliaCore.VisitorInfo, Error>) -> Void) {
+    public func getVisitorInfo(completion: @escaping (Result<VisitorInfo, Error>) -> Void) {
         guard configuration != nil else {
             completion(.failure(GliaError.sdkIsNotConfigured))
             return

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -10,9 +10,10 @@ struct CoreSdkClient {
     var clearSession: () -> Void
     var localeProvider: LocaleProvider
 
-    typealias GetVisitorInfo = (_ completion: @escaping (Result<Self.Salemove.VisitorInfo, Error>) -> Void) -> Void
+    typealias GetVisitorInfo = (_ completion: @escaping (Result<VisitorInfo, Error>) -> Void) -> Void
 
     var getVisitorInfo: GetVisitorInfo
+    var getVisitorInfoDeprecated: (_ completion: @escaping (Result<GliaCore.VisitorInfo, Error>) -> Void) -> Void
 
     typealias UpdateVisitorInfo = (
         _ info: Self.VisitorInfoUpdate,

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
@@ -9,7 +9,18 @@ extension CoreSdkClient {
             createAppDelegate: Self.AppDelegate.live,
             clearSession: GliaCore.sharedInstance.clearSession,
             localeProvider: .init(getRemoteString: GliaCore.sharedInstance.localeProvider.getRemoteString(_:)),
-            getVisitorInfo: GliaCore.sharedInstance.fetchVisitorInfo(_:),
+            getVisitorInfo: { completion in
+                GliaCore.sharedInstance.fetchVisitorInfo { result in
+                    switch result {
+                    case let .success(coreVisitorInfo):
+                        let visitorInfo = coreVisitorInfo.asWidgetSdkVisitorInfo()
+                        completion(.success(visitorInfo))
+                    case let .failure(error):
+                        completion(.failure(error))
+                    }
+                }
+            },
+            getVisitorInfoDeprecated: GliaCore.sharedInstance.fetchVisitorInfo(_:),
             updateVisitorInfo: GliaCore.sharedInstance.updateVisitorInfo(_:completion:),
             configureWithConfiguration: GliaCore.sharedInstance.configure(with:completion:),
             configureWithInteractor: GliaCore.sharedInstance.configure(interactor:),

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -11,6 +11,7 @@ extension CoreSdkClient {
         clearSession: {},
         localeProvider: .mock,
         getVisitorInfo: { _ in },
+        getVisitorInfoDeprecated: { _ in},
         updateVisitorInfo: { _, _ in },
         configureWithConfiguration: { _, _ in },
         configureWithInteractor: { _ in },

--- a/GliaWidgets/Sources/VisitorInfo/VisitorInfo.swift
+++ b/GliaWidgets/Sources/VisitorInfo/VisitorInfo.swift
@@ -1,0 +1,51 @@
+import Foundation
+import GliaCoreSDK
+
+public struct VisitorInfo : Equatable, Decodable {
+    /// Visitor's name
+    public let name: String?
+
+    /// Visitor's email address
+    public let email: String?
+
+    /// Visitor's phone number
+    public let phone: String?
+
+    /// Visitor related note
+    public let note: String?
+
+    /// Visitor's custom attributes
+    public let customAttributes: [String : String]?
+
+    /// Is visitor banned
+    public let banned: Bool
+
+    /// Visitor's generated name
+    public let generatedName: String?
+
+    /// Visitor's href
+    public let href: String?
+
+    /// Visitor's id
+    public let id: String?
+
+    /// Visitor's external id
+    public let externalId: String?
+}
+
+extension GliaCore.VisitorInfo {
+    func asWidgetSdkVisitorInfo() -> VisitorInfo {
+        .init(
+            name: name,
+            email: email,
+            phone: phone,
+            note: note,
+            customAttributes: customAttributes,
+            banned: banned,
+            generatedName: generatedName,
+            href: href,
+            id: id,
+            externalId: externalId
+        )
+    }
+}

--- a/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
@@ -9,6 +9,7 @@ extension CoreSdkClient {
         clearSession: { fail("\(Self.self).clearSession") },
         localeProvider: .failing,
         getVisitorInfo: { _ in fail("\(Self.self).getVisitorInfo") },
+        getVisitorInfoDeprecated: { _ in fail("\(Self.self).getVisitorInfoDeprecated")},
         updateVisitorInfo: { _, _ in fail("\(Self.self).updateVisitorInfo") },
         configureWithConfiguration: { _, _ in fail("\(Self.self).configureWithConfiguration") },
         configureWithInteractor: { _ in fail("\(Self.self).configureWithInteractor") },

--- a/TestingApp/VisitorInfo/VisitorInfoModel.swift
+++ b/TestingApp/VisitorInfo/VisitorInfoModel.swift
@@ -30,7 +30,7 @@ final class VisitorInfoModel {
     }
 
     // Keeps track of *fetch* visitor info request state.
-    var fetchInfoRequestState: RequestState<GliaCore.VisitorInfo>? {
+    var fetchInfoRequestState: RequestState<VisitorInfo>? {
         didSet {
             requestPropsRendered()
         }
@@ -442,7 +442,7 @@ final class VisitorInfoModel {
 
 extension VisitorInfoModel {
     struct Environment {
-        let getVisitorInfo: (@escaping (Result<GliaCore.VisitorInfo, Error>) -> Void) -> Void
+        let getVisitorInfo: (@escaping (Result<VisitorInfo, Error>) -> Void) -> Void
         let updateVisitorInfo: (VisitorInfoUpdate, @escaping (Result<Bool, Error>) -> Void) -> Void
         let uuid: () -> UUID
     }


### PR DESCRIPTION
**What was solved?**
To avoid a situation where the integrator needs to import CoreSDK, a widgetSDK VisitorInfo object was created

MOB-4335

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
