### PR TITLE
Add VisitorInfoUpdate object to WidgetSDK

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -916,6 +916,9 @@
 		C0C5BB772CAD4278001B2025 /* MediaTypeItemStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C5BB762CAD4259001B2025 /* MediaTypeItemStyle.swift */; };
 		C0C5BB792CAD42FD001B2025 /* MediaTypeItemStyle.RemoteConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C5BB782CAD42FD001B2025 /* MediaTypeItemStyle.RemoteConfig.swift */; };
 		C0CC6CCC2DCB547D003F7997 /* VisitorInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0CC6CCB2DCB5479003F7997 /* VisitorInfo.swift */; };
+		C0CC6CCE2DCB626B003F7997 /* VisitorInfoUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0CC6CCD2DCB6267003F7997 /* VisitorInfoUpdate.swift */; };
+		C0CC6CD02DCB634D003F7997 /* VisitorInfoUpdate.NoteUpdateMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0CC6CCF2DCB6343003F7997 /* VisitorInfoUpdate.NoteUpdateMethod.swift */; };
+		C0CC6CD22DCB6371003F7997 /* VisitorInfoUpdate.CustomAttributesUpdateMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0CC6CD12DCB6363003F7997 /* VisitorInfoUpdate.CustomAttributesUpdateMethod.swift */; };
 		C0D2F02C2991219100803B47 /* VideoCallCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F02B2991219100803B47 /* VideoCallCoordinator.swift */; };
 		C0D2F02E2991221900803B47 /* VideoCallCoordinator.DelegateEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F02D2991221900803B47 /* VideoCallCoordinator.DelegateEvent.swift */; };
 		C0D2F0302991229F00803B47 /* VideoCallCoordinator.Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F02F2991229F00803B47 /* VideoCallCoordinator.Environment.swift */; };
@@ -2017,6 +2020,9 @@
 		C0C5BB762CAD4259001B2025 /* MediaTypeItemStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTypeItemStyle.swift; sourceTree = "<group>"; };
 		C0C5BB782CAD42FD001B2025 /* MediaTypeItemStyle.RemoteConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTypeItemStyle.RemoteConfig.swift; sourceTree = "<group>"; };
 		C0CC6CCB2DCB5479003F7997 /* VisitorInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitorInfo.swift; sourceTree = "<group>"; };
+		C0CC6CCD2DCB6267003F7997 /* VisitorInfoUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitorInfoUpdate.swift; sourceTree = "<group>"; };
+		C0CC6CCF2DCB6343003F7997 /* VisitorInfoUpdate.NoteUpdateMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitorInfoUpdate.NoteUpdateMethod.swift; sourceTree = "<group>"; };
+		C0CC6CD12DCB6363003F7997 /* VisitorInfoUpdate.CustomAttributesUpdateMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitorInfoUpdate.CustomAttributesUpdateMethod.swift; sourceTree = "<group>"; };
 		C0D2F02B2991219100803B47 /* VideoCallCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCallCoordinator.swift; sourceTree = "<group>"; };
 		C0D2F02D2991221900803B47 /* VideoCallCoordinator.DelegateEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCallCoordinator.DelegateEvent.swift; sourceTree = "<group>"; };
 		C0D2F02F2991229F00803B47 /* VideoCallCoordinator.Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCallCoordinator.Environment.swift; sourceTree = "<group>"; };
@@ -5159,6 +5165,9 @@
 			isa = PBXGroup;
 			children = (
 				C0CC6CCB2DCB5479003F7997 /* VisitorInfo.swift */,
+				C0CC6CCD2DCB6267003F7997 /* VisitorInfoUpdate.swift */,
+				C0CC6CCF2DCB6343003F7997 /* VisitorInfoUpdate.NoteUpdateMethod.swift */,
+				C0CC6CD12DCB6363003F7997 /* VisitorInfoUpdate.CustomAttributesUpdateMethod.swift */,
 			);
 			path = VisitorInfo;
 			sourceTree = "<group>";
@@ -6288,6 +6297,7 @@
 				311CAFCD29F8FAE20067B59F /* SecureConversations.TranscriptModel.CustomCard.swift in Sources */,
 				C0D6CA432C19AA0900D4709B /* SecureConversations.MessageTextView.swift in Sources */,
 				9A19926B27D3BA8700161AAE /* ViewFactory.Environment.Mock.swift in Sources */,
+				C0CC6CD02DCB634D003F7997 /* VisitorInfoUpdate.NoteUpdateMethod.swift in Sources */,
 				84681A9B2A669D8800DD7406 /* QuickReplyView.swift in Sources */,
 				1A6EB05725A717CB0007081A /* ChatMessage.swift in Sources */,
 				C0E948062AB1D64700890026 /* HeaderButtonSwiftUI.swift in Sources */,
@@ -6320,6 +6330,7 @@
 				C09046712B7CFE11003C437C /* ConfirmationStyle.TitleStyle.Accessibility.swift in Sources */,
 				C09047252B7E1BBA003C437C /* GvaGalleryCardStyle.ViewStyle.swift in Sources */,
 				1A60B0192567FC8A00E53F53 /* ButtonKind.swift in Sources */,
+				C0CC6CD22DCB6371003F7997 /* VisitorInfoUpdate.CustomAttributesUpdateMethod.swift in Sources */,
 				AFA5E96229F2CF9400F13DB7 /* SecureConversations.TranscriptModel.DividedChatItemsForUnreadCount.swift in Sources */,
 				C42463742673ABE10082C135 /* ScreenShareHandler.Interface.swift in Sources */,
 				216D311D2CFE2ED10019CA9E /* MediaTypeItemsStyle.Mock.swift in Sources */,
@@ -6506,6 +6517,7 @@
 				C090471F2B7E1B1F003C437C /* GvaGalleryCardStyle.ButtonStyle.RemoteConfig.swift in Sources */,
 				AFB6A07B2CCBF53800A1ED9A /* MediaTypeItemStyle.Loading.Accessibility.swift in Sources */,
 				C09047112B7E17AE003C437C /* Theme.Shadow.RemoteConfig.swift in Sources */,
+				C0CC6CCE2DCB626B003F7997 /* VisitorInfoUpdate.swift in Sources */,
 				AFA2FDFA2890827E00428E6D /* BadgeStyle.Mock.swift in Sources */,
 				8491AF002A6FB44200CC3E72 /* GvaGalleryCardCell.swift in Sources */,
 				C0D6CA5B2C19BF1D00D4709B /* SecureConversations.ConfirmationViewModel.Environment.swift in Sources */,

--- a/GliaWidgets/Public/Glia/Glia.Deprecated.swift
+++ b/GliaWidgets/Public/Glia/Glia.Deprecated.swift
@@ -13,4 +13,16 @@ extension Glia {
     public func listQueues(_ completion: @escaping (Result<[Queue], Error>) -> Void) {
         getQueues(completion)
     }
+
+    @available(*, deprecated, message: "Deprecated, use ``Glia.updateVisitorInfo(info:completion:)`` instead.")
+    public func updateVisitorInfo(
+        _ info: GliaCoreSDK.VisitorInfoUpdate,
+        completion: @escaping (Result<Bool, Error>) -> Void
+    ) {
+        guard configuration != nil else {
+            completion(.failure(GliaError.sdkIsNotConfigured))
+            return
+        }
+        environment.coreSdk.updateVisitorInfoDeprecated(info, completion)
+    }
 }

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -16,11 +16,15 @@ struct CoreSdkClient {
     var getVisitorInfoDeprecated: (_ completion: @escaping (Result<GliaCore.VisitorInfo, Error>) -> Void) -> Void
 
     typealias UpdateVisitorInfo = (
-        _ info: Self.VisitorInfoUpdate,
+        _ info: VisitorInfoUpdate,
         _ completion: @escaping (Result<Bool, Error>) -> Void
     ) -> Void
 
     var updateVisitorInfo: UpdateVisitorInfo
+    var updateVisitorInfoDeprecated: (
+        _ info: GliaCoreSDK.VisitorInfoUpdate,
+        _ completion: @escaping (Result<Bool, Error>) -> Void
+    ) -> Void
 
     typealias ConfigureWithConfiguration = (
         _ sdkConfiguration: Self.Salemove.Configuration,
@@ -340,7 +344,6 @@ extension CoreSdkClient {
     typealias VideoStreamAddedBlock = GliaCoreSDK.VideoStreamAddedBlock
     typealias VisitorContext = GliaCoreSDK.VisitorContext
     typealias ContextType = GliaCoreSDK.VisitorContext.ContextType
-    typealias VisitorInfoUpdate = GliaCoreSDK.VisitorInfoUpdate
     typealias VisitorScreenSharingState = GliaCoreSDK.VisitorScreenSharingState
     typealias VisitorScreenSharingStateChange = GliaCoreSDK.VisitorScreenSharingStateChange
     typealias Engagement = GliaCoreSDK.Engagement

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
@@ -21,7 +21,11 @@ extension CoreSdkClient {
                 }
             },
             getVisitorInfoDeprecated: GliaCore.sharedInstance.fetchVisitorInfo(_:),
-            updateVisitorInfo: GliaCore.sharedInstance.updateVisitorInfo(_:completion:),
+            updateVisitorInfo: { visitorInfoUpdate, completion in
+                let coreSdkVisitorInfoUpdate = visitorInfoUpdate.asCoreSdkVisitorInfoUpdate()
+                GliaCore.sharedInstance.updateVisitorInfo(coreSdkVisitorInfoUpdate, completion: completion)
+            },
+            updateVisitorInfoDeprecated: GliaCore.sharedInstance.updateVisitorInfo(_:completion:),
             configureWithConfiguration: GliaCore.sharedInstance.configure(with:completion:),
             configureWithInteractor: GliaCore.sharedInstance.configure(interactor:),
             getQueues: { completion in

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -13,6 +13,7 @@ extension CoreSdkClient {
         getVisitorInfo: { _ in },
         getVisitorInfoDeprecated: { _ in},
         updateVisitorInfo: { _, _ in },
+        updateVisitorInfoDeprecated: { _, _ in },
         configureWithConfiguration: { _, _ in },
         configureWithInteractor: { _ in },
         getQueues: { _ in },

--- a/GliaWidgets/Sources/VisitorInfo/VisitorInfo.swift
+++ b/GliaWidgets/Sources/VisitorInfo/VisitorInfo.swift
@@ -1,7 +1,7 @@
 import Foundation
 import GliaCoreSDK
 
-public struct VisitorInfo : Equatable, Decodable {
+public struct VisitorInfo: Equatable, Decodable {
     /// Visitor's name
     public let name: String?
 
@@ -15,7 +15,7 @@ public struct VisitorInfo : Equatable, Decodable {
     public let note: String?
 
     /// Visitor's custom attributes
-    public let customAttributes: [String : String]?
+    public let customAttributes: [String: String]?
 
     /// Is visitor banned
     public let banned: Bool

--- a/GliaWidgets/Sources/VisitorInfo/VisitorInfoUpdate.CustomAttributesUpdateMethod.swift
+++ b/GliaWidgets/Sources/VisitorInfo/VisitorInfoUpdate.CustomAttributesUpdateMethod.swift
@@ -1,0 +1,24 @@
+import Foundation
+import GliaCoreSDK
+
+extension VisitorInfoUpdate {
+    /// Specifies a method for updating custom attributes.
+    public enum CustomAttributesUpdateMethod: String, Encodable {
+        /// All custom attributes for the Visitor will be overwritten by the field.
+        case replace
+        /// Only custom attributes present in the request will be added or updated. In case of merge it is
+        /// possible to remove a custom attribute by setting its value to `nil`.
+        case merge
+    }
+}
+
+extension VisitorInfoUpdate.CustomAttributesUpdateMethod {
+    func asCoreSdkNoteUpdateMethod() -> GliaCoreSDK.VisitorInfoUpdate.CustomAttributesUpdateMethod {
+        switch self {
+        case .replace:
+            return .replace
+        case .merge:
+            return .merge
+        }
+    }
+}

--- a/GliaWidgets/Sources/VisitorInfo/VisitorInfoUpdate.NoteUpdateMethod.swift
+++ b/GliaWidgets/Sources/VisitorInfo/VisitorInfoUpdate.NoteUpdateMethod.swift
@@ -1,0 +1,24 @@
+import Foundation
+import GliaCoreSDK
+
+extension VisitorInfoUpdate {
+    /// Specifies a method for updating the Visitor's notes.
+    public enum NoteUpdateMethod: String {
+        /// The notes for the Visitor will be overwritten by the  field `note` in the request.
+        case replace
+        /// A line break (`\n`) will be added and field `note` in the request will be appended to the existing
+        /// Visitor’s notes.
+        case append
+    }
+}
+
+extension VisitorInfoUpdate.NoteUpdateMethod {
+    func asCoreSdkNoteUpdateMethod() -> GliaCoreSDK.VisitorInfoUpdate.NoteUpdateMethod {
+        switch self {
+        case .replace:
+            return .replace
+        case .append:
+            return .append
+        }
+    }
+}

--- a/GliaWidgets/Sources/VisitorInfo/VisitorInfoUpdate.swift
+++ b/GliaWidgets/Sources/VisitorInfo/VisitorInfoUpdate.swift
@@ -1,0 +1,79 @@
+import Foundation
+import GliaCoreSDK
+
+/// The information for updating Visitor
+public struct VisitorInfoUpdate {
+    /// Name of the Visitor.
+    public var name: String?
+
+    /// Email of the Visitor.
+    public var email: String?
+
+    /// Phone of the Visitor.
+    public var phone: String?
+
+    /// Notes associated with the Visitor.
+    public var note: String?
+
+    /// Method for updating the Visitor's note.
+    public var noteUpdateMethod: NoteUpdateMethod?
+
+    /// External ID to be used in third-party integrations.
+    public var externalID: String?
+
+    /// A dictionary with custom attributes.
+    public var customAttributes: [String: String]?
+
+    /// Method for updating custom attributes.
+    public var customAttributesUpdateMethod: CustomAttributesUpdateMethod?
+
+    /// Parameters:
+    /// - name: The Visitor's name. The default value is `nil`.
+    /// - email: The Visitor's email address. The default value is `nil`.
+    /// - phone: The Visitor's phone number. The default value is `nil`.
+    /// - note: The notes associated with the Visitor. The default value is `nil`.
+    /// - noteUpdateMethod:  The method for updating the visitor's note. The default value is `nil`.
+    /// - externalId: The Visitor's unique identifier in scope of the current Site. Valuable information about the
+    /// current Visitor may often be available in CRMs and other systems external to Glia. This field allows
+    /// matching the Visitor to their record in such CRMs and other external systems. For example, a Visitor can have an
+    /// ID within Salesforce. By setting the 'external_id' to the current Visitor's Salesforce ID, they can easily be
+    /// matched to their record within Salesforce. The default value is `nil`.
+    /// - customAttributes: An object with custom key-value pairs to be assigned to the Visitor. The server treats all
+    /// keys and values as strings and also returns them as strings. Nested key-value pairs are not supported. The default value is `nil`.
+    /// - customAttributesUpdateMethod: The method for updating custom attributes. The default value is `nil`.
+    ///
+    public init(
+        name: String? = nil,
+        email: String? = nil,
+        phone: String? = nil,
+        note: String? = nil,
+        noteUpdateMethod: NoteUpdateMethod? = nil,
+        externalID: String? = nil,
+        customAttributes: [String: String]? = nil,
+        customAttributesUpdateMethod: CustomAttributesUpdateMethod? = nil
+    ) {
+        self.name = name
+        self.email = email
+        self.phone = phone
+        self.note = note
+        self.noteUpdateMethod = noteUpdateMethod
+        self.externalID = externalID
+        self.customAttributes = customAttributes
+        self.customAttributesUpdateMethod = customAttributesUpdateMethod
+    }
+}
+
+extension VisitorInfoUpdate {
+    func asCoreSdkVisitorInfoUpdate() -> GliaCoreSDK.VisitorInfoUpdate {
+        .init(
+            name: name,
+            email: email,
+            phone: phone,
+            note: note,
+            noteUpdateMethod: noteUpdateMethod?.asCoreSdkNoteUpdateMethod(),
+            externalID: externalID,
+            customAttributes: customAttributes,
+            customAttributesUpdateMethod: customAttributesUpdateMethod?.asCoreSdkNoteUpdateMethod()
+        )
+    }
+}

--- a/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
@@ -11,6 +11,7 @@ extension CoreSdkClient {
         getVisitorInfo: { _ in fail("\(Self.self).getVisitorInfo") },
         getVisitorInfoDeprecated: { _ in fail("\(Self.self).getVisitorInfoDeprecated")},
         updateVisitorInfo: { _, _ in fail("\(Self.self).updateVisitorInfo") },
+        updateVisitorInfoDeprecated: { _, _ in fail("\(Self.self).updateVisitorInfoDeprecated") },
         configureWithConfiguration: { _, _ in fail("\(Self.self).configureWithConfiguration") },
         configureWithInteractor: { _ in fail("\(Self.self).configureWithInteractor") },
         getQueues: { _ in fail("\(Self.self).listQueues") },

--- a/TestingApp/VisitorInfo/VisitorInfoModel.swift
+++ b/TestingApp/VisitorInfo/VisitorInfoModel.swift
@@ -1,6 +1,5 @@
 import Combine
 import GliaWidgets
-import GliaCoreSDK
 
 final class VisitorInfoModel {
     typealias Props = VisitorInfoViewController.Props


### PR DESCRIPTION
**What was solved?**
To avoid a situation where the integrator needs to import CoreSDK, a widgetSDK VisitorInfoUpdate object was created

MOB-4341
**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
