### PR TITLE
Add shouldStopPushNotifications for deauthenticate to public interface

### DIFF
--- a/GliaWidgets/Public/Glia/Glia.OpaqueAuthentication.swift
+++ b/GliaWidgets/Public/Glia/Glia.OpaqueAuthentication.swift
@@ -8,7 +8,7 @@ extension Glia {
         typealias GetVisitor = () -> Void
 
         var authenticateWithIdToken: (_ idToken: IdToken, _ accessToken: AccessToken?, _ callback: @escaping Callback) -> Void
-        var deauthenticateWithCallback: (@escaping Callback) -> Void
+        var deauthenticateWithCallback: (_ shouldStopPushNotifications: Bool, @escaping Callback) -> Void
         var isAuthenticatedClosure: () -> Bool
         var refresh: (
             _ idToken: IdToken,
@@ -102,9 +102,9 @@ extension Glia {
                     }
                 )
             },
-            deauthenticateWithCallback: { [weak self] callback in
+            deauthenticateWithCallback: { [weak self] shouldStopPushNotifications, callback in
                 self?.loggerPhase.logger.prefixed(Self.self).info("Unauthenticate")
-                auth.deauthenticate { result in
+                auth.deauthenticate(shouldStopPushNotifications: shouldStopPushNotifications) { result in
                     switch result {
                     case .success:
                         // Erase interactor state.
@@ -264,10 +264,11 @@ extension Glia.Authentication {
     /// Deauthenticate Visitor.
     ///
     /// - Parameters:
+    ///   - shouldStopPushNotifications: Boolean that indicates whether to stop Push Notifications after deauthentication or not.
     ///   - completion: Completion handler.
     ///
-    public func deauthenticate(completion: @escaping (Result<Void, Error>) -> Void) {
-        self.deauthenticateWithCallback(completion)
+    public func deauthenticate(shouldStopPushNotifications: Bool = false, completion: @escaping (Result<Void, Error>) -> Void) {
+        self.deauthenticateWithCallback(shouldStopPushNotifications, completion)
     }
 
     /// Initialize placeholder instance.

--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -215,6 +215,9 @@ public class Glia {
                 .receive(on: environment.combineScheduler.main)
                 .first { $0 == .restored }
                 .sink { _ in
+                    self.loggerPhase.logger.prefixed(Self.self).info(
+                        "Chat transcript is opened from Secure Conversation push notification message"
+                    )
                     let engagementLauncher = try? self.getEngagementLauncher(queueIds: [senderQueueId].compactMap { $0 })
                     try? engagementLauncher?.startSecureMessaging(initialScreen: .chatTranscript)
                 }


### PR DESCRIPTION
**What was solved?**
This PR adds shouldStopPushNotifications for deauthenticate to public interface

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [X] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

