### PR TITLE
Fix LiveObservation bridge between WidgetSDK and CoreSDK

### DIFF
--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
@@ -123,8 +123,12 @@ extension CoreSdkClient.SecureConversations {
 
 extension CoreSdkClient.LiveObservation {
     static let live = Self(
-        pause: GliaCore.sharedInstance.liveObservation.pause,
-        resume: GliaCore.sharedInstance.liveObservation.resume
+        pause: {
+            GliaCore.sharedInstance.liveObservation.pause()
+        },
+        resume: {
+            GliaCore.sharedInstance.liveObservation.resume()
+        }
     )
 }
 


### PR DESCRIPTION
**What was solved?**
This PR fixes the issue where live observation interfaces didn't trigger desired action.

MOB-4380
**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
