### PR TITLE
Handle `ENABLE_PUSH_NOTIFICATIONS` boolean value from ProcessInfo

### DIFF
--- a/TestingApp/ViewController/ViewController+Configure.swift
+++ b/TestingApp/ViewController/ViewController+Configure.swift
@@ -48,10 +48,19 @@ extension ViewController {
     }
 
     func setupPushNotificationConfig() {
+        let pushNotifications: Configuration.PushNotifications
+
         #if DEBUG
-        let pushNotifications = Configuration.PushNotifications.sandbox
+        pushNotifications = .sandbox
         #else
-        let pushNotifications = Configuration.PushNotifications.disabled
+        // `ENABLE_PUSH_NOTIFICATIONS` is used for turning PNs on/off
+        // for specific acceptance test.
+        let enablePushes = ProcessInfo.processInfo.environment["ENABLE_PUSH_NOTIFICATIONS"] == "true"
+        if enablePushes {
+            pushNotifications = Configuration.PushNotifications.production
+        } else {
+            pushNotifications = Configuration.PushNotifications.disabled
+        }
         #endif
         configuration.pushNotifications = pushNotifications
 


### PR DESCRIPTION
MOB-4353

**What was solved?**
Passing `ENABLE_PUSH_NOTIFICATIONS` into ProcessInfo from acceptance tests gives a way to enable push notifications for specific test. This value will be used for push notification tests.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
