### PR TITLE
Fix Unified UI for Entry Widget

### DIFF
--- a/GliaWidgets/Sources/EntryWidget/EntryWidgetViewModel.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidgetViewModel.swift
@@ -11,12 +11,12 @@ extension EntryWidgetView {
 
         var style: EntryWidgetStyle {
             if let mediaTypeItemsStyle = configuration.mediaTypeItemsStyle {
-                var widgetStyle = theme.entryWidgetStyle
+                var widgetStyle = theme.entryWidget
                 widgetStyle.mediaTypeItem = mediaTypeItemsStyle.mediaItemStyle
                 widgetStyle.dividerColor = mediaTypeItemsStyle.dividerColor
                 return widgetStyle
             } else {
-                return theme.entryWidgetStyle
+                return theme.entryWidget
             }
         }
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
     - AccessibilitySnapshot/Core
     - SnapshotTesting (~> 1.0)
   - GliaCoreDependency (2.3.0)
-  - GliaCoreSDK (2.1.4):
+  - GliaCoreSDK (2.1.5):
     - GliaCoreDependency (= 2.3.0)
     - TwilioVoice (= 6.8.0)
     - WebRTC-lib (= 119.0.0)
@@ -34,7 +34,7 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   AccessibilitySnapshot: a91e4a69f870188b51f43863d9fc7269d07cdd93
   GliaCoreDependency: 37f48a5a32e2646617b87cbe9d4b30eedd123f6f
-  GliaCoreSDK: b6bf1088d0ff5e73aa84a19c5069df7801ecfe32
+  GliaCoreSDK: a3163e83e6b5a0d2cc7a1e22179cfba16ec10a73
   SnapshotTesting: 6141c48b6aa76ead61431ca665c14ab9a066c53b
   SwiftLint: 3d48e2fb2a3468fdaccf049e5e755df22fb40c2c
   TwilioVoice: 9563c9ad71b9ab7bbad0b59b67cfe4be96c75d23


### PR DESCRIPTION
MOB-4382

**What was solved?**
Customization from Unified UI was not applied to EntryWidget. This PR fixes the issue.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
![Simulator Screenshot - iPhone 16 Pro - 2025-05-26 at 18 17 33](https://github.com/user-attachments/assets/6c197a79-3ffe-4e6b-b522-d58a74d8b900)
![Simulator Screenshot - iPhone 16 Pro - 2025-05-26 at 18 17 44](https://github.com/user-attachments/assets/df4fea95-31e0-4b30-a426-78dc40d00123)
![Simulator Screenshot - iPhone 16 Pro - 2025-05-26 at 18 18 23](https://github.com/user-attachments/assets/4a622a54-04c6-402c-b9c7-59b4cb9b0848)