### PR TITLE
Fix End button visibility bug

### DIFF
--- a/GliaWidgets/Sources/ViewController/Call/CallViewController.Mock.swift
+++ b/GliaWidgets/Sources/ViewController/Call/CallViewController.Mock.swift
@@ -115,6 +115,7 @@ extension CallViewController {
             unreadMessages: unreadMessages,
             startWith: startAction
         )
+        viewModel.activeEngagement = .mock()
         let theme = Theme.mock()
         let viewFactEnv = ViewFactory.Environment.mock
         let viewFactory: ViewFactory = .mock(
@@ -144,6 +145,7 @@ extension CallViewController {
             unreadMessages: unreadMessages,
             startWith: startAction
         )
+        viewModel.activeEngagement = .mock()
         let theme = Theme.mock()
         var viewFactEnv = ViewFactory.Environment.mock
         viewFactEnv.imageViewCache.getImageForKey = { _ in .mock }
@@ -218,6 +220,7 @@ extension CallViewController {
             startWith: startAction,
             environment: callViewModelEnv
         )
+        viewModel.activeEngagement = .mock()
         let theme = Theme.mock()
         let viewFactEnv = ViewFactory.Environment.mock
         let viewFactory: ViewFactory = .mock(
@@ -268,6 +271,7 @@ extension CallViewController {
             startWith: startAction,
             environment: callViewModelEnv
         )
+        viewModel.activeEngagement = .mock()
         let viewFactEnv = ViewFactory.Environment.mock
         let viewFactory: ViewFactory = .mock(
             theme: theme,

--- a/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
@@ -182,7 +182,9 @@ class EngagementViewModel: CommonEngagementModel {
         case .stopped where interactor.currentEngagement?.isTransferredSecureConversation == true:
             engagementAction?(.showCloseButton)
         case .stopped:
-            engagementAction?(.showEndButton)
+            if activeEngagement != nil {
+                engagementAction?(.showEndButton)
+            }
         }
     }
 }

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -1282,7 +1282,7 @@ class ChatViewModelTests: XCTestCase {
             chatType: .secureTranscript(upgradedFromChat: true),
             environment: viewModelEnv
         )
-        
+        viewModel.activeEngagement = .mock()
         enum Call { case refreshAll, showEndButton }
         var calls: [Call] = []
         viewModel.engagementAction = { action in

--- a/GliaWidgetsTests/Sources/EngagementViewModel/EngagementViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/EngagementViewModel/EngagementViewModelTests.swift
@@ -33,6 +33,7 @@ final class EngagementViewModelTests: XCTestCase {
         )
         enum Call { case showEndButton }
         var calls: [Call] = []
+        viewModel.activeEngagement = .mock()
         viewModel.engagementAction = { action in
             switch action {
             case .showEndButton:


### PR DESCRIPTION
**What was solved?**
When a visitor exits enqueued engagement early, the endbutton is briefly shown, which is not intended. This was caused by screensharing handler, that started a flow, in which part of it mistakenly changed the endbutton visibility.

To fix it, we need to check if there is an active engagement, to continue with that part of the flow.

2 scenarios:

1. If there is active engagement, and screensharing is stopped/cleared - show endbutton (expected, and is currently working)
2. If there is no active engagement, and screensharing is stopped/cleared - skip showing endbutton

MOB-4439
**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
