### PR TITLE
Cache endedEngagement for engagement ended by visitor

### DIFF
--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
@@ -286,8 +286,10 @@ extension EngagementCoordinator {
                 environment.log.prefixed(Self.self).info("Submit survey answers")
                 environment.submitSurveyAnswer($0, $1, $2, $3)
             },
-            cancel: {
+            cancel: { [weak self] in
+                guard let self else { return }
                 viewController.dismiss(animated: true) {
+                    self.interactor.cleanup()
                     dismissGliaViewController()
                 }
             },
@@ -295,13 +297,16 @@ extension EngagementCoordinator {
             updateProps: { viewController.props = $0 },
             onError: { [weak self] error in
                 guard let self else { return }
+                self.interactor.cleanup()
                 environment.alertManager.present(
                     in: .root(viewController),
                     as: .error(error: error)
                 )
             },
-            completion: {
+            completion: { [weak self] in
+                guard let self else { return }
                 viewController.dismiss(animated: true) {
+                    self.interactor.cleanup()
                     dismissGliaViewController()
                 }
             }

--- a/GliaWidgets/Sources/Interactor/Interactor.swift
+++ b/GliaWidgets/Sources/Interactor/Interactor.swift
@@ -243,15 +243,25 @@ extension Interactor {
 
     func endEngagement(completion: @escaping (Result<Void, Error>) -> Void) {
         environment.coreSdk.endEngagement { [weak self] _, error in
+            guard let self else { return }
             if let error = error {
                 completion(.failure(error))
             } else {
-                self?.state = .ended(.byVisitor)
+                self.state = .ended(.byVisitor)
+                // Save engagement ended by visitor to fetch a survey
+                self.endedEngagement = self.environment.coreSdk.getCurrentEngagement()
                 completion(.success(()))
             }
         }
     }
 
+    /**
+        Clean up interactor.
+     
+        Used to clean up:
+        * Cached `endedEngagement` that is used for presenting survey.
+        * Interactor `state`.
+    */
     func cleanup() {
         state = .none
         endedEngagement = nil


### PR DESCRIPTION
**What was solved?**
This PR caches endedEngagement for engagement ended by visitor and clean ups interactor after survey ended.

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [X] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

