### PR TITLE
Fix marking messages as read

### DIFF
--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
@@ -275,6 +275,7 @@ extension ChatCoordinator {
             availability: .init(environment: .create(with: environment)),
             deliveredStatusText: viewFactory.theme.chat.visitorMessageStyle.delivered,
             failedToDeliverStatusText: viewFactory.theme.chat.visitorMessageStyle.failedToDeliver,
+            unreadMessages: unreadMessages,
             interactor: interactor
         )
 

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
@@ -648,6 +648,7 @@ extension ChatViewController {
             availability: .mock(),
             deliveredStatusText: "deliveredStatusText",
             failedToDeliverStatusText: "failedToDeliverStatusText",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: .mock()
         )
 
@@ -684,6 +685,7 @@ extension ChatViewController {
             availability: .mock(),
             deliveredStatusText: "deliveredStatusText",
             failedToDeliverStatusText: "failedToDeliverStatusText",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: .mock()
         )
 

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModel.MigrateTests.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModel.MigrateTests.swift
@@ -43,6 +43,7 @@ final class TranscriptModelMigrateTests: XCTestCase {
             ),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: interactor
         )
 

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+GVA.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+GVA.swift
@@ -164,6 +164,7 @@ extension SecureConversationsTranscriptModelTests {
             availability: .init(environment: availabilityEnv),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: .failing
         )
         viewModel.action = { action in
@@ -212,6 +213,7 @@ private extension SecureConversationsTranscriptModelTests {
             availability: .init(environment: availabilityEnv),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: .failing
         )
     }

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+MessageRetry.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+MessageRetry.swift
@@ -150,6 +150,7 @@ private extension SecureConversationsTranscriptModelTests {
             availability: .init(environment: availabilityEnv),
             deliveredStatusText: "",
             failedToDeliverStatusText: "Failed",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: .failing
         )
     }

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+ResponseCard.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+ResponseCard.swift
@@ -58,6 +58,7 @@ private extension SecureConversationsTranscriptModelTests {
             availability: .init(environment: availabilityEnv),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: .failing
         )
     }

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+URLs.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+URLs.swift
@@ -121,6 +121,7 @@ private extension SecureConversationsTranscriptModelTests {
             availability: .init(environment: availabilityEnv),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: .failing
         )
     }

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests.swift
@@ -34,6 +34,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             ),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: .failing
         )
 
@@ -67,6 +68,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             ),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: .failing
         )
 
@@ -104,6 +106,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             ),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: .failing
         )
 
@@ -152,6 +155,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             ),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: .failing
         )
         viewModel.start(isTranscriptFetchNeeded: true)
@@ -187,6 +191,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             ),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: .failing
         )
         viewModel.start(isTranscriptFetchNeeded: true)
@@ -236,6 +241,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             ),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: .failing
         )
 
@@ -279,6 +285,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             ),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: .failing
         )
 
@@ -318,6 +325,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             ),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: .failing
         )
 
@@ -363,6 +371,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             ),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: .failing
         )
 
@@ -405,6 +414,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             ),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: .failing
         )
 
@@ -456,6 +466,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             ),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: .failing
         )
 
@@ -510,6 +521,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             ),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: interactor
         )
 
@@ -578,6 +590,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             ),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: interactor
         )
 
@@ -636,6 +649,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             availability: .init(environment: availabilityEnv),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: .failing
         )
         XCTAssertFalse(model.isSecureConversationsAvailable)
@@ -668,6 +682,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             availability: .init(environment: availabilityEnv),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: .failing
         )
         XCTAssertFalse(model.isSecureConversationsAvailable)
@@ -699,6 +714,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             availability: .init(environment: availabilityEnv),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: .failing
         )
         XCTAssertFalse(model.isSecureConversationsAvailable)
@@ -732,6 +748,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             availability: .init(environment: availabilityEnv),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: .failing
         )
         XCTAssertFalse(model.isSecureConversationsAvailable)
@@ -765,6 +782,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             availability: .init(environment: availabilityEnv),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: .failing
         )
         var actions: [TranscriptModel.Action] = []
@@ -813,7 +831,6 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             Empty<Notification, Never>().eraseToAnyPublisher()
         }
 
-
         let availabilityEnv = SecureConversations.Availability.Environment(
             getQueues: modelEnv.getQueues,
             isAuthenticated: { true },
@@ -830,8 +847,11 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             ),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: 5),
             interactor: .failing
         )
+
+        viewModel.isViewActive.value = true
 
         viewModel.start(isTranscriptFetchNeeded: true)
         scheduler.run()
@@ -882,6 +902,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             ),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: .failing
         )
 
@@ -939,8 +960,11 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             ),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: .failing
         )
+
+        viewModel.isViewActive.value = true
 
         viewModel.engagementAction = { action in
             if case .showAlert(let type) = action, case let .leaveCurrentConversation(_, declined) = type {
@@ -1006,8 +1030,11 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             ),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: interactor
         )
+
+        viewModel.isViewActive.value = true
 
         viewModel.start(isTranscriptFetchNeeded: true)
         scheduler.run()
@@ -1069,6 +1096,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             ),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: .failing
         )
         viewModel.engagementAction = { action in
@@ -1126,6 +1154,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
             ),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: .failing
         )
         viewModel.engagementAction = { action in

--- a/GliaWidgetsTests/SecureConversations/SecureConversations.ChatWithTranscriptModel/SecureConversations.ChatWithTranscriptModelTests.swift
+++ b/GliaWidgetsTests/SecureConversations/SecureConversations.ChatWithTranscriptModel/SecureConversations.ChatWithTranscriptModelTests.swift
@@ -78,6 +78,7 @@ final class SecureConversationsChatWithTranscriptModelTests: XCTestCase {
                 availability: .mock,
                 deliveredStatusText: "Delivered",
                 failedToDeliverStatusText: "Failed to deliver",
+                unreadMessages: ObservableValue<Int>.init(with: .zero),
                 interactor: .mock()
             )
         )

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -532,6 +532,7 @@ class ChatViewModelTests: XCTestCase {
             ),
             deliveredStatusText: "",
             failedToDeliverStatusText: "",
+            unreadMessages: ObservableValue<Int>.init(with: .zero),
             interactor: .failing
         )
 


### PR DESCRIPTION
MOB-4338

**What was solved?**
This PR fixes the issue when operator message received while the Chat screen is minimized are not marked as read properly. This led to the situation when Unread Message Indicator did not disappear even if the messages became read.

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.