### PR TITLE
Fix endbutton missing during engagement

### DIFF
--- a/GliaWidgets/Sources/ViewController/Call/CallViewController.Mock.swift
+++ b/GliaWidgets/Sources/ViewController/Call/CallViewController.Mock.swift
@@ -115,7 +115,8 @@ extension CallViewController {
             unreadMessages: unreadMessages,
             startWith: startAction
         )
-        viewModel.activeEngagement = .mock()
+        interactor.state = .engaged(nil)
+
         let theme = Theme.mock()
         let viewFactEnv = ViewFactory.Environment.mock
         let viewFactory: ViewFactory = .mock(
@@ -220,7 +221,7 @@ extension CallViewController {
             startWith: startAction,
             environment: callViewModelEnv
         )
-        viewModel.activeEngagement = .mock()
+        interactor.state = .engaged(nil)
         let theme = Theme.mock()
         let viewFactEnv = ViewFactory.Environment.mock
         let viewFactory: ViewFactory = .mock(
@@ -271,7 +272,7 @@ extension CallViewController {
             startWith: startAction,
             environment: callViewModelEnv
         )
-        viewModel.activeEngagement = .mock()
+        viewModel.interactor.state = .engaged(nil)
         let viewFactEnv = ViewFactory.Environment.mock
         let viewFactory: ViewFactory = .mock(
             theme: theme,

--- a/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
@@ -182,7 +182,10 @@ class EngagementViewModel: CommonEngagementModel {
         case .stopped where interactor.currentEngagement?.isTransferredSecureConversation == true:
             engagementAction?(.showCloseButton)
         case .stopped:
-            if activeEngagement != nil {
+            switch interactor.state {
+            case .none, .enqueueing, .enqueued, .ended:
+                break
+            case .engaged:
                 engagementAction?(.showEndButton)
             }
         }

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -1283,7 +1283,6 @@ class ChatViewModelTests: XCTestCase {
             chatType: .secureTranscript(upgradedFromChat: true),
             environment: viewModelEnv
         )
-        viewModel.activeEngagement = .mock()
         enum Call { case refreshAll, showEndButton }
         var calls: [Call] = []
         viewModel.engagementAction = { action in
@@ -1299,7 +1298,7 @@ class ChatViewModelTests: XCTestCase {
         interactor.state = .engaged(nil)
 
         XCTAssertEqual(viewModel.chatType, .authenticated)
-        XCTAssertEqual(calls, [.refreshAll, .showEndButton, .refreshAll])
+        XCTAssertEqual(calls, [.refreshAll, .refreshAll])
     }
 
     func test_messageReceivedMarksAsReadIfOnEndIsRetain() {

--- a/GliaWidgetsTests/Sources/EngagementViewModel/EngagementViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/EngagementViewModel/EngagementViewModelTests.swift
@@ -25,15 +25,16 @@ final class EngagementViewModelTests: XCTestCase {
     }
 
     func testHandleScreenSharingStatusShowsEndButton() {
+        let interactor: Interactor = .mock()
+        interactor.state = .engaged(nil)
         let viewModel = EngagementViewModel(
-            interactor: .failing,
-            screenShareHandler: .mock, 
+            interactor: interactor,
+            screenShareHandler: .mock,
             replaceExistingEnqueueing: false,
             environment: .mock
         )
         enum Call { case showEndButton }
         var calls: [Call] = []
-        viewModel.activeEngagement = .mock()
         viewModel.engagementAction = { action in
             switch action {
             case .showEndButton:


### PR DESCRIPTION
**What was solved?**
Endbutton was missing from live engagement. The new logic will display endbutton appropriately, only during engagement
**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
