### PR TITLE
Remove release notes from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,9 @@
 **What was solved?**
 
-**Release notes:**
-
- - [ ] Feature
- - [ ] Ignore
- - [ ] Release notes (Is it clear from the description here?)
- - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)
-
 **Additional info:**
 
 - [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
- - [ ] Did you add logging beneficial for troubleshooting of customer issues?
- - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.
+- [ ] Did you add logging beneficial for troubleshooting of customer issues?
+- [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.
 
 **Screenshots:**


### PR DESCRIPTION



**What was solved?**
[MOB-4469](https://glia.atlassian.net/browse/MOB-4469)
We have agreed that release notes are going to be generated based on Jira tickets

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
- [ ] Did you add logging beneficial for troubleshooting of customer issues?
- [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**


[MOB-4469]: https://glia.atlassian.net/browse/MOB-4469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ