### PR TITLE
Adjust operator avatar placeholder layout with customizable paddings

### DIFF
--- a/GliaWidgets/Sources/Component/ImageView/User/UserImageView.swift
+++ b/GliaWidgets/Sources/Component/ImageView/User/UserImageView.swift
@@ -2,15 +2,19 @@ import UIKit
 
 final class UserImageView: BaseView {
     private let style: UserImageStyle
+    private let placeholderInsets: UIEdgeInsets
     private let placeholderImageView = UIImageView()
+    private let placeholderBackgroundView = UIView()
     private let operatorImageView: ImageView
     private let environment: Environment
 
     init(
         with style: UserImageStyle,
+        placeholderInsets: UIEdgeInsets = .zero,
         environment: Environment
     ) {
         self.style = style
+        self.placeholderInsets = placeholderInsets
         self.environment = environment
         self.operatorImageView = ImageView(environment: .create(with: environment))
         super.init()
@@ -36,9 +40,14 @@ final class UserImageView: BaseView {
         super.defineLayout()
 
         var constraints = [NSLayoutConstraint](); defer { constraints.activate() }
+
+        addSubview(placeholderBackgroundView)
+        placeholderBackgroundView.translatesAutoresizingMaskIntoConstraints = false
+        constraints += placeholderBackgroundView.layoutInSuperview()
+
         addSubview(placeholderImageView)
         placeholderImageView.translatesAutoresizingMaskIntoConstraints = false
-        constraints += placeholderImageView.layoutInSuperview()
+        constraints += placeholderImageView.layoutInSuperview(insets: placeholderInsets)
 
         addSubview(operatorImageView)
         operatorImageView.translatesAutoresizingMaskIntoConstraints = false
@@ -51,9 +60,9 @@ final class UserImageView: BaseView {
         updatePlaceholderContentMode()
         switch style.placeholderBackgroundColor {
         case .fill(let color):
-            placeholderImageView.backgroundColor = color
+            placeholderBackgroundView.backgroundColor = color
         case .gradient(let colors):
-            placeholderImageView.makeGradientBackground(colors: colors)
+            placeholderBackgroundView.makeGradientBackground(colors: colors)
         }
         switch style.imageBackgroundColor {
         case .fill(let color):
@@ -95,6 +104,7 @@ final class UserImageView: BaseView {
 
     private func changeOperatorImageVisibility(visible: Bool) {
         placeholderImageView.isHidden = visible
+        placeholderBackgroundView.isHidden = visible
         operatorImageView.isHidden = !visible
     }
 }

--- a/GliaWidgets/Sources/View/Chat/Message/OperatorChatMessageView.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/OperatorChatMessageView.swift
@@ -1,5 +1,9 @@
 import UIKit
 
+private extension UIEdgeInsets {
+    static let placeholderInsets: Self = .init(top: 2, left: 2, bottom: 2, right: 2)
+}
+
 class OperatorChatMessageView: ChatMessageView {
     var showsOperatorImage: Bool = false {
         didSet {
@@ -7,6 +11,7 @@ class OperatorChatMessageView: ChatMessageView {
                 guard operatorImageView == nil else { return }
                 let operatorImageView = UserImageView(
                     with: viewStyle.operatorImage,
+                    placeholderInsets: .placeholderInsets,
                     environment: .create(with: environment)
                 )
                 self.operatorImageView = operatorImageView


### PR DESCRIPTION
MOB-4471

**What was solved?**
- added the ability to set UIEdgeInsets to adjust paddings for UserImageView.placeholderImageView;
- added 2pt side paddings for OperatorChatMessageView.operatorImageView;

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 ```
Added:
- Paddings for operator message placeholder on Chat screen.
```
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
![Simulator Screenshot - iPhone 16 Pro - 2025-06-20 at 16 55 24](https://github.com/user-attachments/assets/2282c8e7-bcf0-4bf4-a0ce-dfdb62c972ac)