### PR TITLE
Fix option selection on SingleChoiceQuestionView

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -494,6 +494,7 @@
 		8492F9172CAD2F2000242691 /* TranscriptModelTests+ResponseCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8492F9162CAD2F2000242691 /* TranscriptModelTests+ResponseCard.swift */; };
 		8492F9192CAD329800242691 /* TranscriptModelTests+MessageRetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8492F9182CAD329800242691 /* TranscriptModelTests+MessageRetry.swift */; };
 		8492F91B2CAD6ADE00242691 /* ChatViewModelTests+MessageRetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8492F91A2CAD6ADE00242691 /* ChatViewModelTests+MessageRetry.swift */; };
+		8497C1E82E0952F300FE1F1F /* SingleChoiceQuestionViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8497C1E72E0952F300FE1F1F /* SingleChoiceQuestionViewTests.swift */; };
 		84A318A12869ECFC00CA1DE5 /* Unavailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A318A02869ECFC00CA1DE5 /* Unavailable.swift */; };
 		84C24CF82B8353A00089A388 /* ProcessInfoHandling.Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C24CF72B8353A00089A388 /* ProcessInfoHandling.Interface.swift */; };
 		84C24CFA2B83541F0089A388 /* ProcessInfoHandling.Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C24CF92B83541F0089A388 /* ProcessInfoHandling.Mock.swift */; };
@@ -1594,6 +1595,7 @@
 		8492F9162CAD2F2000242691 /* TranscriptModelTests+ResponseCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TranscriptModelTests+ResponseCard.swift"; sourceTree = "<group>"; };
 		8492F9182CAD329800242691 /* TranscriptModelTests+MessageRetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TranscriptModelTests+MessageRetry.swift"; sourceTree = "<group>"; };
 		8492F91A2CAD6ADE00242691 /* ChatViewModelTests+MessageRetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatViewModelTests+MessageRetry.swift"; sourceTree = "<group>"; };
+		8497C1E72E0952F300FE1F1F /* SingleChoiceQuestionViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleChoiceQuestionViewTests.swift; sourceTree = "<group>"; };
 		84A318A02869ECFC00CA1DE5 /* Unavailable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Unavailable.swift; sourceTree = "<group>"; };
 		84C24CF72B8353A00089A388 /* ProcessInfoHandling.Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessInfoHandling.Interface.swift; sourceTree = "<group>"; };
 		84C24CF92B83541F0089A388 /* ProcessInfoHandling.Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessInfoHandling.Mock.swift; sourceTree = "<group>"; };
@@ -2855,10 +2857,6 @@
 		1A60AFC12566857200E53F53 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				C0193DD82D957D0500801CF6 /* PushNotifications */,
-				2198B7AA2CAEB13E002C442B /* QueuesMonitor */,
-				215A25922CA44D900013023E /* EngagementLauncher */,
-				C0F3DE352C69F4A700DE6D7B /* EntryWidget */,
 				C0D6C9E72C09C70B00D4709B /* AlertManager */,
 				C4794E6E270673FC00F989F7 /* Animation */,
 				75940965298D38B6008B173A /* BundleManaging */,
@@ -3767,6 +3765,7 @@
 		7512A57827BF9FB800319DF1 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				8497C1E52E0952D400FE1F1F /* Survey */,
 				84551A962D4A5AFC00C55DA2 /* EngagementViewModel */,
 				84551A932D478BAD00C55DA2 /* CoreSdkClient */,
 				C06B6D4A2CCB916300A66D8A /* EntryWidget */,
@@ -4552,6 +4551,22 @@
 				8492F9142CAAE30F00242691 /* SecureConversations.ChatWithTranscriptModelTests.swift */,
 			);
 			path = SecureConversations.ChatWithTranscriptModel;
+			sourceTree = "<group>";
+		};
+		8497C1E52E0952D400FE1F1F /* Survey */ = {
+			isa = PBXGroup;
+			children = (
+				8497C1E62E0952E200FE1F1F /* SingleChoiceQuestionView */,
+			);
+			path = Survey;
+			sourceTree = "<group>";
+		};
+		8497C1E62E0952E200FE1F1F /* SingleChoiceQuestionView */ = {
+			isa = PBXGroup;
+			children = (
+				8497C1E72E0952F300FE1F1F /* SingleChoiceQuestionViewTests.swift */,
+			);
+			path = SingleChoiceQuestionView;
 			sourceTree = "<group>";
 		};
 		84C24CF62B8353840089A388 /* ProcessInfoHandling */ = {
@@ -6800,6 +6815,7 @@
 				84551A982D4A5B0F00C55DA2 /* EngagementViewModelTests.swift in Sources */,
 				AF1C19802B14FE9F00F8810F /* ConditionalCompilationClient.Failing.swift in Sources */,
 				84520BED2B19FD3000F97617 /* CallVisualizerTests+LO.swift in Sources */,
+				8497C1E82E0952F300FE1F1F /* SingleChoiceQuestionViewTests.swift in Sources */,
 				9A19927027D3BCAE00161AAE /* GCD.Failing.swift in Sources */,
 				215A25982CABC7DF0013023E /* EngagementLauncherTests.swift in Sources */,
 				3142696A29FFB712003DF62E /* Interactor.Failing.swift in Sources */,

--- a/GliaWidgets/Sources/Theme/Theme.Text.swift
+++ b/GliaWidgets/Sources/Theme/Theme.Text.swift
@@ -12,7 +12,7 @@ extension Theme {
         /// Text style
         public var textStyle: UIFont.TextStyle
 
-        /// Text aligmment
+        /// Text alignment
         public var alignment: NSTextAlignment
 
         /// Accessibility related properties
@@ -22,7 +22,7 @@ extension Theme {
         ///   - color: Foreground hex color
         ///   - font: Font
         ///   - textStyle: Text style
-        ///   - alignment: Text aligmment
+        ///   - alignment: Text alignment
         ///   - accessibility: Accessibility related properties
         ///
         public init(

--- a/GliaWidgets/Sources/ViewController/Survey/Components/SingleChoiceQuestionView/Survey.SingleChoiceQuestionView.swift
+++ b/GliaWidgets/Sources/ViewController/Survey/Components/SingleChoiceQuestionView/Survey.SingleChoiceQuestionView.swift
@@ -102,7 +102,7 @@ extension Survey {
             option opt: Survey.Option<String>
         ) -> CheckboxView.State {
             // If user selected or it should be selected by default.
-            let isSelected = props.selected == opt || props.defaultOption == opt
+            let isSelected = props.selected == opt || (props.defaultOption == opt && props.selected == nil)
 
             // Trigger selection manually because the option has
             // been selected by default, not because of user input.

--- a/GliaWidgets/Sources/ViewController/Survey/Mocks/Survey.ViewController.Props.Mock.swift
+++ b/GliaWidgets/Sources/ViewController/Survey/Mocks/Survey.ViewController.Props.Mock.swift
@@ -71,7 +71,7 @@ extension Survey.ViewController.Props {
     }
 }
 
-private extension Survey.ViewController.Props {
+extension Survey.ViewController.Props {
     static func makeScalePropsMock(
         selectedOption: Survey.Option<Int>? = nil,
         showValidationError: Bool = false
@@ -114,6 +114,11 @@ private extension Survey.ViewController.Props {
     }
 
     static func makeSinglePropsMock(
+        options: [Survey.Option<String>] = [
+            .init(name: "First option", value: "\(1)"),
+            .init(name: "Second option", value: "\(2)"),
+            .init(name: "Third option", value: "\(3)")
+        ],
         selectedOption: Survey.Option<String>? = nil,
         defaultOption: Survey.Option<String>? = nil,
         showValidationError: Bool = false
@@ -125,11 +130,7 @@ private extension Survey.ViewController.Props {
             showValidationError: showValidationError,
             accessibility: .init(value: "Required")
         )
-        props.options = [
-            .init(name: "First option", value: "\(1)"),
-            .init(name: "Second option", value: "\(2)"),
-            .init(name: "Third option", value: "\(3)")
-        ].compactMap { $0 }
+        props.options = options.compactMap { $0 }
         props.defaultOption = defaultOption
         props.selected = selectedOption
         return props

--- a/GliaWidgetsTests/Sources/Survey/SingleChoiceQuestionView/SingleChoiceQuestionViewTests.swift
+++ b/GliaWidgetsTests/Sources/Survey/SingleChoiceQuestionView/SingleChoiceQuestionViewTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+@testable import GliaWidgets
+import XCTest
+
+final class SingleChoiceQuestionViewTests: XCTestCase {
+
+    func testHandleSelectionWhenNoOptionIsSelected() {
+        enum Call: Equatable { case select(Survey.Option<String>) }
+        var calls: [Call] = []
+
+        let failureClosure: (Survey.Option<String>) -> Void = { option in
+            XCTFail("Non-default option \(option) should be selected programmatically")
+        }
+        let firstOption = Survey.Option<String>(name: "First option", value: "\(1)", select: failureClosure)
+        let secondOption = Survey.Option<String>.init(name: "Second option", value: "\(2)") { option in
+            calls.append(.select(option))
+        }
+        let thirdOption = Survey.Option<String>.init(name: "Third option", value: "\(3)", select: failureClosure)
+
+        let props = Survey.ViewController.Props.makeSinglePropsMock(
+            options: [
+                firstOption,
+                secondOption,
+                thirdOption
+            ],
+            selectedOption: nil,
+            defaultOption: secondOption,
+            showValidationError: false
+        )
+        
+        [
+            (firstOption, .active),
+            (secondOption, .selected),
+            (thirdOption, .active)
+        ].forEach {
+            testOption($0, props: props, expectedState: $1)
+        }
+
+        XCTAssertEqual(calls, [.select(secondOption)])
+    }
+
+    func testHandleSelectionWhenNonDefaultOptionIsSelected() {
+        let failureClosure: (Survey.Option<String>) -> Void = { option in
+            XCTFail("Non of options should be selected programmatically if selected option already exists")
+        }
+        let firstOption = Survey.Option<String>(name: "First option", value: "\(1)", select: failureClosure)
+        let secondOption = Survey.Option<String>.init(name: "Second option", value: "\(2)", select: failureClosure)
+        let thirdOption = Survey.Option<String>.init(name: "Third option", value: "\(3)", select: failureClosure)
+
+        let props = Survey.ViewController.Props.makeSinglePropsMock(
+            options: [
+                firstOption,
+                secondOption,
+                thirdOption
+            ],
+            selectedOption: firstOption,
+            defaultOption: secondOption,
+            showValidationError: false
+        )
+
+        [
+            (firstOption, .selected),
+            (secondOption, .active),
+            (thirdOption, .active)
+        ].forEach {
+            testOption($0, props: props, expectedState: $1)
+        }
+    }
+
+    func testHandleSelectionWhenDefaultOptionIsSelected() {
+        let failureClosure: (Survey.Option<String>) -> Void = { option in
+            XCTFail("Non of options should be selected programmatically if selected option already exists")
+        }
+        let firstOption = Survey.Option<String>(name: "First option", value: "\(1)", select: failureClosure)
+        let secondOption = Survey.Option<String>.init(name: "Second option", value: "\(2)", select: failureClosure)
+        let thirdOption = Survey.Option<String>.init(name: "Third option", value: "\(3)", select: failureClosure)
+
+        let props = Survey.ViewController.Props.makeSinglePropsMock(
+            options: [
+                firstOption,
+                secondOption,
+                thirdOption
+            ],
+            selectedOption: secondOption,
+            defaultOption: secondOption,
+            showValidationError: false
+        )
+
+        [
+            (firstOption, .active),
+            (secondOption, .selected),
+            (thirdOption, .active)
+        ].forEach {
+            testOption($0, props: props, expectedState: $1)
+        }
+    }
+}
+
+private extension SingleChoiceQuestionViewTests {
+    func testOption(
+        _ option: Survey.Option<String>,
+        props: Survey.SingleChoiceQuestionView.Props,
+        expectedState: Survey.CheckboxView.State
+    ) {
+        let state = Survey.SingleChoiceQuestionView.handleSelection(
+            with: props,
+            option: option
+        )
+
+        XCTAssertEqual(state, expectedState)
+    }
+}


### PR DESCRIPTION
MOB-4474

**What was solved?**
PR fixes the issue that it was unable to deselect “default” selected option

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 ```
Fixed:
- inability to deselect “default” selected option for Single Choice Question on Survey
```

 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.