### PR TITLE
Update Survey UI

### DIFF
--- a/GliaWidgets/Sources/Theme/Survey/Theme.Survey.BooleanQuestion.swift
+++ b/GliaWidgets/Sources/Theme/Survey/Theme.Survey.BooleanQuestion.swift
@@ -34,7 +34,7 @@ public extension Theme.SurveyStyle {
                         accessibility: .init(isFontScalingEnabled: true)
                     ),
                     normalLayer: .init(
-                        borderColor: color.baseNormal.cgColor,
+                        borderColor: color.baseNormal.withAlphaComponent(0.3).cgColor,
                         borderWidth: 1,
                         cornerRadius: 4
                     ),

--- a/GliaWidgets/Sources/Theme/Survey/Theme.Survey.ScaleQuestion.swift
+++ b/GliaWidgets/Sources/Theme/Survey/Theme.Survey.ScaleQuestion.swift
@@ -34,7 +34,7 @@ public extension Theme.SurveyStyle {
                         accessibility: .init(isFontScalingEnabled: true)
                     ),
                     normalLayer: .init(
-                        borderColor: color.baseNormal.cgColor,
+                        borderColor: color.baseNormal.withAlphaComponent(0.3).cgColor,
                         borderWidth: 1,
                         cornerRadius: 4
                     ),

--- a/GliaWidgets/Sources/ViewController/Survey/Components/BooleanQuestionView/Survey.BooleanQuestionView.swift
+++ b/GliaWidgets/Sources/ViewController/Survey/Components/BooleanQuestionView/Survey.BooleanQuestionView.swift
@@ -56,7 +56,7 @@ extension Survey {
                 (0..<abs(delta)).forEach { _ in
                     let buttonView = ButtonView(style: style.option)
                     constraints.append(buttonView.widthAnchor.constraint(greaterThanOrEqualToConstant: 48))
-                    constraints.append(buttonView.heightAnchor.constraint(equalToConstant: 52))
+                    constraints.append(buttonView.heightAnchor.constraint(equalToConstant: 48))
                     optionsStack.addArrangedSubview(buttonView)
                 }
             case ..<0:

--- a/GliaWidgets/Sources/ViewController/Survey/Components/ScaleQuestionView/Survey.ScaleQuestionView.swift
+++ b/GliaWidgets/Sources/ViewController/Survey/Components/ScaleQuestionView/Survey.ScaleQuestionView.swift
@@ -65,7 +65,7 @@ extension Survey {
                 (0..<delta).forEach { _ in
                     let buttonView = ButtonView(style: style.option)
                     constraints.append(buttonView.widthAnchor.constraint(equalToConstant: 48))
-                    constraints.append(buttonView.heightAnchor.constraint(equalToConstant: 52))
+                    constraints.append(buttonView.heightAnchor.constraint(equalToConstant: 48))
                     optionsStack.addArrangedSubview(buttonView)
                 }
             case ..<0:


### PR DESCRIPTION
MOB-4465

**What was solved?**
- change button height on BooleanQuestionView and ScaleQuestionView from 52pt to 48pt;
- change button border color for normal state on BooleanQuestionView and ScaleQuestionView;

**Release notes:**

 - [ ] Feature
 - [ ] Ignore
 - [x] Release notes (Is it clear from the description here?)
 ```
Fixed:
- Survey screen UI is aligned between platforms now;
```
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.