### PR TITLE
Align operator placeholder paddings

### DIFF
--- a/GliaWidgets/Sources/Component/Bubble/BubbleView.swift
+++ b/GliaWidgets/Sources/Component/Bubble/BubbleView.swift
@@ -1,5 +1,9 @@
 import UIKit
 
+private extension UIEdgeInsets {
+    static let placeholderInsets: Self = .init(top: 18, left: 18, bottom: 18, right: 18)
+}
+
 enum BubbleKind {
     case userImage(url: String?)
     case view(UIView)
@@ -128,6 +132,7 @@ class BubbleView: BaseView {
             guard let userImageView = userImageView else {
                 let userImageView = UserImageView(
                     with: style.userImage,
+                    placeholderInsets: .placeholderInsets,
                     environment: .create(with: environment)
                 )
                 userImageView.setOperatorImage(fromUrl: url, animated: true)

--- a/GliaWidgets/Sources/Component/Bubble/BubbleWindow.swift
+++ b/GliaWidgets/Sources/Component/Bubble/BubbleWindow.swift
@@ -10,7 +10,7 @@ class BubbleWindow: UIWindow {
     private let environment: Environment
     private let bubbleView: BubbleView
     private let kSize = CGSize(width: 80, height: 80)
-    private let kBubbleInset: CGFloat = 10
+    private let kBubbleInset: CGFloat = 8
     private let kEdgeInset: CGFloat = 0
     private var initialFrame: CGRect {
         let bounds = environment.uiApplication.windows().first?.frame ?? environment.uiScreen.bounds()

--- a/GliaWidgets/Sources/View/Chat/Message/OperatorChatMessageView.swift
+++ b/GliaWidgets/Sources/View/Chat/Message/OperatorChatMessageView.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 private extension UIEdgeInsets {
-    static let placeholderInsets: Self = .init(top: 2, left: 2, bottom: 2, right: 2)
+    static let placeholderInsets: Self = .init(top: 6, left: 6, bottom: 6, right: 6)
 }
 
 class OperatorChatMessageView: ChatMessageView {

--- a/SnapshotTests/BubbleViewDynamicTypeFontTests.swift
+++ b/SnapshotTests/BubbleViewDynamicTypeFontTests.swift
@@ -6,7 +6,7 @@ import XCTest
 final class BubbleViewDynamicTypeFontTests: SnapshotTestCase {
     func test_bubble_extra3Large() {
         let bubble = ViewFactory.mock().makeBubbleView()
-        bubble.frame = .init(origin: .zero, size: .init(width: 50, height: 50))
+        bubble.frame = .init(origin: .zero, size: .init(width: 64, height: 64))
         bubble.assertSnapshot(as: .extra3LargeFont, in: .portrait)
         bubble.assertSnapshot(as: .extra3LargeFont, in: .landscape)
     }

--- a/SnapshotTests/BubbleViewLayoutTests.swift
+++ b/SnapshotTests/BubbleViewLayoutTests.swift
@@ -5,7 +5,7 @@ import XCTest
 final class BubbleViewLayoutTests: SnapshotTestCase {
     func test_bubble() {
         let bubble = ViewFactory.mock().makeBubbleView()
-        bubble.frame = .init(origin: .zero, size: .init(width: 50, height: 50))
+        bubble.frame = .init(origin: .zero, size: .init(width: 64, height: 64))
         bubble.assertSnapshot(as: .image, in: .portrait)
         bubble.assertSnapshot(as: .image, in: .landscape)
     }

--- a/SnapshotTests/BubbleViewVoiceOverTests.swift
+++ b/SnapshotTests/BubbleViewVoiceOverTests.swift
@@ -6,7 +6,7 @@ import XCTest
 final class BubbleViewVoiceOverTests: SnapshotTestCase {
     func test_bubble() {
         let bubble = ViewFactory.mock().makeBubbleView()
-        bubble.frame = .init(origin: .zero, size: .init(width: 50, height: 50))
+        bubble.frame = .init(origin: .zero, size: .init(width: 64, height: 64))
         bubble.assertSnapshot(as: .accessibilityImage)
     }
 }

--- a/SnapshotTests/BubbleWindowLayoutTests.swift
+++ b/SnapshotTests/BubbleWindowLayoutTests.swift
@@ -5,7 +5,7 @@ import XCTest
 final class BubbleWindowLayoutTests: XCTestCase {
     func test_bubbleWindow() {
         let bubble = ViewFactory.mock().makeBubbleView()
-        bubble.frame = .init(origin: .zero, size: .init(width: 50, height: 50))
+        bubble.frame = .init(origin: .zero, size: .init(width: 64, height: 64))
         let bubbleWindow = BubbleWindow(
             bubbleView: bubble,
             environment: .init(


### PR DESCRIPTION
MOB-4471

**What was solved?**
This PR updates operator placeholder paddings for:
- operator message bubble;
- in-app bubble

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.