### PR TITLE
Fix GVAResponseTextView avatar placeholder

### DIFF
--- a/GliaWidgets/Sources/View/Chat/GVA/GvaResponseTextView.swift
+++ b/GliaWidgets/Sources/View/Chat/GVA/GvaResponseTextView.swift
@@ -1,5 +1,9 @@
 import UIKit
 
+private extension UIEdgeInsets {
+    static let placeholderInsets: Self = .init(top: 6, left: 6, bottom: 6, right: 6)
+}
+
 final class GvaResponseTextView: ChatMessageView {
     var showsOperatorImage: Bool = false {
         didSet {
@@ -7,6 +11,7 @@ final class GvaResponseTextView: ChatMessageView {
                 guard operatorImageView == nil else { return }
                 let operatorImageView = UserImageView(
                     with: viewStyle.operatorImage,
+                    placeholderInsets: .placeholderInsets,
                     environment: .create(with: environment)
                 )
                 self.operatorImageView = operatorImageView

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
@@ -408,7 +408,7 @@ extension ChatViewController {
         chatViewModelEnv.fetchChatHistory = { $0(.success(messages)) }
 
         var viewFactoryEnv = ViewFactory.Environment.mock
-        viewFactoryEnv.imageViewCache.getImageForKey = { _ in UIImage.mock }
+        viewFactoryEnv.imageViewCache.getImageForKey = { _ in nil }
 
         let chatViewModel = ChatViewModel.mock(environment: chatViewModelEnv)
         let controller = ChatViewController.mock(


### PR DESCRIPTION
MOB-4471

**What was solved?**
This view was missed during fixing avatar placeholder paddings. This commit fixes the paddings for GVAResponseTextView

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.