### PR TITLE
Fix showing close button for transferred SC

### DIFF
--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -252,6 +252,7 @@ class ChatViewModel: EngagementViewModel {
             onEngagementTransferring()
         case .onLiveToSecureConversationsEngagementTransferring:
             setChatType(.secureTranscript(upgradedFromChat: true))
+            engagementAction?(.showCloseButton)
             action?(.refreshAll)
         case .engagementTransferred:
             onEngagementTransferred()


### PR DESCRIPTION
MOB-4079

**What was solved?**
Removal of Screen Sharing caused the issue when close button was not shown for Transferred SC. No need to add release notes, because the issue itself has been released yet.

**Release notes:**

 - [ ] Feature
 - [x] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.