### PR TITLE
Add configuration property that allows to disable Push Notification proxy

### DIFF
--- a/GliaWidgets/Public/Configuration/Configuration.swift
+++ b/GliaWidgets/Public/Configuration/Configuration.swift
@@ -33,6 +33,11 @@ public struct Configuration {
     /// permissions during authentication.
     public var suppressPushNotificationsPermissionRequestDuringAuthentication: Bool
 
+    /// If `true`, the SDK will intercept the notification center delegate setup,
+    /// set itself as the main delegate, and then proxy all events to the
+    /// previously set delegate.
+    public var isPushNotificationProxyEnabled: Bool
+
     /// Initializes the configuration.
     ///
     /// - Parameters:
@@ -57,7 +62,8 @@ public struct Configuration {
         isWhiteLabelApp: Bool = false,
         companyName: String = "",
         manualLocaleOverride: String? = nil,
-        suppressPushNotificationsPermissionRequestDuringAuthentication: Bool = false
+        suppressPushNotificationsPermissionRequestDuringAuthentication: Bool = false,
+        isPushNotificationProxyEnabled: Bool = true
     ) {
         self.authorizationMethod = authorizationMethod
         self.environment = environment
@@ -68,6 +74,7 @@ public struct Configuration {
         self.companyName = companyName
         self.manualLocaleOverride = manualLocaleOverride
         self.suppressPushNotificationsPermissionRequestDuringAuthentication = suppressPushNotificationsPermissionRequestDuringAuthentication
+        self.isPushNotificationProxyEnabled = isPushNotificationProxyEnabled
     }
 }
 

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -260,6 +260,16 @@ extension CoreSdkClient {
         var pushHandler: () -> PushHandler?
         var subscribeTo: ([GliaCoreSDK.PushNotificationsType]) -> Void
         var actions: Actions
+        var userNotificationCenterWillPresent: (
+            _ center: UNUserNotificationCenter,
+            _ willPresentNotification: UNNotification,
+            _ completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+        ) -> Void
+        var userNotificationCenterDidReceiveResponse: (
+            _ center: UNUserNotificationCenter,
+            _ didReceiveResponse: UNNotificationResponse,
+            _ completionHandler: @escaping () -> Void
+        ) -> Void
     }
 }
 

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
@@ -152,7 +152,13 @@ extension CoreSdkClient.PushNotifications {
         actions: .init(
             setSecureMessageAction: { GliaCore.sharedInstance.pushNotificationsActionProcessor.secureMessagePushNotificationAction = $0 },
             secureMessageAction: { GliaCore.sharedInstance.pushNotificationsActionProcessor.secureMessagePushNotificationAction }
-        )
+        ),
+        userNotificationCenterWillPresent: { center, notification, completionHandler in
+            GliaCore.sharedInstance.pushNotifications.widgetsNotificationCenter(center, willPresent: notification, withCompletionHandler: completionHandler)
+        },
+        userNotificationCenterDidReceiveResponse: { center, response, completionHandler in
+            GliaCore.sharedInstance.pushNotifications.widgetsNotificationCenter(center, didReceive: response, withCompletionHandler: completionHandler)
+        }
     )
 }
 

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -79,7 +79,9 @@ extension CoreSdkClient.PushNotifications {
         setPushHandler: { _ in },
         pushHandler: { nil },
         subscribeTo: { _ in },
-        actions: .mock
+        actions: .mock,
+        userNotificationCenterWillPresent: { _, _, _ in },
+        userNotificationCenterDidReceiveResponse: { _, _, _ in }
     )
 }
 

--- a/GliaWidgets/Sources/CoreSDKConfigurator/CoreSDKConfigurator.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKConfigurator/CoreSDKConfigurator.Interface.swift
@@ -17,7 +17,8 @@ extension CoreSDKConfigurator {
                     pushNotifications: configuration.pushNotifications.coreSdk,
                     manualLocaleOverride: configuration.manualLocaleOverride,
                     suppressPushNotificationsPermissionRequestDuringAuthentication: configuration
-                        .suppressPushNotificationsPermissionRequestDuringAuthentication
+                        .suppressPushNotificationsPermissionRequestDuringAuthentication,
+                    isPushNotificationProxyEnabled: configuration.isPushNotificationProxyEnabled
                 )
                 coreSdk.configureWithConfiguration(sdkConfiguration, completion)
             }

--- a/GliaWidgets/Sources/PushNotifications/PushNotifications.swift
+++ b/GliaWidgets/Sources/PushNotifications/PushNotifications.swift
@@ -42,6 +42,50 @@ public struct PushNotifications {
         )
     }
 
+    /// Forwards the notification delivery event to the underlying SDK when a notification is about to be presented.
+    ///
+    /// This method should be called from `UNUserNotificationCenterDelegate`'s
+    /// `userNotificationCenter(_:willPresent:withCompletionHandler:)` method.
+    ///
+    /// - Parameters:
+    ///   - center: The `UNUserNotificationCenter` instance handling the notification.
+    ///   - willPresentNotificationCenter: The `UNNotification` to be presented.
+    ///   - completionHandler: A closure that takes the presentation options for the notification.
+    ///
+    public func userNotificationCenterWillPresent(
+        center: UNUserNotificationCenter,
+        willPresent: UNNotification,
+        completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        environment.coreSdk.pushNotifications.userNotificationCenterWillPresent(
+            center,
+            willPresent,
+            completionHandler
+        )
+    }
+
+    /// Forwards the user's response for a delivered notification to the underlying SDK.
+    ///
+    /// This method should be invoked from `UNUserNotificationCenterDelegate`'s
+    /// `userNotificationCenter(_:didReceive:withCompletionHandler:)` method.
+    ///
+    /// - Parameters:
+    ///   - center: The `UNUserNotificationCenter` instance that handled the response.
+    ///   - didReceiveResponseCenter: The `UNNotificationResponse` received from the user.
+    ///   - completionHandler: A closure executed once the response has been handled.
+    ///
+    public func userNotificationCenterDidReceiveResponse(
+        center: UNUserNotificationCenter,
+        didReceive: UNNotificationResponse,
+        completionHandler: @escaping () -> Void
+    ) {
+        environment.coreSdk.pushNotifications.userNotificationCenterDidReceiveResponse(
+            center,
+            didReceive,
+            completionHandler
+        )
+    }
+
     /// Sets the current push action handler that the SDK uses to forward notification actions.
     ///
     /// This handler is executed in response to user interactions with notifications (via

--- a/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
@@ -138,7 +138,9 @@ extension CoreSdkClient.PushNotifications {
         actions: .init(
             setSecureMessageAction: { _ in },
             secureMessageAction: { return nil }
-        )
+        ),
+        userNotificationCenterWillPresent: { _, _, _ in },
+        userNotificationCenterDidReceiveResponse: { _, _, _ in }
     )
 }
 


### PR DESCRIPTION
**What was solved?**
Add configuration property that allows to disable Push Notification proxy

**Release notes:**

 - [ ] Feature
 - [X] Ignore
 - [ ] Release notes (Is it clear from the description here?)
 - [ ] Migration guide (If changes are needed for integrator already using the SDK - what needs to be communicated? Add underneath please)

**Additional info:**

- [X] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
 - [ ] Did you add logging beneficial for troubleshooting of customer issues?
 - [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

