### PR TITLE
Fix automatic enqueueing on Chat screen

### DIFF
--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -164,7 +164,7 @@ class ChatViewModel: EngagementViewModel {
             // We enqueue eagerly in case if this is the first engagement for visitor (by  evaluating previous chat history)
             // or in case if engagement has been restored.
 
-            if history.isEmpty || self.environment.getNonTransferredSecureConversationEngagement() != nil {
+            if history.isEmpty || self.environment.getNonTransferredSecureConversationEngagement() != nil || self.replaceExistingEnqueueing {
                 self.interactor.state = .enqueueing(.chat)
             }
         }

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -1246,6 +1246,100 @@ class ChatViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.shouldForceEnqueueing)
     }
 
+    func testLoadHistoryStartsEnqueueingWhenReplaceExistingEnqueueingIsTrue() throws {
+        var interactorEnv = Interactor.Environment.failing
+        interactorEnv.gcd.mainQueue.async = { $0() }
+
+        let interactor = Interactor.mock(environment: interactorEnv)
+
+        var viewModelEnv = ChatViewModel.Environment.failing()
+        viewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
+        viewModelEnv.fileManager.createDirectoryAtUrlWithIntermediateDirectories = { _, _, _ in }
+        let fileUploadListViewModelEnv = SecureConversations.FileUploadListViewModel.Environment.mock
+        fileUploadListViewModelEnv.uploader.uploads = []
+        viewModelEnv.createFileUploadListModel = { _ in .mock(environment: fileUploadListViewModelEnv) }
+        viewModelEnv.createEntryWidget = { _ in .mock() }
+        viewModelEnv.fetchSiteConfigurations = { _ in }
+        viewModelEnv.loadChatMessagesFromHistory = { true }
+        viewModelEnv.fetchChatHistory = { callback in
+            callback(.success([.mock()]))
+        }
+        viewModelEnv.getNonTransferredSecureConversationEngagement = { nil }
+
+        let viewModel = ChatViewModel.mock(
+            interactor: interactor,
+            chatType: .authenticated,
+            replaceExistingEnqueueing: true,
+            environment: viewModelEnv
+        )
+
+        viewModel.start()
+
+        XCTAssertEqual(interactor.state, .enqueueing(.chat))
+    }
+
+    func testLoadHistoryStartsEnqueueingWhenTranscriptIsEmpty() throws {
+        var interactorEnv = Interactor.Environment.failing
+        interactorEnv.gcd.mainQueue.async = { $0() }
+
+        let interactor = Interactor.mock(environment: interactorEnv)
+
+        var viewModelEnv = ChatViewModel.Environment.failing()
+        viewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
+        viewModelEnv.fileManager.createDirectoryAtUrlWithIntermediateDirectories = { _, _, _ in }
+        let fileUploadListViewModelEnv = SecureConversations.FileUploadListViewModel.Environment.mock
+        fileUploadListViewModelEnv.uploader.uploads = []
+        viewModelEnv.createFileUploadListModel = { _ in .mock(environment: fileUploadListViewModelEnv) }
+        viewModelEnv.createEntryWidget = { _ in .mock() }
+        viewModelEnv.fetchSiteConfigurations = { _ in }
+        viewModelEnv.loadChatMessagesFromHistory = { true }
+        viewModelEnv.fetchChatHistory = { callback in
+            callback(.success([]))
+        }
+        viewModelEnv.getNonTransferredSecureConversationEngagement = { nil }
+
+        let viewModel = ChatViewModel.mock(
+            interactor: interactor,
+            chatType: .authenticated,
+            environment: viewModelEnv
+        )
+
+        viewModel.start()
+
+        XCTAssertEqual(interactor.state, .enqueueing(.chat))
+    }
+
+    func testLoadHistoryStartsEnqueueingWhenOngoingEngagementExists() throws {
+        var interactorEnv = Interactor.Environment.failing
+        interactorEnv.gcd.mainQueue.async = { $0() }
+
+        let interactor = Interactor.mock(environment: interactorEnv)
+
+        var viewModelEnv = ChatViewModel.Environment.failing()
+        viewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
+        viewModelEnv.fileManager.createDirectoryAtUrlWithIntermediateDirectories = { _, _, _ in }
+        let fileUploadListViewModelEnv = SecureConversations.FileUploadListViewModel.Environment.mock
+        fileUploadListViewModelEnv.uploader.uploads = []
+        viewModelEnv.createFileUploadListModel = { _ in .mock(environment: fileUploadListViewModelEnv) }
+        viewModelEnv.createEntryWidget = { _ in .mock() }
+        viewModelEnv.fetchSiteConfigurations = { _ in }
+        viewModelEnv.loadChatMessagesFromHistory = { true }
+        viewModelEnv.fetchChatHistory = { callback in
+            callback(.success([.mock()]))
+        }
+        viewModelEnv.getNonTransferredSecureConversationEngagement = { .mock() }
+
+        let viewModel = ChatViewModel.mock(
+            interactor: interactor,
+            chatType: .authenticated,
+            environment: viewModelEnv
+        )
+
+        viewModel.start()
+
+        XCTAssertEqual(interactor.state, .enqueueing(.chat))
+    }
+
     func testTransferredScSwitchesChatTypeToAuthenticatedOnEngagedState() throws {
         var interactorEnv = Interactor.Environment.failing
         interactorEnv.gcd.mainQueue.async = { $0() }


### PR DESCRIPTION
MOB-4081

**What was solved?**
This PR fixes the issue when visitor does not get enqueued automatically if they press Leave button on Leave Current Conversation dialog.

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
- [ ] Did you add logging beneficial for troubleshooting of customer issues?
- [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.