### PR TITLE
Convert requestEngagedOperator interface to async

### DIFF
--- a/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
+++ b/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
@@ -162,7 +162,9 @@ extension CallVisualizer {
             }
             switch event {
             case let .upgradeOffer(offer, answer):
-                environment.coreSdk.requestEngagedOperator { operators, _ in
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    let operators = try? await self.environment.coreSdk.requestEngagedOperator()
                     self.environment.alertManager.present(
                         in: .global,
                         as: .mediaUpgrade(

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -48,10 +48,7 @@ struct CoreSdkClient {
     var cancelQueueTicket: CancelQueueTicket
 
     var endEngagement: () async throws -> Bool
-
-    typealias RequestEngagedOperator = (_ completion: @escaping Self.OperatorBlock) -> Void
-
-    var requestEngagedOperator: RequestEngagedOperator
+    var requestEngagedOperator: () async throws -> [GliaCoreSDK.Operator]?
 
     typealias UploadFileToEngagement = (
         _ file: Self.EngagementFile,

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
@@ -97,7 +97,17 @@ extension CoreSdkClient {
                     }
                 }
             },
-            requestEngagedOperator: GliaCore.sharedInstance.requestEngagedOperator(completion:),
+            requestEngagedOperator: {
+                try await withCheckedThrowingContinuation { continuation in
+                    GliaCore.sharedInstance.requestEngagedOperator { success, error in
+                        if let error = error {
+                            continuation.resume(throwing: error)
+                        } else {
+                            continuation.resume(returning: success)
+                        }
+                    }
+                }
+            },
             uploadFileToEngagement: GliaCore.sharedInstance.uploadFileToEngagement(_:progress:completion:),
             fetchFile: GliaCore.sharedInstance.fetchFile(engagementFile:progress:completion:),
             getCurrentEngagement: GliaCore.sharedInstance.getCurrentEngagement,

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -20,7 +20,7 @@ extension CoreSdkClient {
         sendMessageWithMessagePayload: { _ in .mock() },
         cancelQueueTicket: { _, _ in },
         endEngagement: { true },
-        requestEngagedOperator: { _ in },
+        requestEngagedOperator: { [] },
         uploadFileToEngagement: { _, _, _ in },
         fetchFile: { _, _, _ in },
         getCurrentEngagement: { return nil },

--- a/GliaWidgets/Sources/Interactor/Interactor.swift
+++ b/GliaWidgets/Sources/Interactor/Interactor.swift
@@ -370,25 +370,25 @@ extension Interactor: CoreSdkClient.Interactable {
         notify(.receivedMessage(message))
     }
 
-    func start() {
-        environment.coreSdk.requestEngagedOperator { [weak self] operators, _ in
-            let engagedOperator = operators?.first
-            self?.state = .engaged(engagedOperator)
-        }
+    func start() async {
+        let operators = try? await environment.coreSdk.requestEngagedOperator()
+        let engagedOperator = operators?.first
+        state = .engaged(engagedOperator)
         currentEngagement = environment.coreSdk.getCurrentEngagement()
     }
 
     func start(engagement: CoreSdkClient.Engagement) {
         switch engagement.source {
         case .coreEngagement:
-            start()
-
+            Task {
+               await start()
+            }
         case .callVisualizer:
-            start()
-
+            Task {
+                await start()
+            }
         case .unknown(let type):
             debugPrint("Unknown engagement started (type='\(type)').")
-
         @unknown default:
             assertionFailure("Unexpected case in 'EngaagementSource' enum.")
         }

--- a/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
@@ -30,9 +30,12 @@ extension CoreSdkClient {
         cancelQueueTicket: { _, _ in fail("cancelQueueTicket") },
         endEngagement: {
             fail("\(Self.self).endEngagement")
-            throw NSError(domain: "Mock", code: -1)
+            throw NSError(domain: "endEngagement", code: -1)
         },
-        requestEngagedOperator: { _ in fail("\(Self.self).requestEngagedOperator") },
+        requestEngagedOperator: {
+            fail("\(Self.self).requestEngagedOperator")
+            throw NSError(domain: "requestEngagedOperator", code: -1)
+        },
         uploadFileToEngagement: { _, _, _ in fail("\(Self.self).uploadFileToEngagement") },
         fetchFile: { _, _, _ in fail("\(Self.self).fetchFile") },
         getCurrentEngagement: { return nil },

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -717,7 +717,8 @@ final class GliaTests: XCTestCase {
         XCTAssertFalse(try XCTUnwrap(sdk.pendingInteraction).hasPendingInteraction)
     }
 
-    func test_deauthenticateErasesInteractorState() throws {
+    @MainActor
+    func test_deauthenticateErasesInteractorState() async throws {
         var uuidGen = UUID.incrementing
         var gliaEnv = Glia.Environment.failing
         var logger = CoreSdkClient.Logger.failing
@@ -736,7 +737,7 @@ final class GliaTests: XCTestCase {
             callback(.success(()))
         })
         gliaEnv.coreSdk.authentication = { _ in authentication }
-        gliaEnv.coreSdk.requestEngagedOperator = { $0([], nil) }
+        gliaEnv.coreSdk.requestEngagedOperator = { [] }
         gliaEnv.gcd.mainQueue.async = { $0() }
         gliaEnv.coreSdk.fetchSiteConfigurations = { _ in }
         gliaEnv.coreSdk.localeProvider.getRemoteString = { _ in nil }
@@ -759,7 +760,7 @@ final class GliaTests: XCTestCase {
             theme: .mock()
         ) { _ in }
 
-        sdk.interactor?.start()
+        await sdk.interactor?.start()
 
         XCTAssertEqual(sdk.interactor?.state, .engaged(nil))
 
@@ -789,7 +790,7 @@ final class GliaTests: XCTestCase {
             completion(.success(()))
         })
         gliaEnv.coreSdk.authentication = { _ in authentication }
-        gliaEnv.coreSdk.requestEngagedOperator = { $0([], nil) }
+        gliaEnv.coreSdk.requestEngagedOperator = { [] }
         gliaEnv.gcd.mainQueue.async = { $0() }
         gliaEnv.gcd.mainQueue.asyncAfterDeadline = { _, _ in }
         gliaEnv.coreSdk.fetchSiteConfigurations = { _ in }

--- a/GliaWidgetsTests/Sources/InteractorTests.swift
+++ b/GliaWidgetsTests/Sources/InteractorTests.swift
@@ -365,14 +365,14 @@ class InteractorTests: XCTestCase {
 
         XCTAssertEqual(callbacks, [.endEngagement])
     }
-    
-    func test_startRequestsEngagedOperatorAndSetsStateToEngaged() throws {
+
+    func test_startRequestsEngagedOperatorAndSetsStateToEngaged() async throws {
         enum Callback: Equatable {
             case engaged
         }
         var callbacks: [Callback] = []
         var interactorEnv = Interactor.Environment.failing
-        interactorEnv.coreSdk.requestEngagedOperator = { $0([.mock()], nil) }
+        interactorEnv.coreSdk.requestEngagedOperator = { [.mock()] }
         interactorEnv.gcd = .mock
         let interactor = Interactor.mock(environment: interactorEnv)
 
@@ -388,11 +388,11 @@ class InteractorTests: XCTestCase {
             }
         }
 
-        interactor.start()
+        await interactor.start()
 
         XCTAssertEqual(callbacks, [.engaged])
     }
-    
+
     func test_endSetsStateToEnded() throws {
         enum Callback: Equatable {
             case ended


### PR DESCRIPTION
This PR converts requestEngagedOperator interface to async and also removes start interfaces from interactor, because they are not in use anywhere in the codebase, except in some tests. Hence, dead weight.

MOB-4564