### PR TITLE
Convert cancel queue ticket interface to async

### DIFF
--- a/GliaWidgets/Public/Glia/Glia.swift
+++ b/GliaWidgets/Public/Glia/Glia.swift
@@ -504,8 +504,14 @@ public class Glia {
             completion(.failure(GliaError.sdkIsNotConfigured))
             return
         }
-
-        interactor?.endSession(completion: completion)
+        Task {
+            do {
+                try await interactor?.endSession()
+                completion(.success(()))
+            } catch {
+                completion(.failure(error))
+            }
+        }
     }
 
     /// List all queues of the configured site. It is also possible to monitor queues changes with

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -40,10 +40,7 @@ struct CoreSdkClient {
     var sendMessagePreview: (_ message: String) async throws -> Bool
     var sendMessageWithMessagePayload: (_ payload: SendMessagePayload) async throws -> Message
 
-    typealias CancelQueueTicket = (
-        _ queueTicket: Self.QueueTicket,
-        _ completion: @escaping GliaCoreSDK.SuccessBlock
-    ) -> Void
+    typealias CancelQueueTicket = (_ queueTicket: Self.QueueTicket) async throws -> Bool
 
     var cancelQueueTicket: CancelQueueTicket
 

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
@@ -85,7 +85,18 @@ extension CoreSdkClient {
                     }
                 }
             },
-            cancelQueueTicket: GliaCore.sharedInstance.cancel(queueTicket:completion:),
+            cancelQueueTicket: { queueTicket in
+                try await withCheckedThrowingContinuation { continuation in
+                    GliaCore.sharedInstance.cancel(queueTicket: queueTicket) { result, error in
+                        if let error {
+                            continuation.resume(throwing: error)
+                            return
+                        } else {
+                            continuation.resume(returning: result)
+                        }
+                    }
+                }
+            },
             endEngagement: {
                 try await withCheckedThrowingContinuation { continuation in
                     GliaCore.sharedInstance.endEngagement { success, error in

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -18,7 +18,7 @@ extension CoreSdkClient {
         queueForEngagement: { _, _, _ in },
         sendMessagePreview: { _ in true },
         sendMessageWithMessagePayload: { _ in .mock() },
-        cancelQueueTicket: { _, _ in },
+        cancelQueueTicket: { _ in true },
         endEngagement: { true },
         requestEngagedOperator: { [] },
         uploadFileToEngagement: { _, _, _ in },

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.InteractorChangedState.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.InteractorChangedState.swift
@@ -22,7 +22,9 @@ extension ChatViewModel {
         case .ended(.byOperator):
             func handleOperatorEndedEngagement() {
                 engagementAction?(.showAlert(.operatorEndedEngagement(action: { [weak self] in
-                    self?.endSession()
+                    Task { [weak self] in
+                        await self?.endSession()
+                    }
                 })))
             }
 
@@ -36,7 +38,9 @@ extension ChatViewModel {
 
             switch endedEngagement.actionOnEnd {
             case .showSurvey:
-                endSession()
+                Task { [weak self] in
+                    await self?.endSession()
+                }
             case .retain:
                 delegate?(.liveChatEngagementUpgradedToSecureMessaging(self))
             case .showEndedNotification:

--- a/GliaWidgetsTests/Sources/CallViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/CallViewModelTests.swift
@@ -469,7 +469,7 @@ class CallViewModelTests: XCTestCase {
         XCTAssertEqual(interactor.state, .enqueued(.mock, .audioCall))
     }
 
-    func test_liveObservationDeclineTriggersNone() throws {
+    func test_liveObservationDeclineTriggersNone() async throws {
         enum Call {
             case queueForEngagement
         }
@@ -505,6 +505,11 @@ class CallViewModelTests: XCTestCase {
         }
         interactor.state = .enqueueing(.audioCall)
         alertConfig?.declined()
+
+        /// Will be removed when AlertManager is refactored in MOB-4574
+        await waitUntil {
+            interactor.state == .ended(.byVisitor)
+        }
         XCTAssertEqual(interactor.state, .ended(.byVisitor))
         XCTAssertTrue(calls.isEmpty)
     }

--- a/GliaWidgetsTests/Sources/ChatView/ChatViewTest.swift
+++ b/GliaWidgetsTests/Sources/ChatView/ChatViewTest.swift
@@ -48,7 +48,8 @@ final class ChatViewTest: XCTestCase {
         }
     }
 
-    func test_viewIsReleasedOnceModuleIsClosedWithResponseCardsInTranscript() throws {
+    @MainActor
+    func test_viewIsReleasedOnceModuleIsClosedWithResponseCardsInTranscript() async throws {
         guard #available(iOS 17, *) else {
             throw XCTSkip("""
                 This test does not pass on OS lower than iOS 17, but actual fix work well.
@@ -103,7 +104,10 @@ final class ChatViewTest: XCTestCase {
         weak var controller = try XCTUnwrap(coordinator.navigationPresenter.viewControllers.last as? ChatViewController)
         weak var viewModel = try XCTUnwrap(controller?.viewModel.engagementModel as? ChatViewModel)
         viewModel?.event(.closeTapped)
-        
+
+        await waitUntil {
+            controller == nil
+        }
         XCTAssertNil(controller)
         XCTAssertNil(viewModel)
     }

--- a/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
@@ -27,7 +27,10 @@ extension CoreSdkClient {
         sendMessageWithMessagePayload: { _ in fail("\(Self.self).sendMessageWithMessagePayload")
             throw NSError(domain: "CoreSdkClient", code: -1, userInfo: nil)
         },
-        cancelQueueTicket: { _, _ in fail("cancelQueueTicket") },
+        cancelQueueTicket: { _ in
+            fail("cancelQueueTicket")
+            throw NSError(domain: "cancelQueueTicket", code: -1, userInfo: nil)
+        },
         endEngagement: {
             fail("\(Self.self).endEngagement")
             throw NSError(domain: "endEngagement", code: -1)


### PR DESCRIPTION
This PR converts cancelQueueTicket interface to async. Unfortunately at least 5 waitUntils were introduced, because refactoring decline/dismissed/confirm actions in Alerts to async at this stage would break all Alerts and make this PR way bigger than the needed scope.

Rest assured, these changes will be introduced in a later PR.

MOB-4565