### PR TITLE
Keep non nil engagement until visitor ends survey

### DIFF
--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
@@ -221,6 +221,9 @@ extension EngagementCoordinator {
         guard let engagement = interactor.endedEngagement,
                 engagement.actionOnEnd == .showSurvey,
                 surveyPresentation == .presentSurvey else {
+            environment.log.prefixed(Self.self).info(
+                "Dismiss Glia screen without showing survey. On end action: \(String(describing: interactor.endedEngagement?.actionOnEnd))"
+            )
             dismissGliaViewController()
             return
         }
@@ -238,6 +241,7 @@ extension EngagementCoordinator {
                     dismissGliaViewController: dismissGliaViewController
                 )
             case .success(.none):
+                environment.log.prefixed(Self.self).info("Survey loaded with no content")
                 dismissGliaViewController()
             case let .failure(error):
                 presentSurveyError(error, dismissGliaViewController: dismissGliaViewController)

--- a/GliaWidgets/Sources/Interactor/Interactor.swift
+++ b/GliaWidgets/Sources/Interactor/Interactor.swift
@@ -73,7 +73,7 @@ class Interactor {
     let visitorContext: Configuration.VisitorContext?
     @Published private(set) var currentEngagement: CoreSdkClient.Engagement?
 
-    // Used to save engagement ended by operator to fetch a survey
+    // Used to save ended engagement to fetch a survey
     private(set) var endedEngagement: CoreSdkClient.Engagement?
 
     private var observers = [() -> (AnyObject?, EventHandler)]()
@@ -245,8 +245,6 @@ extension Interactor {
                 completion(.failure(error))
             } else {
                 self.state = .ended(.byVisitor)
-                // Save engagement ended by visitor to fetch a survey
-                self.endedEngagement = self.environment.coreSdk.getCurrentEngagement()
                 completion(.success(()))
             }
         }
@@ -271,6 +269,10 @@ extension Interactor: CoreSdkClient.Interactable {
     var onEngagementChanged: CoreSdkClient.EngagementChangedBlock {
         return { [weak self] engagement in
             self?.currentEngagement = engagement
+            if let engagement {
+                // Save non-nil engagement ended to fetch a survey
+                self?.endedEngagement = engagement
+            }
         }
     }
 


### PR DESCRIPTION
**What was solved?**
Keep non nil engagement until visitor ends survey

**Additional info:**

- [X] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
- [X] Did you add logging beneficial for troubleshooting of customer issues?
- [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.


