### PR TITLE
End session unconditionally if site settings retrieval fails

### DIFF
--- a/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
@@ -126,7 +126,7 @@ class EngagementViewModel: CommonEngagementModel {
                 case let .failure(error):
                     self.engagementAction?(.showAlert(.error(
                         error: error,
-                        dismissed: conditionallyEndSession
+                        dismissed: endSession
                     )))
                 }
             }
@@ -138,15 +138,6 @@ class EngagementViewModel: CommonEngagementModel {
     func endSession() {
         interactor.endSession { [weak self] _ in
             self?.engagementDelegate?(.finished)
-        }
-    }
-
-    func conditionallyEndSession() {
-        switch self.interactor.state {
-        case .ended:
-            self.endSession()
-        default:
-            break
         }
     }
 


### PR DESCRIPTION
**What was solved?**
This PR ends session unconditionally if site settings retrieval fails

**Additional info:**

- [X] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
- [ ] Did you add logging beneficial for troubleshooting of customer issues?
- [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.
