### PR TITLE
Add shadow to the header in the chatview

### DIFF
--- a/GliaWidgets/Sources/View/Chat/ChatView.DefineLayout.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatView.DefineLayout.swift
@@ -17,6 +17,19 @@ extension ChatView {
         addSubview(tableAndIndicatorStack)
         tableAndIndicatorStack.translatesAutoresizingMaskIntoConstraints = false
         constraints += tableAndIndicatorStack.layoutInSuperview(edges: .horizontal)
+        addSubview(topContentShadowView)
+        topContentShadowView.translatesAutoresizingMaskIntoConstraints = false
+        constraints += [
+            topContentShadowView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            topContentShadowView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            topContentShadowView.topAnchor.constraint(equalTo: tableAndIndicatorStack.topAnchor),
+            topContentShadowView.heightAnchor.constraint(equalToConstant: 12)
+        ]
+        topContentShadowView.isUserInteractionEnabled = false
+        topContentShadowView.backgroundColor = .clear
+        if topContentShadowGradient.superlayer == nil {
+            topContentShadowView.layer.addSublayer(topContentShadowGradient)
+        }
 
         constraints += [
             typingIndicatorView.leadingAnchor.constraint(equalTo: typingIndicatorContainer.leadingAnchor, constant: 10),

--- a/GliaWidgets/Sources/View/Chat/ChatView.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatView.swift
@@ -71,6 +71,8 @@ class ChatView: EngagementView {
         return CGRect(x: x, y: y, width: width, height: height)
     }
 
+    let topContentShadowView = UIView()
+    let topContentShadowGradient = CAGradientLayer()
     // Made internal for Snapshot test purposes
     @Published private(set) var isTopBannerExpanded = false
     @Published private(set) var isTopBannerHidden = true
@@ -124,6 +126,14 @@ class ChatView: EngagementView {
     override func layoutSubviews() {
         super.layoutSubviews()
         moveCallBubbleVisible()
+        topContentShadowGradient.frame = topContentShadowView.bounds
+        topContentShadowGradient.startPoint = CGPoint(x: 0.5, y: 0.0)
+        topContentShadowGradient.endPoint   = CGPoint(x: 0.5, y: 1.0)
+        topContentShadowGradient.colors = [
+            UIColor.black.withAlphaComponent(0.1).cgColor,
+            UIColor.clear.cgColor
+        ]
+        topContentShadowGradient.locations = [0, 1]
     }
 
     override func setup() {


### PR DESCRIPTION
From the user's perspective, the title is accurate. However, from a technical perspective, the shadow is added to the chat scrollview instead, because of the Entry Widget container in Secure Conversations. Innser shadow provides the desired look, so that all the scrolled items disappear underneath the header or header+entryWidget.

MOB-4601
