### PR TITLE
Convert secure conversations get unread message count interface to async

### DIFF
--- a/GliaWidgets/SecureConversations/SecureConversations.MessagesWithUnreadCountLoader.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.MessagesWithUnreadCountLoader.swift
@@ -17,64 +17,91 @@ extension SecureConversations {
         var environment: Environment
 
         func loadMessagesWithUnreadCount(callback: @escaping (Result<MessagesWithUnreadCount, Error>) -> Void) {
-            typealias ReactiveSwift = CoreSdkClient.ReactiveSwift
-            let unreadCountTimeoutProducer = ReactiveSwift.SignalProducer<Void, Never>(value: ())
-            let unreadCountRequestSource = ReactiveSwift.Signal<Result<Int, Error>, Never>.pipe()
-            let unreadCountTimeoutSource = ReactiveSwift.Signal<Result<Int, Error>, Never>.pipe()
-            // In case if `unreadCount` will never be delivered,
-            // (for example if sockets are disconnected, because
-            // `unreadCount` is based on sockets)
-            // we will still receive callback by timeout.
-            let unreadCountRequestWithTimeoutSource = ReactiveSwift.Signal.merge(
-                unreadCountRequestSource.output,
-                unreadCountTimeoutSource.output
-            ).take(first: 1)
+            let stateQueue = DispatchQueue(label: "MessagesWithUnreadCountLoader.state")
+            var didCallback = false
+            var messagesResult: Result<[ChatMessage], Error>?
+            var unreadResult: Result<Int, Error>?
 
-            let messagesSource = ReactiveSwift.Signal<Result<[ChatMessage], CoreSdkClient.SalemoveError>, Never>.pipe()
-
-            let combined = ReactiveSwift.Signal.zip(
-                messagesSource.output,
-                unreadCountRequestWithTimeoutSource
-            )
-
-            unreadCountTimeoutProducer
-                .delay(Self.unreadCountFallbackTimeoutSeconds, on: environment.scheduler)
-                .startWithCompleted {
-                    unreadCountTimeoutSource.input.send(value: .failure(TimeoutError()))
-                }
-
-            combined
-                .observe(on: environment.scheduler)
-                .observeValues { messageResult, unreadCountResult in
-                    callback(
-                        Self.messageWithUnreadCountResult(
-                            messageResult: messageResult.mapError { $0 as Error },
-                            unreadCountResult: unreadCountResult
-                        )
+            func finishIfReady() {
+                stateQueue.async {
+                    guard !didCallback,
+                          let m = messagesResult,
+                          let u = unreadResult
+                    else { return }
+                    didCallback = true
+                    let combined = Self.messageWithUnreadCountResult(
+                        messageResult: m,
+                        unreadCountResult: u
                     )
+                    DispatchQueue.main.async {
+                        callback(combined)
+                    }
                 }
+            }
 
-            environment.getSecureUnreadMessageCount(unreadCountRequestSource.input.send(value:))
-            environment.fetchChatHistory(messagesSource.input.send(value:))
+            Task {
+                do {
+                    let count = try await Self.withTimeout(seconds: Self.unreadCountFallbackTimeoutSeconds) {
+                        try await environment.getSecureUnreadMessageCount()
+                    }
+                    stateQueue.async {
+                        unreadResult = .success(count)
+                        finishIfReady()
+                    }
+                } catch {
+                    stateQueue.async {
+                        unreadResult = .failure(error)
+                        finishIfReady()
+                    }
+                }
+            }
+
+            environment.fetchChatHistory { (result: Result<[ChatMessage], CoreSdkClient.SalemoveError>) in
+                let mapped: Result<[ChatMessage], Error> = result.mapError { $0 as Error }
+                stateQueue.async {
+                    messagesResult = mapped
+                    finishIfReady()
+                }
+            }
         }
 
         static func messageWithUnreadCountResult(
             messageResult: Result<[ChatMessage], Error>,
             unreadCountResult: Result<Int, Error>
         ) -> Result<MessagesWithUnreadCount, Error> {
-                // Without messages unread count does not make much sense,
-                // that is why we prefer to report error for messages in case
-                // of failure for both requests. Same for success - ignore
-                // unreadCount failure in case of successful loading of messages.
-                switch (messageResult, unreadCountResult) {
-                case let (.success(messages), .success(unreadCount)):
-                    return .success(MessagesWithUnreadCount(messages: messages, unreadCount: unreadCount))
-                case let (.success(messages), .failure):
-                    return .success(MessagesWithUnreadCount(messages: messages, unreadCount: .zero))
-                case let (.failure(error), .failure), let (.failure(error), .success):
-                    return .failure(error)
-                }
+            // Without messages unread count does not make much sense,
+            // that is why we prefer to report error for messages in case
+            // of failure for both requests. Same for success - ignore
+            // unreadCount failure in case of successful loading of messages.
+            switch (messageResult, unreadCountResult) {
+            case let (.success(messages), .success(unreadCount)):
+                return .success(MessagesWithUnreadCount(messages: messages, unreadCount: unreadCount))
+            case let (.success(messages), .failure):
+                return .success(MessagesWithUnreadCount(messages: messages, unreadCount: .zero))
+            case let (.failure(error), .failure), let (.failure(error), .success):
+                return .failure(error)
             }
+        }
+
+        private static func withTimeout<T>(
+            seconds: TimeInterval,
+            operation: @escaping () async throws -> T
+        ) async throws -> T {
+            try await withThrowingTaskGroup(of: T.self) { group in
+                group.addTask { try await operation() }
+                group.addTask {
+                    try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+                    throw TimeoutError()
+                }
+
+                guard let first = try await group.next() else {
+                    throw TimeoutError()
+                }
+
+                group.cancelAll()
+                return first
+            }
+        }
     }
 }
 

--- a/GliaWidgets/SecureConversations/SecureConversations.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.swift
@@ -11,7 +11,14 @@ public struct SecureConversations {
     /// - Parameter completion: A callback that will return a `Result` with the number of unread
     /// secure conversation messages on success, or `Swift.Error` on failure.
     public func getUnreadMessageCount(_ callback: @escaping (Result<Int, Error>) -> Void) {
-        environment.coreSdk.secureConversations.getUnreadMessageCount(callback)
+        Task {
+            do {
+                let unreadMessageCount = try await environment.coreSdk.secureConversations.getUnreadMessageCount()
+                callback(.success(unreadMessageCount))
+            } catch {
+                callback(.failure(error))
+            }
+        }
     }
 
     /// Observes the count of unread messages sent through secure conversations.

--- a/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/Chat/ChatCoordinator.swift
@@ -97,7 +97,11 @@ class ChatCoordinator: SubFlowCoordinator, FlowCoordinator {
             // from view did load initiating socket events observation and loading
             // chat transcript. Now, because of migration back from chat to SC is
             // possible we need to call `start` here.
-            start = { transcriptModel.start(isTranscriptFetchNeeded: true) }
+            start = {
+                Task {
+                    await transcriptModel.start(isTranscriptFetchNeeded: true)
+                }
+            }
         } else {
             model = .chat(chatModel(replaceExistingEnqueueing: replaceExistingEnqueueing))
             start = {}

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -159,7 +159,7 @@ extension CoreSdkClient.SecureConversations {
         _ completion: @escaping (Result<EngagementFileInformation, Swift.Error>) -> Void
     ) -> Cancellable
 
-    typealias GetUnreadMessageCount = (_ callback: @escaping (Result<Int, Error>) -> Void) -> Void
+    typealias GetUnreadMessageCount = () async throws -> Int
 
     typealias MarkMessagesAsRead = (_ callback: @escaping (Result<Void, Error>) -> Void) -> Cancellable
 

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
@@ -193,7 +193,18 @@ extension CoreSdkClient.SecureConversations {
     static let live = Self(
         sendMessagePayload: GliaCore.sharedInstance.secureConversations.send(secureMessagePayload:queueIds:completion:),
         uploadFile: GliaCore.sharedInstance.secureConversations.uploadFile(_:progress:completion:),
-        getUnreadMessageCount: GliaCore.sharedInstance.secureConversations.getUnreadMessageCount(completion:),
+        getUnreadMessageCount: {
+            try await withCheckedThrowingContinuation { continuation in
+                GliaCore.sharedInstance.secureConversations.getUnreadMessageCount { result in
+                    switch result {
+                    case let .success(count):
+                        continuation.resume(returning: count)
+                    case let .failure(error):
+                        continuation.resume(throwing: error)
+                    }
+                }
+            }
+        },
         markMessagesAsRead: GliaCore.sharedInstance.secureConversations.markMessagesAsRead(completion:),
         downloadFile: GliaCore.sharedInstance.secureConversations.downloadFile(_:progress:completion:),
         subscribeForUnreadMessageCount: GliaCore.sharedInstance.secureConversations.subscribeToUnreadMessageCount(completion:),

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -44,7 +44,7 @@ extension CoreSdkClient.SecureConversations {
     static let mock = Self(
         sendMessagePayload: { _, _, _ in .mock },
         uploadFile: { _, _, _ in .mock },
-        getUnreadMessageCount: { _ in },
+        getUnreadMessageCount: { 0 },
         markMessagesAsRead: { _ in .mock },
         downloadFile: { _, _, _ in .mock },
         subscribeForUnreadMessageCount: { _ in UUID.mock.uuidString },

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+GVA.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+GVA.swift
@@ -114,7 +114,7 @@ extension SecureConversationsTranscriptModelTests {
         XCTAssertEqual(calls, [.showAlert])
     }
 
-    func test_quickReplyIsShownWhenItIsLastMessage() throws {
+    func test_quickReplyIsShownWhenItIsLastMessage() async throws {
         enum Call { case quickReply }
         var calls: [Call] = []
 
@@ -144,7 +144,7 @@ extension SecureConversationsTranscriptModelTests {
         modelEnv.fetchChatHistory = { $0(.success([message])) }
         modelEnv.loadChatMessagesFromHistory = { true }
         modelEnv.fetchSiteConfigurations = { _ in }
-        modelEnv.secureConversations.getUnreadMessageCount = { $0(.success(0)) }
+        modelEnv.secureConversations.getUnreadMessageCount = { 0 }
         modelEnv.startSocketObservation = {}
         modelEnv.shouldShowLeaveSecureConversationDialog = { _ in false }
         let scheduler = CoreSdkClient.ReactiveSwift.TestScheduler()
@@ -173,6 +173,11 @@ extension SecureConversationsTranscriptModelTests {
         }
         viewModel.start(isTranscriptFetchNeeded: true)
         scheduler.run()
+
+        // Will be removed when fetchChatHistory is converted to async
+        await waitUntil {
+            calls == [.quickReply]
+        }
 
         XCTAssertEqual(calls, [.quickReply])
     }

--- a/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
@@ -102,8 +102,9 @@ extension CoreSdkClient.SecureConversations {
             fail("\(Self.self).uploadFile")
             return .mock
         },
-        getUnreadMessageCount: { _ in
+        getUnreadMessageCount: {
             fail("\(Self.self).getUnreadMessageCount")
+            throw NSError(domain: "getUnreadMessageCount", code: -1)
         },
         markMessagesAsRead: { _ in
             fail("\(Self.self).markMessagesAsRead")

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
@@ -22,7 +22,7 @@ extension GliaTests {
         logger.infoClosure = { _, _, _, _ in }
         sdkEnv.coreSdk.createLogger = { _ in logger }
         sdkEnv.coreSdk.secureConversations.pendingStatus = { _ in }
-        sdkEnv.coreSdk.secureConversations.getUnreadMessageCount = { $0(.success(0)) }
+        sdkEnv.coreSdk.secureConversations.getUnreadMessageCount = { 0 }
         sdkEnv.coreSdk.secureConversations.observePendingStatus = { _ in nil }
         sdkEnv.conditionalCompilation.isDebug = { true }
         sdkEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
@@ -106,7 +106,7 @@ extension GliaTests {
         }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
         environment.coreSdk.getCurrentEngagement = { nil }
-        environment.coreSdk.secureConversations.getUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.secureConversations.getUnreadMessageCount = { 0 }
         environment.coreSdk.secureConversations.observePendingStatus = { _ in nil }
         let sdk = Glia(environment: environment)
         sdk.queuesMonitor = .mock()
@@ -152,7 +152,7 @@ extension GliaTests {
         }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
-        environment.coreSdk.secureConversations.getUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.secureConversations.getUnreadMessageCount = { 0 }
         environment.coreSdk.secureConversations.observePendingStatus = { _ in nil }
 
         let sdk = Glia(environment: environment)
@@ -202,7 +202,7 @@ extension GliaTests {
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.secureConversations.pendingStatus = { _ in }
         environment.coreSdk.getCurrentEngagement = { nil }
-        environment.coreSdk.secureConversations.getUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.secureConversations.getUnreadMessageCount = { 0 }
         environment.coreSdk.secureConversations.observePendingStatus = { _ in nil }
 
         var logger = CoreSdkClient.Logger.failing
@@ -266,7 +266,7 @@ extension GliaTests {
         }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
-        environment.coreSdk.secureConversations.getUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.secureConversations.getUnreadMessageCount = { 0 }
         environment.coreSdk.secureConversations.observePendingStatus = { _ in nil }
 
         let sdk = Glia(environment: environment)
@@ -318,7 +318,7 @@ extension GliaTests {
         }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
-        environment.coreSdk.secureConversations.getUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.secureConversations.getUnreadMessageCount = { 0 }
         environment.coreSdk.secureConversations.observePendingStatus = { _ in nil }
 
         let sdk = Glia(environment: environment)
@@ -372,7 +372,7 @@ extension GliaTests {
         }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.getCurrentEngagement = { nil }
-        environment.coreSdk.secureConversations.getUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.secureConversations.getUnreadMessageCount = { 0 }
         environment.coreSdk.secureConversations.observePendingStatus = { _ in nil }
 
         let sdk = Glia(environment: environment)
@@ -430,7 +430,7 @@ extension GliaTests {
             completion(.success(()))
         }
         environment.coreSdk.getCurrentEngagement = { nil }
-        environment.coreSdk.secureConversations.getUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.secureConversations.getUnreadMessageCount = { 0 }
         environment.coreSdk.secureConversations.observePendingStatus = { _ in nil }
 
         let sdk = Glia(environment: environment)
@@ -523,7 +523,7 @@ extension GliaTests {
             completion(.success(()))
         }
         environment.coreSdk.getCurrentEngagement = { nil }
-        environment.coreSdk.secureConversations.getUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.secureConversations.getUnreadMessageCount = { 0 }
         environment.coreSdk.secureConversations.observePendingStatus = { _ in nil }
 
         let sdk = Glia(environment: environment)
@@ -613,7 +613,7 @@ extension GliaTests {
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
-        environment.coreSdk.secureConversations.getUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.secureConversations.getUnreadMessageCount = { 0 }
         environment.coreSdk.secureConversations.subscribeForUnreadMessageCount = { _ in nil }
         environment.coreSdk.secureConversations.observePendingStatus = { _ in nil }
         environment.coreSdk.fetchSiteConfigurations = { _ in }

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -518,7 +518,7 @@ final class GliaTests: XCTestCase {
         environment.conditionalCompilation.isDebug = { true }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSdk.localeProvider.getRemoteString = { _ in nil }
-        environment.coreSdk.secureConversations.getUnreadMessageCount = { $0(.success(0)) }
+        environment.coreSdk.secureConversations.getUnreadMessageCount = { 0 }
         var engCoordEnvironment = EngagementCoordinator.Environment.engagementCoordEnvironmentWithKeyWindow
         engCoordEnvironment.fileManager = .mock
         environment.createRootCoordinator = { _, _, _, _, _, _ in EngagementCoordinator.mock(environment: engCoordEnvironment) }


### PR DESCRIPTION
This PR converts Secure Conversations getUnreadMessageCount interface to async. In tests, couple of waitUntils were introduced, and will be removed once fetchChatHistory interface is converted.

MOB-4611
