### PR TITLE
Convert secure conversations markMessagesAsRead interface to async

### DIFF
--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -161,7 +161,7 @@ extension CoreSdkClient.SecureConversations {
 
     typealias GetUnreadMessageCount = () async throws -> Int
 
-    typealias MarkMessagesAsRead = (_ callback: @escaping (Result<Void, Error>) -> Void) -> Cancellable
+    typealias MarkMessagesAsRead = () async throws -> Void
 
     typealias DownloadFile = (
         _ file: EngagementFile,

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
@@ -205,7 +205,18 @@ extension CoreSdkClient.SecureConversations {
                 }
             }
         },
-        markMessagesAsRead: GliaCore.sharedInstance.secureConversations.markMessagesAsRead(completion:),
+        markMessagesAsRead: {
+            try await withCheckedThrowingContinuation { continuation in
+                GliaCore.sharedInstance.secureConversations.markMessagesAsRead { result in
+                    switch result {
+                    case .success:
+                        continuation.resume()
+                    case let .failure(error):
+                        continuation.resume(throwing: error)
+                    }
+                }
+            }
+        },
         downloadFile: GliaCore.sharedInstance.secureConversations.downloadFile(_:progress:completion:),
         subscribeForUnreadMessageCount: GliaCore.sharedInstance.secureConversations.subscribeToUnreadMessageCount(completion:),
         unsubscribeFromUnreadMessageCount: GliaCore.sharedInstance.secureConversations.unsubscribeFromUnreadMessageCount,

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -45,7 +45,7 @@ extension CoreSdkClient.SecureConversations {
         sendMessagePayload: { _, _, _ in .mock },
         uploadFile: { _, _, _ in .mock },
         getUnreadMessageCount: { 0 },
-        markMessagesAsRead: { _ in .mock },
+        markMessagesAsRead: {},
         downloadFile: { _, _, _ in .mock },
         subscribeForUnreadMessageCount: { _ in UUID.mock.uuidString },
         unsubscribeFromUnreadMessageCount: { _ in },

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -1130,7 +1130,9 @@ extension ChatViewModel: ApplicationVisibilityTracker {
             delayScheduler: environment.combineScheduler.global
         )
         .sink { [weak self] _ in
-            _ = self?.environment.secureConversations.markMessagesAsRead { _ in }
+            Task {
+                try? await self?.environment.secureConversations.markMessagesAsRead()
+            }
         }
         .store(in: &markMessagesAsReadCancellables)
     }

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests.swift
@@ -833,10 +833,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.uiApplication.applicationState = { .active }
         enum Call: Equatable { case secureMarkMessagesAsRead }
         var calls: [Call] = []
-        modelEnv.secureConversations.markMessagesAsRead = { completion in
+        modelEnv.secureConversations.markMessagesAsRead = {
             calls.append(.secureMarkMessagesAsRead)
-            completion(.success(()))
-            return .mock
         }
         modelEnv.shouldShowLeaveSecureConversationDialog = { _ in false }
         modelEnv.markUnreadMessagesDelay = { .zero }
@@ -895,10 +893,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.messagesWithUnreadCountLoaderScheduler = scheduler
         enum Call: Equatable { case secureMarkMessagesAsRead }
         var calls: [Call] = []
-        modelEnv.secureConversations.markMessagesAsRead = { completion in
+        modelEnv.secureConversations.markMessagesAsRead = {
             calls.append(.secureMarkMessagesAsRead)
-            completion(.success(()))
-            return .mock
         }
         modelEnv.shouldShowLeaveSecureConversationDialog = { _ in true }
         modelEnv.markUnreadMessagesDelay = { .zero }
@@ -949,10 +945,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.messagesWithUnreadCountLoaderScheduler = scheduler
         enum Call: Equatable { case secureMarkMessagesAsRead }
         var calls: [Call] = []
-        modelEnv.secureConversations.markMessagesAsRead = { completion in
+        modelEnv.secureConversations.markMessagesAsRead = {
             calls.append(.secureMarkMessagesAsRead)
-            completion(.success(()))
-            return .mock
         }
         modelEnv.shouldShowLeaveSecureConversationDialog = { _ in true }
         modelEnv.leaveCurrentSecureConversation = .nop
@@ -1019,10 +1013,8 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
         modelEnv.loadChatMessagesFromHistory = { true }
         modelEnv.createEntryWidget = { _ in .mock() }
         modelEnv.uiApplication.applicationState = { .active }
-        modelEnv.secureConversations.markMessagesAsRead = { completion in
+        modelEnv.secureConversations.markMessagesAsRead = {
             calls.append(.secureMarkMessagesAsRead)
-            completion(.success(()))
-            return .mock
         }
         modelEnv.fetchChatHistory = { completion in
             completion(.success([.mock()]))

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -1458,7 +1458,7 @@ class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(calls, [.showCloseButton, .refreshAll])
     }
 
-    func test_messageReceivedMarksAsReadIfOnEndIsRetain() {
+    func test_messageReceivedMarksAsReadIfOnEndIsRetain() async {
         enum Call: Equatable { case secureMarkMessagesAsRead }
         var calls: [Call] = []
         var viewModelEnv = ChatViewModel.Environment.failing()
@@ -1476,10 +1476,8 @@ class ChatViewModelTests: XCTestCase {
         viewModelEnv.notificationCenter.publisherForNotification = { _ in
             Empty<Notification, Never>().eraseToAnyPublisher()
         }
-        viewModelEnv.secureConversations.markMessagesAsRead = { completion in
+        viewModelEnv.secureConversations.markMessagesAsRead = {
             calls.append(.secureMarkMessagesAsRead)
-            completion(.success(()))
-            return .mock
         }
         viewModelEnv.createEntryWidget = { _ in .mock() }
         let viewModel: ChatViewModel = .mock(environment: viewModelEnv)
@@ -1489,6 +1487,10 @@ class ChatViewModelTests: XCTestCase {
 
         viewModel.interactorEvent(.receivedMessage(.mock(sender: .init(type: .operator))))
 
+        // To-do will be removed when combine and async/await bridge is implemented
+        await waitUntil {
+            calls == [.secureMarkMessagesAsRead]
+        }
         XCTAssertEqual(calls, [.secureMarkMessagesAsRead])
     }
     
@@ -1510,10 +1512,8 @@ class ChatViewModelTests: XCTestCase {
         viewModelEnv.notificationCenter.publisherForNotification = { _ in
             Empty<Notification, Never>().eraseToAnyPublisher()
         }
-        viewModelEnv.secureConversations.markMessagesAsRead = { completion in
+        viewModelEnv.secureConversations.markMessagesAsRead = {
             calls.append(.secureMarkMessagesAsRead)
-            completion(.success(()))
-            return .mock
         }
         viewModelEnv.createEntryWidget = { _ in .mock() }
         let viewModel: ChatViewModel = .mock(environment: viewModelEnv)
@@ -1544,10 +1544,8 @@ class ChatViewModelTests: XCTestCase {
         viewModelEnv.notificationCenter.publisherForNotification = { _ in
             Empty<Notification, Never>().eraseToAnyPublisher()
         }
-        viewModelEnv.secureConversations.markMessagesAsRead = { completion in
+        viewModelEnv.secureConversations.markMessagesAsRead = {
             calls.append(.secureMarkMessagesAsRead)
-            completion(.success(()))
-            return .mock
         }
         viewModelEnv.createEntryWidget = { _ in .mock() }
         let viewModel: ChatViewModel = .mock(environment: viewModelEnv)
@@ -1560,7 +1558,7 @@ class ChatViewModelTests: XCTestCase {
         XCTAssertTrue(calls.isEmpty)
     }
     
-    func test_markMessagesAsRead() {
+    func test_markMessagesAsRead() async {
         enum Call: Equatable { case secureMarkMessagesAsRead }
         var calls: [Call] = []
         var viewModelEnv = ChatViewModel.Environment.failing()
@@ -1573,16 +1571,19 @@ class ChatViewModelTests: XCTestCase {
         viewModelEnv.notificationCenter.publisherForNotification = { _ in
             Empty<Notification, Never>().eraseToAnyPublisher()
         }
-        viewModelEnv.secureConversations.markMessagesAsRead = { completion in
+        viewModelEnv.secureConversations.markMessagesAsRead = {
             calls.append(.secureMarkMessagesAsRead)
-            completion(.success(()))
-            return .mock
         }
         viewModelEnv.createEntryWidget = { _ in .mock() }
         let viewModel: ChatViewModel = .mock(environment: viewModelEnv)
         viewModel.event(EngagementViewModel.Event.viewDidAppear)
 
         viewModel.markMessagesAsRead()
+
+        // To-do will be removed when combine and async/await bridge is implemented
+        await waitUntil {
+            calls == [.secureMarkMessagesAsRead]
+        }
 
         XCTAssertEqual(calls, [.secureMarkMessagesAsRead])
     }
@@ -1601,10 +1602,8 @@ class ChatViewModelTests: XCTestCase {
         viewModelEnv.notificationCenter.publisherForNotification = { _ in
             Empty<Notification, Never>().eraseToAnyPublisher()
         }
-        viewModelEnv.secureConversations.markMessagesAsRead = { completion in
+        viewModelEnv.secureConversations.markMessagesAsRead = {
             calls.append(.secureMarkMessagesAsRead)
-            completion(.success(()))
-            return .mock
         }
         viewModelEnv.createEntryWidget = { _ in .mock() }
         let viewModel: ChatViewModel = .mock(environment: viewModelEnv)
@@ -1628,10 +1627,8 @@ class ChatViewModelTests: XCTestCase {
         viewModelEnv.notificationCenter.publisherForNotification = { type in
             Empty<Notification, Never>().eraseToAnyPublisher()
         }
-        viewModelEnv.secureConversations.markMessagesAsRead = { completion in
+        viewModelEnv.secureConversations.markMessagesAsRead = {
             calls.append(.secureMarkMessagesAsRead)
-            completion(.success(()))
-            return .mock
         }
         viewModelEnv.createEntryWidget = { _ in .mock() }
         let viewModel: ChatViewModel = .mock(environment: viewModelEnv)
@@ -1660,10 +1657,8 @@ class ChatViewModelTests: XCTestCase {
             }
             return Empty<Notification, Never>().eraseToAnyPublisher()
         }
-        viewModelEnv.secureConversations.markMessagesAsRead = { completion in
+        viewModelEnv.secureConversations.markMessagesAsRead = {
             calls.append(.secureMarkMessagesAsRead)
-            completion(.success(()))
-            return .mock
         }
         viewModelEnv.createEntryWidget = { _ in .mock() }
         let viewModel: ChatViewModel = .mock(environment: viewModelEnv)
@@ -1674,7 +1669,7 @@ class ChatViewModelTests: XCTestCase {
         XCTAssertTrue(calls.isEmpty)
     }
     
-    func test_markMessagesAsReadNotTriggerIfApplicationGoForeground() {
+    func test_markMessagesAsReadNotTriggerIfApplicationGoForeground() async {
         enum Call: Equatable { case secureMarkMessagesAsRead }
         var calls: [Call] = []
         var viewModelEnv = ChatViewModel.Environment.failing()
@@ -1692,10 +1687,8 @@ class ChatViewModelTests: XCTestCase {
             }
             return Empty<Notification, Never>().eraseToAnyPublisher()
         }
-        viewModelEnv.secureConversations.markMessagesAsRead = { completion in
+        viewModelEnv.secureConversations.markMessagesAsRead = {
             calls.append(.secureMarkMessagesAsRead)
-            completion(.success(()))
-            return .mock
         }
         viewModelEnv.createEntryWidget = { _ in .mock() }
         let viewModel: ChatViewModel = .mock(environment: viewModelEnv)
@@ -1704,6 +1697,10 @@ class ChatViewModelTests: XCTestCase {
         viewModel.markMessagesAsRead()
         notificationPublisher.send(.init(name: UIApplication.willEnterForegroundNotification))
 
+        // To-do will be removed when combine and async/await bridge is implemented
+        await waitUntil {
+            calls == [.secureMarkMessagesAsRead]
+        }
         XCTAssertEqual(calls, [.secureMarkMessagesAsRead])
     }
     
@@ -1721,10 +1718,8 @@ class ChatViewModelTests: XCTestCase {
         viewModelEnv.notificationCenter.publisherForNotification = { type in
             Empty<Notification, Never>().eraseToAnyPublisher()
         }
-        viewModelEnv.secureConversations.markMessagesAsRead = { completion in
+        viewModelEnv.secureConversations.markMessagesAsRead = {
             calls.append(.secureMarkMessagesAsRead)
-            completion(.success(()))
-            return .mock
         }
         viewModelEnv.createEntryWidget = { _ in .mock() }
         let viewModel: ChatViewModel = .mock(environment: viewModelEnv)

--- a/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
@@ -106,9 +106,9 @@ extension CoreSdkClient.SecureConversations {
             fail("\(Self.self).getUnreadMessageCount")
             throw NSError(domain: "getUnreadMessageCount", code: -1)
         },
-        markMessagesAsRead: { _ in
+        markMessagesAsRead: {
             fail("\(Self.self).markMessagesAsRead")
-            return .mock
+            throw NSError(domain: "markMessagesAsRead", code: -1)
         },
         downloadFile: { _, _, _ in
             fail("\(Self.self).downloadFile")


### PR DESCRIPTION
Convert SecureConversations markMessagesAsRead interface to async
This PR converts Secure Conversations markMessagesAsRead interface to async.

MOB-4621