### PR TITLE
Survey. Pin title and bottom bar

### DIFF
--- a/GliaWidgets/Sources/ViewController/Survey/SurveyViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Survey/SurveyViewController.swift
@@ -177,7 +177,8 @@ extension Survey.ViewController {
             let endValue = userInfo[UIResponder.keyboardFrameEndUserInfoKey],
             let durationValue = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] {
             let endRect = view.convert((endValue as AnyObject).cgRectValue, from: view.window)
-            contentView.showKeyboard(keyboardHeight: endRect.height)
+            let height = endRect.height - (view.window?.safeAreaInsets.bottom ?? 0)
+            contentView.showKeyboard(keyboardHeight: height)
             let duration = (durationValue as AnyObject).doubleValue ?? 0.3
             UIView.animate(withDuration: duration) {
                 self.view.layoutIfNeeded()


### PR DESCRIPTION
**What was solved?**
This PR fixes bottom bar behaviour while keyboard is shown. Now it's kept visible when an input field is active.
It also brings the changes that make survey title pinned to top, so it's now always visible during content scrolling.

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
- [ ] Did you add logging beneficial for troubleshooting of customer issues?
- [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.