### PR TITLE
Fix applying textAlignments on Survey screen

### DIFF
--- a/GliaWidgets/Sources/Component/PlaceholderTextView/PlaceholderTextView.swift
+++ b/GliaWidgets/Sources/Component/PlaceholderTextView/PlaceholderTextView.swift
@@ -1,5 +1,10 @@
 import UIKit
 
+private extension CGFloat {
+    static let placeholderVerticalInset: CGFloat = 4
+    static let placeholderHorizontalInset: CGFloat = 8
+}
+
 final class PlaceholderTextView: UITextView {
     private var style: Style {
         didSet {
@@ -44,25 +49,37 @@ final class PlaceholderTextView: UITextView {
         renderStyle()
     }
 
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        let width = bounds.width - 2 * .placeholderHorizontalInset
+        let size = placeholderLabel.sizeThatFits(
+            CGSize(
+                width: width,
+                height: .greatestFiniteMagnitude
+            )
+        )
+        placeholderLabel.frame = .init(
+            x: .placeholderVerticalInset,
+            y: .placeholderHorizontalInset,
+            width: width,
+            height: size.height - 2 * .placeholderVerticalInset
+        )
+    }
+
     private func setupPlaceholder() {
         addSubview(placeholderLabel)
-
-        // Add constraints to position the label
-        placeholderLabel.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            placeholderLabel.topAnchor.constraint(equalTo: self.topAnchor, constant: 4),
-            placeholderLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 8),
-            placeholderLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -8)
-        ])
-
         renderStyle()
     }
 
     private func renderStyle() {
         placeholderLabel.font = style.placeholder.font
         placeholderLabel.textColor = UIColor(hex: style.placeholder.color)
+        placeholderLabel.textAlignment = style.placeholder.alignment
+
         font = style.text.font
         textColor = UIColor(hex: style.text.color)
+        textAlignment = style.text.alignment
     }
 }
 

--- a/GliaWidgets/Sources/Theme/Survey/Theme.Survey.BooleanQuestion.swift
+++ b/GliaWidgets/Sources/Theme/Survey/Theme.Survey.BooleanQuestion.swift
@@ -24,6 +24,7 @@ public extension Theme.SurveyStyle {
                     color: color.baseDark.hex,
                     font: font.mediumSubtitle1,
                     textStyle: .headline,
+                    alignment: .left,
                     accessibility: .init(isFontScalingEnabled: true)
                 ),
                 option: .init(

--- a/GliaWidgets/Sources/Theme/Survey/Theme.Survey.InputQuestion.swift
+++ b/GliaWidgets/Sources/Theme/Survey/Theme.Survey.InputQuestion.swift
@@ -30,6 +30,7 @@ public extension Theme.SurveyStyle {
                     color: color.baseDark.hex,
                     font: font.mediumSubtitle1,
                     textStyle: .headline,
+                    alignment: .left,
                     accessibility: .init(isFontScalingEnabled: true)
                 ),
                 option: .init(
@@ -37,6 +38,7 @@ public extension Theme.SurveyStyle {
                         color: color.baseDark.hex,
                         font: font.bodyText,
                         textStyle: .body,
+                        alignment: .left,
                         accessibility: .init(isFontScalingEnabled: true)
                     ),
                     normalLayer: .init(
@@ -49,6 +51,7 @@ public extension Theme.SurveyStyle {
                         color: color.baseDark.hex,
                         font: font.bodyText,
                         textStyle: .body,
+                        alignment: .left,
                         accessibility: .init(isFontScalingEnabled: true)
                     ),
                     selectedLayer: .init(
@@ -61,6 +64,7 @@ public extension Theme.SurveyStyle {
                         color: color.systemNegative.hex,
                         font: font.bodyText,
                         textStyle: .body,
+                        alignment: .left,
                         accessibility: .init(isFontScalingEnabled: true)
                     ),
                     highlightedLayer: .init(
@@ -83,6 +87,7 @@ public extension Theme.SurveyStyle {
                     color: color.baseNormal.hex,
                     font: font.bodyText,
                     textStyle: .footnote,
+                    alignment: .left,
                     accessibility: .init(isFontScalingEnabled: true)
                 ),
                 error: .default(color: color, font: font),

--- a/GliaWidgets/Sources/Theme/Survey/Theme.Survey.ScaleQuestion.swift
+++ b/GliaWidgets/Sources/Theme/Survey/Theme.Survey.ScaleQuestion.swift
@@ -24,6 +24,7 @@ public extension Theme.SurveyStyle {
                     color: color.baseDark.hex,
                     font: font.mediumSubtitle1,
                     textStyle: .headline,
+                    alignment: .left,
                     accessibility: .init(isFontScalingEnabled: true)
                 ),
                 option: .init(

--- a/GliaWidgets/Sources/Theme/Survey/Theme.Survey.SingleQuestion.swift
+++ b/GliaWidgets/Sources/Theme/Survey/Theme.Survey.SingleQuestion.swift
@@ -27,6 +27,7 @@ public extension Theme.SurveyStyle {
                     color: color.baseDark.hex,
                     font: font.mediumSubtitle1,
                     textStyle: .headline,
+                    alignment: .left,
                     accessibility: .init(isFontScalingEnabled: true)
                 ),
                 tintColor: color.primary.hex,
@@ -35,6 +36,7 @@ public extension Theme.SurveyStyle {
                         color: color.baseDark.hex,
                         font: font.bodyText,
                         textStyle: .body,
+                        alignment: .left,
                         accessibility: .init(isFontScalingEnabled: true)
                     ),
                     accessibility: .init(isFontScalingEnabled: true)

--- a/GliaWidgets/Sources/ViewController/Survey/Components/BooleanQuestionView/Survey.BooleanQuestionView.swift
+++ b/GliaWidgets/Sources/ViewController/Survey/Components/BooleanQuestionView/Survey.BooleanQuestionView.swift
@@ -75,6 +75,7 @@ extension Survey {
                 isRequired: props.isRequired,
                 text: props.title
             )
+            title.textAlignment = style.title.alignment
 
             title.accessibilityLabel = props.title
             title.accessibilityValue = props.accessibility.value

--- a/GliaWidgets/Sources/ViewController/Survey/Components/CheckboxView/Survey.Checkbox.swift
+++ b/GliaWidgets/Sources/ViewController/Survey/Components/CheckboxView/Survey.Checkbox.swift
@@ -124,6 +124,8 @@ extension Survey {
             }
             value.font = style.title.font
             value.textColor = .init(hex: textStyle.color)
+            value.textAlignment = style.title.alignment
+
 			checkImageView.tintColor = checkedTintColor
         }
 

--- a/GliaWidgets/Sources/ViewController/Survey/Components/InputQuestionView/Survey.InputQuestionView.swift
+++ b/GliaWidgets/Sources/ViewController/Survey/Components/InputQuestionView/Survey.InputQuestionView.swift
@@ -68,6 +68,7 @@ extension Survey {
                 text: props.title
             )
 
+            title.textAlignment = style.title.alignment
             title.accessibilityLabel = props.title
             title.accessibilityValue = props.accessibility.titleValue
             textView.accessibilityHint = props.accessibility.fieldHint

--- a/GliaWidgets/Sources/ViewController/Survey/Components/ScaleQuestionView/Survey.ScaleQuestionView.swift
+++ b/GliaWidgets/Sources/ViewController/Survey/Components/ScaleQuestionView/Survey.ScaleQuestionView.swift
@@ -84,6 +84,7 @@ extension Survey {
                 isRequired: props.isRequired,
                 text: props.title
             )
+            title.textAlignment = style.title.alignment
 
             title.accessibilityLabel = props.title
             title.accessibilityValue = props.accessibility.value

--- a/GliaWidgets/Sources/ViewController/Survey/Components/SingleChoiceQuestionView/Survey.SingleChoiceQuestionView.swift
+++ b/GliaWidgets/Sources/ViewController/Survey/Components/SingleChoiceQuestionView/Survey.SingleChoiceQuestionView.swift
@@ -77,6 +77,7 @@ extension Survey {
                 isRequired: props.isRequired,
                 text: props.title
             )
+            title.textAlignment = style.title.alignment
 
             title.accessibilityLabel = props.title
             title.accessibilityValue = props.accessibility.value


### PR DESCRIPTION
MOB-4634

**What was solved?**
This PR introduces applying of `alignment` property for basic text elements on Survey screen.
This PR also fixes placeholder layout on InputQuestionView to be able to adjust its testAlignment.

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
- [ ] Did you add logging beneficial for troubleshooting of customer issues?
- [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.