### PR TITLE
Remove secure conversations pending status interface

### DIFF
--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -136,7 +136,6 @@ extension CoreSdkClient {
         var downloadFile: DownloadFile
         var subscribeForUnreadMessageCount: SubscribeForUnreadMessageCount
         var unsubscribeFromUnreadMessageCount: UnsubscribeFromUnreadCount
-        var pendingStatus: PendingStatus
         var observePendingStatus: ObservePendingStatus
         var unsubscribeFromPendingStatus: UnsubscribeFromPendingStatus
     }
@@ -173,8 +172,6 @@ extension CoreSdkClient.SecureConversations {
     ) -> String?
 
     typealias UnsubscribeFromUnreadCount = (String) -> Void
-
-    typealias PendingStatus = (_ callback: @escaping (Result<Bool, Error>) -> Void) -> Void
 
     typealias ObservePendingStatus = (_ callback: @escaping (Result<Bool, Error>) -> Void) -> String?
 

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
@@ -235,7 +235,6 @@ extension CoreSdkClient.SecureConversations {
         downloadFile: GliaCore.sharedInstance.secureConversations.downloadFile(_:progress:completion:),
         subscribeForUnreadMessageCount: GliaCore.sharedInstance.secureConversations.subscribeToUnreadMessageCount(completion:),
         unsubscribeFromUnreadMessageCount: GliaCore.sharedInstance.secureConversations.unsubscribeFromUnreadMessageCount,
-        pendingStatus: GliaCore.sharedInstance.secureConversations.pendingSecureConversationStatus,
         observePendingStatus: GliaCore.sharedInstance.secureConversations.subscribeToPendingSecureConversationStatus,
         unsubscribeFromPendingStatus: { GliaCore.sharedInstance.secureConversations.unsubscribeFromPendingSecureConversationStatus($0) }
     )

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -49,7 +49,6 @@ extension CoreSdkClient.SecureConversations {
         downloadFile: { _, _, _ in .mock },
         subscribeForUnreadMessageCount: { _ in UUID.mock.uuidString },
         unsubscribeFromUnreadMessageCount: { _ in },
-        pendingStatus: { $0(.success(false)) },
         observePendingStatus: { _ in nil },
         unsubscribeFromPendingStatus: { _ in }
     )

--- a/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
@@ -121,9 +121,6 @@ extension CoreSdkClient.SecureConversations {
         unsubscribeFromUnreadMessageCount: { _ in
             fail("\(Self.self).unsubscribeFromUnreadCount")
         },
-        pendingStatus: { _ in
-            fail("\(Self.self).pendingStatus")
-        },
         observePendingStatus: { _ in
             fail("\(Self.self).observePendingStatus")
             return nil

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+RestoreEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+RestoreEngagement.swift
@@ -229,7 +229,6 @@ extension GliaTests {
         sdkEnv.coreSdk.createLogger = { _ in logger }
         let siteMock = try CoreSdkClient.Site.mock()
         sdkEnv.coreSdk.fetchSiteConfigurations = { callback in callback(.success(siteMock)) }
-        sdkEnv.coreSdk.secureConversations.pendingStatus = { _ in }
         sdkEnv.conditionalCompilation.isDebug = { true }
         sdkEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))

--- a/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests+StartEngagement.swift
@@ -21,7 +21,6 @@ extension GliaTests {
         logger.prefixedClosure = { _ in logger }
         logger.infoClosure = { _, _, _, _ in }
         sdkEnv.coreSdk.createLogger = { _ in logger }
-        sdkEnv.coreSdk.secureConversations.pendingStatus = { _ in }
         sdkEnv.coreSdk.secureConversations.getUnreadMessageCount = { 0 }
         sdkEnv.coreSdk.secureConversations.observePendingStatus = { _ in nil }
         sdkEnv.conditionalCompilation.isDebug = { true }
@@ -200,7 +199,6 @@ extension GliaTests {
             completion(.success(()))
         }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
-        environment.coreSdk.secureConversations.pendingStatus = { _ in }
         environment.coreSdk.getCurrentEngagement = { nil }
         environment.coreSdk.secureConversations.getUnreadMessageCount = { 0 }
         environment.coreSdk.secureConversations.observePendingStatus = { _ in nil }
@@ -468,7 +466,6 @@ extension GliaTests {
         }
 
         environment.coreSdk.localeProvider.getRemoteString = { _ in "" }
-        environment.coreSdk.secureConversations.pendingStatus = { $0(.success(true)) }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
@@ -517,7 +514,6 @@ extension GliaTests {
         }
 
         environment.coreSdk.localeProvider.getRemoteString = { _ in "" }
-        environment.coreSdk.secureConversations.pendingStatus = { $0(.success(false)) }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
@@ -559,7 +555,6 @@ extension GliaTests {
         }
 
         environment.coreSdk.localeProvider.getRemoteString = { _ in "" }
-        environment.coreSdk.secureConversations.pendingStatus = { $0(.success(true)) }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
@@ -608,7 +603,6 @@ extension GliaTests {
         }
 
         environment.coreSdk.localeProvider.getRemoteString = { _ in "" }
-        environment.coreSdk.secureConversations.pendingStatus = { $0(.success(false)) }
         environment.coreSDKConfigurator.configureWithInteractor = { _ in }
         environment.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -706,7 +706,6 @@ final class GliaTests: XCTestCase {
         logger.infoClosure = { _, _, _, _ in }
         logger.prefixedClosure = { _ in logger }
         gliaEnv.coreSdk.createLogger = { _ in logger }
-        gliaEnv.coreSdk.secureConversations.pendingStatus = { $0(.success(false)) }
         gliaEnv.conditionalCompilation.isDebug = { true }
         gliaEnv.coreSdk.secureConversations.subscribeForUnreadMessageCount = { _ in uuidGen().uuidString }
         gliaEnv.coreSdk.secureConversations.observePendingStatus = { _ in uuidGen().uuidString }
@@ -736,7 +735,6 @@ final class GliaTests: XCTestCase {
         logger.infoClosure = { _, _, _, _ in }
         logger.prefixedClosure = { _ in logger }
         gliaEnv.coreSdk.createLogger = { _ in logger }
-        gliaEnv.coreSdk.secureConversations.pendingStatus = { $0(.success(false)) }
         gliaEnv.conditionalCompilation.isDebug = { true }
         gliaEnv.coreSdk.secureConversations.subscribeForUnreadMessageCount = { _ in uuidGen().uuidString }
         gliaEnv.coreSdk.secureConversations.observePendingStatus = { _ in uuidGen().uuidString }
@@ -788,7 +786,6 @@ final class GliaTests: XCTestCase {
         logger.infoClosure = { _, _, _, _ in }
         logger.prefixedClosure = { _ in logger }
         gliaEnv.coreSdk.createLogger = { _ in logger }
-        gliaEnv.coreSdk.secureConversations.pendingStatus = { $0(.success(false)) }
         gliaEnv.conditionalCompilation.isDebug = { true }
         gliaEnv.coreSdk.secureConversations.subscribeForUnreadMessageCount = { _ in uuidGen().uuidString }
         gliaEnv.coreSdk.secureConversations.observePendingStatus = { _ in uuidGen().uuidString }


### PR DESCRIPTION
This interface is not used in the codebase anymore. Pending status can be observed through `observePendingStatus` interface

MOB-4641