### PR TITLE
Allow async operations in alerts

### DIFF
--- a/GliaWidgets/Public/Glia/Glia.Deprecated.swift
+++ b/GliaWidgets/Public/Glia/Glia.Deprecated.swift
@@ -1,6 +1,4 @@
 import Foundation
 import GliaCoreSDK
 
-extension Glia {
-
-}
+extension Glia {}

--- a/GliaWidgets/Sources/AlertManager/Alert/AlertViewController+Confirmation.swift
+++ b/GliaWidgets/Sources/AlertManager/Alert/AlertViewController+Confirmation.swift
@@ -27,14 +27,18 @@ extension AlertViewController {
         let confirmButton: ActionButton = ActionButton(
             props: .init(
                 style: negativeButtonStyle,
-                tap: .init { [weak self] in self?.dismiss(animated: true) { confirmed() } },
+                tap: .sync(
+                    .init { [weak self] in self?.dismiss(animated: true) { confirmed() } }
+                ),
                 accessibilityIdentifier: "alert_negative_button"
             )
         )
         let declineButton = ActionButton(
             props: ActionButton.Props(
                 style: positiveButtonStyle,
-                tap: .init { [weak self] in self?.dismiss(animated: true) { declined?() } },
+                tap: .sync(
+                    .init { [weak self] in self?.dismiss(animated: true) { declined?() } }
+                ),
                 accessibilityIdentifier: "alert_positive_button"
             )
         )
@@ -46,9 +50,9 @@ extension AlertViewController {
     func makeConfirmationAlertView(
         with conf: ConfirmationAlertConfiguration,
         accessibilityIdentifier: String,
-        confirmed: @escaping () -> Void
+        confirmed: @escaping () async -> Void
     ) -> AlertView {
-        let alertView = makeAlertView(
+        let alertView = makeAsyncAlertView(
             with: conf,
             accessibilityIdentifier: accessibilityIdentifier,
             confirmed: confirmed
@@ -68,14 +72,23 @@ extension AlertViewController {
         let declineButton: ActionButton = ActionButton(
             props: .init(
                 style: negativeButtonStyle,
-                tap: .init { [weak self] in self?.dismiss(animated: true) },
+                tap: .sync(
+                    .init { [weak self] in
+                        self?.dismiss(animated: true)
+                    }
+                ),
                 accessibilityIdentifier: "alert_negative_button"
             )
         )
         let confirmButton = ActionButton(
-            props: ActionButton.Props(
+            props: .init(
                 style: positiveButtonStyle,
-                tap: .init { [weak self] in self?.dismiss(animated: true) { confirmed() } },
+                tap: .async(
+                    .init { [weak self] in
+                        await confirmed()
+                        self?.dismiss(animated: true)
+                    }
+                ),
                 accessibilityIdentifier: "alert_positive_button"
             )
         )
@@ -89,6 +102,20 @@ extension AlertViewController {
         with conf: ConfirmationAlertConfiguration,
         accessibilityIdentifier: String,
         confirmed: @escaping () -> Void
+    ) -> AlertView {
+        let alertView = viewFactory.makeAlertView()
+        alertView.title = conf.title
+        alertView.message = conf.message
+        alertView.showsPoweredBy = conf.showsPoweredBy
+        alertView.accessibilityIdentifier = accessibilityIdentifier
+
+        return alertView
+    }
+
+    private func makeAsyncAlertView(
+        with conf: ConfirmationAlertConfiguration,
+        accessibilityIdentifier: String,
+        confirmed: @escaping () async -> Void
     ) -> AlertView {
         let alertView = viewFactory.makeAlertView()
         alertView.title = conf.title

--- a/GliaWidgets/Sources/AlertManager/Alert/AlertViewController+Message.swift
+++ b/GliaWidgets/Sources/AlertManager/Alert/AlertViewController+Message.swift
@@ -4,16 +4,15 @@ extension AlertViewController {
     func makeMessageAlertView(
         with conf: MessageAlertConfiguration,
         accessibilityIdentifier: String?,
-        dismissed: (() -> Void)?
+        dismissed: (() async -> Void)?
     ) -> AlertView {
         let alertView = viewFactory.makeAlertView()
         alertView.title = conf.title
         alertView.message = conf.message
         alertView.showsCloseButton = conf.shouldShowCloseButton
         alertView.closeTapped = { [weak self] in
-            self?.dismiss(animated: true) {
-                dismissed?()
-            }
+            self?.dismiss(animated: true)
+            await dismissed?()
         }
         alertView.accessibilityIdentifier = accessibilityIdentifier
         return alertView

--- a/GliaWidgets/Sources/AlertManager/Alert/AlertViewController+RequestPushNotificationsPermissions.swift
+++ b/GliaWidgets/Sources/AlertManager/Alert/AlertViewController+RequestPushNotificationsPermissions.swift
@@ -22,14 +22,18 @@ extension AlertViewController {
         let declineButton = ActionButton(
             props: .init(
                 style: declineButtonStyle,
-                tap: .init { [weak self] in self?.dismiss(animated: true, completion: declined) }
+                tap: .sync(
+                    .init { [weak self] in self?.dismiss(animated: true, completion: declined) }
+                )
             )
         )
 
         let acceptButton = ActionButton(
             props: .init(
                 style: acceptButtonStyle,
-                tap: .init { [weak self] in self?.dismiss(animated: true, completion: accepted) }
+                tap: .sync(
+                    .init { [weak self] in self?.dismiss(animated: true, completion: accepted) }
+                )
             )
         )
         alertView.addActionView(declineButton)

--- a/GliaWidgets/Sources/AlertManager/Alert/AlertViewController+SingleAction.swift
+++ b/GliaWidgets/Sources/AlertManager/Alert/AlertViewController+SingleAction.swift
@@ -4,7 +4,7 @@ extension AlertViewController {
     func makeSingleActionAlertView(
         with conf: SingleActionAlertConfiguration,
         accessibilityIdentifier: String,
-        actionTapped: @escaping () -> Void
+        actionTapped: @escaping () async -> Void
     ) -> AlertView {
         let alertView = viewFactory.makeAlertView()
         alertView.title = conf.title
@@ -15,7 +15,12 @@ extension AlertViewController {
         let button = ActionButton(
             props: .init(
                 style: buttonStyle,
-                tap: .init { [weak self] in self?.dismiss(animated: true); actionTapped() },
+                tap: .async(
+                    .init { [weak self] in
+                        self?.dismiss(animated: true)
+                        await actionTapped()
+                    }
+                ),
                 accessibilityIdentifier: accessibilityIdentifier
             )
         )

--- a/GliaWidgets/Sources/AlertManager/Alert/AlertViewController+SingleMediaUpgrade.swift
+++ b/GliaWidgets/Sources/AlertManager/Alert/AlertViewController+SingleMediaUpgrade.swift
@@ -21,7 +21,9 @@ extension AlertViewController {
         let declineButton = ActionButton(
             props: .init(
                 style: declineButtonStyle,
-                tap: .init { [weak self] in self?.dismiss(animated: true, completion: declined) },
+                tap: .sync(
+                    .init { [weak self] in self?.dismiss(animated: true, completion: declined) }
+                ),
                 accessibilityIdentifier: "alert_negative_button"
             )
         )
@@ -29,7 +31,9 @@ extension AlertViewController {
         let acceptButton = ActionButton(
             props: .init(
                 style: acceptButtonStyle,
-                tap: .init { [weak self] in self?.dismiss(animated: true, completion: accepted) },
+                tap: .sync(
+                    .init { [weak self] in self?.dismiss(animated: true, completion: accepted) }
+                ),
                 accessibilityIdentifier: "alert_positive_button"
             )
         )

--- a/GliaWidgets/Sources/AlertManager/AlertInputType.swift
+++ b/GliaWidgets/Sources/AlertManager/AlertInputType.swift
@@ -3,19 +3,19 @@ import Foundation
 enum AlertInputType: Equatable {
     case error(
         error: (any Error)?,
-        dismissed: (() -> Void)? = nil
+        dismissed: (() async -> Void)? = nil
     )
     case cameraSettings(dismissed: (() -> Void)? = nil)
-    case endEngagement(confirmed: () -> Void)
-    case leaveQueue(confirmed: () -> Void)
+    case endEngagement(confirmed: () async -> Void)
+    case leaveQueue(confirmed: () async -> Void)
     case liveObservationConfirmation(
         link: (WebViewController.Link) -> Void,
-        accepted: () -> Void,
-        declined: () -> Void
+        accepted: () async -> Void,
+        declined: () async -> Void
     )
     case mediaSourceNotAvailable(dismissed: (() -> Void)? = nil)
     case microphoneSettings(dismissed: (() -> Void)? = nil)
-    case operatorEndedEngagement(action: () -> Void)
+    case operatorEndedEngagement(action: () async -> Void)
     case unsupportedGvaBroadcastError(dismissed: (() -> Void)? = nil)
     case unavailableMessageCenter(dismissed: (() -> Void)? = nil)
     case unavailableMessageCenterForBeingUnauthenticated(dismissed: (() -> Void)? = nil)

--- a/GliaWidgets/Sources/AlertManager/AlertType.swift
+++ b/GliaWidgets/Sources/AlertManager/AlertType.swift
@@ -4,17 +4,17 @@ enum AlertType {
     case message(
         conf: MessageAlertConfiguration,
         accessibilityIdentifier: String?,
-        dismissed: (() -> Void)?
+        dismissed: (() async -> Void)?
     )
     case criticalError(
         conf: MessageAlertConfiguration,
         accessibilityIdentifier: String?,
-        dismissed: (() -> Void)?
+        dismissed: (() async -> Void)?
     )
     case confirmation(
         conf: ConfirmationAlertConfiguration,
         accessibilityIdentifier: String,
-        confirmed: () -> Void
+        confirmed: () async -> Void
     )
     case leaveConversation(
         conf: ConfirmationAlertConfiguration,
@@ -25,7 +25,7 @@ enum AlertType {
     case singleAction(
         conf: SingleActionAlertConfiguration,
         accessibilityIdentifier: String,
-        actionTapped: () -> Void
+        actionTapped: () async -> Void
     )
     case singleMediaUpgrade(
         SingleMediaUpgradeAlertConfiguration,
@@ -35,8 +35,8 @@ enum AlertType {
     case liveObservationConfirmation(
         ConfirmationAlertConfiguration,
         link: (WebViewController.Link) -> Void,
-        accepted: () -> Void,
-        declined: () -> Void
+        accepted: () async -> Void,
+        declined: () async -> Void
     )
     case systemAlert(
         conf: SettingsAlertConfiguration,

--- a/GliaWidgets/Sources/AlertManager/AlertTypeComposer.swift
+++ b/GliaWidgets/Sources/AlertManager/AlertTypeComposer.swift
@@ -101,7 +101,7 @@ private extension AlertManager.AlertTypeComposer {
     ///
     func composeErrorAlert(
         error: (any Error)?,
-        dismissed: (() -> Void)? = nil
+        dismissed: (() async -> Void)? = nil
     ) -> AlertType {
         switch error {
         case let queueError as CoreSdkClient.QueueError:
@@ -125,7 +125,7 @@ private extension AlertManager.AlertTypeComposer {
         }
     }
 
-    func queueClosedAlertType(dismissed: (() -> Void)? = nil) -> AlertType {
+    func queueClosedAlertType(dismissed: (() async -> Void)? = nil) -> AlertType {
         .message(
             conf: theme.alertConfiguration.operatorsUnavailable,
             accessibilityIdentifier: "alert_queue_closed",
@@ -133,7 +133,7 @@ private extension AlertManager.AlertTypeComposer {
         )
     }
 
-    func queueFullAlertType(dismissed: (() -> Void)? = nil) -> AlertType {
+    func queueFullAlertType(dismissed: (() async -> Void)? = nil) -> AlertType {
         environment.log.prefixed(Self.self).info("Show No More Operators Dialog")
         return .message(
             conf: theme.alertConfiguration.operatorsUnavailable,
@@ -142,7 +142,7 @@ private extension AlertManager.AlertTypeComposer {
         )
     }
 
-    func unexpectedErrorAlertType(dismissed: (() -> Void)? = nil) -> AlertType {
+    func unexpectedErrorAlertType(dismissed: (() async -> Void)? = nil) -> AlertType {
         environment.log.prefixed(Self.self).info("Show Unexpected error Dialog")
         return .message(
             conf: theme.alertConfiguration.unexpectedError,
@@ -151,7 +151,7 @@ private extension AlertManager.AlertTypeComposer {
         )
     }
 
-    func expiredAccessTokenAlertType(dismissed: (() -> Void)? = nil) -> AlertType {
+    func expiredAccessTokenAlertType(dismissed: (() async -> Void)? = nil) -> AlertType {
         environment.log.prefixed(Self.self).info("Show authentication error Dialog")
         return .criticalError(
             conf: theme.alertConfiguration.expiredAccessTokenError,
@@ -210,8 +210,8 @@ private extension AlertManager.AlertTypeComposer {
 
     func liveObservationConfirmationAlertType(
         link: @escaping (WebViewController.Link) -> Void,
-        accepted: @escaping () -> Void,
-        declined: @escaping () -> Void
+        accepted: @escaping () async -> Void,
+        declined: @escaping () async -> Void
     ) -> AlertType {
         .liveObservationConfirmation(
             theme.alertConfiguration.liveObservationConfirmation,
@@ -221,7 +221,7 @@ private extension AlertManager.AlertTypeComposer {
         )
     }
 
-    func operatorEndedEngagementAlertType(action: @escaping () -> Void) -> AlertType {
+    func operatorEndedEngagementAlertType(action: @escaping () async -> Void) -> AlertType {
         environment.log.prefixed(Self.self).info("Show Engagement Ended Dialog")
         return .singleAction(
             conf: theme.alertConfiguration.operatorEndedEngagement,
@@ -230,7 +230,7 @@ private extension AlertManager.AlertTypeComposer {
         )
     }
 
-    func leaveQueueAlertType(confirmed: @escaping () -> Void) -> AlertType {
+    func leaveQueueAlertType(confirmed: @escaping () async -> Void) -> AlertType {
         environment.log.prefixed(Self.self).info("Show Exit Queue Dialog")
         return .confirmation(
             conf: theme.alertConfiguration.leaveQueue,
@@ -239,7 +239,7 @@ private extension AlertManager.AlertTypeComposer {
         )
     }
 
-    func endEngagementAlertType(confirmed: @escaping () -> Void) -> AlertType {
+    func endEngagementAlertType(confirmed: @escaping () async -> Void) -> AlertType {
         environment.log.prefixed(Self.self).info("Show End Engagement Dialog")
         return .confirmation(
             conf: theme.alertConfiguration.endEngagement,

--- a/GliaWidgets/Sources/AlertManager/AlertView.swift
+++ b/GliaWidgets/Sources/AlertManager/AlertView.swift
@@ -56,7 +56,7 @@ class AlertView: BaseView {
         return actionsStackView.arrangedSubviews.count
     }
 
-    var closeTapped: (() -> Void)?
+    var closeTapped: (() async -> Void)?
 
     private let style: AlertStyle
     private let titleImageView = UIImageView().makeView()
@@ -188,7 +188,7 @@ class AlertView: BaseView {
 
         let closeButton = Button(
             kind: .alertClose,
-            tap: { [weak self] in self?.closeTapped?() }
+            tap: closeTapped
         )
 
         switch style.closeButtonColor {

--- a/GliaWidgets/Sources/Component/Button/Action/ActionButton.swift
+++ b/GliaWidgets/Sources/Component/Button/Action/ActionButton.swift
@@ -87,7 +87,14 @@ class ActionButton: UIButton {
     }
 
     @objc private func tapped() {
-        props.tap()
+        switch props.tap {
+        case let .sync(cmd):
+            cmd()
+        case let .async(asyncCmd):
+            Task {
+                await asyncCmd()
+            }
+        }
     }
 }
 
@@ -95,13 +102,13 @@ extension ActionButton {
     struct Props: Equatable {
         var style: ActionButtonStyle
         var height: CGFloat
-        var tap: Cmd
+        var tap: Tap
         var accessibilityIdentifier: String
 
         init(
             style: ActionButtonStyle = .init(title: "", titleFont: .systemFont(ofSize: 16), titleColor: .white, backgroundColor: .fill(color: .blue)),
             height: CGFloat = 40,
-            tap: Cmd = .nop,
+            tap: Tap = .nop,
             accessibilityIdentifier: String = ""
         ) {
             self.style = style
@@ -109,5 +116,12 @@ extension ActionButton {
             self.tap = tap
             self.accessibilityIdentifier = accessibilityIdentifier.isEmpty ? style.title : accessibilityIdentifier
         }
+    }
+
+    enum Tap: Equatable {
+        case sync(Cmd)
+        case async(AsyncCmd)
+
+        static var nop: Tap { .sync(.nop) }
     }
 }

--- a/GliaWidgets/Sources/Component/Button/Button.swift
+++ b/GliaWidgets/Sources/Component/Button/Button.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 class Button: AdjustedTouchAreaButton {
-    var tap: (() -> Void)?
+    var tap: (() async -> Void)?
 
     var touchAreaInsets: TouchAreaInsets?
 
@@ -15,7 +15,7 @@ class Button: AdjustedTouchAreaButton {
     private let kind: ButtonKind
     private var activityIndicator: UIActivityIndicatorView?
 
-    init(kind: ButtonKind, tap: (() -> Void)? = nil) {
+    init(kind: ButtonKind, tap: (() async -> Void)? = nil) {
         self.kind = kind
         self.tap = tap
         super.init(touchAreaInsets: kind.properties.touchAreaInsets)
@@ -58,6 +58,8 @@ class Button: AdjustedTouchAreaButton {
     private func layout() {}
 
     @objc private func tapped() {
-        tap?()
+        Task {
+            await tap?()
+        }
     }
 }

--- a/GliaWidgets/Sources/Component/Header/Header.swift
+++ b/GliaWidgets/Sources/Component/Header/Header.swift
@@ -100,7 +100,7 @@ final class Header: BaseView {
         self.endButton?.isHidden = false
         self.closeButton?.isHidden = true
     }
-    
+
     func hideCloseAndEndButtons() {
         self.endButton?.isHidden = true
         self.closeButton?.isHidden = true

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -197,6 +197,7 @@ extension CoreSdkClient {
                 self.secureMessageAction = secureMessageAction
             }
         }
+
         var applicationDidRegisterForRemoteNotificationsWithDeviceToken: (
             _ application: UIApplication,
             _ deviceToken: Data

--- a/GliaWidgets/Sources/LiveObservation/LiveObservationConfirmation.swift
+++ b/GliaWidgets/Sources/LiveObservation/LiveObservationConfirmation.swift
@@ -3,7 +3,7 @@ import Foundation
 extension LiveObservation {
     struct Confirmation {
         let link: (WebViewController.Link) -> Void
-        let accepted: () -> Void
-        let declined: () -> Void
+        let accepted: () async -> Void
+        let declined: () async -> Void
     }
 }

--- a/GliaWidgets/Sources/View/Chat/GVA/PersistentButton/GvaPersistentButtonView.swift
+++ b/GliaWidgets/Sources/View/Chat/GVA/PersistentButton/GvaPersistentButtonView.swift
@@ -56,9 +56,7 @@ final class GvaPersistentButtonView: OperatorChatMessageView {
                 text: option.text
             )
             optionView.tap = { [weak self] in
-                Task {
-                    await self?.onOptionTapped(option)
-                }
+                await self?.onOptionTapped(option)
             }
             return optionView
         }

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
@@ -246,7 +246,7 @@ final class ChatViewController: EngagementViewController, PopoverPresenter {
         let chatHeader = Header.Props(
             title: chatTheme.title,
             effect: .none,
-            endButton: .init(style: chatTheme.header.endButton, tap: endEvent, accessibilityIdentifier: "header_end_button"),
+            endButton: .init(style: chatTheme.header.endButton, tap: .sync(endEvent), accessibilityIdentifier: "header_end_button"),
             backButton: chatHeaderBackButton,
             closeButton: .init(tap: closeEvent, style: chatTheme.header.closeButton),
             style: chatTheme.header
@@ -255,7 +255,7 @@ final class ChatViewController: EngagementViewController, PopoverPresenter {
         let secureTranscriptHeader = Header.Props(
             title: chatTheme.secureTranscriptTitle,
             effect: .none,
-            endButton: .init(style: chatTheme.secureTranscriptHeader.endButton, tap: endEvent, accessibilityIdentifier: "header_end_button"),
+            endButton: .init(style: chatTheme.secureTranscriptHeader.endButton, tap: .sync(endEvent), accessibilityIdentifier: "header_end_button"),
             backButton: nil,
             closeButton: .init(tap: closeEvent, style: chatTheme.secureTranscriptHeader.closeButton),
             style: chatTheme.secureTranscriptHeader

--- a/GliaWidgets/Sources/ViewController/EngagementViewController.swift
+++ b/GliaWidgets/Sources/ViewController/EngagementViewController.swift
@@ -83,8 +83,8 @@ class EngagementViewController: UIViewController {
 
     private func showLiveObservationConfirmation(
         link: @escaping (WebViewController.Link) -> Void,
-        accepted: @escaping () -> Void,
-        declined: @escaping () -> Void
+        accepted: @escaping () async -> Void,
+        declined: @escaping () async -> Void
     ) {
         let config: LiveObservation.Confirmation = .init(
             link: link,

--- a/GliaWidgets/Sources/ViewFactory/ViewFactory.swift
+++ b/GliaWidgets/Sources/ViewFactory/ViewFactory.swift
@@ -49,7 +49,7 @@ class ViewFactory {
             header: .init(
                 title: theme.chat.title,
                 effect: .none,
-                endButton: .init(style: theme.chat.header.endButton, tap: endCmd, accessibilityIdentifier: "header_end_button"),
+                endButton: .init(style: theme.chat.header.endButton, tap: .sync(endCmd), accessibilityIdentifier: "header_end_button"),
                 backButton: backButton,
                 closeButton: .init(tap: closeCmd, style: theme.chat.header.closeButton),
                 style: theme.chat.header
@@ -86,7 +86,7 @@ class ViewFactory {
             header: .init(
                 title: "",
                 effect: .none,
-                endButton: .init(style: theme.call.header.endButton, tap: endCmd, accessibilityIdentifier: "header_end_button"),
+                endButton: .init(style: theme.call.header.endButton, tap: .sync(endCmd), accessibilityIdentifier: "header_end_button"),
                 backButton: backButton,
                 closeButton: .init(tap: closeCmd, style: theme.call.header.closeButton),
                 style: theme.call.header

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.InteractorChangedState.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.InteractorChangedState.swift
@@ -21,11 +21,7 @@ extension ChatViewModel {
 
         case .ended(.byOperator):
             func handleOperatorEndedEngagement() {
-                engagementAction?(.showAlert(.operatorEndedEngagement(action: { [weak self] in
-                    Task { [weak self] in
-                        await self?.endSession()
-                    }
-                })))
+                engagementAction?(.showAlert(.operatorEndedEngagement(action: endSession)))
             }
 
             // When operator ends engagement, `endedEngagement` supposed to be

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -39,7 +39,9 @@ class ChatViewModel: EngagementViewModel {
     private(set) var messageText = "" {
         didSet {
             validateMessage()
-            sendMessagePreview(messageText)
+            Task {
+                await sendMessagePreview(messageText)
+            }
             action?(.setMessageText(messageText))
         }
     }
@@ -522,10 +524,8 @@ extension ChatViewModel {
         self.receivedMessageIds.contains(messageId.uppercased())
     }
 
-    private func sendMessagePreview(_ message: String) {
-        Task {
-            _ = try? await interactor.sendMessagePreview(message)
-        }
+    private func sendMessagePreview(_ message: String) async {
+        _ = try? await interactor.sendMessagePreview(message)
     }
 
     @MainActor

--- a/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/EngagementViewModel.swift
@@ -160,17 +160,9 @@ private extension EngagementViewModel {
     private func closeTapped() {
         switch interactor.state {
         case .enqueueing, .enqueued:
-            engagementAction?(.showAlert(.leaveQueue(confirmed: { [weak self] in
-                Task { [weak self] in
-                    await self?.endSession()
-                }
-            })))
+            engagementAction?(.showAlert(.leaveQueue(confirmed: endSession)))
         case .engaged where interactor.currentEngagement?.isTransferredSecureConversation == false:
-            engagementAction?(.showAlert(.endEngagement(confirmed: { [weak self] in
-                Task { [weak self] in
-                    await self?.endSession()
-                }
-            })))
+            engagementAction?(.showAlert(.endEngagement(confirmed: endSession)))
         default:
             Task { [weak self] in
                 await self?.endSession()
@@ -199,18 +191,14 @@ extension EngagementViewModel {
                 self?.engagementDelegate?(.openLink(link))
             },
             accepted: { [weak self] in
-                Task { [weak self] in
-                    guard let self else { return }
-                    await self.enqueue(
-                        engagementKind: engagementKind,
-                        replaceExisting: self.replaceExistingEnqueueing
-                    )
-                }
+                guard let self else { return }
+                await self.enqueue(
+                    engagementKind: engagementKind,
+                    replaceExisting: self.replaceExistingEnqueueing
+                )
             },
             declined: { [weak self] in
-                Task { [weak self] in
-                    await self?.endSession()
-                }
+                await self?.endSession()
             }
         ))
     }
@@ -240,8 +228,8 @@ extension EngagementViewModel {
         case showCloseButton
         case showLiveObservationConfirmation(
             link: (WebViewController.Link) -> Void,
-            accepted: () -> Void,
-            declined: () -> Void
+            accepted: () async -> Void,
+            declined: () async -> Void
         )
         case showAlert(AlertInputType)
     }

--- a/GliaWidgetsTests/CallVisualizer/ScreenSharing/Mocks/ActionButton.Mock.swift
+++ b/GliaWidgetsTests/CallVisualizer/ScreenSharing/Mocks/ActionButton.Mock.swift
@@ -6,7 +6,7 @@ extension ActionButton.Props {
     static func mock(
         style: ActionButtonStyle = .mock(),
         height: CGFloat = 40,
-        tap: Cmd = .nop,
+        tap: ActionButton.Tap = .sync(.nop),
         accessibilityIdentifier: String = ""
     ) -> ActionButton.Props {
         return .init(
@@ -17,5 +17,4 @@ extension ActionButton.Props {
         )
     }
 }
-
 #endif

--- a/GliaWidgetsTests/Sources/CallViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/CallViewModelTests.swift
@@ -463,12 +463,8 @@ class CallViewModelTests: XCTestCase {
             }
         }
         interactor.state = .enqueueing(.audioCall)
-        alertConfig?.accepted()
+        await alertConfig?.accepted()
 
-        await waitUntil {
-            interactor.state == .enqueued(.mock, .audioCall)
-        }
-        
         XCTAssertEqual(interactor.state, .enqueued(.mock, .audioCall))
     }
 
@@ -508,12 +504,8 @@ class CallViewModelTests: XCTestCase {
             }
         }
         interactor.state = .enqueueing(.audioCall)
-        alertConfig?.declined()
+        await alertConfig?.declined()
 
-        /// Will be removed when AlertManager is refactored in MOB-4574
-        await waitUntil {
-            interactor.state == .ended(.byVisitor)
-        }
         XCTAssertEqual(interactor.state, .ended(.byVisitor))
         XCTAssertTrue(calls.isEmpty)
     }

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -890,11 +890,8 @@ class ChatViewModelTests: XCTestCase {
             }
         }
         interactor.state = .enqueueing(.audioCall)
-        alertConfig?.accepted()
+        await alertConfig?.accepted()
 
-        await waitUntil {
-            interactor.state == .enqueued(.mock, .audioCall)
-        }
         XCTAssertEqual(interactor.state, .enqueued(.mock, .audioCall))
     }
 
@@ -934,12 +931,8 @@ class ChatViewModelTests: XCTestCase {
             }
         }
         interactor.state = .enqueueing(.audioCall)
-        alertConfig?.declined()
+        await alertConfig?.declined()
 
-        /// Will be removed when AlertManager is refactored in MOB-4574
-        await waitUntil {
-            interactor.state == .ended(.byVisitor)
-        }
         XCTAssertEqual(interactor.state, .ended(.byVisitor))
         XCTAssertTrue(calls.isEmpty)
     }

--- a/TestingApp/VisitorInfo/CustomSegmentedControl.swift
+++ b/TestingApp/VisitorInfo/CustomSegmentedControl.swift
@@ -8,7 +8,7 @@ class CustomSegmentedControl: UIControl {
     weak var delegate: CustomSegmentedControlDelegate?
 
     private var buttons = [UIButton]()
-    private (set) var selectedSegmentIndex = 0
+    private(set) var selectedSegmentIndex = 0
 
     var segments: [String] = [] {
         didSet {


### PR DESCRIPTION
This PR allows alerts to have async actions, which in return allows to
test alerts in a predictable manner. Many waitUntils have been removed from unit tests

MOB-4574