### PR TITLE
Add telemetry logs for Alert Dialogs

### DIFF
--- a/GliaWidgets/Sources/AlertManager/Alert/AlertViewController+Confirmation.swift
+++ b/GliaWidgets/Sources/AlertManager/Alert/AlertViewController+Confirmation.swift
@@ -46,13 +46,19 @@ extension AlertViewController {
     func makeConfirmationAlertView(
         with conf: ConfirmationAlertConfiguration,
         accessibilityIdentifier: String,
-        confirmed: @escaping () -> Void
+        confirmed: @escaping () -> Void,
+        dismissed: (() -> Void)?
     ) -> AlertView {
         let alertView = makeAlertView(
             with: conf,
             accessibilityIdentifier: accessibilityIdentifier,
             confirmed: confirmed
         )
+        alertView.closeTapped = { [weak self] in
+            self?.dismiss(animated: true) {
+                dismissed?()
+            }
+        }
         let alertStyle = viewFactory.theme.alert
         var negativeButtonStyle = alertStyle.negativeAction
         var positiveButtonStyle = alertStyle.positiveAction

--- a/GliaWidgets/Sources/AlertManager/Alert/AlertViewController+LiveObservationConfirmation.swift
+++ b/GliaWidgets/Sources/AlertManager/Alert/AlertViewController+LiveObservationConfirmation.swift
@@ -3,7 +3,8 @@ import UIKit
 extension AlertViewController {
     func makeLiveObservationAlertView(
         with conf: ConfirmationAlertConfiguration,
-        link: @escaping (WebViewController.Link) -> Void,
+        link1: @escaping (WebViewController.Link) -> Void,
+        link2: @escaping (WebViewController.Link) -> Void,
         accepted: @escaping () -> Void,
         declined: @escaping () -> Void
     ) -> AlertView {
@@ -15,15 +16,15 @@ extension AlertViewController {
 
         let alertStyle = viewFactory.theme.alert
         var declineButtonStyle = alertStyle.negativeAction
-        declineButtonStyle.title = conf.negativeTitle ?? ""
+        declineButtonStyle.title = conf.negativeTitle
 
         var acceptButtonStyle = alertStyle.positiveAction
-        acceptButtonStyle.title = conf.positiveTitle ?? ""
+        acceptButtonStyle.title = conf.positiveTitle
 
         if let firstLinkButton = linkButton(
             for: conf.firstLinkButtonUrl,
             style: alertStyle.firstLinkAction,
-            action: .init(closure: link)
+            action: .init(closure: link1)
         ) {
             alertView.addLinkButton(firstLinkButton)
         }
@@ -31,7 +32,7 @@ extension AlertViewController {
         if let secondLinkButton = linkButton(
             for: conf.secondLinkButtonUrl,
             style: alertStyle.secondLinkAction,
-            action: .init(closure: link)
+            action: .init(closure: link2)
         ) {
             alertView.addLinkButton(secondLinkButton)
         }

--- a/GliaWidgets/Sources/AlertManager/Alert/AlertViewController.swift
+++ b/GliaWidgets/Sources/AlertManager/Alert/AlertViewController.swift
@@ -35,7 +35,7 @@ class AlertViewController: UIViewController, Replaceable {
         super.loadView()
         let view = UIView()
 
-        if case let AlertType.message(conf, _, _) = type, !conf.shouldShowCloseButton {
+        if case let AlertType.message(conf, _, _, _) = type, !conf.shouldShowCloseButton {
             view.backgroundColor = UIColor.clear
             view.isUserInteractionEnabled = false
         } else {
@@ -98,41 +98,43 @@ class AlertViewController: UIViewController, Replaceable {
     // swiftlint:disable:next function_body_length
     private func makeAlertView() -> AlertView? {
         switch type {
-        case let .message(conf, accessibilityIdentifier, dismissed):
+        case let .message(conf, accessibilityIdentifier, dismissed, _):
             return makeMessageAlertView(
                 with: conf,
                 accessibilityIdentifier: accessibilityIdentifier,
                 dismissed: dismissed
             )
-        case let .confirmation(conf, accessibilityIdentifier, confirmed):
+        case let .confirmation(conf, accessibilityIdentifier, confirmed, dismissed, _):
             return makeConfirmationAlertView(
                 with: conf,
                 accessibilityIdentifier: accessibilityIdentifier,
-                confirmed: confirmed
+                confirmed: confirmed,
+                dismissed: dismissed
             )
-        case let .leaveConversation(conf, accessibilityIdentifier, confirmed, declined):
+        case let .leaveConversation(conf, accessibilityIdentifier, confirmed, declined, _):
             return makeLeaveConversationAlertView(
                 with: conf,
                 accessibilityIdentifier: accessibilityIdentifier,
                 confirmed: confirmed,
                 declined: declined
             )
-        case let .singleAction(conf, accessibilityIdentifier, actionTapped):
+        case let .singleAction(conf, accessibilityIdentifier, actionTapped, _):
             return makeSingleActionAlertView(
                 with: conf,
                 accessibilityIdentifier: accessibilityIdentifier,
                 actionTapped: actionTapped
             )
-        case let .singleMediaUpgrade(conf, accepted, declined):
+        case let .singleMediaUpgrade(conf, accepted, declined, _):
             return makeMediaUpgradeAlertView(
                 with: conf,
                 accepted: accepted,
                 declined: declined
             )
-        case let .liveObservationConfirmation(conf, link, accepted, declined):
+        case let .liveObservationConfirmation(conf, link1, link2, accepted, declined, _):
             return makeLiveObservationAlertView(
                 with: conf,
-                link: link,
+                link1: link1,
+                link2: link2,
                 accepted: accepted,
                 declined: declined
             )
@@ -141,19 +143,19 @@ class AlertViewController: UIViewController, Replaceable {
             /// displayed as UIAlertController and not AlertView. We only need
             /// this case to differenciate between alert types.
             return nil
-        case let .view(conf, accessibilityIdentifier, dismissed):
+        case let .view(conf, accessibilityIdentifier, dismissed, _):
             return makeMessageAlertView(
                 with: conf,
                 accessibilityIdentifier: accessibilityIdentifier,
                 dismissed: dismissed
             )
-        case let .criticalError(conf, accessibilityIdentifier, dismissed):
+        case let .criticalError(conf, accessibilityIdentifier, dismissed, _):
             return makeMessageAlertView(
                 with: conf,
                 accessibilityIdentifier: accessibilityIdentifier,
                 dismissed: dismissed
             )
-        case let .requestPushNotificationsPermissions(conf, accepted, declined):
+        case let .requestPushNotificationsPermissions(conf, accepted, declined, _):
             return makeRequestPNPermissionsAlertView(
                 with: conf,
                 accepted: accepted,

--- a/GliaWidgets/Sources/AlertManager/AlertManager.swift
+++ b/GliaWidgets/Sources/AlertManager/AlertManager.swift
@@ -78,6 +78,7 @@ extension AlertManager {
 
     func dismissCurrentAlert() {
         guard let alertViewController = alertViewController else { return }
+        alertViewController.dismiss(animated: true)
         cleanup()
     }
 }
@@ -97,13 +98,14 @@ private extension AlertManager {
     ) {
         let alertViewController = createAlertViewController(type: type)
         alertViewController.onDismissed = { [weak self] in
+            type.onCloseAction()
             self?.cleanup()
         }
         guard isAlertReplacable(offer: alertViewController) else { return }
         self.alertViewController = alertViewController
         self.currentAlert = input
         switch type {
-        case let .systemAlert(conf, cancelled):
+        case let .systemAlert(conf, cancelled, _):
             let alert = createSystemAlert(
                 conf: conf,
                 cancelled: cancelled
@@ -153,6 +155,7 @@ private extension AlertManager {
     ) {
         let alertViewController = createAlertViewController(type: type)
         alertViewController.onDismissed = { [weak self] in
+            type.onCloseAction()
             self?.cleanup()
         }
         guard isAlertReplacable(offer: alertViewController) else { return }
@@ -208,7 +211,6 @@ private extension AlertManager {
     }
 
     func cleanup() {
-        alertViewController?.dismiss(animated: true)
         alertViewController = nil
         alertWindow?.isHidden = true
         alertWindow = nil

--- a/GliaWidgets/Sources/AlertManager/AlertType.swift
+++ b/GliaWidgets/Sources/AlertManager/AlertType.swift
@@ -4,53 +4,65 @@ enum AlertType {
     case message(
         conf: MessageAlertConfiguration,
         accessibilityIdentifier: String?,
-        dismissed: (() -> Void)?
+        dismissed: (() -> Void)?,
+        onClose: () -> Void
     )
     case criticalError(
         conf: MessageAlertConfiguration,
         accessibilityIdentifier: String?,
-        dismissed: (() -> Void)?
+        dismissed: (() -> Void)?,
+        onClose: () -> Void
     )
     case confirmation(
         conf: ConfirmationAlertConfiguration,
         accessibilityIdentifier: String,
-        confirmed: () -> Void
+        confirmed: () -> Void,
+        dismissed: (() -> Void)?,
+        onClose: () -> Void
     )
     case leaveConversation(
         conf: ConfirmationAlertConfiguration,
         accessibilityIdentifier: String,
         confirmed: () -> Void,
-        declined: (() -> Void)?
+        declined: (() -> Void)?,
+        onClose: () -> Void
     )
     case singleAction(
         conf: SingleActionAlertConfiguration,
         accessibilityIdentifier: String,
-        actionTapped: () -> Void
+        actionTapped: () -> Void,
+        onClose: () -> Void
     )
     case singleMediaUpgrade(
         SingleMediaUpgradeAlertConfiguration,
         accepted: () -> Void,
-        declined: () -> Void
+        declined: () -> Void,
+        onClose: () -> Void
     )
     case liveObservationConfirmation(
         ConfirmationAlertConfiguration,
-        link: (WebViewController.Link) -> Void,
+        link1: (WebViewController.Link) -> Void,
+        link2: (WebViewController.Link) -> Void,
         accepted: () -> Void,
-        declined: () -> Void
+        declined: () -> Void,
+        onClose: () -> Void
     )
     case systemAlert(
         conf: SettingsAlertConfiguration,
-        cancelled: (() -> Void)?
+        cancelled: (() -> Void)?,
+        onClose: () -> Void
     )
     case view(
         conf: MessageAlertConfiguration,
         accessibilityIdentifier: String?,
-        dismissed: (() -> Void)?
+        dismissed: (() -> Void)?,
+        onClose: () -> Void
     )
     case requestPushNotificationsPermissions(
         conf: ConfirmationAlertConfiguration,
         accepted: () -> Void,
-        declined: () -> Void
+        declined: () -> Void,
+        onClose: () -> Void
     )
 
     /// Indicating presentation priority of an alert.
@@ -63,6 +75,22 @@ enum AlertType {
             return .high
         case .message, .systemAlert, .view, .leaveConversation:
             return .regular
+        }
+    }
+
+    var onCloseAction: () -> Void {
+        switch self {
+        case .message(_, _, _, let onClose),
+                .criticalError(_, _, _, let onClose),
+                .confirmation(_, _, _, _, let onClose),
+                .leaveConversation(_, _, _, _, let onClose),
+                .singleAction(_, _, _, let onClose),
+                .singleMediaUpgrade(_, _, _, let onClose),
+                .liveObservationConfirmation(_, _, _, _, _, let onClose),
+                .systemAlert(_, _, let onClose),
+                .view(_, _, _, let onClose),
+                .requestPushNotificationsPermissions(_, _, _, let onClose):
+            return onClose
         }
     }
 }

--- a/GliaWidgets/Sources/AlertManager/AlertTypeComposer.Environment.swift
+++ b/GliaWidgets/Sources/AlertManager/AlertTypeComposer.Environment.swift
@@ -1,8 +1,10 @@
 import Foundation
+import GliaCoreSDK
 
 extension AlertManager.AlertTypeComposer {
     struct Environment {
         let log: CoreSdkClient.Logger
+        @Dependency(\.widgets.openTelemetry) var openTelemetry: OpenTelemetry
     }
 }
 

--- a/GliaWidgets/Sources/AlertManager/AlertTypeComposer.swift
+++ b/GliaWidgets/Sources/AlertManager/AlertTypeComposer.swift
@@ -126,85 +126,146 @@ private extension AlertManager.AlertTypeComposer {
     }
 
     func queueClosedAlertType(dismissed: (() -> Void)? = nil) -> AlertType {
-        .message(
+        logDialogShown(dialog: .queueIsClosed)
+        return .message(
             conf: theme.alertConfiguration.operatorsUnavailable,
             accessibilityIdentifier: "alert_queue_closed",
-            dismissed: dismissed
+            dismissed: {
+                logButtonClicked(button: .close, dialog: .queueIsClosed)
+                dismissed?()
+            }, onClose: {
+                logDialogClosed(dialog: .queueIsClosed)
+            }
         )
     }
 
     func queueFullAlertType(dismissed: (() -> Void)? = nil) -> AlertType {
+        logDialogShown(dialog: .queueIsClosed)
         environment.log.prefixed(Self.self).info("Show No More Operators Dialog")
         return .message(
             conf: theme.alertConfiguration.operatorsUnavailable,
             accessibilityIdentifier: "alert_queue_full",
-            dismissed: dismissed
+            dismissed: {
+                logButtonClicked(button: .close, dialog: .queueIsClosed)
+                dismissed?()
+            }, onClose: {
+                logDialogClosed(dialog: .queueIsClosed)
+            }
         )
     }
 
     func unexpectedErrorAlertType(dismissed: (() -> Void)? = nil) -> AlertType {
         environment.log.prefixed(Self.self).info("Show Unexpected error Dialog")
+        logDialogShown(dialog: .unexpectedError)
         return .message(
             conf: theme.alertConfiguration.unexpectedError,
             accessibilityIdentifier: nil,
-            dismissed: dismissed
+            dismissed: {
+                logButtonClicked(button: .close, dialog: .unexpectedError)
+                dismissed?()
+            }, onClose: {
+                logDialogClosed(dialog: .unexpectedError)
+            }
         )
     }
 
     func expiredAccessTokenAlertType(dismissed: (() -> Void)? = nil) -> AlertType {
         environment.log.prefixed(Self.self).info("Show authentication error Dialog")
+        logDialogShown(dialog: .unauthenticatedError)
         return .criticalError(
             conf: theme.alertConfiguration.expiredAccessTokenError,
             accessibilityIdentifier: "alert_expired_access_token",
-            dismissed: dismissed
+            dismissed: {
+                logButtonClicked(button: .close, dialog: .unauthenticatedError)
+                dismissed?()
+            }, onClose: {
+                logDialogClosed(dialog: .unauthenticatedError)
+            }
         )
     }
 
     func mediaTypeNotAvailableAlertType(dismissed: (() -> Void)? = nil) -> AlertType {
-        .message(
+        logDialogShown(dialog: .unavailableMediaSource)
+        return .message(
             conf: theme.alertConfiguration.mediaSourceNotAvailable,
             accessibilityIdentifier: nil,
-            dismissed: dismissed
+            dismissed: {
+                logButtonClicked(button: .close, dialog: .unavailableMediaSource)
+
+                dismissed?()
+            }, onClose: {
+                logDialogClosed(dialog: .unavailableMediaSource)
+            }
         )
     }
 
     func noCameraPermissionAlertType(dismissed: (() -> Void)? = nil) -> AlertType {
-        .systemAlert(
+        logDialogShown(dialog: .additionalPermissionsRequest)
+        return .systemAlert(
             conf: theme.alertConfiguration.cameraSettings,
-            cancelled: dismissed
+            cancelled: {
+                logButtonClicked(button: .close, dialog: .additionalPermissionsRequest)
+                dismissed?()
+            }, onClose: {
+                logDialogClosed(dialog: .additionalPermissionsRequest)
+            }
         )
     }
 
     func noMicrophonePermissionAlertType(dismissed: (() -> Void)? = nil) -> AlertType {
-        .systemAlert(
+        logDialogShown(dialog: .additionalPermissionsRequest)
+        return .systemAlert(
             conf: theme.alertConfiguration.microphoneSettings,
-            cancelled: dismissed
+            cancelled: {
+                logButtonClicked(button: .close, dialog: .additionalPermissionsRequest)
+                dismissed?()
+            }, onClose: {
+                logDialogClosed(dialog: .additionalPermissionsRequest)
+            }
         )
     }
 
     func unsupportedGvaBroadcastErrorAlertType(dismissed: (() -> Void)? = nil) -> AlertType {
-        .message(
+        logDialogShown(dialog: .unsupportedGvaBroadcast)
+        return .message(
             conf: theme.alertConfiguration.unsupportedGvaBroadcastError,
             accessibilityIdentifier: nil,
-            dismissed: dismissed
+            dismissed: {
+                logButtonClicked(button: .ok, dialog: .unsupportedGvaBroadcast)
+                dismissed?()
+            }, onClose: {
+                logDialogClosed(dialog: .unsupportedGvaBroadcast)
+            }
         )
     }
 
     func unavailableMessageCenterAlertType(dismissed: (() -> Void)? = nil) -> AlertType {
         environment.log.prefixed(Self.self).info("Show Message Center Unavailable Dialog")
+        logDialogShown(dialog: .secureConversationUnavailableError)
         return .view(
             conf: theme.alertConfiguration.unavailableMessageCenter,
             accessibilityIdentifier: "unavailable_message_center_alert_identifier",
-            dismissed: dismissed
+            dismissed: {
+                logButtonClicked(button: .negative, dialog: .secureConversationUnavailableError)
+                dismissed?()
+            }, onClose: {
+                logDialogClosed(dialog: .secureConversationUnavailableError)
+            }
         )
     }
 
     func unavailableMessageCenterForBeingUnauthenticatedAlertType(dismissed: (() -> Void)? = nil) -> AlertType {
         self.environment.log.prefixed(Self.self).info("Show Unauthenticated Dialog")
+        logDialogShown(dialog: .unauthenticatedError)
         return .view(
             conf: theme.alertConfiguration.unavailableMessageCenterForBeingUnauthenticated,
             accessibilityIdentifier: "unavailable_message_center_alert_identifier",
-            dismissed: dismissed
+            dismissed: {
+                logButtonClicked(button: .negative, dialog: .unauthenticatedError)
+                dismissed?()
+            }, onClose: {
+                logDialogClosed(dialog: .unauthenticatedError)
+            }
         )
     }
 
@@ -213,38 +274,78 @@ private extension AlertManager.AlertTypeComposer {
         accepted: @escaping () -> Void,
         declined: @escaping () -> Void
     ) -> AlertType {
-        .liveObservationConfirmation(
+        logDialogShown(dialog: .liveObservationConfirmation)
+        return .liveObservationConfirmation(
             theme.alertConfiguration.liveObservationConfirmation,
-            link: link,
-            accepted: accepted,
-            declined: declined
+            link1: {
+                logButtonClicked(button: .liveObservationLink1, dialog: .liveObservationConfirmation)
+                link($0)
+            },
+            link2: {
+                logButtonClicked(button: .liveObservationLink2, dialog: .liveObservationConfirmation)
+                link($0)
+            },
+            accepted: {
+                logButtonClicked(button: .positive, dialog: .liveObservationConfirmation)
+                accepted()
+            },
+            declined: {
+                logButtonClicked(button: .negative, dialog: .liveObservationConfirmation)
+                declined()
+            }, onClose: {
+                logDialogClosed(dialog: .liveObservationConfirmation)
+            }
         )
     }
 
     func operatorEndedEngagementAlertType(action: @escaping () -> Void) -> AlertType {
         environment.log.prefixed(Self.self).info("Show Engagement Ended Dialog")
+        logDialogShown(dialog: .engagementEnded)
         return .singleAction(
             conf: theme.alertConfiguration.operatorEndedEngagement,
             accessibilityIdentifier: "alert_close_engagementEnded",
-            actionTapped: action
+            actionTapped: {
+                logButtonClicked(button: .ok, dialog: .engagementEnded)
+                action()
+            }, onClose: {
+                logDialogClosed(dialog: .engagementEnded)
+            }
         )
     }
 
     func leaveQueueAlertType(confirmed: @escaping () -> Void) -> AlertType {
         environment.log.prefixed(Self.self).info("Show Exit Queue Dialog")
+        logDialogShown(dialog: .leaveQueueConfirmation)
         return .confirmation(
             conf: theme.alertConfiguration.leaveQueue,
             accessibilityIdentifier: "alert_confirmation_leaveQueue",
-            confirmed: confirmed
+            confirmed: {
+                logButtonClicked(button: .positive, dialog: .leaveQueueConfirmation)
+                confirmed()
+            },
+            dismissed: {
+                logButtonClicked(button: .negative, dialog: .leaveQueueConfirmation)
+            }, onClose: {
+                logDialogClosed(dialog: .leaveQueueConfirmation)
+            }
         )
     }
 
     func endEngagementAlertType(confirmed: @escaping () -> Void) -> AlertType {
         environment.log.prefixed(Self.self).info("Show End Engagement Dialog")
+        logDialogShown(dialog: .leaveEngagementConfirmation)
         return .confirmation(
             conf: theme.alertConfiguration.endEngagement,
             accessibilityIdentifier: "alert_confirmation_endEngagement",
-            confirmed: confirmed
+            confirmed: {
+                logButtonClicked(button: .positive, dialog: .leaveEngagementConfirmation)
+                confirmed()
+            },
+            dismissed: {
+                logButtonClicked(button: .negative, dialog: .leaveEngagementConfirmation)
+            }, onClose: {
+                logDialogClosed(dialog: .leaveEngagementConfirmation)
+            }
         )
     }
 
@@ -256,12 +357,14 @@ private extension AlertManager.AlertTypeComposer {
         answer: @escaping CoreSdkClient.AnswerWithSuccessBlock
     ) throws -> AlertType {
         let acceptedOffer: () -> Void = {
+            logButtonClicked(button: .positive, dialog: .mediaUpgradeConfirmation, mediaOffer: offer)
             self.environment.log.prefixed(Self.self).info("Upgrade offer accepted by visitor")
             accepted?()
             answer(true, nil)
         }
 
         let declinedOffer: () -> Void = {
+            logButtonClicked(button: .negative, dialog: .mediaUpgradeConfirmation, mediaOffer: offer)
             self.environment.log.prefixed(Self.self).info("Upgrade offer declined by visitor")
             declined?()
             answer(false, nil)
@@ -287,20 +390,37 @@ private extension AlertManager.AlertTypeComposer {
             throw GliaError.internalError
         }
 
+        logDialogShown(dialog: .mediaUpgradeConfirmation, mediaOffer: offer)
+
         return .singleMediaUpgrade(
             configuration,
             accepted: acceptedOffer,
-            declined: declinedOffer
+            declined: declinedOffer,
+            onClose: {
+                logDialogClosed(dialog: .mediaUpgradeConfirmation, mediaOffer: offer)
+            }
         )
     }
 
-    func leaveCurrentConversationAlertType(confirmed: @escaping () -> Void, declined: (() -> Void)?) -> AlertType {
+    func leaveCurrentConversationAlertType(
+        confirmed: @escaping () -> Void,
+        declined: (() -> Void)?
+    ) -> AlertType {
         environment.log.prefixed(Self.self).info("Show Leave Current Conversations Dialog")
+        logDialogShown(dialog: .leaveSecureConversationsConfirmation)
         return .leaveConversation(
             conf: theme.alertConfiguration.leaveCurrentConversation,
             accessibilityIdentifier: "alert_confirmation_leaveCurrentConversation",
-            confirmed: confirmed,
-            declined: declined
+            confirmed: {
+                logButtonClicked(button: .positive, dialog: .leaveSecureConversationsConfirmation)
+                confirmed()
+            },
+            declined: {
+                logButtonClicked(button: .negative, dialog: .leaveSecureConversationsConfirmation)
+                declined?()
+            }, onClose: {
+                logDialogClosed(dialog: .leaveSecureConversationsConfirmation)
+            }
         )
     }
 
@@ -309,10 +429,73 @@ private extension AlertManager.AlertTypeComposer {
         declined: @escaping () -> Void
     ) -> AlertType {
         environment.log.prefixed(Self.self).info("Show Push Notifications Intermediate Dialog")
+        logDialogShown(dialog: .allowPushNotification)
         return .requestPushNotificationsPermissions(
             conf: theme.alertConfiguration.pushNotificationsPermissions,
-            accepted: accepted,
-            declined: declined
+            accepted: {
+                logButtonClicked(button: .positive, dialog: .allowPushNotification)
+                accepted()
+            },
+            declined: {
+                logButtonClicked(button: .negative, dialog: .allowPushNotification)
+                declined()
+            }, onClose: {
+                logDialogClosed(dialog: .allowPushNotification)
+            }
         )
+    }
+}
+
+extension AlertManager.AlertTypeComposer {
+    func logDialogShown(
+        dialog: OtelDialogNames,
+        mediaOffer: CoreSdkClient.MediaUpgradeOffer? = nil
+    ) {
+        logEvent(
+            event: .dialogShown,
+            dialog: dialog,
+            mediaOffer: mediaOffer
+        )
+    }
+
+    func logDialogClosed(
+        dialog: OtelDialogNames,
+        mediaOffer: CoreSdkClient.MediaUpgradeOffer? = nil
+    ) {
+        logEvent(
+            event: .dialogClosed,
+            dialog: dialog,
+            mediaOffer: mediaOffer
+        )
+    }
+
+    func logButtonClicked(
+        button: OtelButtonNames,
+        dialog: OtelDialogNames,
+        mediaOffer: CoreSdkClient.MediaUpgradeOffer? = nil
+    ) {
+        logEvent(
+            event: .dialogButtonClicked,
+            dialog: dialog,
+            button: button,
+            mediaOffer: mediaOffer
+        )
+    }
+
+    private func logEvent(
+        event: OtelLogEvents,
+        dialog: OtelDialogNames,
+        button: OtelButtonNames? = nil,
+        mediaOffer: CoreSdkClient.MediaUpgradeOffer? = nil
+    ) {
+        environment.openTelemetry.logger.i(event) {
+            $0[.dialogName] = .string(dialog.rawValue)
+            if let button {
+                $0[.buttonName] = .string(button.rawValue)
+            }
+            if let offerAttribute = mediaOffer?.otelAttribute {
+                $0[.mediaUpgradeOffer] = offerAttribute
+            }
+        }
     }
 }

--- a/GliaWidgets/Sources/OpenTelemetry/OpenTelemetry.swift
+++ b/GliaWidgets/Sources/OpenTelemetry/OpenTelemetry.swift
@@ -1,6 +1,9 @@
 import GliaCoreSDK
 
 typealias OpenTelemetry = GliaCoreSDK.OpenTelemetry
+typealias OtelLogEvents = GliaCoreSDK.OtelLogEvents
+typealias OtelAttributes = GliaCoreSDK.OtelAttributes
+typealias OtelAttributeValue = GliaCoreSDK.OtelAttributeValue
 typealias OtelButtonNames = GliaCoreSDK.OtelButtonNames
 typealias OtelDialogNames = GliaCoreSDK.OtelDialogNames
 typealias OtelGvaActionTypes = GliaCoreSDK.OtelGvaActionTypes


### PR DESCRIPTION
MOB-4703

**What was solved?**
Add telemetry logs for Alert Dialogs:
- dialog_shown;
- dialog_closed;
- dialog_button_clicked;

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
- [ ] Did you add logging beneficial for troubleshooting of customer issues?
- [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.