### PR TITLE
Add Call screen telemetry logging

### DIFF
--- a/GliaWidgets/Sources/ViewController/Call/CallViewController.Environment.swift
+++ b/GliaWidgets/Sources/ViewController/Call/CallViewController.Environment.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GliaCoreSDK
 
 extension CallViewController {
     struct Environment {
@@ -9,6 +10,7 @@ extension CallViewController {
         var gcd: GCD
         var snackBar: SnackBar
         var alertManager: AlertManager
+        @Dependency(\.widgets.openTelemetry) var openTelemetry: OpenTelemetry
     }
 }
 

--- a/GliaWidgets/Sources/ViewController/Call/CallViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Call/CallViewController.swift
@@ -23,9 +23,18 @@ final class CallViewController: EngagementViewController {
 
     override public func loadView() {
         let view = viewFactory.makeCallView(
-            endCmd: .init { [weak self] in self?.viewModel.event(.closeTapped) },
-            closeCmd: .init { [weak self] in self?.viewModel.event(.closeTapped) },
-            backCmd: .init { [weak self] in self?.viewModel.event(.backTapped) }
+            endCmd: .init { [weak self] in
+                self?.logButtonClicked(.end)
+                self?.viewModel.event(.closeTapped)
+            },
+            closeCmd: .init { [weak self] in
+                self?.logButtonClicked(.close)
+                self?.viewModel.event(.closeTapped)
+            },
+            backCmd: .init { [weak self] in
+                self?.logButtonClicked(.back)
+                self?.viewModel.event(.backTapped)
+            }
         )
         self.view = view
 
@@ -153,6 +162,15 @@ private extension CallViewController {
             gcd: environment.gcd,
             notificationCenter: environment.notificationCenter
         )
+    }
+}
+
+// MARK: - OpenTelemetry
+extension CallViewController {
+    private func logButtonClicked(_ button: OtelButtonNames) {
+        environment.openTelemetry.logger.i(.callScreenButtonClicked) {
+            $0[.buttonName] = .string(button.rawValue)
+        }
     }
 }
 


### PR DESCRIPTION
MOB-4689

**What was solved?**
Added logs for events:
- call_screen_shown;
- call_screen_closed;
- call_screen_button_clicked;

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
- [ ] Did you add logging beneficial for troubleshooting of customer issues?
- [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.