### PR TITLE
Add SC Welcome screen telemetry logging

### DIFF
--- a/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
+++ b/GliaWidgets/SecureConversations/SecureConversations.Coordinator.swift
@@ -7,7 +7,6 @@ extension SecureConversations {
         private let viewFactory: ViewFactory
         private let navigationPresenter: NavigationPresenter
         private let environment: Environment
-        private(set) var viewModel: SecureConversations.WelcomeViewModel?
         private(set) var selectedPickerController: SelectedPickerController?
         private var messagingInitialScreen: SecureConversations.InitialScreen
 
@@ -52,6 +51,7 @@ extension SecureConversations {
 
             let controller = SecureConversations.WelcomeViewController(
                 viewFactory: viewFactory,
+                viewModel: viewModel,
                 props: viewModel.props(),
                 environment: .create(with: environment)
             )
@@ -59,9 +59,6 @@ extension SecureConversations {
             viewModel.delegate = { [weak self, weak controller] event in
                 self?.bindDelegate(to: event, controller: controller)
             }
-
-            // Store view model, so that it would not be deallocated.
-            self.viewModel = viewModel
 
             return controller
         }

--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeView.Environment.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeView.Environment.swift
@@ -9,7 +9,7 @@ extension SecureConversations.WelcomeView {
 }
 
 extension SecureConversations.WelcomeView.Environemnt {
-    static func create(with environment: SecureConversations.WelcomeViewController.Environemnt) -> Self {
+    static func create(with environment: SecureConversations.WelcomeViewController.Environment) -> Self {
         .init(
             gcd: environment.gcd,
             uiScreen: environment.uiScreen,

--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewController.Environment.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewController.Environment.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension SecureConversations.WelcomeViewController {
-    struct Environemnt {
+    struct Environment {
         let gcd: GCD
         let uiScreen: UIKitBased.UIScreen
         let notificationCenter: FoundationBased.NotificationCenter
@@ -9,7 +9,7 @@ extension SecureConversations.WelcomeViewController {
     }
 }
 
-extension SecureConversations.WelcomeViewController.Environemnt {
+extension SecureConversations.WelcomeViewController.Environment {
     static func create(with environment: SecureConversations.Coordinator.Environment) -> Self {
         .init(
             gcd: environment.gcd,
@@ -21,7 +21,7 @@ extension SecureConversations.WelcomeViewController.Environemnt {
 }
 
 #if DEBUG
-extension SecureConversations.WelcomeViewController.Environemnt {
+extension SecureConversations.WelcomeViewController.Environment {
     static func mock(
         gcd: GCD = .mock,
         uiScreen: UIKitBased.UIScreen = .mock,

--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewController.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewController.swift
@@ -10,16 +10,19 @@ extension SecureConversations {
         }
 
         let viewFactory: ViewFactory
-        let environment: Environemnt
+        let environment: Environment
+        private let viewModel: WelcomeViewModel
 
         init(
             viewFactory: ViewFactory,
+            viewModel: WelcomeViewModel,
             props: Props,
-            environment: Environemnt
+            environment: Environment
         ) {
             self.viewFactory = viewFactory
             self.props = props
             self.environment = environment
+            self.viewModel = viewModel
             super.init(nibName: nil, bundle: nil)
         }
 
@@ -31,6 +34,16 @@ extension SecureConversations {
         override func loadView() {
             super.loadView()
             renderProps()
+        }
+
+        override func viewDidAppear(_ animated: Bool) {
+            super.viewDidAppear(animated)
+            viewModel.event(.viewDidAppear)
+        }
+
+        override func viewDidDisappear(_ animated: Bool) {
+            super.viewDidDisappear(animated)
+            viewModel.event(.viewDidDisappear)
         }
 
         func renderProps() {

--- a/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.Environment.swift
+++ b/GliaWidgets/SecureConversations/Welcome/SecureConversations.WelcomeViewModel.Environment.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GliaCoreSDK
 
 extension SecureConversations.WelcomeViewModel {
     struct Environment {
@@ -16,6 +17,7 @@ extension SecureConversations.WelcomeViewModel {
         var uploadFileToEngagement: CoreSdkClient.UploadFileToEngagement
         var createSendMessagePayload: CoreSdkClient.CreateSendMessagePayload
         var log: CoreSdkClient.Logger
+        @Dependency(\.widgets.openTelemetry) var openTelemetry: OpenTelemetry
     }
 }
 


### PR DESCRIPTION
MOB-4691

**What was solved?**
Added events:
- sc_welcome_screen_shown;
- sc_welcome_screen_closed;
- sc_welcome_screen_button_clicked;

**Additional info:**
- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
- [ ] Did you add logging beneficial for troubleshooting of customer issues?
- [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.