### PR TITLE
Add SC Confirmation screen telemetry logging

### DIFF
--- a/GliaWidgets/SecureConversations/Confirmation/SecureConversations.ConfirmationViewController.swift
+++ b/GliaWidgets/SecureConversations/Confirmation/SecureConversations.ConfirmationViewController.swift
@@ -33,5 +33,16 @@ extension SecureConversations {
                 hostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor)
             ])
         }
+
+        override func viewDidAppear(_ animated: Bool) {
+            super.viewDidAppear(animated)
+            model.event(.viewDidAppear)
+        }
+
+        override func viewDidDisappear(_ animated: Bool) {
+            super.viewDidDisappear(animated)
+
+            model.event(.viewDidDisappear)
+        }
     }
 }

--- a/GliaWidgets/SecureConversations/Confirmation/SecureConversations.ConfirmationViewModel.Environment.swift
+++ b/GliaWidgets/SecureConversations/Confirmation/SecureConversations.ConfirmationViewModel.Environment.swift
@@ -1,9 +1,11 @@
 import Foundation
+import GliaCoreSDK
 
 extension SecureConversations.ConfirmationViewSwiftUI.Model {
     struct Environment {
         var orientationManager: OrientationManager
         var uiApplication: UIKitBased.UIApplication
+        @Dependency(\.widgets.openTelemetry) var openTelemetry: OpenTelemetry
     }
 }
 


### PR DESCRIPTION
MOB-4710

**What was solved?**
Added events:
- sc_confirmation_screen_shown;
- sc_confirmation_screen_closed;
- sc_confirmation_screen_button_clicked;

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
- [ ] Did you add logging beneficial for troubleshooting of customer issues?
- [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.