### PR TITLE
Add Entry Widget telemetry logging

### DIFF
--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
@@ -152,6 +152,7 @@ public extension EntryWidget {
             className: Self.self,
             methodName: "hide"
         )
+        environment.openTelemetry.logger.i(.entryWidgetDismissed)
         hostedViewController?.dismiss(animated: true, completion: nil)
         hostedViewController = nil
     }
@@ -182,6 +183,7 @@ extension EntryWidget {
             configurationAction(mediaTypeItem)
             return
         }
+        logEngagementTypeSelection(mediaTypeItem.type)
         hideViewIfNecessary {
             do {
                 switch mediaTypeItem.type {
@@ -255,6 +257,7 @@ private extension EntryWidget {
             completion()
             return
         }
+        environment.openTelemetry.logger.i(.entryWidgetDismissed)
         hostedViewController?.dismiss(animated: true, completion: completion)
         hostedViewController = nil
     }
@@ -276,6 +279,7 @@ private extension EntryWidget {
     }
 
     func showView(in parentView: UIView) {
+        environment.openTelemetry.logger.i(.entryWidgetShown)
         parentView.subviews.forEach { $0.removeFromSuperview() }
         let model = makeViewModel(showHeader: false)
         let view = makeView(model: model)
@@ -459,6 +463,26 @@ private extension EntryWidget {
         case .failed(let error):
             environment.log.prefixed(Self.self).error("Setting up queues. Failed to get site queues \(error)")
             return .error
+        }
+    }
+}
+
+// MARK: - OpenTelemetry
+extension EntryWidget {
+    private func logEngagementTypeSelection(_ type: EngagementType) {
+        environment.openTelemetry.logger.i(.entryWidgetItemClicked) {
+            switch type {
+            case .chat:
+                $0[.itemType] = .string(OtelEntryWidgetItemTypes.chat.rawValue)
+            case .audio:
+                $0[.itemType] = .string(OtelEntryWidgetItemTypes.audio.rawValue)
+            case .video:
+                $0[.itemType] = .string(OtelEntryWidgetItemTypes.video.rawValue)
+            case .secureMessaging:
+                $0[.itemType] = .string(OtelEntryWidgetItemTypes.secureMessaging.rawValue)
+            case .callVisualizer:
+                $0[.itemType] = .string(OtelEntryWidgetItemTypes.callVisualizer.rawValue)
+            }
         }
     }
 }

--- a/GliaWidgets/Sources/OpenTelemetry/OpenTelemetry.swift
+++ b/GliaWidgets/Sources/OpenTelemetry/OpenTelemetry.swift
@@ -7,3 +7,4 @@ typealias OtelAttributeValue = GliaCoreSDK.OtelAttributeValue
 typealias OtelButtonNames = GliaCoreSDK.OtelButtonNames
 typealias OtelDialogNames = GliaCoreSDK.OtelDialogNames
 typealias OtelGvaActionTypes = GliaCoreSDK.OtelGvaActionTypes
+typealias OtelEntryWidgetItemTypes = GliaCoreSDK.OtelEntryWidgetItemTypes


### PR DESCRIPTION
MOB-4687

**What was solved?**
Added events:
- entry_widget_shown;
- entry_widget_dismissed;
- entry_widget_item_clicked;

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
- [ ] Did you add logging beneficial for troubleshooting of customer issues?
- [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
