### PR TITLE
Rename Otel events and attributes

### DIFF
--- a/GliaWidgets/Sources/AlertManager/AlertTypeComposer.swift
+++ b/GliaWidgets/Sources/AlertManager/AlertTypeComposer.swift
@@ -200,27 +200,27 @@ private extension AlertManager.AlertTypeComposer {
     }
 
     func noCameraPermissionAlertType(dismissed: (() -> Void)? = nil) -> AlertType {
-        logDialogShown(dialog: .additionalPermissionsRequest)
+        logDialogShown(dialog: .missingPermission)
         return .systemAlert(
             conf: theme.alertConfiguration.cameraSettings,
             cancelled: {
-                logButtonClicked(button: .close, dialog: .additionalPermissionsRequest)
+                logButtonClicked(button: .close, dialog: .missingPermission)
                 dismissed?()
             }, onClose: {
-                logDialogClosed(dialog: .additionalPermissionsRequest)
+                logDialogClosed(dialog: .missingPermission)
             }
         )
     }
 
     func noMicrophonePermissionAlertType(dismissed: (() -> Void)? = nil) -> AlertType {
-        logDialogShown(dialog: .additionalPermissionsRequest)
+        logDialogShown(dialog: .missingPermission)
         return .systemAlert(
             conf: theme.alertConfiguration.microphoneSettings,
             cancelled: {
-                logButtonClicked(button: .close, dialog: .additionalPermissionsRequest)
+                logButtonClicked(button: .close, dialog: .missingPermission)
                 dismissed?()
             }, onClose: {
-                logDialogClosed(dialog: .additionalPermissionsRequest)
+                logDialogClosed(dialog: .missingPermission)
             }
         )
     }
@@ -278,11 +278,11 @@ private extension AlertManager.AlertTypeComposer {
         return .liveObservationConfirmation(
             theme.alertConfiguration.liveObservationConfirmation,
             link1: {
-                logButtonClicked(button: .liveObservationLink1, dialog: .liveObservationConfirmation)
+                logButtonClicked(button: .engagementConfirmationLink1, dialog: .liveObservationConfirmation)
                 link($0)
             },
             link2: {
-                logButtonClicked(button: .liveObservationLink2, dialog: .liveObservationConfirmation)
+                logButtonClicked(button: .engagementConfirmationLink2, dialog: .liveObservationConfirmation)
                 link($0)
             },
             accepted: {
@@ -494,7 +494,7 @@ extension AlertManager.AlertTypeComposer {
                 $0[.buttonName] = .string(button.rawValue)
             }
             if let offerAttribute = mediaOffer?.otelAttribute {
-                $0[.mediaUpgradeOffer] = offerAttribute
+                $0[.engagementType] = offerAttribute
             }
         }
     }

--- a/GliaWidgets/Sources/CallVisualizer/VideoCall/ViewModel/VideoCallViewModel.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VideoCall/ViewModel/VideoCallViewModel.swift
@@ -311,12 +311,14 @@ private extension CallVisualizer.VideoCallViewModel {
     }
 
     func toggleVideo() {
+        environment.openTelemetry.logger.i(.callScreenButtonClicked) { [weak self] in
+            guard let self else { return }
+            let button: OtelButtonNames = call.hasVisitorTurnedOffVideo ? .videoOn : .videoOff
+            $0[.buttonName] = .string(button.rawValue)
+        }
         call.toggleVideo()
         updateVideoButton()
         updateLocalVideoVisible()
-        environment.openTelemetry.logger.i(.callScreenButtonClicked) {
-            $0[.buttonName] = .string(OtelButtonNames.video.rawValue)
-        }
     }
 
     func setButtonState(kind: CallButton.Kind, state: CallButton.State) {

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
@@ -473,15 +473,15 @@ extension EntryWidget {
         environment.openTelemetry.logger.i(.entryWidgetItemClicked) {
             switch type {
             case .chat:
-                $0[.itemType] = .string(OtelEntryWidgetItemTypes.chat.rawValue)
+                $0[.engagementType] = .string(OtelEngagementTypes.chat.rawValue)
             case .audio:
-                $0[.itemType] = .string(OtelEntryWidgetItemTypes.audio.rawValue)
+                $0[.engagementType] = .string(OtelEngagementTypes.audio.rawValue)
             case .video:
-                $0[.itemType] = .string(OtelEntryWidgetItemTypes.video.rawValue)
+                $0[.engagementType] = .string(OtelEngagementTypes.twoWayVideo.rawValue)
             case .secureMessaging:
-                $0[.itemType] = .string(OtelEntryWidgetItemTypes.secureMessaging.rawValue)
+                $0[.engagementType] = .string(OtelEngagementTypes.secureMessaging.rawValue)
             case .callVisualizer:
-                $0[.itemType] = .string(OtelEntryWidgetItemTypes.callVisualizer.rawValue)
+                $0[.engagementType] = .string(OtelEngagementTypes.callVisualizer.rawValue)
             }
         }
     }

--- a/GliaWidgets/Sources/OpenTelemetry/OpenTelemetry.swift
+++ b/GliaWidgets/Sources/OpenTelemetry/OpenTelemetry.swift
@@ -7,4 +7,6 @@ typealias OtelAttributeValue = GliaCoreSDK.OtelAttributeValue
 typealias OtelButtonNames = GliaCoreSDK.OtelButtonNames
 typealias OtelDialogNames = GliaCoreSDK.OtelDialogNames
 typealias OtelGvaActionTypes = GliaCoreSDK.OtelGvaActionTypes
-typealias OtelEntryWidgetItemTypes = GliaCoreSDK.OtelEntryWidgetItemTypes
+typealias OtelEngagementTypes = GliaCoreSDK.OtelEngagementTypes
+typealias OtelEngagementSources = GliaCoreSDK.OtelEngagementSources
+typealias OtelMediaTypes = GliaCoreSDK.OtelMediaTypes

--- a/GliaWidgets/Sources/ViewModel/Call/CallViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Call/CallViewModel.swift
@@ -465,13 +465,21 @@ extension CallViewModel {
             logButtonClicked(.chat)
             delegate?(.chat)
         case .video:
-            logButtonClicked(.video)
+            if call.hasVisitorTurnedOffVideo {
+                logButtonClicked(.videoOn)
+            } else {
+                logButtonClicked(.videoOff)
+            }
             toggleVideo()
         case .mute:
             logButtonClicked(.mute)
             toggleMute()
         case .speaker:
-            logButtonClicked(.speaker)
+            if call.audioPortOverride == .speaker {
+                logButtonClicked(.speakerOff)
+            } else {
+                logButtonClicked(.speakerOn)
+            }
             toggleSpeaker()
         case .minimize:
             logButtonClicked(.minimize)

--- a/GliaWidgets/Sources/ViewModel/Call/Data/Call.swift
+++ b/GliaWidgets/Sources/ViewModel/Call/Data/Call.swift
@@ -143,7 +143,7 @@ class Call {
         if stream.isRemote {
             stream.onHold = { [weak self] in
                 self?.environment.openTelemetry.logger.i(.mediaOnHold) { builder in
-                    builder[.mediaType] = .string("audio")
+                    builder[.mediaType] = .string(OtelMediaTypes.remoteAudio.rawValue)
                 }
                 self?.isVisitorOnHold.value = $0
             }
@@ -160,7 +160,7 @@ class Call {
         if stream.isRemote {
             stream.onHold = { [weak self] in
                 self?.environment.openTelemetry.logger.i(.mediaOnHold) { builder in
-                    builder[.mediaType] = .string("video")
+                    builder[.mediaType] = .string(OtelMediaTypes.remoteVideo.rawValue)
                 }
                 self?.isVisitorOnHold.value = $0
             }
@@ -173,13 +173,13 @@ class Call {
                 self.hasVisitorTurnedOffVideo = false
                 $0.resume()
                 self.environment.openTelemetry.logger.i(.mediaResumed) { builder in
-                    builder[.mediaType] = .string("video")
+                    builder[.mediaType] = .string(OtelMediaTypes.localVideo.rawValue)
                 }
             } else {
                 self.hasVisitorTurnedOffVideo = true
                 $0.pause()
                 self.environment.openTelemetry.logger.i(.mediaPaused) { builder in
-                    builder[.mediaType] = .string("video")
+                    builder[.mediaType] = .string(OtelMediaTypes.localVideo.rawValue)
                 }
             }
         }
@@ -191,13 +191,13 @@ class Call {
                 self.hasVisitorMutedAudio = false
                 $0.unmute()
                 self.environment.openTelemetry.logger.i(.mediaResumed) { builder in
-                    builder[.mediaType] = .string("audio")
+                    builder[.mediaType] = .string(OtelMediaTypes.localAudio.rawValue)
                 }
             } else {
                 self.hasVisitorMutedAudio = true
                 $0.mute()
                 self.environment.openTelemetry.logger.i(.mediaPaused) { builder in
-                    builder[.mediaType] = .string("audio")
+                    builder[.mediaType] = .string(OtelMediaTypes.localAudio.rawValue)
                 }
             }
         }


### PR DESCRIPTION
MOB-4724

**What was solved?**
This is done to align event and attribute names between platforms

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
- [ ] Did you add logging beneficial for troubleshooting of customer issues?
- [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.