### PR TITLE
Fix operator name when upgrading engagements

### DIFF
--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -473,7 +473,7 @@ extension ChatViewModel {
         environment.alertManager.present(
             in: .global,
             as: .mediaUpgrade(
-                operators: interactor.engagedOperator?.name ?? "",
+                operators: interactor.engagedOperator?.firstName ?? "",
                 offer: offer,
                 accepted: { [weak self] in
                     self?.delegate?(.mediaUpgradeAccepted(offer: offer, answer: answer))


### PR DESCRIPTION
https://glia.atlassian.net/browse/MOB-4728

**What was solved?**

When upgrading engagement to audio/video from chat the popup dialog should only show operator first name. 

**Additional info:**

- [X] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
- [ ] Did you add logging beneficial for troubleshooting of customer issues?
- [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
