### PR TITLE
Add new telemetry events and attributes

### DIFF
--- a/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
@@ -69,7 +69,14 @@ extension CallVisualizer.Coordinator {
         }
 
         coordinator.start()
-        self.environment.openTelemetry.logger.i(.visitorCodeShown)
+        self.environment.openTelemetry.logger.i(.visitorCodeShown) {
+            switch presentation {
+            case .embedded:
+                $0[.viewType] = .string(OtelViewTypes.embedded.rawValue)
+            case .alert:
+                $0[.viewType] = .string(OtelViewTypes.dialog.rawValue)
+            }
+        }
         self.visitorCodeCoordinator = coordinator
     }
 

--- a/GliaWidgets/Sources/Component/Bubble/BubbleView.swift
+++ b/GliaWidgets/Sources/Component/Bubble/BubbleView.swift
@@ -72,7 +72,7 @@ class BubbleView: BaseView {
     func showOnHoldView() {
         onHoldView.removeFromSuperview()
         environment.openTelemetry.logger.i(.bubbleStateChanged) {
-            $0[.newState] = .string(OtelBubbleStates.onHold.rawValue)
+            $0[.bubbleState] = .string(OtelBubbleStates.onHold.rawValue)
         }
         // In case of badge-view being shown
         // place on-hold view under it.
@@ -85,7 +85,7 @@ class BubbleView: BaseView {
 
     func hideOnHoldView() {
         environment.openTelemetry.logger.i(.bubbleStateChanged) {
-            $0[.newState] = .string(OtelBubbleStates.operatorConnected.rawValue)
+            $0[.bubbleState] = .string(OtelBubbleStates.operatorConnected.rawValue)
         }
         onHoldView.removeFromSuperview()
     }

--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.MediaTypeItem.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.MediaTypeItem.swift
@@ -92,6 +92,16 @@ extension EntryWidget {
             case .callVisualizer: return "callVisualizer"
             }
         }
+
+        var toOtelAttribute: OtelEngagementTypes {
+            switch self {
+            case .video: return .twoWayVideo
+            case .audio: return .audio
+            case .chat: return .chat
+            case .secureMessaging: return .secureMessaging
+            case .callVisualizer: return .callVisualizer
+            }
+        }
     }
 }
 

--- a/GliaWidgets/Sources/OpenTelemetry/OpenTelemetry.swift
+++ b/GliaWidgets/Sources/OpenTelemetry/OpenTelemetry.swift
@@ -11,3 +11,5 @@ typealias OtelEngagementTypes = GliaCoreSDK.OtelEngagementTypes
 typealias OtelEngagementSources = GliaCoreSDK.OtelEngagementSources
 typealias OtelMediaTypes = GliaCoreSDK.OtelMediaTypes
 typealias OtelBubbleStates = GliaCoreSDK.OtelBubbleStates
+typealias OtelViewTypes = GliaCoreSDK.OtelViewTypes
+typealias OtelEntryWidgetStates = GliaCoreSDK.OtelEntryWidgetStates

--- a/GliaWidgets/Sources/ViewController/GliaViewController.swift
+++ b/GliaWidgets/Sources/ViewController/GliaViewController.swift
@@ -14,7 +14,7 @@ class GliaViewController: UIViewController {
         willSet {
             environment.openTelemetry.logger.i(.bubbleStateChanged) {
                 guard case .userImage = newValue else { return }
-                $0[.newState] = .string(OtelBubbleStates.operatorConnected.rawValue)
+                $0[.bubbleState] = .string(OtelBubbleStates.operatorConnected.rawValue)
             }
         }
         didSet {


### PR DESCRIPTION
MOB-4740

**What was solved?**
Added new telemetry events and attributes:
- added `view_type` attribute for `visitor_code_shown` and `entry_widget_shown` events;
- replaced `new_state` attribute with `bubble_state` one for `bubble_state_changed` event;
- added `entry_widget_button_clicked` event;

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
- [ ] Did you add logging beneficial for troubleshooting of customer issues?
- [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.