### PR TITLE
Avoid entry widget state logs duplication

### DIFF
--- a/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
+++ b/GliaWidgets/Sources/EntryWidget/EntryWidget.swift
@@ -379,6 +379,7 @@ private extension EntryWidget {
             receiveValue(state)
         }
         $viewState
+            .removeDuplicates()
             .receive(on: RunLoop.main)
             .sink(receiveValue: logViewStateChanged)
             .store(in: &cancellables)


### PR DESCRIPTION
**What was solved?**
Avoid entry widget state logs duplication

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
- [ ] Did you add logging beneficial for troubleshooting of customer issues?
- [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.
