### PR TITLE
Fix operator message containing link not clickable in i os 26

### DIFF
--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
@@ -432,6 +432,11 @@ extension SecureConversations.TranscriptModel {
     }
 
     func linkTapped(_ url: URL) {
+        if url.scheme == URLScheme.http.rawValue || url.scheme == URLScheme.https.rawValue {
+            environment.uiApplication.open(url)
+            return
+        }
+
         guard environment.uiApplication.canOpenURL(url) else {
             environment.log.prefixed(Self.self).error("No dialer uri - \(url)")
             return

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -947,6 +947,11 @@ extension ChatViewModel {
     }
 
     func linkTapped(_ url: URL) {
+        if url.scheme == URLScheme.http.rawValue || url.scheme == URLScheme.https.rawValue {
+            environment.uiApplication.open(url)
+            return
+        }
+
         guard environment.uiApplication.canOpenURL(url) else {
             environment.log.prefixed(Self.self).error("No dialer uri - \(url)")
             return

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+URLs.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests+URLs.swift
@@ -50,7 +50,7 @@ extension SecureConversationsTranscriptModelTests {
         let linkUrl = try XCTUnwrap(URL(string: "https://mock.mock"))
         viewModel.linkTapped(linkUrl)
 
-        XCTAssertEqual(calls, [.canOpen(linkUrl), .open(linkUrl)])
+        XCTAssertEqual(calls, [.open(linkUrl)])
     }
 
     func test_handleUrlWithRandomScheme() throws {
@@ -85,10 +85,10 @@ extension SecureConversationsTranscriptModelTests {
             return .mock
         }
 
-        let linkUrl = try XCTUnwrap(URL(string: "https://mock.mock"))
-        viewModel.linkTapped(linkUrl)
+        let unsupportedUrl = try XCTUnwrap(URL(string: "mock://mock"))
+        viewModel.linkTapped(unsupportedUrl)
 
-        XCTAssertEqual(calls, [.canOpen(linkUrl), .log])
+        XCTAssertEqual(calls, [.canOpen(unsupportedUrl), .log])
     }
 }
 

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -368,7 +368,7 @@ class ChatViewModelTests: XCTestCase {
         let linkUrl = try XCTUnwrap(URL(string: "https://mock.mock"))
         viewModel.linkTapped(linkUrl)
 
-        XCTAssertEqual(calls, [.canOpen(linkUrl), .open(linkUrl)])
+        XCTAssertEqual(calls, [.open(linkUrl)])
     }
     
     func test_handleUrlThatCanNotBeOpenedShouldLog() throws {
@@ -394,10 +394,10 @@ class ChatViewModelTests: XCTestCase {
             environment: viewModelEnv
         )
 
-        let linkUrl = try XCTUnwrap(URL(string: "https://mock.mock"))
-        viewModel.linkTapped(linkUrl)
+        let unsupportedUrl = try XCTUnwrap(URL(string: "mock://mock"))
+        viewModel.linkTapped(unsupportedUrl)
 
-        XCTAssertEqual(calls, [.canOpen(linkUrl), .log])
+        XCTAssertEqual(calls, [.canOpen(unsupportedUrl), .log])
     }
 
     func test_handleUrlWithRandomScheme() throws {


### PR DESCRIPTION
in iOS 17+, the operator message, containing URL, didn't open. This PR fixes it. 