### PR TITLE
Fix GliaTestApp visitor info custom attributes sorting and Save button state

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.9)
+    CFPropertyList (3.0.8)
     abbrev (0.1.2)
     activesupport (7.2.3.1)
       base64

--- a/GliaTestApp/Views/VisitorInfo/VisitorInfoViewModel.swift
+++ b/GliaTestApp/Views/VisitorInfo/VisitorInfoViewModel.swift
@@ -3,10 +3,10 @@ import GliaWidgets
 
 @MainActor
 final class VisitorInfoViewModel: ObservableObject {
-    @Published var name: String = ""
-    @Published var email: String = ""
-    @Published var phoneNumber: String = ""
-    @Published var notes: String = ""
+    @Published var name: String = "" { didSet { if oldValue != name { hasChanges = true } } }
+    @Published var email: String = "" { didSet { if oldValue != email { hasChanges = true } } }
+    @Published var phoneNumber: String = "" { didSet { if oldValue != phoneNumber { hasChanges = true } } }
+    @Published var notes: String = "" { didSet { if oldValue != notes { hasChanges = true } } }
     @Published var externalId: String = ""
     @Published var visitorId: String = ""
     @Published var customAttributes: [CustomAttribute] = []
@@ -99,7 +99,7 @@ final class VisitorInfoViewModel: ObservableObject {
         visitorId = info.id ?? ""
 
         if let attributes = info.customAttributes {
-            customAttributes = attributes.map { CustomAttribute(key: $0.key, value: $0.value) }
+            customAttributes = attributes.sorted { $0.key < $1.key }.map { CustomAttribute(key: $0.key, value: $0.value) }
         }
 
         hasChanges = false


### PR DESCRIPTION
**What was solved?**
Fix GliaTestApp visitor info custom attributes sorting and Save button state

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
- [ ] Did you add logging beneficial for troubleshooting of customer issues?
- [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
