### PR TITLE
Update info plist to allow file injection

### DIFF
--- a/GliaTestApp/Info.plist
+++ b/GliaTestApp/Info.plist
@@ -22,6 +22,8 @@
     <string>1</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
+    <key>LSSupportsOpeningDocumentsInPlace</key>
+    <true/>
     <key>UIApplicationSceneManifest</key>
     <dict>
         <key>UIApplicationSupportsMultipleScenes</key>
@@ -92,5 +94,7 @@
         <string>voip</string>
         <string>remote-notification</string>
     </array>
+    <key>UIFileSharingEnabled</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
Adds Files app document sharing support to GliaTestApp by enabling LSSupportsOpeningDocumentsInPlace and UIFileSharingEnabled.

This lets files pushed into the app’s Documents container, such as sample.pdf used by iOS acceptance tests, appear in the iOS Files picker like they already do for the old TestingApp.