### PR TITLE
Migrate acceptance tests to new testing app

### DIFF
--- a/GliaTestApp/Views/ContentView/ContentView.swift
+++ b/GliaTestApp/Views/ContentView/ContentView.swift
@@ -24,6 +24,7 @@ struct ContentView: View {
                 }
                 .padding()
             }
+            .accessibilityIdentifier("screen_main")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(
@@ -155,7 +156,7 @@ private extension ContentView {
                 ) {
                     viewModel.showVisitorCodeAlert()
                 }
-                .accessibilityIdentifier("main_present_visitor_code_as_alert_button")
+                .accessibilityIdentifier("main_visitor_code_alert_button")
 
                 EmbeddableWidgetContainer(
                     isExpanded: $viewModel.isVisitorCodeEmbedded,
@@ -169,7 +170,7 @@ private extension ContentView {
                     },
                     expandedHeight: 228
                 )
-                .accessibilityIdentifier("main_embed_visitor_code_view_button")
+                .accessibilityIdentifier("main_visitor_code_embedded_view_button")
             }
         }
     }
@@ -298,12 +299,14 @@ private extension ContentView {
                 label: {
                     Label("Update Visitor Info", systemImage: "person.text.rectangle")
                 })
+            .accessibilityIdentifier("main_visitorInfo_button")
 
             Button(
                 action: viewModel.showSensitiveDataTapped,
                 label: {
                     Label("Show Sensitive Data", systemImage: "eye.trianglebadge.exclamationmark")
                 })
+            .accessibilityIdentifier("main_sensitiveData_button")
 
             Button(
                 action: viewModel.resumeEngagement,
@@ -311,6 +314,7 @@ private extension ContentView {
                     Label("Resume Engagement", systemImage: "play.circle")
                 }
             )
+            .accessibilityIdentifier("main_resume_button")
 
             Divider()
 

--- a/GliaTestApp/Views/Settings/SettingsView.swift
+++ b/GliaTestApp/Views/Settings/SettingsView.swift
@@ -129,7 +129,9 @@ private extension SettingsView {
                 Text("Beta").tag(EnvironmentSelection.beta)
                 Text("US").tag(EnvironmentSelection.us)
                 Text("EU").tag(EnvironmentSelection.eu)
-                Text("Custom").tag(EnvironmentSelection.custom)
+                Text("Custom")
+                    .tag(EnvironmentSelection.custom)
+                    .accessibilityIdentifier("settings_environment_custom_segment")
             }
             .pickerStyle(.segmented)
             .accessibilityIdentifier("settings_environment_picker")
@@ -153,8 +155,12 @@ private extension SettingsView {
                 .accessibilityIdentifier("settings_companyName_textfield")
 
             Picker("Auth Method", selection: $viewModel.authorizationMethodSelection) {
-                Text("Site API Key").tag(SettingsView.AuthorizationMethodSelection.siteApiKey)
-                Text("User API Key").tag(SettingsView.AuthorizationMethodSelection.userApiKey)
+                Text("Site API Key")
+                    .tag(SettingsView.AuthorizationMethodSelection.siteApiKey)
+                    .accessibilityIdentifier("settings_authMethod_siteApiKey_segment")
+                Text("User API Key")
+                    .tag(SettingsView.AuthorizationMethodSelection.userApiKey)
+                    .accessibilityIdentifier("settings_authMethod_userApiKey_segment")
             }
             .pickerStyle(.segmented)
             .accessibilityIdentifier("settings_authMethod_segmentedControl")

--- a/GliaTestApp/Views/VisitorInfo/VisitorInfoView.swift
+++ b/GliaTestApp/Views/VisitorInfo/VisitorInfoView.swift
@@ -126,8 +126,12 @@ struct VisitorInfoView: View {
                         .font(.headline)
                     Spacer()
                     Picker("", selection: $viewModel.notesUpdateMethod) {
-                        Text("Replace").tag(VisitorInfoUpdate.NoteUpdateMethod.replace)
-                        Text("Append").tag(VisitorInfoUpdate.NoteUpdateMethod.append)
+                        Text("Replace")
+                            .tag(VisitorInfoUpdate.NoteUpdateMethod.replace)
+                            .accessibilityIdentifier("visitor_info_notes_method_1")
+                        Text("Append")
+                            .tag(VisitorInfoUpdate.NoteUpdateMethod.append)
+                            .accessibilityIdentifier("visitor_info_notes_method_0")
                     }
                     .pickerStyle(.segmented)
                     .frame(width: 150)
@@ -150,8 +154,12 @@ struct VisitorInfoView: View {
                     .font(.headline)
                 Spacer()
                 Picker("", selection: $viewModel.attributesUpdateMethod) {
-                    Text("Replace").tag(VisitorInfoUpdate.CustomAttributesUpdateMethod.replace)
-                    Text("Merge").tag(VisitorInfoUpdate.CustomAttributesUpdateMethod.merge)
+                    Text("Replace")
+                        .tag(VisitorInfoUpdate.CustomAttributesUpdateMethod.replace)
+                        .accessibilityIdentifier("visitor_info_custom_attribute_method_1")
+                    Text("Merge")
+                        .tag(VisitorInfoUpdate.CustomAttributesUpdateMethod.merge)
+                        .accessibilityIdentifier("visitor_info_custom_attribute_method_0")
                 }
                 .pickerStyle(.segmented)
                 .frame(width: 150)
@@ -163,13 +171,13 @@ struct VisitorInfoView: View {
                         get: { attribute.key },
                         set: { viewModel.updateCustomAttributeKey(at: index, key: $0) }
                     ))
-                    .accessibilityIdentifier("visitor_info_custom_attribute_key_\(index)")
+                    .accessibilityIdentifier("visitor_info_custom_attribute_key_input_\(index)")
 
                     TextField("Value", text: Binding(
                         get: { attribute.value },
                         set: { viewModel.updateCustomAttributeValue(at: index, value: $0) }
                     ))
-                    .accessibilityIdentifier("visitor_info_custom_attribute_value_\(index)")
+                    .accessibilityIdentifier("visitor_info_custom_attribute_value_input_\(index)")
                 }
                 .swipeActions(edge: .trailing, allowsFullSwipe: true) {
                     Button(role: .destructive) {
@@ -187,6 +195,7 @@ struct VisitorInfoView: View {
                     Text("Add Custom Attribute")
                 }
             }
+            .accessibilityIdentifier("visitor_info_add_custom_attribute_button")
         }
     }
 }

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -289,7 +289,7 @@ app:
     APP_SCHEME: GliaTestApp
   - opts:
       is_expand: false
-    BROWSERSTACK_APP_SCHEME: TestingApp
+    BROWSERSTACK_APP_SCHEME: GliaTestApp
   - opts:
       is_expand: false
     BITRISE_EXPORT_METHOD: development


### PR DESCRIPTION
This PR adds final accessibility identifiers to the GliaTestApp, and swaps out Acceptance tests target for the new testing app
