### PR TITLE
Fix wrong operator header behavior after engagement transfers

### DIFF
--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
@@ -914,7 +914,7 @@ extension SecureConversations.TranscriptModel {
         let items = chatModel.sections.flatMap(\.items).filter {
             switch $0.kind {
             case .callUpgrade,
-                    .operatorConnected,
+                    .operatorConnected(_, _),
                     .queueOperator,
                     .transferring,
                     .unreadMessageDivider:

--- a/GliaWidgets/Sources/View/Chat/ChatView.swift
+++ b/GliaWidgets/Sources/View/Chat/ChatView.swift
@@ -417,8 +417,8 @@ extension ChatView {
             )
         case let .callUpgrade(kind, duration):
             return callUpgradeContent(kind: kind, duration: duration)
-        case .operatorConnected:
-            return operatorConnectedContent()
+        case let .operatorConnected(name, imageUrl):
+            return operatorConnectedContent(name: name, imageUrl: imageUrl)
         case .transferring:
             return transferringContent()
         case .unreadMessageDivider:
@@ -967,12 +967,22 @@ extension ChatView {
         return .callUpgrade(view)
     }
 
-    private func operatorConnectedContent() -> ChatItemCell.Content {
-        return .queueOperator(connectView)
+    private func operatorConnectedContent(name: String?, imageUrl: String?) -> ChatItemCell.Content {
+        let view = ChatConnectViewHost(
+            connectStyle: style.connect,
+            imageCache: environment.imageViewCache
+        )
+        view.setState(.connected(name: name, imageUrl: imageUrl))
+        return .queueOperator(view)
     }
 
     private func transferringContent() -> ChatItemCell.Content {
-        return .queueOperator(connectView)
+        let view = ChatConnectViewHost(
+            connectStyle: style.connect,
+            imageCache: environment.imageViewCache
+        )
+        view.setState(.transferring)
+        return .queueOperator(view)
     }
 
     private func unreadMessageDividerContent() -> ChatItemCell.Content {

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
@@ -633,7 +633,7 @@ extension ChatViewController {
                 environment: viewFactoryEnv
             )
         )
-        chatViewModel.action?(.enqueueing)
+        chatViewModel.action?(.connected(name: nil, imageUrl: nil))
         chatViewModel.invokeSetTextAndSendMessage(text: "mock")
         chatViewModel.invokeSetTextAndSendMessage(text: "mock mock")
         controller.view.updateConstraints()

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -205,7 +205,7 @@ class ChatViewModel: EngagementViewModel {
             environment.log.prefixed(Self.self).info("Operator connected")
             let name = engagedOperator?.firstName
             let pictureUrl = engagedOperator?.picture?.url
-            let chatItem = ChatItem(kind: .operatorConnected)
+            let chatItem = ChatItem(kind: .operatorConnected(name: name, imageUrl: pictureUrl))
 
             setItems([], to: queueOperatorSection)
             appendItem(

--- a/GliaWidgets/Sources/ViewModel/Chat/Data/ChatItem.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/Data/ChatItem.swift
@@ -86,7 +86,7 @@ extension ChatItem {
         // in case when metadata can't be handled
         case customCard(ChatMessage, showsImage: Bool, imageUrl: String?, isActive: Bool)
         case callUpgrade(ObservableValue<CallKind>, duration: ObservableValue<Int>)
-        case operatorConnected
+        case operatorConnected(name: String?, imageUrl: String?)
         case transferring
         case unreadMessageDivider
         case systemMessage(ChatMessage)

--- a/GliaWidgetsTests/Lib/ChatItem/ChatItem+Equatable.swift
+++ b/GliaWidgetsTests/Lib/ChatItem/ChatItem+Equatable.swift
@@ -22,7 +22,7 @@ extension ChatItem.Kind: Equatable {
             return lhsKind.value == rhsKind.value
                 && lhsDuration.value == rhsDuration.value
 
-        case (.operatorConnected, .operatorConnected):
+        case (.operatorConnected(_, _), .operatorConnected(_, _)):
             return true
 
         case (.transferring, .transferring):

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Transferring.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Transferring.swift
@@ -82,4 +82,59 @@ extension ChatViewModelTests {
             ]
         )
     }
+
+    func test_multipleTransfersAccumulateOperatorConnectedItems() {
+        var interactorEnv: Interactor.Environment = .failing
+        interactorEnv.gcd.mainQueue.async = { $0() }
+        interactorEnv.log.infoClosure = { _, _, _, _ in }
+        interactorEnv.log.prefixedClosure = { _ in interactorEnv.log }
+        var viewModelEnv = ChatViewModel.Environment.failing()
+        viewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
+        viewModelEnv.fileManager.createDirectoryAtUrlWithIntermediateDirectories = { _, _, _ in }
+        viewModelEnv.loadChatMessagesFromHistory = { true }
+        viewModelEnv.fetchSiteConfigurations = { _ in }
+        viewModelEnv.createFileUploadListModel = { _ in .mock() }
+        viewModelEnv.log.infoClosure = { _, _, _, _ in }
+        viewModelEnv.log.prefixedClosure = { _ in viewModelEnv.log }
+        viewModelEnv.createEntryWidget = { _ in .mock() }
+
+        let interactor: Interactor = .mock(environment: interactorEnv)
+        interactor.setCurrentEngagement(.mock())
+        let viewModel: ChatViewModel = .mock(interactor: interactor, environment: viewModelEnv)
+
+        let op1 = CoreSdkClient.Operator.mock(name: "Alice Operator")
+        let op2 = CoreSdkClient.Operator.mock(name: "Bob Operator")
+
+        // First transfer: queue → op1 accepts
+        interactor.onEngagementTransferring()
+        interactor.onEngagementTransfer([op1])
+
+        // Second transfer: op1 → queue → op2 accepts
+        interactor.onEngagementTransferring()
+        interactor.onEngagementTransfer([op2])
+
+        let operatorConnectedItems = viewModel.messagesSection.items.filter {
+            if case .operatorConnected(_, _) = $0.kind { return true }
+            return false
+        }
+
+        XCTAssertEqual(operatorConnectedItems.count, 2)
+
+        if case let .operatorConnected(name, _) = operatorConnectedItems[0].kind {
+            XCTAssertEqual(name, "Alice")
+        } else {
+            XCTFail("Expected .operatorConnected(name:imageUrl:) for first item")
+        }
+
+        if case let .operatorConnected(name, _) = operatorConnectedItems[1].kind {
+            XCTAssertEqual(name, "Bob")
+        } else {
+            XCTFail("Expected .operatorConnected(name:imageUrl:) for second item")
+        }
+
+        XCTAssertFalse(
+            viewModel.messagesSection.items.contains(where: { $0.kind == .transferring }),
+            "No transferring items should remain after transfer completes"
+        )
+    }
 }

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -239,7 +239,7 @@ class ChatViewModelTests: XCTestCase {
         
         let viewModel: ChatViewModel = .mock(interactor: interactor, environment: viewModelEnv)
         let mockOperator: CoreSdkClient.Operator = .mock()
-        let mockItemKind: ChatItem.Kind = .operatorConnected
+        let mockItemKind: ChatItem.Kind = .operatorConnected(name: nil, imageUrl: nil)
 
         interactor.onEngagementTransfer([mockOperator])
 

--- a/GliaWidgetsTests/ViewModel/Chat/ChatItemTests.swift
+++ b/GliaWidgetsTests/ViewModel/Chat/ChatItemTests.swift
@@ -43,7 +43,7 @@ final class ChatItemTests: XCTestCase {
             case .gvaGallery, .gvaQuickReply, .gvaResponseText, .gvaPersistentButton:
                 XCTAssertTrue(chatItem.isOperatorMessage)
             case .unreadMessageDivider, .visitorMessage, .transferring,
-                 .outgoingMessage, .queueOperator, .operatorConnected, .callUpgrade:
+                 .outgoingMessage, .queueOperator, .operatorConnected(_, _), .callUpgrade:
                 XCTAssertFalse(chatItem.isOperatorMessage)
             }
         }

--- a/GliaWidgetsTests/ViewModel/Chat/Mocks/ChatItem.Kind.Mock.swift
+++ b/GliaWidgetsTests/ViewModel/Chat/Mocks/ChatItem.Kind.Mock.swift
@@ -41,7 +41,7 @@ extension ChatItem.Kind {
                 .init(with: .audio),
                 duration: .init(with: .zero)
             )
-        case .operatorConnected: return .operatorConnected
+        case .operatorConnected: return .operatorConnected(name: nil, imageUrl: nil)
         case .transferring: return .transferring
         case .unreadMessageDivider: return .unreadMessageDivider
         case .systemMessage: return .systemMessage(.mock())


### PR DESCRIPTION
MOB-5159
MOB-5182

**What was solved?**
Each history cell for `.operatorConnected` and `.transferring` now owns its own `ChatConnectViewHost` instance. Previously a single shared instance was re-parented on every `cellForRow` call, causing **UIKit** to silently remove it from the previous cell and leave empty gaps while scrolling.

Also adds name/imageUrl associated values to `ChatItem.Kind.operatorConnected` so each historical cell correctly reflects the operator active at that point in the session, and a regression test covering the multi-transfer scenario.

**Additional info:**

- [x] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
- [ ] Did you add logging beneficial for troubleshooting of customer issues?
- [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
