### PR TITLE
Avoid UI background thread access in CallVisualizer

### DIFF
--- a/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
+++ b/GliaWidgets/Sources/CallVisualizer/CallVisualizer.swift
@@ -143,6 +143,13 @@ extension CallVisualizer {
     }
 
     func endSession() {
+        Task { @MainActor [weak self] in
+            self?.endSessionOnMain()
+        }
+    }
+
+    @MainActor
+    private func endSessionOnMain() {
         coordinator.end()
         activeInteractor?.cleanup()
         delegate?(.engagementEnded)

--- a/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/Coordinator/CallVisualizer.Coordinator.swift
@@ -134,6 +134,7 @@ extension CallVisualizer.Coordinator {
         }
     }
 
+    @MainActor
     func end() {
         removeBubbleView()
         videoCallCoordinator?.finish()
@@ -217,7 +218,9 @@ extension CallVisualizer.Coordinator {
 extension CallVisualizer.Coordinator {
     func declineEngagement() {
         activeInteractor?.endEngagement { _ in }
-        end()
+        Task { @MainActor [weak self] in
+            self?.end()
+        }
     }
 
     func minimize() {

--- a/GliaWidgets/Sources/CallVisualizer/VideoCall/Coordinator/VideoCallCoordinator.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VideoCall/Coordinator/VideoCallCoordinator.swift
@@ -33,6 +33,7 @@ extension CallVisualizer {
             viewController?.presentingViewController?.dismiss(animated: true)
         }
 
+        @MainActor
         func finish() {
             viewModel?.close()
             viewController?.presentingViewController?.dismiss(animated: true)

--- a/GliaWidgets/Sources/CallVisualizer/VideoCall/ViewModel/VideoCallViewModel+CallQuality.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VideoCall/ViewModel/VideoCallViewModel+CallQuality.swift
@@ -3,14 +3,13 @@ import GliaCoreSDK
 
 extension CallVisualizer.VideoCallViewModel {
     func subscribeOnCallQualityChanges() {
+        let stream = environment.callQualityMonitor.mediaQualityStream()
         let task = Task { [weak self] in
-            guard let self else { return }
-
             if Task.isCancelled { return }
 
-            let stream = self.environment.callQualityMonitor.mediaQualityStream()
             for await mediaQuality in stream {
                 if Task.isCancelled { return }
+                guard let self else { return }
                 await self.handleMediaQuality(mediaQuality)
             }
         }

--- a/GliaWidgets/Sources/CallVisualizer/VideoCall/ViewModel/VideoCallViewModel+NetworkMonitoring.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VideoCall/ViewModel/VideoCallViewModel+NetworkMonitoring.swift
@@ -3,14 +3,13 @@ import Foundation
 
 extension CallVisualizer.VideoCallViewModel {
     func subscribeOnNetworkReachabilityChanges() {
+        let stream = environment.networkConnectionMonitor.networkStream(true)
         let task = Task { [weak self] in
-            guard let self else { return }
-
             if Task.isCancelled { return }
 
-            let stream = self.environment.networkConnectionMonitor.networkStream(true)
             for await status in stream {
                 if Task.isCancelled { return }
+                guard let self else { return }
                 await self.handleNetworkStatus(status)
             }
         }

--- a/GliaWidgets/Sources/CallVisualizer/VideoCall/ViewModel/VideoCallViewModel.swift
+++ b/GliaWidgets/Sources/CallVisualizer/VideoCall/ViewModel/VideoCallViewModel.swift
@@ -42,6 +42,8 @@ extension CallVisualizer {
 
         private var flipCameraAccLabelWithTap: VideoStreamView.FlipCameraAccLabelWithTap? { didSet { reportChange() } }
 
+        private var isClosed = false
+
         // MARK: - Initializer
 
         init(
@@ -94,8 +96,20 @@ extension CallVisualizer {
             environment.proximityManager.stop()
         }
 
+        @MainActor
         func close() {
+            guard !isClosed else { return }
+            isClosed = true
+
             disposeBag.disposeAll()
+            environment.notificationCenter.removeObserver(self)
+            call.kind.removeObserver(self)
+            call.state.removeObserver(self)
+            call.video.stream.removeObserver(self)
+            call.duration.removeObserver(self)
+            remoteVideoStream = nil
+            localVideoStream = nil
+            flipCameraAccLabelWithTap = nil
         }
     }
 }

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -271,7 +271,7 @@ extension CoreSdkClient {
         }
 
         func getStreamView() -> CoreSdkClient.StreamView {
-            .init()
+            getStreamViewFunc()
         }
 
         func playVideo() {

--- a/GliaWidgetsTests/CallVisualizer/VideoCall/VideoCallTests.swift
+++ b/GliaWidgetsTests/CallVisualizer/VideoCall/VideoCallTests.swift
@@ -51,6 +51,7 @@ final class VideoCallTests: XCTestCase {
         XCTAssertEqual(wasExecuted, true)
     }
 
+    @MainActor
     func test_proximityManagerStartsAndStops() {
         enum Call: Equatable { case isIdleTimerDisabled(Bool), isProximityMonitoringEnabled(Bool) }
         var calls: [Call] = []

--- a/GliaWidgetsTests/Sources/CallVisualizer/VideoCall/Coordinator/VideoCallCoordinatorTests.swift
+++ b/GliaWidgetsTests/Sources/CallVisualizer/VideoCall/Coordinator/VideoCallCoordinatorTests.swift
@@ -34,6 +34,42 @@ final class VideoCallCoordinatorTests: XCTestCase {
         XCTAssertNotNil(coordinator.viewController)
     }
 
+    @MainActor
+    func test_finishDetachesVideoStreamsFromViewHierarchy() throws {
+        let call = Call(.video(direction: .twoWay), environment: .mock)
+        let coordinator = CallVisualizer.VideoCallCoordinator(
+            environment: .mock,
+            theme: .mock(),
+            call: call
+        )
+        let viewController = try XCTUnwrap(coordinator.start() as? CallVisualizer.VideoCallViewController)
+        _ = viewController.view
+
+        let remoteStreamView = CoreSdkClient.StreamView()
+        let localStreamView = CoreSdkClient.StreamView()
+        let remoteStream = CoreSdkClient.MockVideoStreamable.mock(
+            getStreamViewFunc: { remoteStreamView },
+            getIsRemoteFunc: { true }
+        )
+        let localStream = CoreSdkClient.MockVideoStreamable.mock(
+            getStreamViewFunc: { localStreamView },
+            getIsRemoteFunc: { false }
+        )
+
+        call.updateVideoStream(with: remoteStream)
+        call.updateVideoStream(with: localStream)
+
+        XCTAssertNotNil(remoteStreamView.superview)
+        XCTAssertNotNil(localStreamView.superview)
+
+        coordinator.finish()
+
+        XCTAssertNil(remoteStreamView.superview)
+        XCTAssertNil(localStreamView.superview)
+        XCTAssertNil(viewController.props.videoCallViewProps.remoteVideoStream)
+        XCTAssertNil(viewController.props.videoCallViewProps.localVideoStream)
+    }
+
     // Show delegate
 
     func test_showDelegatePropsUpdated() {

--- a/GliaWidgetsTests/Sources/Glia/GliaTests.swift
+++ b/GliaWidgetsTests/Sources/Glia/GliaTests.swift
@@ -150,8 +150,12 @@ final class GliaTests: XCTestCase {
         gliaEnv.coreSdk.secureConversations.observePendingStatus = { _ in nil }
 
         let sdk = Glia(environment: gliaEnv)
+        let ended = expectation(description: "Ended event")
         sdk.onEvent = {
             calls.append(.onEvent($0))
+            if $0 == .ended {
+                ended.fulfill()
+            }
         }
         try sdk.configure(
             with: .mock(),
@@ -161,6 +165,7 @@ final class GliaTests: XCTestCase {
         sdk.interactor?.setEndedEngagement(.mock(source: .callVisualizer))
         sdk.interactor?.state = .ended(.byOperator)
 
+        wait(for: [ended], timeout: 1)
         XCTAssertEqual(calls, [.onEvent(.ended)])
     }
 
@@ -188,8 +193,12 @@ final class GliaTests: XCTestCase {
         gliaEnv.coreSdk.secureConversations.observePendingStatus = { _ in nil }
 
         let sdk = Glia(environment: gliaEnv)
+        let ended = expectation(description: "Ended event")
         sdk.onEvent = {
             calls.append(.onEvent($0))
+            if $0 == .ended {
+                ended.fulfill()
+            }
         }
         try sdk.configure(
             with: .mock(),
@@ -208,6 +217,7 @@ final class GliaTests: XCTestCase {
         /// added successfully, because observer method is called during
         /// interactor creation.
 
+        wait(for: [ended], timeout: 1)
         XCTAssertEqual(calls, [.onEvent(.ended)])
     }
 
@@ -234,6 +244,7 @@ final class GliaTests: XCTestCase {
         gliaEnv.callVisualizerPresenter = .init(presenter: { nil })
         gliaEnv.gcd.mainQueue.async = { callback in callback() }
         gliaEnv.notificationCenter.addObserverClosure = { _, _, _, _ in }
+        gliaEnv.notificationCenter.removeObserverClosure = { _ in }
         gliaEnv.coreSDKConfigurator.configureWithConfiguration = { _, completion in
             completion(.success(()))
         }
@@ -241,8 +252,12 @@ final class GliaTests: XCTestCase {
         gliaEnv.coreSdk.secureConversations.observePendingStatus = { _ in nil }
 
         let sdk = Glia(environment: gliaEnv)
+        let ended = expectation(description: "Ended event")
         sdk.onEvent = {
             calls.append(.onEvent($0))
+            if $0 == .ended {
+                ended.fulfill()
+            }
         }
         try sdk.configure(
             with: .mock(),
@@ -253,6 +268,7 @@ final class GliaTests: XCTestCase {
         sdk.interactor?.setEndedEngagement(.mock(source: .callVisualizer))
         sdk.interactor?.state = .ended(.byOperator)
 
+        wait(for: [ended], timeout: 1)
         XCTAssertEqual(calls, [.onEvent(.maximized), .onEvent(.ended)])
     }
 


### PR DESCRIPTION
This PR fixes a call visualizer crash that could happen when an operator ends a video engagement while the visitor has the video UI minimized. The teardown path now runs call visualizer ending, video coordinator finishing, and video view model cleanup on the main actor, so UIKit and Core SDK stream views are detached from the correct thread.

The implementation keeps the scope inside call visualizer video cleanup and makes the close path idempotent, including observer removal and clearing local/remote stream view references. It also avoids retaining the video call view model for the lifetime of the call quality and network async streams.

MOB-5334