### PR TITLE
Split sendMessage() to send text and each file as separate messages

### DIFF
--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Interface.swift
@@ -75,6 +75,14 @@ struct CoreSdkClient {
 
     var sendMessageWithMessagePayload: SendMessageWithMessagePayload
 
+    typealias SendFileCallback = (Result<Self.Message, Self.GliaCoreError>) -> Void
+    typealias SendFile = (
+        _ file: Self.EngagementFile,
+        _ completion: @escaping SendFileCallback
+    ) -> Void
+
+    var sendFile: SendFile
+
     typealias CancelQueueTicket = (
         _ queueTicket: Self.QueueTicket,
         _ completion: @escaping GliaCoreSDK.SuccessBlock

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Live.swift
@@ -58,6 +58,7 @@ extension CoreSdkClient {
             requestMediaUpgradeWithOffer: GliaCore.sharedInstance.requestMediaUpgrade(offer:completion:),
             sendMessagePreview: GliaCore.sharedInstance.sendMessagePreview(message:completion:),
             sendMessageWithMessagePayload: GliaCore.sharedInstance.send(messagePayload:completion:),
+            sendFile: GliaCore.sharedInstance.send(file:completion:),
             cancelQueueTicket: GliaCore.sharedInstance.cancel(queueTicket:completion:),
             endEngagement: GliaCore.sharedInstance.endEngagement(completion:),
             requestEngagedOperator: GliaCore.sharedInstance.requestEngagedOperator(completion:),

--- a/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
+++ b/GliaWidgets/Sources/CoreSDKClient/CoreSDKClient.Mock.swift
@@ -21,6 +21,7 @@ extension CoreSdkClient {
         requestMediaUpgradeWithOffer: { _, _ in },
         sendMessagePreview: { _, _ in },
         sendMessageWithMessagePayload: { _, _ in },
+        sendFile: { _, _ in },
         cancelQueueTicket: { _, _ in },
         endEngagement: { _ in },
         requestEngagedOperator: { _ in },

--- a/GliaWidgets/Sources/Interactor/Interactor.swift
+++ b/GliaWidgets/Sources/Interactor/Interactor.swift
@@ -198,6 +198,13 @@ extension Interactor {
         environment.coreSdk.sendMessageWithMessagePayload(messagePayload, completion)
     }
 
+    func sendFile(
+        file: CoreSdkClient.EngagementFile,
+        completion: @escaping (Result<CoreSdkClient.Message, CoreSdkClient.GliaCoreError>) -> Void
+    ) {
+        environment.coreSdk.sendFile(file, completion)
+    }
+
     func endSession(completion: @escaping (Result<Void, Error>) -> Void) {
         switch state {
         case .none:

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -221,30 +221,8 @@ class ChatViewModel: EngagementViewModel {
             fetchSiteConfigurations()
 
             pendingMessages.forEach { [weak self] outgoingMessage in
-                self?.interactor.send(messagePayload: outgoingMessage.payload) {  [weak self] result in
-                    guard let self else { return }
-                    switch result {
-                    case let .success(message):
-                        // When pending message is successfully delivered,
-                        // it has to be removed from the `pendingMessages` list, to avoid
-                        // situation where it gets sent again, for example after
-                        // transfer to another operator.
-                        removePendingMessage(by: message.id)
-                        self.replace(
-                            outgoingMessage,
-                            uploads: [],
-                            with: message,
-                            in: self.messagesSection
-                        )
-
-                        self.action?(.scrollToBottom(animated: true))
-                    case .failure:
-                        self.markMessageAsFailed(
-                            outgoingMessage,
-                            in: self.messagesSection
-                        )
-                    }
-                }
+                guard let self else { return }
+                sendOutgoingMessage(outgoingMessage, movingFrom: pendingSection, to: messagesSection)
             }
         default:
             break
@@ -526,59 +504,128 @@ extension ChatViewModel {
         interactor.sendMessagePreview(message)
     }
 
+    private func sendOutgoingMessage(
+        _ outgoingMessage: OutgoingMessage,
+        movingFrom pendingSection: Section<ChatItem>,
+        to messagesSection: Section<ChatItem>
+    ) {
+        let files = outgoingMessage.payload.attachment?.files ?? []
+        if let file = files.first, files.count == 1,
+           outgoingMessage.payload.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            interactor.sendFile(file: file) { [weak self] result in
+                guard let self else { return }
+                switch result {
+                case let .success(message):
+                    self.removePendingMessage(by: message.id)
+                    self.replace(outgoingMessage, uploads: [], with: message, in: messagesSection)
+                    self.action?(.scrollToBottom(animated: true))
+                case .failure:
+                    self.markMessageAsFailed(outgoingMessage, in: messagesSection)
+                }
+            }
+        } else {
+            interactor.send(messagePayload: outgoingMessage.payload) { [weak self] result in
+                guard let self else { return }
+                switch result {
+                case let .success(message):
+                    // When pending message is successfully delivered,
+                    // it has to be removed from the `pendingMessages` list, to avoid
+                    // situation where it gets sent again, for example after
+                    // transfer to another operator.
+                    self.removePendingMessage(by: message.id)
+                    self.replace(outgoingMessage, uploads: [], with: message, in: messagesSection)
+                    self.action?(.scrollToBottom(animated: true))
+                case .failure:
+                    self.markMessageAsFailed(outgoingMessage, in: messagesSection)
+                }
+            }
+        }
+    }
+
     private func sendMessage() {
         guard validateMessage() else { return }
 
-        let attachment = fileUploadListModel.attachment
         let uploads = fileUploadListModel.succeededUploads
-        let files = uploads.map { $0.localFile }
+        let capturedText = messageText
 
-        let payload = environment.createSendMessagePayload(messageText, attachment)
-
-        let outgoingMessage = OutgoingMessage(
-            payload: payload,
-            files: files
-        )
+        fileUploadListModel.succeededUploads.forEach { action?(.removeUpload($0)) }
+        fileUploadListModel.removeSucceededUploads()
+        messageText = ""
+        action?(.scrollToBottom(animated: true))
 
         switch interactor.state {
         case .engaged where shouldForceEnqueueing, .enqueueing, .ended, .none:
-            handle(pendingMessage: outgoingMessage)
+            var pendingItems: [OutgoingMessage] = []
+            if !capturedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                let textPayload = environment.createSendMessagePayload(capturedText, nil)
+                pendingItems.append(OutgoingMessage(payload: textPayload))
+            }
+            for upload in uploads {
+                guard let info = upload.engagementFileInformation else { continue }
+                let file = CoreSdkClient.EngagementFile(id: info.id)
+                let filePayload = environment.createSendMessagePayload("", CoreSdkClient.Attachment(file: file))
+                pendingItems.append(OutgoingMessage(payload: filePayload, files: [upload.localFile]))
+            }
+            pendingItems.forEach { handle(pendingMessage: $0) }
             interactor.state = .enqueueing(.chat)
+
         case .engaged:
-            let item = ChatItem(with: outgoingMessage)
-            appendItem(item, to: messagesSection, animated: true)
-            fileUploadListModel.succeededUploads.forEach { action?(.removeUpload($0)) }
-            fileUploadListModel.removeSucceededUploads()
-            action?(.scrollToBottom(animated: true))
-            messageText = ""
+            if !capturedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                let textPayload = environment.createSendMessagePayload(capturedText, nil)
+                let textOutgoing = OutgoingMessage(payload: textPayload)
+                appendItem(ChatItem(with: textOutgoing), to: messagesSection, animated: true)
 
-            interactor.send(messagePayload: outgoingMessage.payload) { [weak self] result in
-                guard let self else { return }
-
-                switch result {
-                case let .success(message):
-                    if !self.hasReceivedMessage(messageId: message.id) {
-                        self.registerReceivedMessage(messageId: message.id)
-                        self.replace(
-                            outgoingMessage,
-                            uploads: uploads,
-                            with: message,
-                            in: self.messagesSection
-                        )
-                        self.action?(.scrollToBottom(animated: true))
+                interactor.send(messagePayload: textOutgoing.payload) { [weak self] result in
+                    guard let self else { return }
+                    switch result {
+                    case let .success(message):
+                        if !self.hasReceivedMessage(messageId: message.id) {
+                            self.registerReceivedMessage(messageId: message.id)
+                            self.replace(textOutgoing, uploads: [], with: message, in: self.messagesSection)
+                            self.action?(.scrollToBottom(animated: true))
+                        }
+                    case .failure:
+                        self.markMessageAsFailed(textOutgoing, in: self.messagesSection)
                     }
-                case .failure:
-                    self.markMessageAsFailed(
-                        outgoingMessage,
-                        in: self.messagesSection
-                    )
                 }
             }
-        case .enqueued:
-            handle(pendingMessage: outgoingMessage)
-        }
 
-        messageText = ""
+            for upload in uploads {
+                guard let info = upload.engagementFileInformation else { continue }
+                let file = CoreSdkClient.EngagementFile(id: info.id)
+                let filePayload = environment.createSendMessagePayload("", CoreSdkClient.Attachment(file: file))
+                let fileOutgoing = OutgoingMessage(payload: filePayload, files: [upload.localFile])
+                appendItem(ChatItem(with: fileOutgoing), to: messagesSection, animated: true)
+
+                interactor.sendFile(file: file) { [weak self] result in
+                    guard let self else { return }
+                    switch result {
+                    case let .success(message):
+                        if !self.hasReceivedMessage(messageId: message.id) {
+                            self.registerReceivedMessage(messageId: message.id)
+                            self.replace(fileOutgoing, uploads: [], with: message, in: self.messagesSection)
+                            self.action?(.scrollToBottom(animated: true))
+                        }
+                    case .failure:
+                        self.markMessageAsFailed(fileOutgoing, in: self.messagesSection)
+                    }
+                }
+            }
+
+        case .enqueued:
+            var pendingItems: [OutgoingMessage] = []
+            if !capturedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                let textPayload = environment.createSendMessagePayload(capturedText, nil)
+                pendingItems.append(OutgoingMessage(payload: textPayload))
+            }
+            for upload in uploads {
+                guard let info = upload.engagementFileInformation else { continue }
+                let file = CoreSdkClient.EngagementFile(id: info.id)
+                let filePayload = environment.createSendMessagePayload("", CoreSdkClient.Attachment(file: file))
+                pendingItems.append(OutgoingMessage(payload: filePayload, files: [upload.localFile]))
+            }
+            pendingItems.forEach { handle(pendingMessage: $0) }
+        }
     }
 
     func handle(pendingMessage: OutgoingMessage) {
@@ -977,38 +1024,41 @@ extension ChatViewModel {
 
 extension ChatViewModel {
     private func retryMessageSending(_ outgoingMessage: OutgoingMessage) {
-        removeMessage(
-            outgoingMessage,
-            in: messagesSection
-        )
-
+        removeMessage(outgoingMessage, in: messagesSection)
         let item = ChatItem(with: outgoingMessage)
         appendItem(item, to: messagesSection, animated: true)
         action?(.scrollToBottom(animated: true))
 
-        interactor.send(messagePayload: outgoingMessage.payload) { [weak self] result in
-            guard let self else { return }
-
-            switch result {
-            case let .success(message):
-                if !self.hasReceivedMessage(messageId: message.id) {
-                    self.registerReceivedMessage(messageId: message.id)
-
-                    self.replace(
-                        outgoingMessage,
-                        uploads: [],
-                        with: message,
-                        in: self.messagesSection
-                    )
-                    self.action?(.scrollToBottom(animated: true))
+        let files = outgoingMessage.payload.attachment?.files ?? []
+        if let file = files.first, files.count == 1,
+           outgoingMessage.payload.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            interactor.sendFile(file: file) { [weak self] result in
+                guard let self else { return }
+                switch result {
+                case let .success(message):
+                    if !self.hasReceivedMessage(messageId: message.id) {
+                        self.registerReceivedMessage(messageId: message.id)
+                        self.replace(outgoingMessage, uploads: [], with: message, in: self.messagesSection)
+                        self.action?(.scrollToBottom(animated: true))
+                    }
+                case .failure:
+                    self.markMessageAsFailed(outgoingMessage, in: self.messagesSection)
                 }
-
-                self.updateSelectedOption(with: outgoingMessage)
-            case .failure:
-                self.markMessageAsFailed(
-                    outgoingMessage,
-                    in: self.messagesSection
-                )
+            }
+        } else {
+            interactor.send(messagePayload: outgoingMessage.payload) { [weak self] result in
+                guard let self else { return }
+                switch result {
+                case let .success(message):
+                    if !self.hasReceivedMessage(messageId: message.id) {
+                        self.registerReceivedMessage(messageId: message.id)
+                        self.replace(outgoingMessage, uploads: [], with: message, in: self.messagesSection)
+                        self.action?(.scrollToBottom(animated: true))
+                    }
+                    self.updateSelectedOption(with: outgoingMessage)
+                case .failure:
+                    self.markMessageAsFailed(outgoingMessage, in: self.messagesSection)
+                }
             }
         }
     }

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests.swift
@@ -1041,6 +1041,9 @@ class ChatViewModelTests: XCTestCase {
         interactorEnv.coreSdk.sendMessageWithMessagePayload = { _, callback in
             callback(.failure(.mock()))
         }
+        interactorEnv.coreSdk.sendFile = { _, callback in
+            callback(.failure(.mock()))
+        }
         interactorEnv.coreSdk.sendMessagePreview = { _, _ in }
         let interactor = Interactor.mock(environment: interactorEnv)
         interactor.state = .engaged(nil)
@@ -1054,7 +1057,7 @@ class ChatViewModelTests: XCTestCase {
         let fileUploadListViewModelEnv = SecureConversations.FileUploadListViewModel.Environment.mock
         fileUploadListViewModelEnv.uploader.uploads = [upload]
         viewModelEnv.createFileUploadListModel = { _ in .mock(environment: fileUploadListViewModelEnv) }
-        viewModelEnv.createSendMessagePayload = { .mock(content: $0, attachment: $1) }
+        viewModelEnv.createSendMessagePayload = { CoreSdkClient.SendMessagePayload(content: $0, attachment: $1) }
         viewModelEnv.createEntryWidget = { _ in .mock() }
 
         let viewModel = ChatViewModel.mock(interactor: interactor, environment: viewModelEnv)
@@ -1062,13 +1065,20 @@ class ChatViewModelTests: XCTestCase {
         let messageContent = "Mock"
         viewModel.invokeSetTextAndSendMessage(text: messageContent)
 
-        switch viewModel.messagesSection.items.last?.kind {
-        case let .outgoingMessage(message, _):
-            XCTAssertNotNil(message.payload.attachment)
-            XCTAssertEqual(message.payload.content, messageContent)
-        default:
-            XCTFail("message kind should be `visitorMessage`")
+        // Text and file are sent as separate messages; both are preserved after failure.
+        let outgoingMessages = viewModel.messagesSection.items.compactMap { item -> OutgoingMessage? in
+            if case let .outgoingMessage(message, _) = item.kind { return message }
+            return nil
         }
+        XCTAssertEqual(outgoingMessages.count, 2)
+        XCTAssertTrue(
+            outgoingMessages.contains(where: { $0.payload.content == messageContent }),
+            "text message content should be preserved after failure"
+        )
+        XCTAssertTrue(
+            outgoingMessages.contains(where: { $0.payload.attachment != nil }),
+            "file attachment should be preserved after failure"
+        )
     }
 
     func test_engagementEndedByOperatorCallsEngagementAndDelegateActions() {

--- a/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
+++ b/GliaWidgetsTests/Sources/CoreSdkClient/CoreSDKClient.Failing.swift
@@ -21,6 +21,7 @@ extension CoreSdkClient {
         requestMediaUpgradeWithOffer: { _, _ in fail("\(Self.self).requestMediaUpgradeWithOffer") },
         sendMessagePreview: { _, _ in fail("\(Self.self).sendMessagePreview") },
         sendMessageWithMessagePayload: { _, _ in fail("\(Self.self).sendMessageWithMessagePayload") },
+        sendFile: { _, _ in fail("\(Self.self).sendFile") },
         cancelQueueTicket: { _, _ in fail("cancelQueueTicket") },
         endEngagement: { _ in fail("\(Self.self).endEngagement") },
         requestEngagedOperator: { _ in fail("\(Self.self).requestEngagedOperator") },

--- a/Package.swift
+++ b/Package.swift
@@ -50,8 +50,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "PhoenixChannelsClient",
-            url: "https://github.com/salemove/phoenix-channels-kmm-bundle/releases/download/1.1.3/PhoenixChannelsClient.xcframework.zip",
-            checksum: "ed1396ab1c96d6371b95f45b9c39e33fdcc44dae7180cc58e8cbadcaafac5c03"
+            url: "https://github.com/salemove/phoenix-channels-kmm-bundle/releases/download/1.2.0/PhoenixChannelsClient.xcframework.zip",
+            checksum: "5f9ba724c41196b6d200786dbd2c5cd9c275dcea99cbfe76a169eb9bb2c66bc2"
         ),
         .target(
             name: "GliaWidgets",

--- a/templates/Package.swift
+++ b/templates/Package.swift
@@ -50,8 +50,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "PhoenixChannelsClient",
-            url: "https://github.com/salemove/phoenix-channels-kmm-bundle/releases/download/1.1.3/PhoenixChannelsClient.xcframework.zip",
-            checksum: "ed1396ab1c96d6371b95f45b9c39e33fdcc44dae7180cc58e8cbadcaafac5c03"
+            url: "https://github.com/salemove/phoenix-channels-kmm-bundle/releases/download/1.2.0/PhoenixChannelsClient.xcframework.zip",
+            checksum: "5f9ba724c41196b6d200786dbd2c5cd9c275dcea99cbfe76a169eb9bb2c66bc2"
         ),
         .target(
             name: "GliaWidgets",


### PR DESCRIPTION
MOB-5352

**What was solved?**
- Plumb sendFile through CoreSDKClient and Interactor in Widgets SDK
- sendMessage() emits one text OutgoingMessage (if non-empty) and one per
  uploaded file, calling sendFile() per file instead of bundling everything
  into a single sendMessagePayload
- pending-queue flush and retryMessageSending updated to route file-only
  items through sendFile() and text/legacy items through sendMessagePayload()
- sendOutgoingMessage() helper added to centralise the routing logic
- Updated test to assert both text content and attachment survive separate
  failure paths, using real SendMessagePayload init to avoid messageId collisions

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
- [ ] Did you add logging beneficial for troubleshooting of customer issues?
- [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
