### PR TITLE
Update-Bitrise-stack

### DIFF
--- a/GliaWidgetsTests/Sources/ChatView/ChatViewTest.swift
+++ b/GliaWidgetsTests/Sources/ChatView/ChatViewTest.swift
@@ -97,15 +97,36 @@ final class ChatViewTest: XCTestCase {
             engagementLaunching: .direct(kind: .chat),
             environment: coordinatorEnv
         )
-        coordinator.start()
+        weak var controller: ChatViewController?
+        weak var viewModel: ChatViewModel?
 
-        weak var controller = try XCTUnwrap(coordinator.navigationPresenter.viewControllers.last as? ChatViewController)
-        weak var viewModel = try XCTUnwrap(controller?.viewModel.engagementModel as? ChatViewModel)
-        viewModel?.interactorEvent(.stateChanged(.ended(.byVisitor)))
-        viewModel?.event(.closeTapped)
-        
-        XCTAssertNil(controller)
-        XCTAssertNil(viewModel)
+        try autoreleasepool {
+            coordinator.start()
+
+            let chatController = try XCTUnwrap(coordinator.navigationPresenter.viewControllers.last as? ChatViewController)
+            let chatViewModel = try XCTUnwrap(chatController.viewModel.engagementModel as? ChatViewModel)
+            controller = chatController
+            viewModel = chatViewModel
+            chatViewModel.interactorEvent(.stateChanged(.ended(.byVisitor)))
+            chatViewModel.event(.closeTapped)
+        }
+
+        assertChatViewIsReleased(controller: { controller }, viewModel: { viewModel })
+    }
+
+    private func assertChatViewIsReleased(
+        controller: @escaping () -> ChatViewController?,
+        viewModel: @escaping () -> ChatViewModel?,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let releaseExpectation = expectation(description: "Chat view is released")
+        DispatchQueue.main.async {
+            XCTAssertNil(controller(), file: file, line: line)
+            XCTAssertNil(viewModel(), file: file, line: line)
+            releaseExpectation.fulfill()
+        }
+        wait(for: [releaseExpectation], timeout: 1)
     }
 
     func test_isTopBannerHiddenWhenIsTopBannerAllowedIsFalse() throws {

--- a/SnapshotTests/SnapshotTestCase.swift
+++ b/SnapshotTests/SnapshotTestCase.swift
@@ -27,9 +27,9 @@ extension SnapshotTestCase {
     }
 
     private static let testedDevices = [
-        // iPhone 16, iOS 18.2
+        // iPhone 16, iOS 18.6
         TestDeviceConfig(
-            systemVersion: "18.2",
+            systemVersion: "18.6",
             screenSize: CGSize(
                 width: 393,
                 height: 852

--- a/SnapshotTests/extensions/UIView+Extensions.swift
+++ b/SnapshotTests/extensions/UIView+Extensions.swift
@@ -14,7 +14,10 @@ extension UIView {
         let snapshotting: Snapshotting<UIView, UIImage>
         switch mode {
         case .accessibilityImage:
-            snapshotting = .accessibilityImage(precision: SnapshotTestCase.possiblePrecision)
+            snapshotting = .accessibilityImage(
+                showActivationPoints: .never,
+                precision: SnapshotTestCase.possiblePrecision
+            )
         case .image:
             snapshotting = orientation == .portrait ? .image : .imageLandscape
         case .extra3LargeFont:

--- a/SnapshotTests/extensions/UIViewController+Extensions.swift
+++ b/SnapshotTests/extensions/UIViewController+Extensions.swift
@@ -16,7 +16,10 @@ extension UIViewController {
         let snapshotting: Snapshotting<UIViewController, UIImage>
         switch mode {
         case .accessibilityImage:
-            snapshotting = .accessibilityImage(precision: SnapshotTestCase.possiblePrecision)
+            snapshotting = .accessibilityImage(
+                showActivationPoints: .never,
+                precision: SnapshotTestCase.possiblePrecision
+            )
         case .image:
             snapshotting = orientation == .portrait ? .image : .imageLandscape
         case .extra3LargeFont:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -76,7 +76,7 @@ workflows:
     - xcode-test@6:
         inputs:
         - scheme: $TEST_SCHEME
-        - destination: platform=iOS Simulator,name=iPhone 16,OS=18.2
+        - destination: platform=iOS Simulator,name=iPhone 16,OS=18.6
     - git-tag@1:
         inputs:
         - tag: $NEW_VERSION
@@ -198,11 +198,11 @@ workflows:
     - xcode-test@6:
         inputs:
         - scheme: $TEST_SCHEME
-        - destination: platform=iOS Simulator,name=iPhone 16,OS=18.2
+        - destination: platform=iOS Simulator,name=iPhone 16,OS=18.6
     - xcode-test:
         inputs:
         - scheme: $SNAPSHOTS_SCHEME
-        - destination: platform=iOS Simulator,name=iPhone 16,OS=18.2
+        - destination: platform=iOS Simulator,name=iPhone 16,OS=18.6
     - xcode-archive@5:
         inputs:
         - scheme: $APP_SCHEME
@@ -318,5 +318,5 @@ trigger_map:
   workflow: pull-request
 meta:
   bitrise.io:
-    stack: osx-xcode-16.2.x
+    stack: osx-xcode-26.5.x
     machine_type_id: g2.mac.medium


### PR DESCRIPTION
This PR updates the Bitrise macOS build stack to the stable Xcode 26.5 image so CI runs on the current stable Xcode 26 environment without relying on older Xcode 16 images or the retired Xcode 26 Edge stack.
