### PR TITLE
iOS Chat Attachments Blank Screen

### DIFF
--- a/GliaWidgets.xcodeproj/project.pbxproj
+++ b/GliaWidgets.xcodeproj/project.pbxproj
@@ -486,6 +486,7 @@
 		8491AF632AA20F9D00CC3E72 /* GliaViewControllerDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF622AA20F9D00CC3E72 /* GliaViewControllerDelegateMock.swift */; };
 		8491AF652AAB281500CC3E72 /* ChatViewModelTests+CustomCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF642AAB281500CC3E72 /* ChatViewModelTests+CustomCard.swift */; };
 		8491AF672AB8707600CC3E72 /* ChatViewModelTests+Transferring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491AF662AB8707600CC3E72 /* ChatViewModelTests+Transferring.swift */; };
+		5451B0012E8C1A2B3C4D5E6F /* ChatViewModelTests+AttachmentButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5451A0012E8C1A2B3C4D5E6F /* ChatViewModelTests+AttachmentButton.swift */; };
 		8492F9152CAAE30F00242691 /* SecureConversations.ChatWithTranscriptModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8492F9142CAAE30F00242691 /* SecureConversations.ChatWithTranscriptModelTests.swift */; };
 		8492F9172CAD2F2000242691 /* TranscriptModelTests+ResponseCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8492F9162CAD2F2000242691 /* TranscriptModelTests+ResponseCard.swift */; };
 		8492F9192CAD329800242691 /* TranscriptModelTests+MessageRetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8492F9182CAD329800242691 /* TranscriptModelTests+MessageRetry.swift */; };
@@ -1634,6 +1635,7 @@
 		8491AF622AA20F9D00CC3E72 /* GliaViewControllerDelegateMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GliaViewControllerDelegateMock.swift; sourceTree = "<group>"; };
 		8491AF642AAB281500CC3E72 /* ChatViewModelTests+CustomCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatViewModelTests+CustomCard.swift"; sourceTree = "<group>"; };
 		8491AF662AB8707600CC3E72 /* ChatViewModelTests+Transferring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatViewModelTests+Transferring.swift"; sourceTree = "<group>"; };
+		5451A0012E8C1A2B3C4D5E6F /* ChatViewModelTests+AttachmentButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatViewModelTests+AttachmentButton.swift"; sourceTree = "<group>"; };
 		8492F9142CAAE30F00242691 /* SecureConversations.ChatWithTranscriptModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConversations.ChatWithTranscriptModelTests.swift; sourceTree = "<group>"; };
 		8492F9162CAD2F2000242691 /* TranscriptModelTests+ResponseCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TranscriptModelTests+ResponseCard.swift"; sourceTree = "<group>"; };
 		8492F9182CAD329800242691 /* TranscriptModelTests+MessageRetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TranscriptModelTests+MessageRetry.swift"; sourceTree = "<group>"; };
@@ -4436,6 +4438,7 @@
 				84681A942A61844000DD7406 /* ChatViewModelTests+Gva.swift */,
 				8491AF642AAB281500CC3E72 /* ChatViewModelTests+CustomCard.swift */,
 				8491AF662AB8707600CC3E72 /* ChatViewModelTests+Transferring.swift */,
+				5451A0012E8C1A2B3C4D5E6F /* ChatViewModelTests+AttachmentButton.swift */,
 				8492F91A2CAD6ADE00242691 /* ChatViewModelTests+MessageRetry.swift */,
 			);
 			path = ChatViewModel;
@@ -7180,6 +7183,7 @@
 				7552DFB12A6FB7DF0093519B /* ChatMessageTests.swift in Sources */,
 				31CCE3E82BCE8F3A00F92535 /* VideoCallCoordinatorTests.swift in Sources */,
 				8491AF672AB8707600CC3E72 /* ChatViewModelTests+Transferring.swift in Sources */,
+				5451B0012E8C1A2B3C4D5E6F /* ChatViewModelTests+AttachmentButton.swift in Sources */,
 				AFEF5C7429929A8D005C3D8D /* SecureConversations.FileUploadListViewModel.Environment.Failing.swift in Sources */,
 				AFF9542C2ADDA10600C277E0 /* CoreSDKConfigurator.Failing.swift in Sources */,
 				31758EC42B5FB192007BBD9F /* EngagementCoordinatorTests.swift in Sources */,

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.ChatWithTranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.ChatWithTranscriptModel.swift
@@ -83,6 +83,15 @@ extension SecureConversations.ChatWithTranscriptModel {
         }
     }
 
+    var mediaPickerButtonEnabling: MediaPickerButtonEnabling {
+        switch self {
+        case let .chat(model):
+            return model.mediaPickerButtonEnabling
+        case let .transcript(model):
+            return model.mediaPickerButtonEnabling
+        }
+    }
+
     var numberOfSections: Int {
         switch self {
         case let .chat(model):

--- a/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
+++ b/GliaWidgets/SecureConversations/ChatTranscript/SecureConversations.TranscriptModel.swift
@@ -63,6 +63,7 @@ extension SecureConversations {
             guard let site = siteConfiguration else { return .disabled }
             guard site.allowedFileSenders.visitor else { return .disabled }
             guard !site.allowedFileContentTypes.isEmpty else { return .disabled }
+            guard !fileUploadListModel.isLimitReached else { return .disabled }
             return .enabled(.secureMessaging)
         }
 
@@ -146,8 +147,9 @@ extension SecureConversations {
                 self?.action?(.updateUnreadMessageIndicator(itemCount: unreadCount))
             }
 
-            uploader.limitReached.addObserver(self) { [weak self] limitReached, _ in
-                self?.action?(.pickMediaButtonEnabled(!limitReached))
+            uploader.limitReached.addObserver(self) { [weak self] _, _ in
+                guard let self else { return }
+                self.action?(.setAttachmentButtonEnabling(self.mediaPickerButtonEnabling))
             }
             checkSecureConversationsAvailability()
         }

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.Mock.swift
@@ -269,7 +269,6 @@ extension ChatViewController {
         chatViewModel.action?(.setChoiceCardInputModeEnabled(false))
         chatViewModel.action?(.connected(name: "Mocked Operator Name", imageUrl: localFileURL.absoluteString))
         chatViewModel.action?(.setAttachmentButtonEnabling(.enabled(.engagementConnection(isConnected: true))))
-        chatViewModel.action?(.pickMediaButtonEnabled(true))
         chatViewModel.action?(.setOperatorTypingIndicatorIsHiddenTo(false, false))
 
         chatViewModel.action?(.fileUploadListPropsUpdated(chatViewModel.fileUploadListModel.props()))

--- a/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
+++ b/GliaWidgets/Sources/ViewController/Chat/ChatViewController.swift
@@ -127,6 +127,12 @@ final class ChatViewController: EngagementViewController, PopoverPresenter {
     private func bind(viewModel: SecureConversations.ChatWithTranscriptModel, to view: ChatView) {
         view.entryWidget = viewModel.entryWidget
 
+        // The view outlives the model it is bound to when chat and transcript models are
+        // swapped, so the attachment state has to start from scratch. Otherwise the button
+        // stays tappable on the incoming model's behalf until it has fetched site
+        // configuration, and tapping it offers no attachment sources at all.
+        view.messageEntryView.setPickMediaButtonVisibility(viewModel.mediaPickerButtonEnabling)
+
         view.header.showBackButton()
 
         let type = Self.currentChatModelType(viewModel)
@@ -393,8 +399,6 @@ extension ChatViewController {
             view?.messageEntryView.messageText = text
         case .sendButtonDisabled(let isDisabled):
             view?.messageEntryView.isSendButtonEnabled = !isDisabled
-        case .pickMediaButtonEnabled(let enabled):
-            view?.messageEntryView.pickMediaButton.isEnabled = enabled
         case .appendRows(let count, let section, let animated):
             view?.appendRows(count, to: section, animated: animated)
         case .refreshRow(let row, let section, let animated):

--- a/GliaWidgets/Sources/ViewController/Common/Popover/PopoverPresenter.swift
+++ b/GliaWidgets/Sources/ViewController/Common/Popover/PopoverPresenter.swift
@@ -16,8 +16,14 @@ extension PopoverPresenter {
         options: [AttachmentSourceItemKind],
         itemSelected: @escaping (AttachmentSourceItemKind) -> Void
     ) {
+        let items = style.items.filter { options.contains($0.kind) }
+        // A popover with no items collapses to a zero-height content size, which UIKit
+        // then replaces with its own default dimensions, producing a blank sheet with
+        // nothing to select. Not presenting at all is the safer outcome.
+        guard !items.isEmpty else { return }
+
         let listView = AttachmentSourceListView(with: style)
-        listView.items = style.items.filter({ options.contains($0.kind) })
+        listView.items = items
         listView.itemTapped = { itemSelected($0) }
 
         let edgeInsets: UIEdgeInsets = .init(top: 0, left: 0, bottom: 0, right: 15)

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+ViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel+ViewModel.swift
@@ -34,7 +34,6 @@ extension ChatViewModel: ViewModel {
         case setChoiceCardInputModeEnabled(Bool)
         case setMessageText(String)
         case sendButtonDisabled(Bool)
-        case pickMediaButtonEnabled(Bool)
         case appendRows(Int, to: Int, animated: Bool)
         case refreshRow(Int, in: Int, animated: Bool)
         case refreshRows([Int], in: Int, animated: Bool)

--- a/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
+++ b/GliaWidgets/Sources/ViewModel/Chat/ChatViewModel.swift
@@ -57,6 +57,7 @@ class ChatViewModel: EngagementViewModel {
         guard let site = siteConfiguration else { return .disabled }
         guard site.allowedFileSenders.visitor else { return .disabled }
         guard !site.allowedFileContentTypes.isEmpty else { return .disabled }
+        guard !fileUploadListModel.isLimitReached else { return .disabled }
         guard environment.getCurrentEngagement() != nil else {
             return .enabled(.engagementConnection(isConnected: false))
         }
@@ -144,8 +145,9 @@ class ChatViewModel: EngagementViewModel {
         uploader.state.addObserver(self) { [weak self] state, _ in
             self?.onUploaderStateChanged(state)
         }
-        uploader.limitReached.addObserver(self) { [weak self] limitReached, _ in
-            self?.action?(.pickMediaButtonEnabled(!limitReached))
+        uploader.limitReached.addObserver(self) { [weak self] _, _ in
+            guard let self else { return }
+            self.action?(.setAttachmentButtonEnabling(self.mediaPickerButtonEnabling))
         }
         isViewActive.addObserver(self) { [weak self] isViewActive, _ in
             if isViewActive {

--- a/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests.swift
+++ b/GliaWidgetsTests/SecureConversations/ChatTranscript/TranscriptModelTests.swift
@@ -78,7 +78,7 @@ final class SecureConversationsTranscriptModelTests: XCTestCase {
     func testMediaPickerButtonEnablingDependsOnSiteConfiguration() throws {
         var modelEnv = TranscriptModel.Environment.failing
         modelEnv.fileManager = .mock
-        modelEnv.createFileUploadListModel = { _ in .mock() }
+        modelEnv.createFileUploadListModel = FileUploadListViewModel.mock(environment:)
         modelEnv.getQueues = { _ in }
         modelEnv.fetchChatHistory = { _ in }
         modelEnv.secureConversations.getUnreadMessageCount = { _ in }

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+AttachmentButton.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+AttachmentButton.swift
@@ -1,0 +1,148 @@
+@testable import GliaWidgets
+@_spi(GliaWidgets) import GliaCoreSDK
+import XCTest
+
+extension ChatViewModelTests {
+    /// Sending a message clears succeeded uploads, which re-publishes the upload limit.
+    /// That signal must not be able to enable the attachment button on its own, otherwise
+    /// tapping it opens an empty "File attachments" popover while there is no engagement.
+    func test_sendingMessageWhileEnqueuedKeepsAttachmentButtonDisabled() throws {
+        var interactorEnv = Interactor.Environment.failing
+        interactorEnv.gcd.mainQueue.async = { $0() }
+        interactorEnv.coreSdk.queueForEngagement = { _, _, _ in }
+        interactorEnv.coreSdk.configureWithInteractor = { _ in }
+        interactorEnv.coreSdk.sendMessagePreview = { _, _ in }
+        interactorEnv.log.prefixedClosure = { _ in interactorEnv.log }
+        interactorEnv.log.infoClosure = { _, _, _, _ in }
+        let interactor = Interactor.mock(environment: interactorEnv)
+
+        var viewModelEnv = ChatViewModel.Environment.mock
+        viewModelEnv.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
+        viewModelEnv.createSendMessagePayload = { _, _ in .mock() }
+        viewModelEnv.fetchChatHistory = { $0(.success([])) }
+        // The visitor is still waiting in the queue, so no engagement is active
+        // and site configuration has not been fetched yet.
+        viewModelEnv.getCurrentEngagement = { nil }
+        viewModelEnv.fetchSiteConfigurations = { _ in }
+
+        let viewModel = ChatViewModel.mock(interactor: interactor, environment: viewModelEnv)
+        let controller = ChatViewController.mock(chatViewModel: viewModel)
+        let entryView = try XCTUnwrap((controller.view as? ChatView)?.messageEntryView)
+
+        XCTAssertFalse(entryView.pickMediaButton.isEnabled)
+
+        interactor.state = .enqueued(.mock, .chat)
+        viewModel.invokeSetTextAndSendMessage(text: "Test")
+
+        XCTAssertTrue(viewModel.mediaPickerButtonEnabling.isDisabled)
+        XCTAssertFalse(
+            entryView.pickMediaButton.isEnabled,
+            "Attachment button must stay disabled while there is no engagement to attach files to"
+        )
+    }
+
+    func test_sendingSecureMessageWithoutSiteConfigurationKeepsAttachmentButtonDisabled() throws {
+        let environment = SecureConversations.TranscriptModel.Environment.mock(
+            createFileUploadListModel: SecureConversations.FileUploadListViewModel.mock(environment:),
+            maximumUploads: { 2 }
+        )
+        let viewModel = SecureConversations.TranscriptModel(
+            isCustomCardSupported: false,
+            environment: environment,
+            availability: .mock(),
+            deliveredStatusText: "",
+            failedToDeliverStatusText: "",
+            unreadMessages: .init(with: 0),
+            interactor: .mock()
+        )
+        let controller = ChatViewController(
+            viewModel: .transcript(viewModel),
+            environment: .mock()
+        )
+        let entryView = try XCTUnwrap((controller.view as? ChatView)?.messageEntryView)
+
+        XCTAssertFalse(entryView.pickMediaButton.isEnabled)
+
+        viewModel.event(.messageTextChanged("Test"))
+        viewModel.event(.sendTapped)
+
+        XCTAssertTrue(viewModel.mediaPickerButtonEnabling.isDisabled)
+        XCTAssertFalse(entryView.pickMediaButton.isEnabled)
+    }
+
+    func test_mediaPickerButtonEnablingRespectsUploadLimit() throws {
+        var environment = ChatViewModel.Environment.mock
+        let site = try CoreSdkClient.Site.mock(
+            allowedFileContentTypes: ["image/jpeg"],
+            allowedFileSenders: .mock(visitor: true)
+        )
+        environment.fetchSiteConfigurations = { $0(.success(site)) }
+        environment.getCurrentEngagement = { .mock() }
+        let viewModel = ChatViewModel.mock(
+            environment: environment,
+            maximumUploads: { 1 }
+        )
+        viewModel.fetchSiteConfigurations()
+
+        XCTAssertFalse(viewModel.mediaPickerButtonEnabling.isDisabled)
+
+        let upload = try XCTUnwrap(viewModel.fileUploadListModel.addUpload(with: .mock))
+
+        XCTAssertTrue(viewModel.fileUploadListModel.isLimitReached)
+        XCTAssertTrue(viewModel.mediaPickerButtonEnabling.isDisabled)
+
+        viewModel.fileUploadListModel.removeUpload(upload)
+
+        XCTAssertFalse(viewModel.fileUploadListModel.isLimitReached)
+        XCTAssertFalse(viewModel.mediaPickerButtonEnabling.isDisabled)
+    }
+
+    func test_swappingModelsRefreshesAttachmentButtonEnabling() throws {
+        let initialViewModel = ChatViewModel.mock()
+        let controller = ChatViewController.mock(chatViewModel: initialViewModel)
+        let entryView = try XCTUnwrap((controller.view as? ChatView)?.messageEntryView)
+        initialViewModel.action?(
+            .setAttachmentButtonEnabling(.enabled(.secureMessaging))
+        )
+        XCTAssertTrue(entryView.pickMediaButton.isEnabled)
+
+        let replacementViewModel = ChatViewModel.mock()
+        controller.swapAndBindViewModel(.chat(replacementViewModel))
+
+        XCTAssertTrue(replacementViewModel.mediaPickerButtonEnabling.isDisabled)
+        XCTAssertFalse(entryView.pickMediaButton.isEnabled)
+    }
+
+    /// An attachment popover with no sources renders as a blank sheet, so it must not be shown.
+    func test_popoverIsNotPresentedWhenNoAttachmentSourcesAreAllowed() {
+        final class PresentationSpy: UIViewController, PopoverPresenter {
+            private(set) var presentedControllers: [UIViewController] = []
+            override func present(
+                _ viewControllerToPresent: UIViewController,
+                animated: Bool,
+                completion: (() -> Void)? = nil
+            ) {
+                presentedControllers.append(viewControllerToPresent)
+            }
+        }
+
+        let presenter = PresentationSpy()
+        let style = Theme().chatStyle.pickMedia
+
+        presenter.presentPopover(
+            with: style,
+            from: presenter.view,
+            options: [],
+            itemSelected: { _ in }
+        )
+        XCTAssertTrue(presenter.presentedControllers.isEmpty)
+
+        presenter.presentPopover(
+            with: style,
+            from: presenter.view,
+            options: [.browse],
+            itemSelected: { _ in }
+        )
+        XCTAssertEqual(presenter.presentedControllers.count, 1)
+    }
+}

--- a/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Transferring.swift
+++ b/GliaWidgetsTests/Sources/ChatViewModel/ChatViewModelTests+Transferring.swift
@@ -30,7 +30,7 @@ extension ChatViewModelTests {
         env.fileManager.fileExistsAtPath = { _ in true }
         env.fileManager.createDirectoryAtUrlWithIntermediateDirectories = { _, _, _ in }
         env.fileManager.urlsForDirectoryInDomainMask = { _, _ in [.mock] }
-        env.createFileUploadListModel = { _ in .mock() }
+        env.createFileUploadListModel = SecureConversations.FileUploadListViewModel.mock(environment:)
         env.createSendMessagePayload = { _, _ in .mock() }
         let site: CoreSdkClient.Site = try .mock(
             allowedFileContentTypes: ["image/jpeg"],

--- a/SnapshotTests/ChatViewControllerLayoutTests.swift
+++ b/SnapshotTests/ChatViewControllerLayoutTests.swift
@@ -73,6 +73,7 @@ final class ChatViewControllerLayoutTests: SnapshotTestCase {
         viewController.assertSnapshot(as: .image, in: .landscape)
     }
 
+    @MainActor
     func test_messageSendingFailedState() throws {
         let viewController = try ChatViewController.mockMessageSendingFailedState()
         viewController.assertSnapshot(as: .image, in: .portrait)


### PR DESCRIPTION
This PR fixes a blank File attachments screen that could appear after sending a message while an engagement was still being established. Attachment availability is now derived from the complete chat or secure messaging state, including site configuration, engagement connectivity, and the upload limit. The attachment state is refreshed when chat and transcript models are rebound, while empty attachment option lists are no longer presented as a defensive fallback.

MOB-5451