### PR TITLE
Visitor Survey Mid chat bug

### DIFF
--- a/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
+++ b/GliaWidgets/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator.swift
@@ -224,11 +224,12 @@ extension EngagementCoordinator {
             }
         }
 
-        guard let engagement = interactor.endedEngagement,
+        let endedEngagement = interactor.takeSurveyEligibleEngagement()
+        guard let engagement = endedEngagement,
                 engagement.actionOnEnd == .showSurvey,
                 surveyPresentation == .presentSurvey else {
             environment.log.prefixed(Self.self).info(
-                "Dismiss Glia screen without showing survey. On end action: \(String(describing: interactor.endedEngagement?.actionOnEnd))"
+                "Dismiss Glia screen without showing survey. On end action: \(String(describing: endedEngagement?.actionOnEnd))"
             )
             dismissGliaViewController()
             return

--- a/GliaWidgets/Sources/Interactor/Interactor.swift
+++ b/GliaWidgets/Sources/Interactor/Interactor.swift
@@ -29,6 +29,12 @@ enum EndEngagementReason {
     case byError
 }
 
+private enum SurveyEligibility {
+    case unavailable
+    case pendingVisitorEnd(requestID: UUID, engagement: CoreSdkClient.Engagement?)
+    case eligible(CoreSdkClient.Engagement)
+}
+
 enum InteractorEvent {
     case stateChanged(InteractorState)
     case receivedMessage(CoreSdkClient.Message)
@@ -73,12 +79,19 @@ class Interactor {
     let visitorContext: Configuration.VisitorContext?
     @Published private(set) var currentEngagement: CoreSdkClient.Engagement?
 
-    // Used to save ended engagement to fetch a survey
+    // The last observed engagement, retained for post-engagement UI decisions.
     private(set) var endedEngagement: CoreSdkClient.Engagement?
+    private var surveyEligibility: SurveyEligibility = .unavailable
 
     private var observers = [() -> (AnyObject?, EventHandler)]()
     private var cancellables = Set<AnyCancellable>()
-    @Published var state: InteractorState = .none
+    @Published var state: InteractorState = .none {
+        willSet {
+            if case .enqueueing = newValue {
+                invalidateSurveyEligibility()
+            }
+        }
+    }
     var environment: Environment
 
     /// Skips Live Observation confirmation alerts/snackbars in
@@ -142,6 +155,8 @@ extension Interactor {
         success: @escaping () -> Void,
         failure: @escaping (CoreSdkClient.SalemoveError) -> Void
     ) {
+        invalidateSurveyEligibility()
+
         switch engagementKind {
         case .chat:
              environment.log.prefixed(Self.self).info("Start queueing for chat engagement")
@@ -239,11 +254,33 @@ extension Interactor {
     }
 
     func endEngagement(completion: @escaping (Result<Void, Error>) -> Void) {
+        let requestID = UUID()
+        surveyEligibility = .pendingVisitorEnd(
+            requestID: requestID,
+            engagement: currentEngagement
+        )
         environment.coreSdk.endEngagement { [weak self] _, error in
             guard let self else { return }
             if let error = error {
+                if case let .pendingVisitorEnd(pendingRequestID, _) = self.surveyEligibility,
+                   pendingRequestID == requestID {
+                    self.surveyEligibility = .unavailable
+                }
                 completion(.failure(error))
             } else {
+                guard case let .pendingVisitorEnd(pendingRequestID, endingEngagement) = self.surveyEligibility,
+                      pendingRequestID == requestID else {
+                    completion(.success(()))
+                    return
+                }
+
+                if let endingEngagement,
+                   self.currentEngagement == nil || self.currentEngagement?.id == endingEngagement.id,
+                   self.endedEngagement?.id == endingEngagement.id {
+                    self.surveyEligibility = .eligible(endingEngagement)
+                } else {
+                    self.surveyEligibility = .unavailable
+                }
                 self.state = .ended(.byVisitor)
                 completion(.success(()))
             }
@@ -254,18 +291,32 @@ extension Interactor {
         Clean up interactor.
      
         Used to clean up:
-        * Cached `endedEngagement` that is used for presenting survey.
+        * Cached `endedEngagement` used for post-engagement UI decisions.
+        * Survey eligibility.
         * Interactor `state`.
     */
     func cleanup(_ policy: CleanupPolicy = .clearEndedEngagement) {
-        state = .none
-
         switch policy {
         case .keepEndedEngagement:
             break
         case .clearEndedEngagement:
             endedEngagement = nil
+            invalidateSurveyEligibility()
         }
+
+        state = .none
+    }
+
+    func takeSurveyEligibleEngagement() -> CoreSdkClient.Engagement? {
+        guard case let .eligible(engagement) = surveyEligibility else {
+            return nil
+        }
+        surveyEligibility = .unavailable
+        return engagement
+    }
+
+    private func invalidateSurveyEligibility() {
+        surveyEligibility = .unavailable
     }
 }
 
@@ -279,13 +330,17 @@ extension Interactor: CoreSdkClient.Interactable {
             currentEngagement = engagement
 
             if let engagement {
-                // Save the last non-nil engagement for survey
                 endedEngagement = engagement
+                if case let .pendingVisitorEnd(_, pendingEngagement?) = surveyEligibility,
+                   pendingEngagement.id == engagement.id {
+                    return
+                }
+                invalidateSurveyEligibility()
                 return
             }
 
-            // engagement became nil:
-            // if we have an ended engagement, keep it for survey; otherwise clear it
+            // Engagement became nil. Keep the last engagement for post-engagement UI
+            // decisions when one was observed; otherwise clear all lifecycle state.
             cleanup(endedEngagement != nil ? .keepEndedEngagement : .clearEndedEngagement)
         }
     }
@@ -414,18 +469,27 @@ extension Interactor: CoreSdkClient.Interactable {
     }
 
     func end(with reason: CoreSdkClient.EngagementEndingReason) {
+        let endReason: EndEngagementReason
+        // Core invokes this callback before clearing its current engagement.
+        endedEngagement = environment.coreSdk.getCurrentEngagement()
+
         switch reason {
         case .visitorHungUp:
-            state = .ended(.byVisitor)
+            endReason = .byVisitor
         case .operatorHungUp, .followUp:
-            // Save engagement ended by operator to fetch a survey
-            endedEngagement = environment.coreSdk.getCurrentEngagement()
-            state = .ended(.byOperator)
+            endReason = .byOperator
         case .error:
-            state = .ended(.byError)
+            endReason = .byError
         @unknown default:
-            state = .ended(.byError)
+            endReason = .byError
         }
+
+        if let endedEngagement {
+            surveyEligibility = .eligible(endedEngagement)
+        } else {
+            surveyEligibility = .unavailable
+        }
+        state = .ended(endReason)
     }
 
     func fail(error: CoreSdkClient.SalemoveError) {

--- a/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator+SurveyTests.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinator+SurveyTests.swift
@@ -2,8 +2,364 @@
 import XCTest
 
 class EngagementCoordinatorSurveyTests: XCTestCase {
+    func test_endDoesNotFetchSurveyWhenQueueingFailsDuringLiveEngagement() {
+        var surveyWasFetched = false
+        let engagement = CoreSdkClient.Engagement.mock(
+            fetchSurvey: { _, _ in
+                surveyWasFetched = true
+            },
+            actionOnEnd: .showSurvey
+        )
+        var coreSdkClient = CoreSdkClient.mock
+        coreSdkClient.queueForEngagement = { _, _, completion in
+            completion(.failure(.mock()))
+        }
+        let interactor = makeInteractor(coreSdk: coreSdkClient)
+        interactor.onEngagementChanged(engagement)
+        interactor.state = .enqueueing(.chat)
+        interactor.enqueueForEngagement(
+            engagementKind: .chat,
+            replaceExisting: false,
+            success: { XCTFail("Expected queueing to fail") },
+            failure: { _ in }
+        )
+        let coordinator = makeCoordinator(interactor: interactor)
+
+        coordinator.end(surveyPresentation: .presentSurvey)
+
+        XCTAssertFalse(surveyWasFetched)
+    }
+
+    func test_enqueueingStateInvalidatesPreviousUnconsumedConfirmedEnd() {
+        var surveyFetchCount = 0
+        let engagement = CoreSdkClient.Engagement.mock(
+            fetchSurvey: { _, _ in
+                surveyFetchCount += 1
+            },
+            actionOnEnd: .showSurvey
+        )
+        var coreSdkClient = CoreSdkClient.mock
+        coreSdkClient.getCurrentEngagement = { engagement }
+        let interactor = makeInteractor(coreSdk: coreSdkClient)
+        interactor.onEngagementChanged(engagement)
+        interactor.end(with: .operatorHungUp)
+        interactor.onEngagementChanged(nil)
+
+        interactor.state = .enqueueing(.chat)
+
+        makeCoordinator(interactor: interactor).end(surveyPresentation: .presentSurvey)
+
+        XCTAssertEqual(surveyFetchCount, 0)
+    }
+
+    func test_coreEndMakesSurveyEligibleBeforeNotifyingObservers() {
+        var surveyFetchCount = 0
+        let engagement = CoreSdkClient.Engagement.mock(
+            fetchSurvey: { _, _ in
+                surveyFetchCount += 1
+            },
+            actionOnEnd: .showSurvey
+        )
+        var coreSdkClient = CoreSdkClient.mock
+        coreSdkClient.getCurrentEngagement = { engagement }
+        let interactor = makeInteractor(coreSdk: coreSdkClient)
+        let coordinator = makeCoordinator(interactor: interactor)
+        interactor.onEngagementChanged(engagement)
+        interactor.addObserver(self) { event in
+            guard case .stateChanged(.ended(.byOperator)) = event else { return }
+            coordinator.end(surveyPresentation: .presentSurvey)
+        }
+
+        interactor.end(with: .operatorHungUp)
+
+        XCTAssertEqual(surveyFetchCount, 1)
+    }
+
+    func test_endFetchesSurveyAfterVisitorEndsEngagement() {
+        var surveyFetchCount = 0
+        let engagement = CoreSdkClient.Engagement.mock(
+            fetchSurvey: { _, _ in
+                surveyFetchCount += 1
+            },
+            actionOnEnd: .showSurvey
+        )
+        var interactor: Interactor!
+        var coordinator: EngagementCoordinator!
+        var coreSdkClient = CoreSdkClient.mock
+        coreSdkClient.endEngagement = { completion in
+            completion(true, nil)
+        }
+        interactor = makeInteractor(coreSdk: coreSdkClient)
+        coordinator = makeCoordinator(interactor: interactor)
+        interactor.onEngagementChanged(engagement)
+        interactor.state = .engaged(.mock())
+        interactor.addObserver(self) { event in
+            guard case .stateChanged(.ended(.byVisitor)) = event else { return }
+            coordinator.end(surveyPresentation: .presentSurvey)
+        }
+
+        interactor.endSession { result in
+            if case let .failure(error) = result {
+                XCTFail("Expected engagement to end successfully, got \(error)")
+            }
+        }
+        interactor.onEngagementChanged(nil)
+
+        XCTAssertEqual(surveyFetchCount, 1)
+    }
+
+    func test_visitorEndCompletionDoesNotConfirmNewerEngagement() {
+        var endingSurveyFetchCount = 0
+        var newerSurveyFetchCount = 0
+        let endingEngagement = CoreSdkClient.Engagement.mock(
+            id: "ending-engagement",
+            fetchSurvey: { _, _ in
+                endingSurveyFetchCount += 1
+            },
+            actionOnEnd: .showSurvey
+        )
+        let newerEngagement = CoreSdkClient.Engagement.mock(
+            id: "newer-engagement",
+            fetchSurvey: { _, _ in
+                newerSurveyFetchCount += 1
+            },
+            actionOnEnd: .showSurvey
+        )
+        var endCompletion: CoreSdkClient.SuccessBlock?
+        var coreSdkClient = CoreSdkClient.mock
+        coreSdkClient.endEngagement = { completion in
+            endCompletion = completion
+        }
+        let interactor = makeInteractor(coreSdk: coreSdkClient)
+        var endResult: Result<Void, Error>?
+        interactor.onEngagementChanged(endingEngagement)
+        interactor.state = .engaged(.mock())
+        interactor.endSession { endResult = $0 }
+        interactor.state = .enqueueing(.chat)
+        interactor.onEngagementChanged(newerEngagement)
+        let newerOperator = CoreSdkClient.Operator.mock(id: "newer-operator")
+        interactor.state = .engaged(newerOperator)
+
+        endCompletion?(true, nil)
+
+        let coordinator = makeCoordinator(interactor: interactor)
+        coordinator.end(surveyPresentation: .presentSurvey)
+        XCTAssertEqual(endingSurveyFetchCount, 0)
+        XCTAssertEqual(newerSurveyFetchCount, 0)
+        XCTAssertEqual(interactor.currentEngagement?.id, newerEngagement.id)
+        XCTAssertEqual(interactor.state, .engaged(newerOperator))
+        assertSuccess(endResult)
+    }
+
+    func test_delayedVisitorEndCompletionDoesNotOutliveNewQueueLifecycle() {
+        var surveyFetchCount = 0
+        let endingEngagement = CoreSdkClient.Engagement.mock(
+            id: "ending-engagement",
+            fetchSurvey: { _, _ in
+                surveyFetchCount += 1
+            },
+            actionOnEnd: .showSurvey
+        )
+        var endCompletion: CoreSdkClient.SuccessBlock?
+        var coreSdkClient = CoreSdkClient.mock
+        coreSdkClient.endEngagement = { completion in
+            endCompletion = completion
+        }
+        let interactor = makeInteractor(coreSdk: coreSdkClient)
+        var endResult: Result<Void, Error>?
+        interactor.onEngagementChanged(endingEngagement)
+        interactor.state = .engaged(.mock())
+        interactor.endSession { endResult = $0 }
+        interactor.onEngagementChanged(nil)
+        interactor.state = .enqueueing(.chat)
+
+        endCompletion?(true, nil)
+
+        makeCoordinator(interactor: interactor).end(surveyPresentation: .presentSurvey)
+        XCTAssertEqual(surveyFetchCount, 0)
+        XCTAssertEqual(interactor.state, .enqueueing(.chat))
+        assertSuccess(endResult)
+    }
+
+    func test_staleVisitorEndFailureDoesNotCancelNewerEndRequest() {
+        var endingSurveyFetchCount = 0
+        var newerSurveyFetchCount = 0
+        let endingEngagement = CoreSdkClient.Engagement.mock(
+            id: "ending-engagement",
+            fetchSurvey: { _, _ in
+                endingSurveyFetchCount += 1
+            },
+            actionOnEnd: .showSurvey
+        )
+        let newerEngagement = CoreSdkClient.Engagement.mock(
+            id: "newer-engagement",
+            fetchSurvey: { _, _ in
+                newerSurveyFetchCount += 1
+            },
+            actionOnEnd: .showSurvey
+        )
+        var endCompletions: [CoreSdkClient.SuccessBlock] = []
+        var coreSdkClient = CoreSdkClient.mock
+        coreSdkClient.endEngagement = { completion in
+            endCompletions.append(completion)
+        }
+        let interactor = makeInteractor(coreSdk: coreSdkClient)
+        interactor.onEngagementChanged(endingEngagement)
+        interactor.state = .engaged(.mock())
+        interactor.endSession { _ in }
+        interactor.state = .enqueueing(.chat)
+        interactor.onEngagementChanged(newerEngagement)
+        interactor.state = .engaged(.mock())
+        interactor.endSession { _ in }
+
+        XCTAssertEqual(endCompletions.count, 2)
+        endCompletions[0](false, .mock())
+        endCompletions[1](true, nil)
+        makeCoordinator(interactor: interactor).end(surveyPresentation: .presentSurvey)
+
+        XCTAssertEqual(endingSurveyFetchCount, 0)
+        XCTAssertEqual(newerSurveyFetchCount, 1)
+    }
+
+    func test_endFetchesSurveyWhenCoreClearsEngagementBeforeVisitorEndCompletion() {
+        var surveyFetchCount = 0
+        let engagement = CoreSdkClient.Engagement.mock(
+            id: "ending-engagement",
+            fetchSurvey: { _, _ in
+                surveyFetchCount += 1
+            },
+            actionOnEnd: .showSurvey
+        )
+        var endCompletion: CoreSdkClient.SuccessBlock?
+        var coreSdkClient = CoreSdkClient.mock
+        coreSdkClient.endEngagement = { completion in
+            endCompletion = completion
+        }
+        let interactor = makeInteractor(coreSdk: coreSdkClient)
+        interactor.onEngagementChanged(engagement)
+        interactor.state = .engaged(.mock())
+        interactor.endSession { result in
+            if case let .failure(error) = result {
+                XCTFail("Expected engagement to end successfully, got \(error)")
+            }
+        }
+
+        interactor.onEngagementChanged(nil)
+        endCompletion?(true, nil)
+        makeCoordinator(interactor: interactor).end(surveyPresentation: .presentSurvey)
+
+        XCTAssertEqual(surveyFetchCount, 1)
+    }
+
+    func test_coreEndUsesCurrentCoreEngagementInsteadOfCachedEngagement() {
+        let reasons: [CoreSdkClient.EngagementEndingReason] = [.visitorHungUp, .error]
+
+        for reason in reasons {
+            var cachedSurveyFetchCount = 0
+            var currentSurveyFetchCount = 0
+            let cachedEngagement = CoreSdkClient.Engagement.mock(
+                id: "cached-engagement",
+                fetchSurvey: { _, _ in
+                    cachedSurveyFetchCount += 1
+                },
+                actionOnEnd: .showSurvey
+            )
+            let currentEngagement = CoreSdkClient.Engagement.mock(
+                id: "current-engagement",
+                fetchSurvey: { _, _ in
+                    currentSurveyFetchCount += 1
+                },
+                actionOnEnd: .showSurvey
+            )
+            var coreSdkClient = CoreSdkClient.mock
+            coreSdkClient.getCurrentEngagement = { currentEngagement }
+            let interactor = makeInteractor(coreSdk: coreSdkClient)
+            interactor.onEngagementChanged(cachedEngagement)
+
+            interactor.end(with: reason)
+            makeCoordinator(interactor: interactor).end(surveyPresentation: .presentSurvey)
+
+            XCTAssertEqual(cachedSurveyFetchCount, 0, "Core end reason: \(reason)")
+            XCTAssertEqual(currentSurveyFetchCount, 1, "Core end reason: \(reason)")
+        }
+    }
+
+    func test_coreEndReasonsRemainEligibleForSurvey() {
+        let reasons: [CoreSdkClient.EngagementEndingReason] = [
+            .visitorHungUp,
+            .operatorHungUp,
+            .followUp,
+            .error
+        ]
+
+        for reason in reasons {
+            var surveyFetchCount = 0
+            let engagement = CoreSdkClient.Engagement.mock(
+                fetchSurvey: { _, _ in
+                    surveyFetchCount += 1
+                },
+                actionOnEnd: .showSurvey
+            )
+            var coreSdkClient = CoreSdkClient.mock
+            coreSdkClient.getCurrentEngagement = { engagement }
+            let interactor = makeInteractor(coreSdk: coreSdkClient)
+            interactor.onEngagementChanged(engagement)
+            interactor.end(with: reason)
+
+            makeCoordinator(interactor: interactor).end(surveyPresentation: .presentSurvey)
+
+            XCTAssertEqual(surveyFetchCount, 1, "Core end reason: \(reason)")
+        }
+    }
+
+    func test_doNotPresentSurveyConsumesConfirmedEnd() {
+        var surveyFetchCount = 0
+        let engagement = CoreSdkClient.Engagement.mock(
+            fetchSurvey: { _, _ in
+                surveyFetchCount += 1
+            },
+            actionOnEnd: .showSurvey
+        )
+        var coreSdkClient = CoreSdkClient.mock
+        coreSdkClient.getCurrentEngagement = { engagement }
+        let interactor = makeInteractor(coreSdk: coreSdkClient)
+        interactor.onEngagementChanged(engagement)
+        interactor.end(with: .operatorHungUp)
+
+        makeCoordinator(interactor: interactor).end(surveyPresentation: .doNotPresentSurvey)
+        makeCoordinator(interactor: interactor).end(surveyPresentation: .presentSurvey)
+
+        XCTAssertEqual(surveyFetchCount, 0)
+    }
+
+    func test_failedVisitorEndDoesNotMakeSurveyEligible() {
+        var surveyFetchCount = 0
+        let engagement = CoreSdkClient.Engagement.mock(
+            fetchSurvey: { _, _ in
+                surveyFetchCount += 1
+            },
+            actionOnEnd: .showSurvey
+        )
+        var coreSdkClient = CoreSdkClient.mock
+        coreSdkClient.endEngagement = { completion in
+            completion(false, .mock())
+        }
+        let interactor = makeInteractor(coreSdk: coreSdkClient)
+        interactor.onEngagementChanged(engagement)
+        interactor.state = .engaged(.mock())
+        interactor.endSession { result in
+            guard case .failure = result else {
+                XCTFail("Expected ending the engagement to fail")
+                return
+            }
+        }
+
+        makeCoordinator(interactor: interactor).end(surveyPresentation: .presentSurvey)
+
+        XCTAssertEqual(surveyFetchCount, 0)
+    }
+
     func test_surveyCompletesWithUnexpectedError() {
-        let coreSdkClient = CoreSdkClient.failing
         let engagement = CoreSdkClient.Engagement.mock(
             fetchSurvey: { _, callback in
                 callback(.failure(.mock()))
@@ -11,8 +367,11 @@ class EngagementCoordinatorSurveyTests: XCTestCase {
             media: .init(audio: .none, video: .oneWay),
             actionOnEnd: .showSurvey
         )
+        var coreSdkClient = CoreSdkClient.failing
+        coreSdkClient.getCurrentEngagement = { engagement }
         let interactor = Interactor.mock(environment: .init(coreSdk: coreSdkClient, queuesMonitor: .mock(), gcd: .failing, log: .failing))
-        interactor.setEndedEngagement(engagement)
+        interactor.onEngagementChanged(engagement)
+        interactor.end(with: .visitorHungUp)
         var alertManagerEnv = AlertManager.Environment.failing()
         var log = CoreSdkClient.Logger.failing
         log.prefixedClosure = { _ in log }
@@ -37,5 +396,45 @@ class EngagementCoordinatorSurveyTests: XCTestCase {
         )
         coordinator.end(surveyPresentation: .presentSurvey)
         XCTAssertEqual(messages, ["Show Unexpected error Dialog"])
+    }
+}
+
+private extension EngagementCoordinatorSurveyTests {
+    func makeInteractor(coreSdk: CoreSdkClient) -> Interactor {
+        Interactor.mock(
+            environment: .init(
+                coreSdk: coreSdk,
+                queuesMonitor: .mock(),
+                gcd: .mock,
+                log: .mock
+            )
+        )
+    }
+
+    func makeCoordinator(interactor: Interactor) -> EngagementCoordinator {
+        EngagementCoordinator(
+            interactor: interactor,
+            viewFactory: .mock(),
+            sceneProvider: nil,
+            engagementLaunching: .direct(kind: .chat),
+            features: [],
+            engagementRestorationState: { .none },
+            environment: .mock()
+        )
+    }
+
+    func assertSuccess(
+        _ result: Result<Void, Error>?,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let result else {
+            XCTFail("Expected stale end request to complete", file: file, line: line)
+            return
+        }
+        guard case .success = result else {
+            XCTFail("Expected successful Core end to remain successful", file: file, line: line)
+            return
+        }
     }
 }

--- a/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinatorTests.swift
+++ b/GliaWidgetsTests/Sources/Coordinators/EngagementCoordinator/EngagementCoordinatorTests.swift
@@ -113,7 +113,10 @@ final class EngagementCoordinatorTests: XCTestCase {
             fetchSurvey: { _, completion in completion(.success(survey)) },
             actionOnEnd: .showSurvey
         )
-        coordinator.interactor.setEndedEngagement(engagement)
+        coordinator.interactor.environment.coreSdk.getCurrentEngagement = { engagement }
+        coordinator.interactor.onEngagementChanged(engagement)
+        coordinator.interactor.end(with: .operatorHungUp)
+        coordinator.interactor.onEngagementChanged(nil)
         coordinator.end(surveyPresentation: .presentSurvey)
 
         let surveyViewController = coordinator.gliaPresenter.topMostViewController as? Survey.ViewController


### PR DESCRIPTION
This PR prevents post-interaction surveys from being presented when queueing fails during an otherwise active engagement. Survey presentation now requires one-shot eligibility established only after Core confirms an engagement end or a visitor-initiated end succeeds, rather than relying on the last observed engagement. The implementation invalidates stale eligibility when a new queue lifecycle begins, prevents delayed end completions from applying to newer engagements, and preserves surveys for genuine engagement-end paths.

MOB-5502