### PR TITLE
Fix Jazzy simulator destination

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -7,4 +7,4 @@ github_url: https://github.com/salemove/ios-sdk-widgets
 root_url: http://ios-sdk-docs.salemove.com.s3-website-us-east-1.amazonaws.com/widgets
 output: docs
 theme: apple
-xcodebuild_arguments: ["-workspace", "GliaWidgets.xcworkspace", "-scheme", "GliaWidgets", "-sdk", "iphonesimulator", "-destination", "platform=iOS Simulator,name=iPhone SE (3rd generation)"]
+xcodebuild_arguments: ["-workspace", "GliaWidgets.xcworkspace", "-scheme", "GliaWidgets", "-sdk", "iphonesimulator", "-destination", "generic/platform=iOS Simulator"]


### PR DESCRIPTION
This PR fixes API documentation generation on the current Bitrise Xcode stack by replacing the hard-coded iPhone SE destination with a generic iOS Simulator destination. This avoids failures when a specific simulator model is unavailable for the stack’s latest runtime.