### PR TITLE
Add Glia standards review bot workflow

### DIFF
--- a/.github/workflows/glia-review.yml
+++ b/.github/workflows/glia-review.yml
@@ -1,0 +1,19 @@
+# Glia standards review bot — reviews new PRs against the Engineering
+# Knowledge Base and posts findings as a non-blocking PR review.
+# Managed centrally: salemove/claude-code-plugins (scripts/glia-review-rollout).
+name: Glia Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  review:
+    uses: salemove/claude-code-plugins/.github/workflows/glia-review.yml@master
+    secrets:
+      GLIA_REVIEW_APP_PRIVATE_KEY: ${{ secrets.GLIA_REVIEW_APP_PRIVATE_KEY }}


### PR DESCRIPTION
**What was solved?**
Added the Glia standards review bot GitHub Action. It runs the centrally managed workflow from salemove/claude-code-plugins on newly opened PRs and posts findings as a non-blocking review.

Mirrors salemove/android-sdk#1151.

**Additional info:**

- [ ] Is the feature sufficiently tested? All tests fixed? Necessary unit, acceptance, snapshots added? Check that at least new public classes & methods are covered with unit tests
- [ ] Did you add logging beneficial for troubleshooting of customer issues?
- [ ] **Did you add new logging?** We would like the logging between platforms to be similar. Refer to **Logging from iOS SDKs** → **Things to consider for newly added logs** in Confluence for more information.

**Screenshots:**
<img width="1107" height="635" alt="image" src="https://github.com/user-attachments/assets/64e684ec-ff45-4360-9c93-3dcf55af36e4" />

Example of the review in details (from the android-sdk rollout): https://github.com/salemove/android-sdk/actions/runs/33869251061
It should also comment the code if the review finds issues.